### PR TITLE
refactor(wiki-js): standardize patch ordering convention

### DIFF
--- a/kubernetes/applications/wiki-js/overlays/dev/kustomization.yaml
+++ b/kubernetes/applications/wiki-js/overlays/dev/kustomization.yaml
@@ -67,24 +67,6 @@ replacements:
           - spec.plugins.0.parameters.serverName
 
 patches:
-  # PostgreSQL Cluster resources
-  - target:
-      kind: Cluster
-      name: wiki-js-db
-    patch: |-
-      - op: test
-        path: /spec/instances
-        value: 1
-      - op: add
-        path: /spec/resources
-        value:
-          requests:
-            cpu: 20m
-            memory: 64Mi
-          limits:
-            cpu: 100m
-            memory: 128Mi
-
   # Wiki.js Deployment resources
   - target:
       kind: Deployment
@@ -102,3 +84,21 @@ patches:
           limits:
             cpu: 250m
             memory: 256Mi
+
+  # PostgreSQL Cluster resources
+  - target:
+      kind: Cluster
+      name: wiki-js-db
+    patch: |-
+      - op: test
+        path: /spec/instances
+        value: 1
+      - op: add
+        path: /spec/resources
+        value:
+          requests:
+            cpu: 20m
+            memory: 64Mi
+          limits:
+            cpu: 100m
+            memory: 128Mi

--- a/kubernetes/applications/wiki-js/overlays/prod/kustomization.yaml
+++ b/kubernetes/applications/wiki-js/overlays/prod/kustomization.yaml
@@ -67,24 +67,6 @@ replacements:
           - spec.plugins.0.parameters.serverName
 
 patches:
-  # PostgreSQL Cluster resources
-  - target:
-      kind: Cluster
-      name: wiki-js-db
-    patch: |-
-      - op: test
-        path: /spec/instances
-        value: 1
-      - op: add
-        path: /spec/resources
-        value:
-          requests:
-            cpu: 50m
-            memory: 128Mi
-          limits:
-            cpu: 200m
-            memory: 256Mi
-
   # Wiki.js Deployment resources
   - target:
       kind: Deployment
@@ -102,6 +84,24 @@ patches:
           limits:
             cpu: 500m
             memory: 512Mi
+
+  # PostgreSQL Cluster resources
+  - target:
+      kind: Cluster
+      name: wiki-js-db
+    patch: |-
+      - op: test
+        path: /spec/instances
+        value: 1
+      - op: add
+        path: /spec/resources
+        value:
+          requests:
+            cpu: 50m
+            memory: 128Mi
+          limits:
+            cpu: 200m
+            memory: 256Mi
 
   # Wiki.js service with static IP and BGP advertisement
   - target:


### PR DESCRIPTION
Reorder patches to follow consistent kind-based ordering: Deployment → CRD → Service. Moves wiki-js Deployment patch before wiki-js-db Cluster CRD patch.