### PR TITLE
fix(infra): switch omni proxmox provider from password to API token auth

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -332,7 +332,12 @@ module "cloud_init_vendor_config" {
       content = try(wf.template_file, null) != null ? templatefile(wf.template_file, merge(
         ## Priority 1: Render template with merged context (Manifest Vars + OpenTofu Secrets)
         try(wf.vars, {}),
-        try(wf.secret_ref, null) != null ? try(var.ci_secrets[wf.secret_ref], {}) : {}
+        try(wf.secret_ref, null) != null ? try(var.ci_secrets[wf.secret_ref], {}) : {},
+        ## Generated API token credentials from pve_cluster_user module
+        try(wf.generated_token, null) != null ? {
+          (wf.generated_token.template_var_id)     = module.pve_cluster_user[wf.generated_token.user].token_id
+          (wf.generated_token.template_var_secret) = module.pve_cluster_user[wf.generated_token.user].token_value
+        } : {}
         )) : join("\n", compact([
           ## Priority 2: Auto-generate Key-Value list from Secrets (if no template)
           try(wf.secret_ref, null) != null ? join("\n", [for k, v in var.ci_secrets[wf.secret_ref] : "${k}=\"${v}\""]) : "",

--- a/infrastructure/manifest/00-cluster/pve-cluster-users.yaml
+++ b/infrastructure/manifest/00-cluster/pve-cluster-users.yaml
@@ -19,6 +19,8 @@ pve_cluster_users:
     omni:
       path: "/"
       role_id: "Administrator"
+      create_token: true
+      token_name: "infra-provider"
 
     ups_monitor:
       path: "/nodes"

--- a/infrastructure/manifest/30-cloud-init/ci-vendor-config.yaml
+++ b/infrastructure/manifest/30-cloud-init/ci-vendor-config.yaml
@@ -159,6 +159,10 @@ ci_vendor_config:
         permissions: "0640"
         owner: "omni:omni"
         defer: true
+        generated_token:
+          user: omni
+          template_var_id: proxmox_token_id
+          template_var_secret: proxmox_token_secret
 
   ## Proxmox Backup Server VM
   proxmox_backup:
@@ -288,9 +292,12 @@ ci_vendor_config:
       ## apcupsd bootstrap configuration (secrets)
       - path: /etc/apcupsd/apcupsd-bootstrap.conf
         template_file: templates/30-cloud-init/ups-monitor/apcupsd-bootstrap.conf.tftpl
-        secret_ref: ups_monitor_bootstrap_conf
         permissions: "0640"
         defer: true
+        generated_token:
+          user: ups_monitor
+          template_var_id: pve_api_token_id
+          template_var_secret: pve_api_token_secret
 
       ## apcupsd bootstrap script
       - path: /usr/local/bin/apcupsd-bootstrap.sh

--- a/infrastructure/templates/30-cloud-init/cluster-mgmt/docker/secrets/omni-proxmox-config.yaml.tftpl
+++ b/infrastructure/templates/30-cloud-init/cluster-mgmt/docker/secrets/omni-proxmox-config.yaml.tftpl
@@ -1,6 +1,5 @@
 proxmox:
-  username: "${proxmox_username}"
-  password: "${proxmox_password}"
+  tokenID: "${proxmox_token_id}"
+  tokenSecret: "${proxmox_token_secret}"
   url: "https://pve-1.zimmermann.eu.com:8006/api2/json"
   insecureSkipVerify: true
-  realm: "pve"

--- a/infrastructure/terraform.tfvars.example
+++ b/infrastructure/terraform.tfvars.example
@@ -64,10 +64,6 @@ ci_secrets = {
     ## Docker volume backup container stack configuration
     pushover_token = "YOUR_PUSHOVER_TOKEN"
     pushover_user  = "YOUR_PUSHOVER_USER"
-    ## Omni Proxmox Infrastructure Provider container stack configuration
-    proxmox_username = "YOUR_PVE_USER"
-    proxmox_password = "YOUR_PVE_PASSWORD"
-    proxmox_url      = "YOUR_PVE_URL"
   }
 
   ## PBS bootstrap configuration
@@ -89,11 +85,5 @@ ci_secrets = {
     ## Primary and SAN domains for ACME certificates
     primary_domain   = "YOUR_PRIMARY_DOMAIN"
     san_domains      = "YOUR_SAN_DOMAINS" # comma-separated list of domains
-  }
-
-  ## UPS Monitor (apcupsd) configuration
-  ups_monitor_bootstrap_conf = {
-    pve_api_token_id     = "YOUR_PVE_API_TOKEN_ID"
-    pve_api_token_secret = "YOUR_PVE_API_TOKEN_SECRET"
   }
 }


### PR DESCRIPTION
Password-based auth sessions expire after ~2h causing "not authorized" errors (siderolabs/omni-infra-provider-proxmox#25). API tokens don't expire, fixing the issue without provider restarts.

Adds a generic `generated_token` mechanism for cloud-init write_files that auto-injects API token credentials from the pve_cluster_user module, removing the need to manually copy token values into tfvars.