### PR TITLE
fix(influxdb): run single combined node for at-home license

### DIFF
--- a/kubernetes/applications/influxdb/base/initialize-influxdb-databases-job.yaml
+++ b/kubernetes/applications/influxdb/base/initialize-influxdb-databases-job.yaml
@@ -29,7 +29,7 @@ spec:
               done
           env:
             - name: INFLUXDB_URL
-              value: "http://influxdb3-querier.influxdb.svc.cluster.local:8181"
+              value: "http://influxdb3-ingester.influxdb.svc.cluster.local:8181"
       containers:
         - name: influxdb3
           image: influxdb:3-enterprise
@@ -37,7 +37,7 @@ spec:
           command: ["/bin/sh", "/scripts/initialize-influxdb-databases.sh"]
           env:
             - name: INFLUXDB_URL
-              value: "http://influxdb3-querier.influxdb.svc.cluster.local:8181"
+              value: "http://influxdb3-ingester.influxdb.svc.cluster.local:8181"
             # Space-separated list of databases to create.
             - name: DATABASES
               value: "homelab"

--- a/kubernetes/applications/influxdb/base/kustomization.yaml
+++ b/kubernetes/applications/influxdb/base/kustomization.yaml
@@ -33,19 +33,32 @@ replacements:
         fieldPaths:
           - spec.template.spec.containers.[name=influxdb3].env.[name=AWS_SECRET_ACCESS_KEY].valueFrom.secretKeyRef.key
 
-# Chart emits INFLUXDB3_ENTERPRISE_LICENSE_FILE (env index 1) whenever
-# license.existingSecret is set, but we only provide license-email (at-home flow).
-# InfluxDB prefers the file over the email and fails. Remove it via JSON Patch —
-# the test op ensures the patch breaks loudly if the chart reorders the array.
 patches:
+  # Chart emits INFLUXDB3_ENTERPRISE_LICENSE_FILE (env index 1) whenever
+  # license.existingSecret is set, but we only provide license-email (at-home flow).
+  # InfluxDB prefers the file over the email and fails.
   - target:
       kind: StatefulSet
+      name: influxdb3-ingester
     patch: |-
       - op: test
         path: /spec/template/spec/containers/0/env/1/name
         value: INFLUXDB3_ENTERPRISE_LICENSE_FILE
       - op: remove
         path: /spec/template/spec/containers/0/env/1
+
+  # Strip --mode=ingest so the single node starts in combined mode
+  # (ingest + query + compact). Home license allows only one node.
+  - target:
+      kind: StatefulSet
+      name: influxdb3-ingester
+    patch: |-
+      - op: test
+        path: /spec/template/spec/containers/0/command/2
+        value: "exec influxdb3 \\\n  serve \\\n  --mode=ingest \\\n  --node-id=$(hostname)\n"
+      - op: replace
+        path: /spec/template/spec/containers/0/command/2
+        value: "exec influxdb3 \\\n  serve \\\n  --node-id=$(hostname)\n"
 
 configMapGenerator:
   - name: influxdb-database-init-script

--- a/kubernetes/applications/influxdb/base/values.yaml
+++ b/kubernetes/applications/influxdb/base/values.yaml
@@ -28,17 +28,22 @@ security:
     # Preconfigured admin token file (mounted via extraVolumes below)
     adminTokenFile: /etc/influxdb3/tokens/admin-token.json
 
-# Single replica per component (at-home license: 2 cores total across cluster).
+# At-Home license allows only ONE node. Run the ingester as the sole component —
+# Kustomize patches strip --mode=ingest so it starts in combined mode
+# (ingest + query + compact in a single process).
 ingester:
   replicas: 1
   persistence:
     storageClass: longhorn
     size: PLACEHOLDER
 
+# Disable separate querier/compactor — the single combined node handles all roles.
 querier:
-  replicas: 1
+  enabled: false
 
-# Python processing engine not needed for homelab.
+compactor:
+  enabled: false
+
 processingEngine:
   enabled: false
 

--- a/kubernetes/applications/influxdb/overlays/dev/kustomization.yaml
+++ b/kubernetes/applications/influxdb/overlays/dev/kustomization.yaml
@@ -15,7 +15,7 @@ replacements:
           - spec.volumeClaimTemplates.0.spec.resources.requests.storage
 
 patches:
-  # Ingester: writes + WAL flush to object store
+  # Combined node: handles ingest + query + compact in a single process
   - target:
       kind: StatefulSet
       name: influxdb3-ingester
@@ -30,41 +30,5 @@ patches:
             cpu: 25m
             memory: 64Mi
           limits:
-            cpu: 200m
-            memory: 256Mi
-
-  # Querier: SQL/InfluxQL over Parquet files
-  - target:
-      kind: StatefulSet
-      name: influxdb3-querier
-    patch: |-
-      - op: test
-        path: /spec/template/spec/containers/0/name
-        value: influxdb3
-      - op: replace
-        path: /spec/template/spec/containers/0/resources
-        value:
-          requests:
-            cpu: 25m
-            memory: 64Mi
-          limits:
-            cpu: 200m
-            memory: 256Mi
-
-  # Compactor: Parquet optimisation (CPU-bound, intermittent)
-  - target:
-      kind: StatefulSet
-      name: influxdb3-compactor
-    patch: |-
-      - op: test
-        path: /spec/template/spec/containers/0/name
-        value: influxdb3
-      - op: replace
-        path: /spec/template/spec/containers/0/resources
-        value:
-          requests:
-            cpu: 25m
-            memory: 64Mi
-          limits:
-            cpu: 200m
+            cpu: 250m
             memory: 256Mi

--- a/kubernetes/applications/influxdb/overlays/prod/kustomization.yaml
+++ b/kubernetes/applications/influxdb/overlays/prod/kustomization.yaml
@@ -15,46 +15,10 @@ replacements:
           - spec.volumeClaimTemplates.0.spec.resources.requests.storage
 
 patches:
-  # Ingester: writes + WAL flush to object store
+  # Combined node: handles ingest + query + compact in a single process
   - target:
       kind: StatefulSet
       name: influxdb3-ingester
-    patch: |-
-      - op: test
-        path: /spec/template/spec/containers/0/name
-        value: influxdb3
-      - op: replace
-        path: /spec/template/spec/containers/0/resources
-        value:
-          requests:
-            cpu: 50m
-            memory: 128Mi
-          limits:
-            cpu: 300m
-            memory: 512Mi
-
-  # Querier: SQL/InfluxQL over Parquet files
-  - target:
-      kind: StatefulSet
-      name: influxdb3-querier
-    patch: |-
-      - op: test
-        path: /spec/template/spec/containers/0/name
-        value: influxdb3
-      - op: replace
-        path: /spec/template/spec/containers/0/resources
-        value:
-          requests:
-            cpu: 50m
-            memory: 128Mi
-          limits:
-            cpu: 300m
-            memory: 512Mi
-
-  # Compactor: Parquet optimisation (CPU-bound, intermittent)
-  - target:
-      kind: StatefulSet
-      name: influxdb3-compactor
     patch: |-
       - op: test
         path: /spec/template/spec/containers/0/name


### PR DESCRIPTION
The at-home license allows only one node. The chart deploys separate ingester/querier/compactor StatefulSets, each counting as a node, so only the first pod starts — the rest fail with "only one node is allowed when using Home License".

Disable querier and compactor in values.yaml, then strip --mode=ingest from the ingester command via JSON Patch (with test guard). Without a mode flag, InfluxDB starts in combined mode handling ingest, query, and compaction in a single process — exactly what the home license permits.

Also update the database-init Job URL to point at the ingester service (the querier service no longer exists).