### PR TITLE
fix(talos): expose kube-controller-manager and kube-scheduler metrics

### DIFF
--- a/cluster/patches/control-plane-settings.yaml
+++ b/cluster/patches/control-plane-settings.yaml
@@ -1,6 +1,16 @@
 ###############################################################################
 ## Control plane patches
 ###############################################################################
+cluster:
+  ## Expose metrics endpoints on all interfaces (default: 127.0.0.1)
+  ## Required for Prometheus ServiceMonitor scraping from within the cluster
+  controllerManager:
+    extraArgs:
+      bind-address: "0.0.0.0"
+  scheduler:
+    extraArgs:
+      bind-address: "0.0.0.0"
+
 machine:
   features:
     ## Enable Talos API access from within Kubernetes


### PR DESCRIPTION
Bind metrics endpoints to 0.0.0.0 instead of 127.0.0.1 so Prometheus ServiceMonitors can scrape them, resolving InstanceDown alerts on all control plane nodes.