### PR TITLE
refactor(loki): standardize patch ordering convention

### DIFF
--- a/kubernetes/applications/loki/overlays/dev/kustomization.yaml
+++ b/kubernetes/applications/loki/overlays/dev/kustomization.yaml
@@ -15,6 +15,24 @@ replacements:
           - spec.volumeClaimTemplates.0.spec.resources.requests.storage
 
 patches:
+  # Loki Gateway (Deployment)
+  - target:
+      kind: Deployment
+      name: loki-gateway
+    patch: |-
+      - op: test
+        path: /spec/template/spec/containers/0/name
+        value: nginx
+      - op: add
+        path: /spec/template/spec/containers/0/resources
+        value:
+          requests:
+            cpu: 10m
+            memory: 32Mi
+          limits:
+            cpu: 100m
+            memory: 64Mi
+
   # Loki SingleBinary (StatefulSet)
   - target:
       kind: StatefulSet
@@ -55,24 +73,6 @@ patches:
         value:
           name: GOMEMLIMIT
           value: "120795955"
-
-  # Loki Gateway (Deployment)
-  - target:
-      kind: Deployment
-      name: loki-gateway
-    patch: |-
-      - op: test
-        path: /spec/template/spec/containers/0/name
-        value: nginx
-      - op: add
-        path: /spec/template/spec/containers/0/resources
-        value:
-          requests:
-            cpu: 10m
-            memory: 32Mi
-          limits:
-            cpu: 100m
-            memory: 64Mi
 
   # Loki Chunks Cache (StatefulSet)
   - target:

--- a/kubernetes/applications/loki/overlays/prod/kustomization.yaml
+++ b/kubernetes/applications/loki/overlays/prod/kustomization.yaml
@@ -15,6 +15,24 @@ replacements:
           - spec.volumeClaimTemplates.0.spec.resources.requests.storage
 
 patches:
+  # Loki Gateway (Deployment)
+  - target:
+      kind: Deployment
+      name: loki-gateway
+    patch: |-
+      - op: test
+        path: /spec/template/spec/containers/0/name
+        value: nginx
+      - op: add
+        path: /spec/template/spec/containers/0/resources
+        value:
+          requests:
+            cpu: 10m
+            memory: 32Mi
+          limits:
+            cpu: 100m
+            memory: 128Mi
+
   # Loki SingleBinary (StatefulSet)
   - target:
       kind: StatefulSet
@@ -55,24 +73,6 @@ patches:
         value:
           name: GOMEMLIMIT
           value: "120795955"
-
-  # Loki Gateway (Deployment)
-  - target:
-      kind: Deployment
-      name: loki-gateway
-    patch: |-
-      - op: test
-        path: /spec/template/spec/containers/0/name
-        value: nginx
-      - op: add
-        path: /spec/template/spec/containers/0/resources
-        value:
-          requests:
-            cpu: 10m
-            memory: 32Mi
-          limits:
-            cpu: 100m
-            memory: 128Mi
 
   # Loki Chunks Cache (StatefulSet)
   - target:


### PR DESCRIPTION
Reorder patches to follow consistent kind-based ordering: Deployment → StatefulSet → DaemonSet → Service. Moves loki-gateway Deployment patch before loki, loki-chunks-cache, and loki-results-cache StatefulSet patches.