### PR TITLE
fix(nats): inject JetStream max_file_store via env var

### DIFF
--- a/kubernetes/applications/nats/base/values.yaml
+++ b/kubernetes/applications/nats/base/values.yaml
@@ -9,6 +9,7 @@ config:
         enabled: true
         size: PLACEHOLDER
         storageClassName: longhorn
+      maxSize: $JETSTREAM_MAX_STORE
 
   # MQTT gateway for IoT device compatibility
   mqtt:

--- a/kubernetes/applications/nats/overlays/dev/kustomization.yaml
+++ b/kubernetes/applications/nats/overlays/dev/kustomization.yaml
@@ -59,3 +59,8 @@ patches:
         value:
           name: GOMEMLIMIT
           value: "482344960"
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: JETSTREAM_MAX_STORE
+          value: "256Mi"

--- a/kubernetes/applications/nats/overlays/prod/kustomization.yaml
+++ b/kubernetes/applications/nats/overlays/prod/kustomization.yaml
@@ -59,6 +59,11 @@ patches:
         value:
           name: GOMEMLIMIT
           value: "966367641"
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: JETSTREAM_MAX_STORE
+          value: "1Gi"
 
   # NATS service with static IP
   - target:


### PR DESCRIPTION
The Helm chart rendered pvc.size PLACEHOLDER into the nats.conf ConfigMap as max_file_store, which NATS cannot parse. Set maxSize to $JETSTREAM_MAX_STORE so NATS resolves it from the environment at startup, injected per overlay alongside GOMEMLIMIT.