### PR TITLE
fix(influxdb): allow unauthenticated /metrics scraping for Prometheus

### DIFF
--- a/kubernetes/applications/influxdb/base/values.yaml
+++ b/kubernetes/applications/influxdb/base/values.yaml
@@ -23,6 +23,11 @@ objectStorage:
     allowHttp: true
     existingSecret: rustfs-admin-credentials
 
+security:
+  auth:
+    # Allow Prometheus to scrape /metrics and kubelet to probe /health without a token.
+    disableAuthz: ["health", "metrics"]
+
 # Chart declares security.auth.adminTokenFile but templates don't render it.
 # Inject the env var via extraEnv until the chart implements it.
 extraEnv:


### PR DESCRIPTION
The chart defaults to disableAuthz: ["health"], which lets kubelet probes through but blocks Prometheus ServiceMonitor scrapes on /metrics with 401. Add "metrics" to the list.