### PR TITLE
fix(influxdb): set fsGroup on Explorer pod to match non-root uid

### DIFF
--- a/kubernetes/applications/influxdb/base/deployment.yaml
+++ b/kubernetes/applications/influxdb/base/deployment.yaml
@@ -102,6 +102,13 @@ spec:
         app.kubernetes.io/name: influxdb-explorer
     spec:
       automountServiceAccountToken: false
+      securityContext:
+        # Explorer 1.7.0+ runs as non-root user 'influxui' (uid 1500);
+        # fsGroup chowns the PVC on mount so /db is writable.
+        runAsUser: 1500
+        runAsGroup: 1500
+        runAsNonRoot: true
+        fsGroup: 1500
       volumes:
         # Default connection settings for the Explorer UI.
         - name: config


### PR DESCRIPTION
Explorer 1.7.0 dropped root and now runs as user 'influxui' (uid 1500). On first start the existing SQLite PVC is still root-owned, so /db is not writable and the container crashes with "Directory '/db' is owned by root and not accessible to the 'influxui' user".

Kubernetes chowns the PVC to fsGroup on mount, so setting fsGroup: 1500 (plus runAsUser/Group for consistency) lets the container come up clean on both fresh deploys and in-place upgrades from the 1.6.3 image.