### PR TITLE
fix(authentik): correct Wiki.js OIDC redirect URI to match strategy ID

### DIFF
--- a/kubernetes/applications/authentik/base/values.yaml
+++ b/kubernetes/applications/authentik/base/values.yaml
@@ -72,7 +72,7 @@ global:
     - name: AUTHENTIK_NODE_RED_REDIRECT_URI
       value: https://PLACEHOLDER_NODE_RED_HOST/auth/strategy/callback/
     - name: AUTHENTIK_WIKIJS_REDIRECT_URI
-      value: https://PLACEHOLDER_WIKIJS_HOST/login/oidc/callback
+      value: https://PLACEHOLDER_WIKIJS_HOST/login/b7746d63-71b4-47c1-bd32-903833a0a8ca/callback
 
     # Optimization: Fewer workers and no preloading saves RAM in small setups
     - name: AUTHENTIK_WEB__WORKERS

--- a/kubernetes/applications/authentik/overlays/dev/kustomization.yaml
+++ b/kubernetes/applications/authentik/overlays/dev/kustomization.yaml
@@ -71,7 +71,7 @@ replacements:
         fieldPaths:
           - spec.template.spec.containers.0.env.[name=AUTHENTIK_NODE_RED_REDIRECT_URI].value
 
-  - sourceValue: https://wiki.zimmermann.phd/login/oidc/callback
+  - sourceValue: https://wiki.zimmermann.phd/login/b7746d63-71b4-47c1-bd32-903833a0a8ca/callback
     targets:
       - select:
           kind: Deployment

--- a/kubernetes/applications/authentik/overlays/prod/kustomization.yaml
+++ b/kubernetes/applications/authentik/overlays/prod/kustomization.yaml
@@ -71,7 +71,7 @@ replacements:
         fieldPaths:
           - spec.template.spec.containers.0.env.[name=AUTHENTIK_NODE_RED_REDIRECT_URI].value
 
-  - sourceValue: https://wiki.zimmermann.sh/login/oidc/callback
+  - sourceValue: https://wiki.zimmermann.sh/login/b7746d63-71b4-47c1-bd32-903833a0a8ca/callback
     targets:
       - select:
           kind: Deployment


### PR DESCRIPTION
Wiki.js generates a UUID-based strategy ID for the callback URL rather than using a predictable path like /login/oidc/callback.