### PR TITLE
fix(argocd): add Content-Type header to token generation API call

### DIFF
--- a/kubernetes/components/gitops-controller/base/scripts/provision-argocd-sa.sh
+++ b/kubernetes/components/gitops-controller/base/scripts/provision-argocd-sa.sh
@@ -49,6 +49,7 @@ while [ "$i" -lt "$COUNT" ]; do
   echo "Generating token for account '$ACCOUNT'..."
   TOKEN=$(curl -sf -X POST \
     -H "Authorization: Bearer $SESSION_TOKEN" \
+    -H "Content-Type: application/json" \
     "$ARGOCD_URL/api/v1/account/$ACCOUNT/token" \
     | jq -r '.token')
 


### PR DESCRIPTION
ArgoCD API returns 415 Unsupported Media Type without the Content-Type: application/json header on the token endpoint.