### PR TITLE
feat(wiki-js): add Wiki.js with CloudNativePG, Authentik OIDC, and S3…

### DIFF
--- a/kubernetes/applications/authentik/base/blueprint-wikijs.yaml
+++ b/kubernetes/applications/authentik/base/blueprint-wikijs.yaml
@@ -1,0 +1,48 @@
+version: 1
+metadata:
+  name: wikijs-oidc
+  labels:
+    blueprints.goauthentik.io/instantiate: "true"
+entries:
+  # OAuth2/OIDC Provider for Wiki.js
+  - model: authentik_providers_oauth2.oauth2provider
+    state: present
+    identifiers:
+      name: Wiki.js
+    attrs:
+      name: Wiki.js
+      authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+      invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+      client_type: confidential
+      client_id: wikijs
+      client_secret: !Env WIKIJS_OIDC_CLIENT_SECRET
+      signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
+      redirect_uris:
+        - matching_mode: strict
+          url: !Env AUTHENTIK_WIKIJS_REDIRECT_URI
+      property_mappings:
+        - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-openid]]
+        - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-email]]
+        - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-profile]]
+        - !Find [authentik_providers_oauth2.scopemapping, [managed, custom.homelab/scope-groups]]
+
+  # Application entry in Authentik's app library
+  - model: authentik_core.application
+    state: present
+    identifiers:
+      slug: wikijs
+    attrs:
+      name: Wiki.js
+      slug: wikijs
+      provider: !Find [authentik_providers_oauth2.oauth2provider, [name, Wiki.js]]
+      policy_engine_mode: any
+
+  # Restrict Wiki.js access to platform-admins group
+  - model: authentik_policies.policybinding
+    state: present
+    identifiers:
+      target: !Find [authentik_core.application, [slug, wikijs]]
+      group: !Find [authentik_core.group, [name, platform-admins]]
+      order: 0
+    attrs:
+      enabled: true

--- a/kubernetes/applications/authentik/base/kustomization.yaml
+++ b/kubernetes/applications/authentik/base/kustomization.yaml
@@ -39,6 +39,9 @@ configMapGenerator:
   - name: authentik-blueprint-node-red
     files:
       - blueprint-node-red.yaml
+  - name: authentik-blueprint-wikijs
+    files:
+      - blueprint-wikijs.yaml
 
 labels:
   - includeSelectors: false

--- a/kubernetes/applications/authentik/base/values.yaml
+++ b/kubernetes/applications/authentik/base/values.yaml
@@ -53,6 +53,12 @@ global:
         secretKeyRef:
           name: node-red-oidc-secret
           key: NODE_RED_OIDC_CLIENT_SECRET
+    # Wiki.js OIDC client secret for the wikijs-oidc blueprint
+    - name: WIKIJS_OIDC_CLIENT_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: wikijs-oidc-secret
+          key: WIKIJS_OIDC_CLIENT_SECRET
 
     # Blueprint variables — injected per environment via overlay replacements
     - name: AUTHENTIK_ARGOCD_REDIRECT_URI
@@ -65,6 +71,8 @@ global:
       value: https://PLACEHOLDER_AUTH_HOST
     - name: AUTHENTIK_NODE_RED_REDIRECT_URI
       value: https://PLACEHOLDER_NODE_RED_HOST/auth/strategy/callback/
+    - name: AUTHENTIK_WIKIJS_REDIRECT_URI
+      value: https://PLACEHOLDER_WIKIJS_HOST/login/oidc/callback
 
     # Optimization: Fewer workers and no preloading saves RAM in small setups
     - name: AUTHENTIK_WEB__WORKERS
@@ -100,6 +108,7 @@ blueprints:
     - authentik-blueprint-forward-auth
     - authentik-blueprint-grafana
     - authentik-blueprint-node-red
+    - authentik-blueprint-wikijs
 
 server:
   # Expose Authentik service via Cilium/BGP-announced LoadBalancer

