### PR TITLE
fix(ingress-controller): strip Authentik cookies and split middleware…

### DIFF
--- a/kubernetes/components/ingress-controller/base/chain-middlewares.yaml
+++ b/kubernetes/components/ingress-controller/base/chain-middlewares.yaml
@@ -1,9 +1,10 @@
-# Standard Middleware Chain: Applies global security headers, rate limiting, and request cleaning
+# Pre-Auth Chain: Runs before any authentication middleware. Authentik
+# forwardAuth runs AFTER this so it can see original X-Forwarded-* / Cf-*
+# headers.
 apiVersion: traefik.io/v1alpha1
 kind: Middleware
-
 metadata:
-  name: chain-standard
+  name: chain-pre-auth
 
 spec:
   chain:
@@ -13,10 +14,36 @@ spec:
       - name: rate-limit
       - name: security-headers
       - name: compress
-      - name: remove-headers
 
 ---
-# Basic Authentication Chain: Standard security + Basic Auth
+# Post-Auth Chain: Runs after authentication. Strips Authentik session cookies
+# and internal proxy headers before forwarding to upstream backends.
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: chain-post-auth
+
+spec:
+  chain:
+    middlewares:
+      - name: strip-cookies
+      - name: strip-headers
+
+---
+# Standard Chain (no auth): pre-auth + post-auth.
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: chain-standard
+
+spec:
+  chain:
+    middlewares:
+      - name: chain-pre-auth
+      - name: chain-post-auth
+
+---
+# Basic Auth Chain: pre-auth + basic-auth + post-auth.
 apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
@@ -25,11 +52,12 @@ metadata:
 spec:
   chain:
     middlewares:
-      - name: chain-standard
+      - name: chain-pre-auth
       - name: basic-auth
+      - name: chain-post-auth
 
 ---
-# Authentik/SSO Chain: Standard security + Authentik ForwardAuth
+# MFA Auth Chain: pre-auth + Authentik forwardAuth + post-auth.
 apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
@@ -38,13 +66,14 @@ metadata:
 spec:
   chain:
     middlewares:
-      - name: chain-standard
+      - name: chain-pre-auth
       - name: authentik
+      - name: chain-post-auth
 
 ---
-# Debug Chain: Authentik ForwardAuth + upstream cookie stripping.
-# Used to isolate whether issues are caused by the surrounding middleware chain
-# or by large session cookies overflowing embedded-device header buffers.
+# Debug Chain: Only Authentik ForwardAuth, no security/cloudflare/crowdsec/etc.
+# Used to isolate whether issues are caused by Authentik or the surrounding
+# middleware chain.
 apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
@@ -54,4 +83,3 @@ spec:
   chain:
     middlewares:
       - name: authentik
-      - name: strip-cookies

--- a/kubernetes/components/ingress-controller/base/middlewares.yaml
+++ b/kubernetes/components/ingress-controller/base/middlewares.yaml
@@ -103,12 +103,13 @@ spec:
       overwriteRequestHeader: false
 
 ---
-# Header Cleanup: Removes sensitive or unnecessary proxy headers before passing to upstream
+# Header Stripping: Removes sensitive or unnecessary proxy headers before
+# passing to upstream
 apiVersion: traefik.io/v1alpha1
 kind: Middleware
 
 metadata:
-  name: remove-headers
+  name: strip-headers
 
 spec:
   headers:
@@ -126,9 +127,14 @@ spec:
       Cdn-Loop: ""
 
 ---
-# Cookie Stripping: Removes the Cookie header before forwarding to upstream.
-# Used for embedded devices with small HTTP header buffers that 502 when
-# browsers send large Authentik session cookies.
+# Cookie Stripping: Removes Authentik session cookies before forwarding to
+# upstream. No backend needs these — Authentik forwardAuth validates them in
+# a prior middleware step. Prevents embedded devices with small header buffers
+# from 502-ing on the ~4 KB cookie payload.
+#
+# The authentik_proxy_* hash is derived from the OAuth2 client ID:
+#   echo -n "<client_id>" | sha256sum | cut -c1-8
+# If a new Authentik Proxy Provider is created, add its cookie here.
 apiVersion: traefik.io/v1alpha1
 kind: Middleware
 
@@ -136,9 +142,12 @@ metadata:
   name: strip-cookies
 
 spec:
-  headers:
-    customRequestHeaders:
-      Cookie: ""
+  plugin:
+    stripcookie:
+      cookies:
+        - authentik_device
+        - authentik_proxy_da05bc94
+        - authentik_session
 
 ---
 # Authentik integration (ForwardAuth): Delegates authentication to the Authentik outpost

--- a/kubernetes/components/ingress-controller/base/values.yaml
+++ b/kubernetes/components/ingress-controller/base/values.yaml
@@ -40,6 +40,10 @@ experimental:
     cloudflare:
       moduleName: github.com/agence-gaya/traefik-plugin-cloudflare
       version: v1.2.0
+    # Strip Cookies: selectively remove cookies by name from requests
+    stripcookie:
+      moduleName: github.com/nilskohrs/stripcookie
+      version: v0.1.0
 
 api:
   # Enable insecure API access on the traefik entrypoint port (8080)


### PR DESCRIPTION
… chains

Restructure middleware chains into pre-auth and post-auth phases:
- chain-pre-auth: cloudflare, crowdsec, rate-limit, security-headers, compress
- chain-post-auth: strip-cookies (new), strip-headers (renamed from remove-headers)

This fixes knx-ip.zimmermann.sh returning 502 because the MDT KNX-IP Interface's embedded HTTP server cannot handle the ~4 KB Authentik session cookie payload. The stripcookie plugin selectively removes only the three Authentik cookies (authentik_device, authentik_proxy_*, authentik_session) so app-specific cookies (FritzBox sid, Proxmox PVEAuthCookie, etc.) still pass through.

As a side benefit, Authentik forwardAuth now correctly sees X-Forwarded-* and Cf-* headers (previously stripped before it ran).