### PR TITLE
refactor(prometheus): standardize patch ordering convention

### DIFF
--- a/kubernetes/applications/prometheus/overlays/dev/kustomization.yaml
+++ b/kubernetes/applications/prometheus/overlays/dev/kustomization.yaml
@@ -109,31 +109,6 @@ patches:
           name: GOMEMLIMIT
           value: "120586240"
 
-  # Prometheus instance: Configure resources and TSDB persistence
-  - target:
-      kind: Prometheus
-      name: prometheus
-    patch: |-
-      - op: test
-        path: /spec/replicas
-        value: 1
-      - op: add
-        path: /spec/resources
-        value:
-          requests:
-            cpu: 50m
-            memory: 128Mi
-          limits:
-            cpu: 250m
-            memory: 512Mi
-      - op: add
-        path: /spec/containers
-        value:
-          - name: prometheus
-            env:
-              - name: GOMEMLIMIT
-                value: "482344960"
-
   # Alertmanager: Configure resources and GOMEMLIMIT
   - target:
       kind: Alertmanager
@@ -158,3 +133,28 @@ patches:
             env:
               - name: GOMEMLIMIT
                 value: "120586240"
+
+  # Prometheus instance: Configure resources and TSDB persistence
+  - target:
+      kind: Prometheus
+      name: prometheus
+    patch: |-
+      - op: test
+        path: /spec/replicas
+        value: 1
+      - op: add
+        path: /spec/resources
+        value:
+          requests:
+            cpu: 50m
+            memory: 128Mi
+          limits:
+            cpu: 250m
+            memory: 512Mi
+      - op: add
+        path: /spec/containers
+        value:
+          - name: prometheus
+            env:
+              - name: GOMEMLIMIT
+                value: "482344960"

--- a/kubernetes/applications/prometheus/overlays/prod/kustomization.yaml
+++ b/kubernetes/applications/prometheus/overlays/prod/kustomization.yaml
@@ -109,31 +109,6 @@ patches:
           name: GOMEMLIMIT
           value: "241172480"
 
-  # Prometheus instance: Configure resources and TSDB persistence
-  - target:
-      kind: Prometheus
-      name: prometheus
-    patch: |-
-      - op: test
-        path: /spec/replicas
-        value: 1
-      - op: add
-        path: /spec/resources
-        value:
-          requests:
-            cpu: 100m
-            memory: 256Mi
-          limits:
-            cpu: 500m
-            memory: 1Gi
-      - op: add
-        path: /spec/containers
-        value:
-          - name: prometheus
-            env:
-              - name: GOMEMLIMIT
-                value: "966787072"
-
   # Alertmanager: Configure resources and GOMEMLIMIT
   - target:
       kind: Alertmanager
@@ -158,6 +133,31 @@ patches:
             env:
               - name: GOMEMLIMIT
                 value: "241172480"
+
+  # Prometheus instance: Configure resources and TSDB persistence
+  - target:
+      kind: Prometheus
+      name: prometheus
+    patch: |-
+      - op: test
+        path: /spec/replicas
+        value: 1
+      - op: add
+        path: /spec/resources
+        value:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            cpu: 500m
+            memory: 1Gi
+      - op: add
+        path: /spec/containers
+        value:
+          - name: prometheus
+            env:
+              - name: GOMEMLIMIT
+                value: "966787072"
 
   # Prometheus service with static IP and BGP advertisement
   - target:


### PR DESCRIPTION
Reorder CRD patches alphabetically by kind: Alertmanager before Prometheus.