### PR TITLE
debug(knx-ip): route via chain-debug-auth with cookie stripping

### DIFF
--- a/kubernetes/applications/external-services/base/ingress-route.yaml
+++ b/kubernetes/applications/external-services/base/ingress-route.yaml
@@ -328,7 +328,7 @@ spec:
     - match: Host(`knx-ip.zimmermann.sh`)
       kind: Rule
       middlewares:
-        - name: chain-mfa-auth
+        - name: chain-debug-auth
           namespace: ingress-controller
       services:
         - name: knx-ip

--- a/kubernetes/components/ingress-controller/base/chain-middlewares.yaml
+++ b/kubernetes/components/ingress-controller/base/chain-middlewares.yaml
@@ -42,9 +42,9 @@ spec:
       - name: authentik
 
 ---
-# Debug Chain: Only Authentik ForwardAuth, no security/cloudflare/crowdsec/etc.
-# Used to isolate whether issues are caused by Authentik or the surrounding
-# middleware chain.
+# Debug Chain: Authentik ForwardAuth + upstream cookie stripping.
+# Used to isolate whether issues are caused by the surrounding middleware chain
+# or by large session cookies overflowing embedded-device header buffers.
 apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
@@ -54,3 +54,4 @@ spec:
   chain:
     middlewares:
       - name: authentik
+      - name: strip-cookies

--- a/kubernetes/components/ingress-controller/base/middlewares.yaml
+++ b/kubernetes/components/ingress-controller/base/middlewares.yaml
@@ -126,6 +126,21 @@ spec:
       Cdn-Loop: ""
 
 ---
+# Cookie Stripping: Removes the Cookie header before forwarding to upstream.
+# Used for embedded devices with small HTTP header buffers that 502 when
+# browsers send large Authentik session cookies.
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+
+metadata:
+  name: strip-cookies
+
+spec:
+  headers:
+    customRequestHeaders:
+      Cookie: ""
+
+---
 # Authentik integration (ForwardAuth): Delegates authentication to the Authentik outpost
 apiVersion: traefik.io/v1alpha1
 kind: Middleware


### PR DESCRIPTION
Test whether knx-ip.zimmermann.sh 502 is caused by large Authentik session cookies overflowing the MDT KNX-IP interface's HTTP header buffer. Adds strip-cookies middleware that clears the Cookie header before forwarding upstream, and chains it after the Authentik ForwardAuth in chain-debug-auth.