### PR TITLE
fix(telegraf): migrate warp and ems-esp MQTT inputs to NATS gateway

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -37,6 +37,7 @@ tasks:
         opentofu
         cilium-cli
         siderolabs/tap/sidero-tools
+        nats-io/nats-tools/nats
         nats-io/nats-tools/nsc
         actionlint
         yq

--- a/kubernetes/applications/telegraf/base/inputs/mqtt.ems.conf
+++ b/kubernetes/applications/telegraf/base/inputs/mqtt.ems.conf
@@ -3,11 +3,11 @@
 # =======================================================
 [[inputs.mqtt_consumer]]
   ## Broker URLs for the MQTT server or cluster
-  servers = ["tcp://mqtt.zimmermann.eu.com:1883"]
+  servers = ["tcp://nats.nats.svc.cluster.local:1883"]
 
   ## Username and password to connect MQTT server
   username = "telegraf"
-  password = "${MQTT_PASSWORD}"
+  password = "${NATS_MQTT_PASSWORD}"
 
   ## Data format to consume.
   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md

--- a/kubernetes/applications/telegraf/base/inputs/mqtt.warp.conf
+++ b/kubernetes/applications/telegraf/base/inputs/mqtt.warp.conf
@@ -3,11 +3,11 @@
 # =======================================================
 [[inputs.mqtt_consumer]]
   ## Broker URLs for the MQTT server or cluster
-  servers = ["tcp://mqtt.zimmermann.eu.com:1883"]
+  servers = ["tcp://nats.nats.svc.cluster.local:1883"]
 
   ## Username and password to connect MQTT server
   username = "telegraf"
-  password = "${MQTT_PASSWORD}"
+  password = "${NATS_MQTT_PASSWORD}"
 
   ## Data format to consume
   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md
@@ -33,11 +33,11 @@
 # =======================================================
 [[inputs.mqtt_consumer]]
   ## Broker URLs for the MQTT server or cluster
-  servers = ["tcp://mqtt.zimmermann.eu.com:1883"]
+  servers = ["tcp://nats.nats.svc.cluster.local:1883"]
 
   ## Username and password to connect MQTT server
   username = "telegraf"
-  password = "${MQTT_PASSWORD}"
+  password = "${NATS_MQTT_PASSWORD}"
 
   ## Data format to consume
   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md
@@ -82,11 +82,11 @@
 # =======================================================
 [[inputs.mqtt_consumer]]
   ## Broker URLs for the MQTT server or cluster
-  servers = ["tcp://mqtt.zimmermann.eu.com:1883"]
+  servers = ["tcp://nats.nats.svc.cluster.local:1883"]
 
   ## Username and password to connect MQTT server
   username = "telegraf"
-  password = "${MQTT_PASSWORD}"
+  password = "${NATS_MQTT_PASSWORD}"
 
   ## Data format to consume
   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md


### PR DESCRIPTION
Switch Telegraf MQTT consumers for warp (wallbox) and ems-esp (heating) from the external broker (mqtt.zimmermann.eu.com) to the internal NATS MQTT gateway (nats.nats.svc.cluster.local). Also add nats CLI to Taskfile dependencies.