--- a/kubernetes/applications/authentik/overlays/dev/kustomization.yaml
+++ b/kubernetes/applications/authentik/overlays/dev/kustomization.yaml
@@ -71,6 +71,19 @@ replacements:
         fieldPaths:
           - spec.template.spec.containers.0.env.[name=AUTHENTIK_NODE_RED_REDIRECT_URI].value
 
+  - sourceValue: https://wiki.zimmermann.phd/login/oidc/callback
+    targets:
+      - select:
+          kind: Deployment
+          name: authentik-worker
+        fieldPaths:
+          - spec.template.spec.containers.0.env.[name=AUTHENTIK_WIKIJS_REDIRECT_URI].value
+      - select:
+          kind: Deployment
+          name: authentik-server
+        fieldPaths:
+          - spec.template.spec.containers.0.env.[name=AUTHENTIK_WIKIJS_REDIRECT_URI].value
+
   - sourceValue: https://auth.zimmermann.phd
     targets:
       - select:

--- a/kubernetes/applications/authentik/overlays/prod/kustomization.yaml
+++ b/kubernetes/applications/authentik/overlays/prod/kustomization.yaml
@@ -71,6 +71,19 @@ replacements:
         fieldPaths:
           - spec.template.spec.containers.0.env.[name=AUTHENTIK_NODE_RED_REDIRECT_URI].value
 
+  - sourceValue: https://wiki.zimmermann.sh/login/oidc/callback
+    targets:
+      - select:
+          kind: Deployment
+          name: authentik-worker
+        fieldPaths:
+          - spec.template.spec.containers.0.env.[name=AUTHENTIK_WIKIJS_REDIRECT_URI].value
+      - select:
+          kind: Deployment
+          name: authentik-server
+        fieldPaths:
+          - spec.template.spec.containers.0.env.[name=AUTHENTIK_WIKIJS_REDIRECT_URI].value
+
   - sourceValue: https://auth.zimmermann.sh
     targets:
       - select:

--- a/kubernetes/applications/wiki-js/base/certificate.yaml
+++ b/kubernetes/applications/wiki-js/base/certificate.yaml
@@ -1,0 +1,14 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+
+metadata:
+  name: wiki-js-tls-cert
+  namespace: wiki-js
+
+spec:
+  secretName: wiki-js-tls-cert
+  issuerRef:
+    name: letsencrypt-dns01-issuer
+    kind: ClusterIssuer
+  dnsNames:
+    - PLACEHOLDER

--- a/kubernetes/applications/wiki-js/base/database.yaml
+++ b/kubernetes/applications/wiki-js/base/database.yaml
@@ -1,0 +1,124 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+
+metadata:
+  name: wiki-js-db
+  namespace: wiki-js
+
+spec:
+  instances: 1
+
+  # Registry authentication for dhi.io images
+  imagePullSecrets:
+    - name: dhi-registry-secret
+
+  # PostgreSQL version and configuration
+  imageName: ghcr.io/cloudnative-pg/postgresql:16.1
+
+  # Rolling update process is managed by Kubernetes
+  primaryUpdateStrategy: unsupervised
+
+  # Storage configuration
+  storage:
+    storageClass: longhorn-postgres
+    size: PLACEHOLDER
+  walStorage:
+    storageClass: longhorn-postgres
+    size: PLACEHOLDER
+
+  # Use non-reusable PVCs for improved failover/rebalance behavior
+  nodeMaintenanceWindow:
+    reusePVC: false
+
+  # Bootstrap from scratch
+  bootstrap:
+    initdb:
+      database: wikijs
+      owner: wikijs
+
+  postgresql:
+    parameters:
+      # Memory settings
+      shared_buffers: "64MB"
+      effective_cache_size: "256MB"
+      work_mem: "4MB"
+      maintenance_work_mem: "64MB"
+      autovacuum_work_mem: "64MB"
+
+      # WAL settings
+      wal_buffers: "16MB"
+      max_wal_size: PLACEHOLDER
+      min_wal_size: "80MB"
+      wal_keep_size: "64MB"
+      wal_compression: "on"
+
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      enabled: true
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: wiki-js-backups
+        serverName: PLACEHOLDER
+        s3-force-path-style: "true"
+
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+
+metadata:
+  name: wiki-js-db-daily
+  namespace: wiki-js
+
+spec:
+  schedule: "0 0 2 * * *"
+  immediate: false
+  backupOwnerReference: cluster
+  cluster:
+    name: wiki-js-db
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io
+
+---
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+
+metadata:
+  name: wiki-js-backups
+  namespace: wiki-js
+
+spec:
+  configuration:
+    destinationPath: s3://wiki-js-backups
+    endpointURL: http://rustfs-svc.rustfs.svc.cluster.local:9000
+    s3Credentials:
+      accessKeyId:
+        name: rustfs-admin-credentials
+        key: RUSTFS_ACCESS_KEY
+      secretAccessKey:
+        name: rustfs-admin-credentials
+        key: RUSTFS_SECRET_KEY
+    wal:
+      compression: bzip2
+      maxParallel: 2
+    data:
+      compression: bzip2
+  retentionPolicy: "14d"
+
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+
+metadata:
+  name: wiki-js-db
+  namespace: wiki-js
+  # Prometheus Operator label (Opt-In)
+  labels:
+    release: prometheus
+
+spec:
+  selector:
+    matchLabels:
+      cnpg.io/cluster: wiki-js-db
+  podMetricsEndpoints:
+    - port: metrics

