### PR TITLE
debug(dali): isolate dali-1 with authentik-only middleware chain

### DIFF
--- a/kubernetes/applications/external-services/base/ingress-route.yaml
+++ b/kubernetes/applications/external-services/base/ingress-route.yaml
@@ -177,14 +177,13 @@ spec:
     - match: Host(`dali-1.zimmermann.sh`)
       kind: Rule
       middlewares:
-        - name: chain-mfa-auth
+        - name: chain-debug-auth
           namespace: ingress-controller
       services:
         - name: dali-1
           port: 443
           scheme: https
           serversTransport: insecure-transport
-          passHostHeader: false
   tls:
     secretName: dali-1-tls-cert
 
@@ -208,7 +207,6 @@ spec:
           port: 443
           scheme: https
           serversTransport: insecure-transport
-          passHostHeader: false
   tls:
     secretName: dali-2-tls-cert
 

--- a/kubernetes/components/ingress-controller/base/chain-middlewares.yaml
+++ b/kubernetes/components/ingress-controller/base/chain-middlewares.yaml
@@ -40,3 +40,17 @@ spec:
     middlewares:
       - name: chain-standard
       - name: authentik
+
+---
+# Debug Chain: Only Authentik ForwardAuth, no security/cloudflare/crowdsec/etc.
+# Used to isolate whether issues are caused by Authentik or the surrounding
+# middleware chain.
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: chain-debug-auth
+
+spec:
+  chain:
+    middlewares:
+      - name: authentik


### PR DESCRIPTION
Add a chain-debug-auth middleware that only runs Authentik ForwardAuth, skipping cloudflare/crowdsec/rate-limit/security-headers/compress/ remove-headers. Switch dali-1 to this chain to determine whether the 400 responses from the device are caused by one of the surrounding middlewares or by something in the Authentik/TLS path itself.

Also revert passHostHeader: false on dali-1 and dali-2 since it did not fix the issue and only made CSS requests fail as well.