### PR TITLE
feat(solaredge2mqtt): add solaredge2mqtt with dual inverter support

### DIFF
--- a/kubernetes/applications/solaredge2mqtt/base/configuration/solaredge-1.yaml
+++ b/kubernetes/applications/solaredge2mqtt/base/configuration/solaredge-1.yaml
@@ -1,0 +1,33 @@
+interval: 5
+logging_level: INFO
+
+modbus:
+  host: solaredge-1.zimmermann.eu.com
+  port: 1502
+  timeout: 1
+  unit: 1
+  meter:
+    - true
+    - false
+    - false
+  battery:
+    - false
+    - false
+  check_grid_status: false
+  advanced_power_controls: disabled
+
+mqtt:
+  client_id: solaredge2mqtt
+  broker: nats.nats.svc.cluster.local
+  port: 1883
+  username: solaredge2mqtt
+  password: !secret mqtt_password
+  topic_prefix: solaredge
+  retain: false
+
+powerflow:
+  external_production: false
+  retain: false
+
+energy:
+  retain: false

--- a/kubernetes/applications/solaredge2mqtt/base/configuration/solaredge-2.yaml
+++ b/kubernetes/applications/solaredge2mqtt/base/configuration/solaredge-2.yaml
@@ -1,0 +1,33 @@
+interval: 5
+logging_level: INFO
+
+modbus:
+  host: solaredge-2.zimmermann.eu.com
+  port: 1502
+  timeout: 1
+  unit: 1
+  meter:
+    - true
+    - false
+    - false
+  battery:
+    - false
+    - false
+  check_grid_status: false
+  advanced_power_controls: disabled
+
+mqtt:
+  client_id: solaredge2mqtt-2
+  broker: nats.nats.svc.cluster.local
+  port: 1883
+  username: solaredge2mqtt
+  password: !secret mqtt_password
+  topic_prefix: solaredge-2
+  retain: false
+
+powerflow:
+  external_production: false
+  retain: false
+
+energy:
+  retain: false

--- a/kubernetes/applications/solaredge2mqtt/base/deployment.yaml
+++ b/kubernetes/applications/solaredge2mqtt/base/deployment.yaml
@@ -1,0 +1,105 @@
+apiVersion: apps/v1
+kind: Deployment
+
+metadata:
+  name: solaredge2mqtt
+
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: solaredge2mqtt
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: solaredge2mqtt
+    spec:
+      automountServiceAccountToken: false
+      volumes:
+        # Non-sensitive configuration from ConfigMap.
+        - name: config-volume
+          configMap:
+            name: solaredge2mqtt-1-config
+        # MQTT credentials (secrets.yml with password).
+        - name: secrets-volume
+          secret:
+            secretName: solaredge2mqtt-credentials
+        # Writable cache directory required by the application.
+        - name: cache-volume
+          emptyDir: {}
+      containers:
+        - name: solaredge2mqtt
+          image: ghcr.io/deroetzi/solaredge2mqtt:main
+          env:
+            - name: TZ
+              value: "Europe/Berlin"
+          volumeMounts:
+            - name: config-volume
+              mountPath: /app/config/configuration.yml
+              subPath: configuration.yml
+              readOnly: true
+            - name: secrets-volume
+              mountPath: /app/config/secrets.yml
+              subPath: secrets.yml
+              readOnly: true
+            - name: cache-volume
+              mountPath: /app/cache
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+
+---
+apiVersion: apps/v1
+kind: Deployment
+
+metadata:
+  name: solaredge2mqtt-2
+
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: solaredge2mqtt-2
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: solaredge2mqtt-2
+    spec:
+      automountServiceAccountToken: false
+      volumes:
+        - name: config-volume
+          configMap:
+            name: solaredge2mqtt-2-config
+        - name: secrets-volume
+          secret:
+            secretName: solaredge2mqtt-credentials
+        - name: cache-volume
+          emptyDir: {}
+      containers:
+        - name: solaredge2mqtt
+          image: ghcr.io/deroetzi/solaredge2mqtt:main
+          env:
+            - name: TZ
+              value: "Europe/Berlin"
+          volumeMounts:
+            - name: config-volume
+              mountPath: /app/config/configuration.yml
+              subPath: configuration.yml
+              readOnly: true
+            - name: secrets-volume
+              mountPath: /app/config/secrets.yml
+              subPath: secrets.yml
+              readOnly: true
+            - name: cache-volume
+              mountPath: /app/cache
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi

--- a/kubernetes/applications/solaredge2mqtt/base/kustomization.yaml
+++ b/kubernetes/applications/solaredge2mqtt/base/kustomization.yaml
@@ -1,0 +1,24 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: solaredge2mqtt
+
+resources:
+  - ./namespace.yaml
+  - ./deployment.yaml
+
+configMapGenerator:
+  - name: solaredge2mqtt-1-config
+    files:
+      - configuration.yml=configuration/solaredge-1.yaml
+  - name: solaredge2mqtt-2-config
+    files:
+      - configuration.yml=configuration/solaredge-2.yaml
+
+labels:
+  - includeSelectors: false
+    pairs:
+      homelab.app: solaredge2mqtt
+
+commonAnnotations:
+  argocd.argoproj.io/sync-wave: "10"

--- a/kubernetes/applications/solaredge2mqtt/base/namespace.yaml
+++ b/kubernetes/applications/solaredge2mqtt/base/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+
+metadata:
+  name: solaredge2mqtt

--- a/kubernetes/applications/solaredge2mqtt/overlays/dev/kustomization.yaml
+++ b/kubernetes/applications/solaredge2mqtt/overlays/dev/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base

--- a/kubernetes/applications/solaredge2mqtt/overlays/prod/kustomization.yaml
+++ b/kubernetes/applications/solaredge2mqtt/overlays/prod/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base

--- a/kubernetes/components/admission-controller/base/clusterpolicy-secrets.yaml
+++ b/kubernetes/components/admission-controller/base/clusterpolicy-secrets.yaml
@@ -228,6 +228,25 @@ spec:
           namespace: rustfs
           name: rustfs-admin-credentials
 
+    # Syncs SolarEdge2MQTT credentials from nats into solaredge2mqtt for MQTT authentication
+    - name: sync-solaredge2mqtt-credentials
+      match:
+        any:
+          - resources:
+              kinds:
+                - Namespace
+              names:
+                - solaredge2mqtt
+      generate:
+        apiVersion: v1
+        kind: Secret
+        name: solaredge2mqtt-credentials
+        namespace: solaredge2mqtt
+        synchronize: true
+        clone:
+          namespace: nats
+          name: solaredge2mqtt-credentials
+
     # Syncs RustFS admin credentials from rustfs into wiki-js for WAL archiving/backup
     - name: sync-rustfs-admin-credentials-wiki-js
       match:


### PR DESCRIPTION
Deploy two solaredge2mqtt instances for solaredge-1 and solaredge-2, publishing to NATS/MQTT with separate topic prefixes. Kyverno policy syncs MQTT credentials into the namespace.