--- a/kubernetes/applications/wiki-js/base/ingress-route.yaml
+++ b/kubernetes/applications/wiki-js/base/ingress-route.yaml
@@ -1,0 +1,35 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+
+metadata:
+  name: wiki-js
+  namespace: wiki-js
+  annotations:
+    # ExternalDNS configuration for Cloudflare
+    external-dns.alpha.kubernetes.io/target: udm-pro.zimmermann.sh
+    external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
+    kubernetes.io/ingress.class: traefik
+    # Homepage Service Discovery
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: "Productivity"
+    gethomepage.dev/name: "Wiki.js"
+    gethomepage.dev/icon: "wikijs.png"
+    gethomepage.dev/weight: "2"
+    gethomepage.dev/href: "https://PLACEHOLDER"
+
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - kind: Rule
+      match: Host(`PLACEHOLDER`)
+      priority: 10
+      middlewares:
+        - name: chain-standard
+          namespace: ingress-controller
+      services:
+        - kind: Service
+          name: wiki-js
+          port: 80
+  tls:
+    secretName: wiki-js-tls-cert

--- a/kubernetes/applications/wiki-js/base/kustomization.yaml
+++ b/kubernetes/applications/wiki-js/base/kustomization.yaml
@@ -1,0 +1,38 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: wiki-js
+resources:
+  - ./namespace.yaml
+  - ./database.yaml
+  - ./certificate.yaml
+  - ./ingress-route.yaml
+
+helmCharts:
+  - name: wiki
+    repo: https://charts.js.wiki
+    releaseName: wiki-js
+    version: 3.0.0
+    valuesFile: values.yaml
+    namespace: wiki-js
+
+patches:
+  # Add Cilium BGP labels to the Helm-generated Service (chart doesn't support custom service labels)
+  - target:
+      kind: Service
+      name: wiki-js
+    patch: |-
+      - op: add
+        path: /metadata/labels/bgp.cilium.io~1ip-pool
+        value: default
+      - op: add
+        path: /metadata/labels/bgp.cilium.io~1advertise-service
+        value: default
+
+labels:
+  - includeSelectors: false
+    pairs:
+      homelab.app: wiki-js
+
+commonAnnotations:
+  argocd.argoproj.io/sync-wave: "10"

--- a/kubernetes/applications/wiki-js/base/namespace.yaml
+++ b/kubernetes/applications/wiki-js/base/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+
+metadata:
+  name: wiki-js

