### PR TITLE
fix(crowdsec): increase autodelete timeout to prevent bouncer deregis…

### DIFF
--- a/kubernetes/applications/crowdsec/base/values.yaml
+++ b/kubernetes/applications/crowdsec/base/values.yaml
@@ -142,6 +142,6 @@ config:
       port: 5432
       flush:
         bouncers_autodelete:
-          api_key: 1h
+          api_key: 168h
         agents_autodelete:
-          login_password: 1h
+          login_password: 168h


### PR DESCRIPTION
…tration

The 1h bouncers_autodelete timeout was too aggressive for the Redis-cached bouncer setup. The bouncer stays active but doesn't query LAPI directly when decisions are cached in Redis, causing LAPI to mistakenly delete the bouncer registration. This led to the bouncer failing closed (403 on all traffic). Increase to 168h to prevent this while retaining cleanup of truly stale bouncers.