### PR TITLE
feat(hubble): add Homepage service discovery annotations

### DIFF
--- a/kubernetes/components/cilium/base/ingress-route.yaml
+++ b/kubernetes/components/cilium/base/ingress-route.yaml
@@ -9,6 +9,13 @@ metadata:
     external-dns.alpha.kubernetes.io/target: udm-pro.zimmermann.sh
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
     kubernetes.io/ingress.class: traefik
+    # Homepage Service Discovery
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: "Observability"
+    gethomepage.dev/name: "Hubble"
+    gethomepage.dev/icon: "hubble.png"
+    gethomepage.dev/weight: "5"
+    gethomepage.dev/href: "https://PLACEHOLDER"
 
 spec:
   entryPoints:

--- a/kubernetes/components/cilium/overlays/dev/kustomization.yaml
+++ b/kubernetes/components/cilium/overlays/dev/kustomization.yaml
@@ -22,6 +22,14 @@ replacements:
         options:
           delimiter: "`"
           index: 1
+      - select:
+          kind: IngressRoute
+          name: hubble
+        fieldPaths:
+          - metadata.annotations.[gethomepage.dev/href]
+        options:
+          delimiter: "//"
+          index: 1
 
   # Inject BGP IP Pool CIDR
   - sourceValue: 192.168.11.0/24

--- a/kubernetes/components/cilium/overlays/prod/kustomization.yaml
+++ b/kubernetes/components/cilium/overlays/prod/kustomization.yaml
@@ -22,6 +22,14 @@ replacements:
         options:
           delimiter: "`"
           index: 1
+      - select:
+          kind: IngressRoute
+          name: hubble
+        fieldPaths:
+          - metadata.annotations.[gethomepage.dev/href]
+        options:
+          delimiter: "//"
+          index: 1
 
   # Inject BGP IP Pool CIDR
   - sourceValue: 192.168.10.0/24


### PR DESCRIPTION
Surface Hubble UI on the Homepage dashboard under the Observability group with domain replacement wired through both prod and dev overlays.