--- a/kubernetes/applications/wiki-js/base/values.yaml
+++ b/kubernetes/applications/wiki-js/base/values.yaml
@@ -1,0 +1,34 @@
+# Disable built-in PostgreSQL (using CloudNativePG instead)
+postgresql:
+  enabled: false
+
+# Disable built-in ingress (using Traefik IngressRoute instead)
+ingress:
+  enabled: false
+
+# No service account needed
+serviceAccount:
+  create: false
+
+# LoadBalancer for Cilium BGP advertisement
+service:
+  type: LoadBalancer
+
+# Database connection via CloudNativePG
+extraEnvVars:
+  - name: DB_HOST
+    value: wiki-js-db-rw
+  - name: DB_PORT
+    value: "5432"
+  - name: DB_NAME
+    value: wikijs
+  - name: DB_USER
+    valueFrom:
+      secretKeyRef:
+        name: wiki-js-db-app
+        key: username
+  - name: DB_PASS
+    valueFrom:
+      secretKeyRef:
+        name: wiki-js-db-app
+        key: password

--- a/kubernetes/applications/wiki-js/overlays/dev/kustomization.yaml
+++ b/kubernetes/applications/wiki-js/overlays/dev/kustomization.yaml
@@ -1,0 +1,104 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+replacements:
+  # Inject domain name into Certificate, IngressRoute, and Homepage href
+  - sourceValue: wiki.zimmermann.phd
+    targets:
+      - select:
+          kind: Certificate
+          name: wiki-js-tls-cert
+        fieldPaths:
+          - spec.dnsNames.0
+      - select:
+          kind: IngressRoute
+          name: wiki-js
+        fieldPaths:
+          - spec.routes.0.match
+        options:
+          delimiter: "`"
+          index: 1
+      - select:
+          kind: IngressRoute
+          name: wiki-js
+        fieldPaths:
+          - metadata.annotations.[gethomepage.dev/href]
+        options:
+          delimiter: "//"
+          index: 1
+
+  # Inject database storage size
+  - sourceValue: 256Mi
+    targets:
+      - select:
+          kind: Cluster
+          name: wiki-js-db
+        fieldPaths:
+          - spec.storage.size
+
+  # Inject database WAL storage size
+  - sourceValue: 128Mi
+    targets:
+      - select:
+          kind: Cluster
+          name: wiki-js-db
+        fieldPaths:
+          - spec.walStorage.size
+
+  # Inject safe max_wal_size based on WAL PVC (80% rule)
+  - sourceValue: "100MB"
+    targets:
+      - select:
+          kind: Cluster
+          name: wiki-js-db
+        fieldPaths:
+          - spec.postgresql.parameters.max_wal_size
+
+  # Inject WAL archive server name to be unique per environment
+  - sourceValue: wiki-js-db-dev
+    targets:
+      - select:
+          kind: Cluster
+          name: wiki-js-db
+        fieldPaths:
+          - spec.plugins.0.parameters.serverName
+
+patches:
+  # PostgreSQL Cluster resources
+  - target:
+      kind: Cluster
+      name: wiki-js-db
+    patch: |-
+      - op: test
+        path: /spec/instances
+        value: 1
+      - op: add
+        path: /spec/resources
+        value:
+          requests:
+            cpu: 20m
+            memory: 64Mi
+          limits:
+            cpu: 100m
+            memory: 128Mi
+
+  # Wiki.js Deployment resources
+  - target:
+      kind: Deployment
+      name: wiki-js
+    patch: |-
+      - op: test
+        path: /spec/template/spec/containers/0/name
+        value: wiki
+      - op: add
+        path: /spec/template/spec/containers/0/resources
+        value:
+          requests:
+            cpu: 50m
+            memory: 128Mi
+          limits:
+            cpu: 250m
+            memory: 256Mi

