### PR TITLE
feat(telegraf): route solaredge metrics to in-cluster InfluxDB 3

### DIFF
--- a/kubernetes/applications/telegraf/base/values.yaml
+++ b/kubernetes/applications/telegraf/base/values.yaml
@@ -7,6 +7,13 @@ env:
       secretKeyRef:
         name: telegraf-mqtt-credentials
         key: NATS_MQTT_PASSWORD
+  # Admin token for the new in-cluster InfluxDB 3 Enterprise.
+  # Secret is cloned from the influxdb namespace by Kyverno.
+  - name: INFLUXDB_V3_TOKEN
+    valueFrom:
+      secretKeyRef:
+        name: influxdb-credentials
+        key: admin-token
 
 # Load input configs from config directory
 args:
@@ -17,11 +24,19 @@ args:
 config:
   processors: []
   outputs:
+    # Legacy Docker InfluxDB v2 — receives everything EXCEPT metrics already migrated to v3.
     - influxdb_v2:
         urls: ["http://influx.zimmermann.eu.com:8086"]
         token: "$INFLUXDB_TOKEN"
         organization: "zimmermann.eu.com"
         bucket: "telegraf/autogen"
+        namedrop: ["solaredge.*"]
+    # In-cluster InfluxDB 3 Enterprise — receives metrics as they are migrated over.
+    - influxdb_v3:
+        urls: ["http://influxdb3.influxdb.svc.cluster.local:8181"]
+        token: "$INFLUXDB_V3_TOKEN"
+        database: "homelab"
+        namepass: ["solaredge.*"]
     - prometheus_client:
         listen: ":9273"
   inputs: []

--- a/kubernetes/components/admission-controller/base/clusterpolicy-secrets.yaml
+++ b/kubernetes/components/admission-controller/base/clusterpolicy-secrets.yaml
@@ -114,6 +114,25 @@ spec:
           namespace: authentik
           name: authentik-homepage-token
 
+    # Syncs InfluxDB admin token from influxdb into telegraf for metric writes
+    - name: sync-influxdb-credentials-telegraf
+      match:
+        any:
+          - resources:
+              kinds:
+                - Namespace
+              names:
+                - telegraf
+      generate:
+        apiVersion: v1
+        kind: Secret
+        name: influxdb-credentials
+        namespace: telegraf
+        synchronize: true
+        clone:
+          namespace: influxdb
+          name: influxdb-credentials
+
     # Syncs InfluxDB admin token from influxdb into grafana for datasource authentication
     - name: sync-influxdb-credentials-grafana
       match:


### PR DESCRIPTION
First step of the gradual InfluxDB migration. SolarEdge metrics flow through NATS already and are a small, low-risk candidate.

Split the outputs:
- influxdb_v2 (legacy Docker) keeps everything except solaredge.* via namedrop — other inputs (knx, ems, warp) stay untouched.
- New influxdb_v3 output writes solaredge.* to the in-cluster influxdb3 service with namepass matching the two measurements (solaredge.inverter, solaredge.powerflow).

Kyverno now clones influxdb-credentials from the influxdb namespace into telegraf so the v3 output can authenticate via INFLUXDB_V3_TOKEN.