### PR TITLE
fix(hubble): add Homepage pod selector annotation

### DIFF
--- a/kubernetes/components/cilium/base/ingress-route.yaml
+++ b/kubernetes/components/cilium/base/ingress-route.yaml
@@ -16,6 +16,7 @@ metadata:
     gethomepage.dev/icon: "hubble.png"
     gethomepage.dev/weight: "5"
     gethomepage.dev/href: "https://PLACEHOLDER"
+    gethomepage.dev/pod-selector: "app.kubernetes.io/name=hubble-ui"
 
 spec:
   entryPoints:


### PR DESCRIPTION
IngressRoute is named "hubble" but the pod carries app.kubernetes.io/name=hubble-ui, so Homepage's default lookup showed "NOT FOUND". Explicit pod-selector fixes it.