### PR TITLE
fix(influxdb): fix idempotency check in database init script

### DIFF
--- a/kubernetes/applications/influxdb/base/scripts/initialize-influxdb-databases.sh
+++ b/kubernetes/applications/influxdb/base/scripts/initialize-influxdb-databases.sh
@@ -1,13 +1,13 @@
 #!/bin/sh
-# Idempotently create a list of InfluxDB 3 Core databases.
+# Idempotently create a list of InfluxDB 3 Enterprise databases.
 # Inputs (environment):
-#   INFLUXDB_URL         — InfluxDB 3 Core base URL (e.g. http://influxdb:8181)
+#   INFLUXDB_URL         — InfluxDB 3 base URL (e.g. http://influxdb3:8181)
 #   INFLUXDB3_AUTH_TOKEN — admin token with create permissions
 #   DATABASES            — space-separated list of database names
 set -eu
 
 for db in $DATABASES; do
-  if influxdb3 show databases --host "$INFLUXDB_URL" --token "$INFLUXDB3_AUTH_TOKEN" | grep -qx "$db"; then
+  if influxdb3 show databases --host "$INFLUXDB_URL" --token "$INFLUXDB3_AUTH_TOKEN" | grep -q " $db "; then
     echo "Database '$db' already exists — skipping"
   else
     influxdb3 create database --host "$INFLUXDB_URL" --token "$INFLUXDB3_AUTH_TOKEN" "$db"


### PR DESCRIPTION
influxdb3 show databases outputs a formatted table with borders:

  +---------------+
  | iox::database |
  +---------------+
  | homelab       |
  +---------------+

The grep -qx matched exact lines, so it never found "homelab" in
"| homelab       |" and tried to re-create the database on every
ArgoCD sync, flooding the logs with 409 errors.

Switch to grep -q " $db " to match the database name inside the table row padding.