### PR TITLE
fix(external-services): disable passHostHeader for dali-1 and dali-2

### DIFF
--- a/kubernetes/applications/external-services/base/ingress-route.yaml
+++ b/kubernetes/applications/external-services/base/ingress-route.yaml
@@ -184,6 +184,7 @@ spec:
           port: 443
           scheme: https
           serversTransport: insecure-transport
+          passHostHeader: false
   tls:
     secretName: dali-1-tls-cert
 
@@ -207,6 +208,7 @@ spec:
           port: 443
           scheme: https
           serversTransport: insecure-transport
+          passHostHeader: false
   tls:
     secretName: dali-2-tls-cert
 


### PR DESCRIPTION
The dali devices reject requests with Host header dali-*.zimmermann.sh, returning "Bad request" on form submissions. Setting passHostHeader to false lets Traefik send the backend hostname (dali-*.zimmermann.eu.com) instead, matching the behavior already used for ems-esp and knx-ip.