### PR TITLE
fix(wiki-js): add Homepage pod selector annotation

### DIFF
--- a/kubernetes/applications/wiki-js/base/ingress-route.yaml
+++ b/kubernetes/applications/wiki-js/base/ingress-route.yaml
@@ -16,6 +16,7 @@ metadata:
     gethomepage.dev/icon: "wikijs.png"
     gethomepage.dev/weight: "2"
     gethomepage.dev/href: "https://PLACEHOLDER"
+    gethomepage.dev/pod-selector: "app.kubernetes.io/name=wiki"
 
 spec:
   entryPoints:


### PR DESCRIPTION
Homepage's default lookup uses the IngressRoute name (wiki-js), but the pod carries app.kubernetes.io/name=wiki, so the status badge showed "NOT FOUND". Explicit pod-selector fixes the match.