--- a/kubernetes/applications/wiki-js/overlays/prod/kustomization.yaml
+++ b/kubernetes/applications/wiki-js/overlays/prod/kustomization.yaml
@@ -1,0 +1,116 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+replacements:
+  # Inject domain name into Certificate, IngressRoute, and Homepage href
+  - sourceValue: wiki.zimmermann.sh
+    targets:
+      - select:
+          kind: Certificate
+          name: wiki-js-tls-cert
+        fieldPaths:
+          - spec.dnsNames.0
+      - select:
+          kind: IngressRoute
+          name: wiki-js
+        fieldPaths:
+          - spec.routes.0.match
+        options:
+          delimiter: "`"
+          index: 1
+      - select:
+          kind: IngressRoute
+          name: wiki-js
+        fieldPaths:
+          - metadata.annotations.[gethomepage.dev/href]
+        options:
+          delimiter: "//"
+          index: 1
+
+  # Inject database storage size
+  - sourceValue: 512Mi
+    targets:
+      - select:
+          kind: Cluster
+          name: wiki-js-db
+        fieldPaths:
+          - spec.storage.size
+
+  # Inject database WAL storage size
+  - sourceValue: 256Mi
+    targets:
+      - select:
+          kind: Cluster
+          name: wiki-js-db
+        fieldPaths:
+          - spec.walStorage.size
+
+  # Inject safe max_wal_size based on WAL PVC (80% rule)
+  - sourceValue: "200MB"
+    targets:
+      - select:
+          kind: Cluster
+          name: wiki-js-db
+        fieldPaths:
+          - spec.postgresql.parameters.max_wal_size
+
+  # Inject WAL archive server name to be unique per environment
+  - sourceValue: wiki-js-db-prod
+    targets:
+      - select:
+          kind: Cluster
+          name: wiki-js-db
+        fieldPaths:
+          - spec.plugins.0.parameters.serverName
+
+patches:
+  # PostgreSQL Cluster resources
+  - target:
+      kind: Cluster
+      name: wiki-js-db
+    patch: |-
+      - op: test
+        path: /spec/instances
+        value: 1
+      - op: add
+        path: /spec/resources
+        value:
+          requests:
+            cpu: 50m
+            memory: 128Mi
+          limits:
+            cpu: 200m
+            memory: 256Mi
+
+  # Wiki.js Deployment resources
+  - target:
+      kind: Deployment
+      name: wiki-js
+    patch: |-
+      - op: test
+        path: /spec/template/spec/containers/0/name
+        value: wiki
+      - op: add
+        path: /spec/template/spec/containers/0/resources
+        value:
+          requests:
+            cpu: 50m
+            memory: 128Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
+
+  # Wiki.js service with static IP and BGP advertisement
+  - target:
+      kind: Service
+      name: wiki-js
+    patch: |-
+      - op: test
+        path: /spec/type
+        value: LoadBalancer
+      - op: add
+        path: /metadata/annotations/io.cilium~1lb-ipam-ips
+        value: "192.168.10.34"

--- a/kubernetes/components/admission-controller/base/clusterpolicy-secrets.yaml
+++ b/kubernetes/components/admission-controller/base/clusterpolicy-secrets.yaml
@@ -227,3 +227,22 @@ spec:
         clone:
           namespace: rustfs
           name: rustfs-admin-credentials
+
+    # Syncs RustFS admin credentials from rustfs into wiki-js for WAL archiving/backup
+    - name: sync-rustfs-admin-credentials-wiki-js
+      match:
+        any:
+          - resources:
+              kinds:
+                - Namespace
+              names:
+                - wiki-js
+      generate:
+        apiVersion: v1
+        kind: Secret
+        name: rustfs-admin-credentials
+        namespace: wiki-js
+        synchronize: true
+        clone:
+          namespace: rustfs
+          name: rustfs-admin-credentials


### PR DESCRIPTION
… backup

Deploy Wiki.js v2 via Helm chart (requarks/wiki 3.0.0) with a dedicated CloudNativePG PostgreSQL cluster, Barman S3 backups to RustFS, Traefik IngressRoute, and an Authentik OIDC blueprint for SSO integration.

- Wiki.js app with Helm chart, CloudNativePG database, cert-manager TLS
- Authentik blueprint for OIDC provider, redirect URI replacements in overlays
- Kyverno rule to sync rustfs-admin-credentials into wiki-js namespace
- Prod/dev overlays with environment-specific domains, storage, and resources