### PR TITLE
fix(influxdb): unset LICENSE_FILE env to fix at-home license registra…

### DIFF
--- a/kubernetes/applications/influxdb/base/values.yaml
+++ b/kubernetes/applications/influxdb/base/values.yaml
@@ -28,6 +28,12 @@ security:
     # Preconfigured admin token file (mounted via extraVolumes below)
     adminTokenFile: /etc/influxdb3/tokens/admin-token.json
 
+# Workaround: chart sets LICENSE_FILE env when existingSecret is used, but we only
+# provide license-email — InfluxDB prefers file over email and fails. Unset it.
+extraEnv:
+  - name: INFLUXDB3_UNSET_VARS
+    value: INFLUXDB3_ENTERPRISE_LICENSE_FILE
+
 # Single replica per component (at-home license: 2 cores total across cluster).
 ingester:
   replicas: 1


### PR DESCRIPTION
…tion

The chart emits INFLUXDB3_ENTERPRISE_LICENSE_FILE whenever license.existingSecret is set, even though our secret only provides the license-email key (at-home license, not commercial). InfluxDB prioritises the file env over the email env — finds the mounted file missing, then ignores the email and refuses to register: "provided --license-email will be ignored since --license-file was provided".

Use INFLUXDB3_UNSET_VARS (processed by the image entrypoint before the binary starts) to strip the LICENSE_FILE var at runtime, so InfluxDB correctly falls back to the email-based registration flow.