### PR TITLE
feat(grafana): add InfluxDB 3 Enterprise datasources (SQL + InfluxQL)

### DIFF
--- a/kubernetes/applications/grafana/base/datasources.yaml
+++ b/kubernetes/applications/grafana/base/datasources.yaml
@@ -40,3 +40,67 @@ spec:
   instanceSelector:
     matchLabels:
       homelab.app: grafana
+
+---
+# InfluxDB 3 Enterprise — SQL (native, Flight SQL over gRPC/HTTP2)
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDatasource
+
+metadata:
+  name: influxdb-sql
+  namespace: grafana
+
+spec:
+  valuesFrom:
+    - targetPath: secureJsonData.token
+      valueFrom:
+        secretKeyRef:
+          name: influxdb-credentials
+          key: admin-token
+  datasource:
+    name: InfluxDB (SQL)
+    type: influxdb
+    access: proxy
+    url: http://influxdb3.influxdb.svc.cluster.local:8181
+    isDefault: false
+    editable: false
+    jsonData:
+      version: SQL
+      dbName: homelab
+      httpMode: POST
+  instanceSelector:
+    matchLabels:
+      homelab.app: grafana
+
+---
+# InfluxDB 3 Enterprise — InfluxQL (v1 compatibility, plain HTTP/1.1)
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDatasource
+
+metadata:
+  name: influxdb-influxql
+  namespace: grafana
+
+spec:
+  valuesFrom:
+    - targetPath: secureJsonData.password
+      valueFrom:
+        secretKeyRef:
+          name: influxdb-credentials
+          key: admin-token
+  datasource:
+    name: InfluxDB (InfluxQL)
+    type: influxdb
+    access: proxy
+    url: http://influxdb3.influxdb.svc.cluster.local:8181
+    isDefault: false
+    editable: false
+    database: homelab
+    user: ignored
+    jsonData:
+      version: InfluxQL
+      dbName: homelab
+      httpMode: POST
+  instanceSelector:
+    matchLabels:
+      homelab.app: grafana

--- a/kubernetes/components/admission-controller/base/clusterpolicy-secrets.yaml
+++ b/kubernetes/components/admission-controller/base/clusterpolicy-secrets.yaml
@@ -114,6 +114,25 @@ spec:
           namespace: authentik
           name: authentik-homepage-token
 
+    # Syncs InfluxDB admin token from influxdb into grafana for datasource authentication
+    - name: sync-influxdb-credentials-grafana
+      match:
+        any:
+          - resources:
+              kinds:
+                - Namespace
+              names:
+                - grafana
+      generate:
+        apiVersion: v1
+        kind: Secret
+        name: influxdb-credentials
+        namespace: grafana
+        synchronize: true
+        clone:
+          namespace: influxdb
+          name: influxdb-credentials
+
     # Syncs Grafana OIDC client secret from authentik into grafana namespace
     - name: sync-grafana-oidc-secret
       match:


### PR DESCRIPTION
Adds two GrafanaDatasource CRs pointing at the cluster-internal influxdb3 service:

- InfluxDB (SQL): native InfluxDB 3 SQL via Flight SQL / gRPC / HTTP2. Fastest path for complex queries, works cluster-internally without proxy layers.
- InfluxDB (InfluxQL): v1-compatible InfluxQL over HTTP/1.1. Keeps the door open for migrating v1-era dashboards.

Both pull the admin token via valuesFrom → secretKeyRef from the influxdb-credentials Secret, which a new Kyverno ClusterPolicy clones from the influxdb namespace into grafana on reconcile.