### PR TITLE
fix(influxdb): inject INFLUXDB3_ADMIN_TOKEN_FILE via extraEnv

### DIFF
--- a/kubernetes/applications/influxdb/base/values.yaml
+++ b/kubernetes/applications/influxdb/base/values.yaml
@@ -23,10 +23,11 @@ objectStorage:
     allowHttp: true
     existingSecret: rustfs-admin-credentials
 
-security:
-  auth:
-    # Preconfigured admin token file (mounted via extraVolumes below)
-    adminTokenFile: /etc/influxdb3/tokens/admin-token.json
+# Chart declares security.auth.adminTokenFile but templates don't render it.
+# Inject the env var via extraEnv until the chart implements it.
+extraEnv:
+  - name: INFLUXDB3_ADMIN_TOKEN_FILE
+    value: /etc/influxdb3/tokens/admin-token.json
 
 # At-Home license allows only ONE node. Run the ingester as the sole component —
 # Kustomize patches strip --mode=ingest so it starts in combined mode


### PR DESCRIPTION
The chart declares security.auth.adminTokenFile in values.yaml but the templates never render it as an env var or CLI flag. Without it, the preconfigured admin token (mounted via extraVolumes) is ignored and all authenticated API calls return 401.

Inject INFLUXDB3_ADMIN_TOKEN_FILE directly via extraEnv so the token file is picked up at startup. The volume mount was already in place.