### PR TITLE
refactor(alloy): standardize patch ordering convention

### DIFF
--- a/kubernetes/applications/alloy/overlays/dev/kustomization.yaml
+++ b/kubernetes/applications/alloy/overlays/dev/kustomization.yaml
@@ -85,6 +85,26 @@ patches:
             cpu: 50m
             memory: 32Mi
 
+  # Alloy Logs: Collects and forwards logs to Loki
+  - target:
+      kind: Alloy
+      name: alloy-alloy-logs
+    patch: |-
+      - op: add
+        path: /spec/alloy/resources
+        value:
+          requests:
+            cpu: 20m
+            memory: 64Mi
+          limits:
+            cpu: 200m
+            memory: 128Mi
+      - op: add
+        path: /spec/alloy/env
+        value:
+          - name: GOMEMLIMIT
+            value: "120795955"
+
   # Alloy Metrics: Handles cluster and application metrics
   - target:
       kind: Alloy
@@ -109,26 +129,6 @@ patches:
   - target:
       kind: Alloy
       name: alloy-alloy-singleton
-    patch: |-
-      - op: add
-        path: /spec/alloy/resources
-        value:
-          requests:
-            cpu: 20m
-            memory: 64Mi
-          limits:
-            cpu: 200m
-            memory: 128Mi
-      - op: add
-        path: /spec/alloy/env
-        value:
-          - name: GOMEMLIMIT
-            value: "120795955"
-
-  # Alloy Logs: Collects and forwards logs to Loki
-  - target:
-      kind: Alloy
-      name: alloy-alloy-logs
     patch: |-
       - op: add
         path: /spec/alloy/resources

--- a/kubernetes/applications/alloy/overlays/prod/kustomization.yaml
+++ b/kubernetes/applications/alloy/overlays/prod/kustomization.yaml
@@ -85,6 +85,26 @@ patches:
             cpu: 100m
             memory: 64Mi
 
+  # Alloy Logs: Collects and forwards logs to Loki
+  - target:
+      kind: Alloy
+      name: alloy-alloy-logs
+    patch: |-
+      - op: add
+        path: /spec/alloy/resources
+        value:
+          requests:
+            cpu: 25m
+            memory: 128Mi
+          limits:
+            cpu: 300m
+            memory: 384Mi
+      - op: add
+        path: /spec/alloy/env
+        value:
+          - name: GOMEMLIMIT
+            value: "362387866"
+
   # Alloy Metrics: Handles cluster and application metrics
   - target:
       kind: Alloy
@@ -125,25 +145,14 @@ patches:
           - name: GOMEMLIMIT
             value: "241591910"
 
-  # Alloy Logs: Collects and forwards logs to Loki
+  # Alloy metrics service with static IP and BGP advertisement
   - target:
-      kind: Alloy
-      name: alloy-alloy-logs
+      kind: Service
+      name: alloy-alloy-metrics
     patch: |-
       - op: add
-        path: /spec/alloy/resources
-        value:
-          requests:
-            cpu: 25m
-            memory: 128Mi
-          limits:
-            cpu: 300m
-            memory: 384Mi
-      - op: add
-        path: /spec/alloy/env
-        value:
-          - name: GOMEMLIMIT
-            value: "362387866"
+        path: /metadata/annotations/io.cilium~1lb-ipam-ips
+        value: "192.168.10.22"
 
   # Alloy Receiver: Syslog service with static IP
   - target:
@@ -153,12 +162,3 @@ patches:
       - op: add
         path: /metadata/annotations/io.cilium~1lb-ipam-ips
         value: "192.168.10.21"
-
-  # Alloy metrics service with static IP and BGP advertisement
-  - target:
-      kind: Service
-      name: alloy-alloy-metrics
-    patch: |-
-      - op: add
-        path: /metadata/annotations/io.cilium~1lb-ipam-ips
-        value: "192.168.10.22"


### PR DESCRIPTION
Reorder CRD and Service patches alphabetically by name: Alloy CRDs now logs → metrics → singleton, Services now alloy-metrics → alloy-receiver.