### PR TITLE
fix(influxdb): remove LICENSE_FILE env via JSON Patch for at-home lic…

### DIFF
--- a/kubernetes/applications/influxdb/base/kustomization.yaml
+++ b/kubernetes/applications/influxdb/base/kustomization.yaml
@@ -33,6 +33,20 @@ replacements:
         fieldPaths:
           - spec.template.spec.containers.[name=influxdb3].env.[name=AWS_SECRET_ACCESS_KEY].valueFrom.secretKeyRef.key
 
+# Chart emits INFLUXDB3_ENTERPRISE_LICENSE_FILE (env index 1) whenever
+# license.existingSecret is set, but we only provide license-email (at-home flow).
+# InfluxDB prefers the file over the email and fails. Remove it via JSON Patch —
+# the test op ensures the patch breaks loudly if the chart reorders the array.
+patches:
+  - target:
+      kind: StatefulSet
+    patch: |-
+      - op: test
+        path: /spec/template/spec/containers/0/env/1/name
+        value: INFLUXDB3_ENTERPRISE_LICENSE_FILE
+      - op: remove
+        path: /spec/template/spec/containers/0/env/1
+
 configMapGenerator:
   - name: influxdb-database-init-script
     options:

--- a/kubernetes/applications/influxdb/base/values.yaml
+++ b/kubernetes/applications/influxdb/base/values.yaml
@@ -28,12 +28,6 @@ security:
     # Preconfigured admin token file (mounted via extraVolumes below)
     adminTokenFile: /etc/influxdb3/tokens/admin-token.json
 
-# Workaround: chart sets LICENSE_FILE env when existingSecret is used, but we only
-# provide license-email — InfluxDB prefers file over email and fails. Unset it.
-extraEnv:
-  - name: INFLUXDB3_UNSET_VARS
-    value: INFLUXDB3_ENTERPRISE_LICENSE_FILE
-
 # Single replica per component (at-home license: 2 cores total across cluster).
 ingester:
   replicas: 1


### PR DESCRIPTION
…ense

Replace the failed INFLUXDB3_UNSET_VARS workaround (enterprise image does not support it) with a JSON Patch that removes the LICENSE_FILE env var (array index 1) from all three StatefulSets. A test op guards the index so the build fails loudly if the chart reorders the array.

Without this, InfluxDB prefers the (empty) license file over the email and skips the at-home registration flow entirely.