### PR TITLE
debug(dali): switch dali-1 to chain-standard to isolate Authentik

### DIFF
--- a/kubernetes/applications/external-services/base/ingress-route.yaml
+++ b/kubernetes/applications/external-services/base/ingress-route.yaml
@@ -177,7 +177,7 @@ spec:
     - match: Host(`dali-1.zimmermann.sh`)
       kind: Rule
       middlewares:
-        - name: chain-debug-auth
+        - name: chain-standard
           namespace: ingress-controller
       services:
         - name: dali-1


### PR DESCRIPTION
Previous test with chain-debug-auth (Authentik only) showed login works but data is missing and refresh causes 400. Now test the inverse: full standard middleware chain (cloudflare/crowdsec/rate-limit/security-headers/ compress/remove-headers) WITHOUT Authentik. The dali device has its own login, so authentication still applies at the device level.

If everything works without Authentik but breaks with it, Authentik is the cause.