### PR TITLE
fix(influxdb): disable authz on health, ping, metrics endpoints

### DIFF
--- a/kubernetes/applications/influxdb/base/deployment.yaml
+++ b/kubernetes/applications/influxdb/base/deployment.yaml
@@ -50,6 +50,8 @@ spec:
             - --node-id=node0
             - --object-store=file
             - --data-dir=/var/lib/influxdb3/data
+            # Allow unauthenticated access to /health, /ping, /metrics for probes and scraping.
+            - --disable-authz=health,ping,metrics
           env:
             # Load preconfigured admin token at startup (idempotent across restarts).
             - name: INFLUXDB3_ADMIN_TOKEN_FILE


### PR DESCRIPTION
The kubelet cannot send a bearer token on HTTPGet probes (only literal string headers are supported, no Secret references), so /health returns 401 and the pod flaps between restarts. Prometheus scraping of /metrics hits the same wall.

Use InfluxDB's built-in --disable-authz flag to unauthenticate exactly these three status endpoints while all writes and queries continue to require the admin token. Mirrors the kube-apiserver pattern in KEP-4633 (selective anonymous access for /livez, /readyz, /healthz).