### PR TITLE
fix(influxdb): inject INFLUXDB3_ADMIN_TOKEN_FILE via extraEnv

### DIFF
--- a/kubernetes/applications/influxdb/base/initialize-influxdb-databases-job.yaml
+++ b/kubernetes/applications/influxdb/base/initialize-influxdb-databases-job.yaml
@@ -29,7 +29,7 @@ spec:
               done
           env:
             - name: INFLUXDB_URL
-              value: "http://influxdb3-ingester.influxdb.svc.cluster.local:8181"
+              value: "http://influxdb3.influxdb.svc.cluster.local:8181"
       containers:
         - name: influxdb3
           image: influxdb:3-enterprise
@@ -37,7 +37,7 @@ spec:
           command: ["/bin/sh", "/scripts/initialize-influxdb-databases.sh"]
           env:
             - name: INFLUXDB_URL
-              value: "http://influxdb3-ingester.influxdb.svc.cluster.local:8181"
+              value: "http://influxdb3.influxdb.svc.cluster.local:8181"
             # Space-separated list of databases to create.
             - name: DATABASES
               value: "homelab"

--- a/kubernetes/applications/influxdb/base/kustomization.yaml
+++ b/kubernetes/applications/influxdb/base/kustomization.yaml
@@ -60,6 +60,32 @@ patches:
         path: /spec/template/spec/containers/0/command/2
         value: "exec influxdb3 \\\n  serve \\\n  --node-id=$(hostname)\n"
 
+  # Rename influxdb3-ingester → influxdb3 since the single node runs all roles.
+  - target:
+      kind: StatefulSet
+      name: influxdb3-ingester
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: influxdb3
+      - op: replace
+        path: /spec/serviceName
+        value: influxdb3
+  - target:
+      kind: Service
+      name: influxdb3-ingester
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: influxdb3
+  - target:
+      kind: ServiceMonitor
+      name: influxdb3-ingester
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: influxdb3
+
 configMapGenerator:
   - name: influxdb-database-init-script
     options:

--- a/kubernetes/applications/influxdb/base/values.yaml
+++ b/kubernetes/applications/influxdb/base/values.yaml
@@ -23,10 +23,11 @@ objectStorage:
     allowHttp: true
     existingSecret: rustfs-admin-credentials
 
-security:
-  auth:
-    # Preconfigured admin token file (mounted via extraVolumes below)
-    adminTokenFile: /etc/influxdb3/tokens/admin-token.json
+# Chart declares security.auth.adminTokenFile but templates don't render it.
+# Inject the env var via extraEnv until the chart implements it.
+extraEnv:
+  - name: INFLUXDB3_ADMIN_TOKEN_FILE
+    value: /etc/influxdb3/tokens/admin-token.json
 
 # At-Home license allows only ONE node. Run the ingester as the sole component —
 # Kustomize patches strip --mode=ingest so it starts in combined mode

--- a/kubernetes/applications/influxdb/overlays/dev/kustomization.yaml
+++ b/kubernetes/applications/influxdb/overlays/dev/kustomization.yaml
@@ -10,7 +10,7 @@ replacements:
     targets:
       - select:
           kind: StatefulSet
-          name: influxdb3-ingester
+          name: influxdb3
         fieldPaths:
           - spec.volumeClaimTemplates.0.spec.resources.requests.storage
 
@@ -18,7 +18,7 @@ patches:
   # Combined node: handles ingest + query + compact in a single process
   - target:
       kind: StatefulSet
-      name: influxdb3-ingester
+      name: influxdb3
     patch: |-
       - op: test
         path: /spec/template/spec/containers/0/name

--- a/kubernetes/applications/influxdb/overlays/prod/kustomization.yaml
+++ b/kubernetes/applications/influxdb/overlays/prod/kustomization.yaml
@@ -10,7 +10,7 @@ replacements:
     targets:
       - select:
           kind: StatefulSet
-          name: influxdb3-ingester
+          name: influxdb3
         fieldPaths:
           - spec.volumeClaimTemplates.0.spec.resources.requests.storage
 
@@ -18,7 +18,7 @@ patches:
   # Combined node: handles ingest + query + compact in a single process
   - target:
       kind: StatefulSet
-      name: influxdb3-ingester
+      name: influxdb3
     patch: |-
       - op: test
         path: /spec/template/spec/containers/0/name


### PR DESCRIPTION
The chart declares security.auth.adminTokenFile in values.yaml but the templates never render it as an env var or CLI flag. Without it, the preconfigured admin token (mounted via extraVolumes) is ignored and all authenticated API calls return 401.

Inject INFLUXDB3_ADMIN_TOKEN_FILE directly via extraEnv so the token file is picked up at startup. The volume mount was already in place.