### PR TITLE
fix(nats): append GOMEMLIMIT env var instead of replacing entire array

### DIFF
--- a/kubernetes/applications/nats/overlays/dev/kustomization.yaml
+++ b/kubernetes/applications/nats/overlays/dev/kustomization.yaml
@@ -55,7 +55,7 @@ patches:
             cpu: 250m
             memory: 512Mi
       - op: add
-        path: /spec/template/spec/containers/0/env
+        path: /spec/template/spec/containers/0/env/-
         value:
-          - name: GOMEMLIMIT
-            value: "482344960"
+          name: GOMEMLIMIT
+          value: "482344960"

--- a/kubernetes/applications/nats/overlays/prod/kustomization.yaml
+++ b/kubernetes/applications/nats/overlays/prod/kustomization.yaml
@@ -55,10 +55,10 @@ patches:
             cpu: 500m
             memory: 1Gi
       - op: add
-        path: /spec/template/spec/containers/0/env
+        path: /spec/template/spec/containers/0/env/-
         value:
-          - name: GOMEMLIMIT
-            value: "966367641"
+          name: GOMEMLIMIT
+          value: "966367641"
 
   # NATS service with static IP
   - target:


### PR DESCRIPTION
The JSON patch replaced the full env array, dropping the chart-generated POD_NAME and SERVER_NAME vars and causing nats-server startup failure.