### PR TITLE
fix(external-services): switch knx-ip from debug to standard MFA chain

### DIFF
--- a/kubernetes/applications/external-services/base/ingress-route.yaml
+++ b/kubernetes/applications/external-services/base/ingress-route.yaml
@@ -328,7 +328,7 @@ spec:
     - match: Host(`knx-ip.zimmermann.sh`)
       kind: Rule
       middlewares:
-        - name: chain-debug-auth
+        - name: chain-mfa-auth
           namespace: ingress-controller
       services:
         - name: knx-ip


### PR DESCRIPTION
The knx-ip IngressRoute was still on chain-debug-auth from a prior debugging session. Now that chain-mfa-auth includes cookie stripping via chain-post-auth, knx-ip should use the standard MFA chain.