### PR TITLE
refactor(crowdsec): standardize patch ordering convention

### DIFF
--- a/kubernetes/applications/crowdsec/overlays/dev/kustomization.yaml
+++ b/kubernetes/applications/crowdsec/overlays/dev/kustomization.yaml
@@ -33,24 +33,6 @@ replacements:
           - spec.postgresql.parameters.max_wal_size
 
 patches:
-  # CrowdSec LAPI: central management component
-  - target:
-      kind: Deployment
-      name: crowdsec-lapi
-    patch: |-
-      - op: test
-        path: /spec/template/spec/containers/0/name
-        value: crowdsec-lapi
-      - op: replace
-        path: /spec/template/spec/containers/0/resources
-        value:
-          requests:
-            cpu: 50m
-            memory: 64Mi
-          limits:
-            cpu: 200m
-            memory: 128Mi
-
   # CrowdSec AppSec: WAF-like security component
   - target:
       kind: Deployment
@@ -67,6 +49,24 @@ patches:
             memory: 64Mi
           limits:
             cpu: 100m
+            memory: 128Mi
+
+  # CrowdSec LAPI: central management component
+  - target:
+      kind: Deployment
+      name: crowdsec-lapi
+    patch: |-
+      - op: test
+        path: /spec/template/spec/containers/0/name
+        value: crowdsec-lapi
+      - op: replace
+        path: /spec/template/spec/containers/0/resources
+        value:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 200m
             memory: 128Mi
 
   # CrowdSec Agent: DaemonSet resources for log parsing

--- a/kubernetes/applications/crowdsec/overlays/prod/kustomization.yaml
+++ b/kubernetes/applications/crowdsec/overlays/prod/kustomization.yaml
@@ -33,14 +33,14 @@ replacements:
           - spec.postgresql.parameters.max_wal_size
 
 patches:
-  # CrowdSec LAPI: central management component
+  # CrowdSec AppSec: WAF-like security component
   - target:
       kind: Deployment
-      name: crowdsec-lapi
+      name: crowdsec-appsec
     patch: |-
       - op: test
         path: /spec/template/spec/containers/0/name
-        value: crowdsec-lapi
+        value: crowdsec-appsec
       - op: replace
         path: /spec/template/spec/containers/0/resources
         value:
@@ -51,14 +51,14 @@ patches:
             cpu: 300m
             memory: 256Mi
 
-  # CrowdSec AppSec: WAF-like security component
+  # CrowdSec LAPI: central management component
   - target:
       kind: Deployment
-      name: crowdsec-appsec
+      name: crowdsec-lapi
     patch: |-
       - op: test
         path: /spec/template/spec/containers/0/name
-        value: crowdsec-appsec
+        value: crowdsec-lapi
       - op: replace
         path: /spec/template/spec/containers/0/resources
         value:


### PR DESCRIPTION
Reorder Deployment patches alphabetically by name: crowdsec-appsec before crowdsec-lapi.