### PR TITLE
fix(infra): improve token output format with token_id key and secret-…

### DIFF
--- a/infrastructure/modules/00-pve-cluster-user/outputs.tf
+++ b/infrastructure/modules/00-pve-cluster-user/outputs.tf
@@ -26,11 +26,11 @@ output "token_id" {
 
 output "token_value" {
   description = <<EOT
-    API token value used for authentication. This is only populated when a new
-    token is created and should be stored securely. Marked as sensitive to avoid
-    accidental exposure.
+    API token secret (UUID portion only) used for authentication. The provider
+    returns the full "id=secret" string, so this output extracts just the secret.
+    Marked as sensitive to avoid accidental exposure.
   EOT
-  value       = try(proxmox_user_token.this[0].value, null)
+  value       = try(split("=", proxmox_user_token.this[0].value)[1], null)
   sensitive   = true
 }
 

--- a/infrastructure/outputs.tf
+++ b/infrastructure/outputs.tf
@@ -7,7 +7,7 @@ output "token_value" {
     API requests to the Proxmox cluster. Only populated when a new token is created.
     Marked as sensitive to prevent exposure of credentials.
   EOT
-  value       = { for k, v in module.pve_cluster_user : k => try(v.token_value, null) }
+  value       = { for k, v in module.pve_cluster_user : v.token_id => v.token_value if v.token_id != null }
   sensitive   = true
 }
 


### PR DESCRIPTION
…only value

The bpg/proxmox provider returns token values as "id=secret". Split to extract just the UUID secret portion, and use the token_id as the output map key for better readability.