### PR TITLE
feat(telegraf): migrate ems-esp metrics to in-cluster InfluxDB 3

### DIFF
--- a/kubernetes/applications/telegraf/base/values.yaml
+++ b/kubernetes/applications/telegraf/base/values.yaml
@@ -30,13 +30,13 @@ config:
         token: "$INFLUXDB_TOKEN"
         organization: "zimmermann.eu.com"
         bucket: "telegraf/autogen"
-        namedrop: ["solaredge.*"]
+        namedrop: ["solaredge.*", "ems-esp"]
     # In-cluster InfluxDB 3 Enterprise — receives metrics as they are migrated over.
     - influxdb_v3:
         urls: ["http://influxdb3.influxdb.svc.cluster.local:8181"]
         token: "$INFLUXDB_V3_TOKEN"
         database: "homelab"
-        namepass: ["solaredge.*"]
+        namepass: ["solaredge.*", "ems-esp"]
     - prometheus_client:
         listen: ":9273"
   inputs: []


### PR DESCRIPTION
Second step of the gradual InfluxDB migration. EMS boiler/thermostat/ mixer data was already flowing through NATS (not a real migration there — only InfluxDB target changes).

Extend the name filters on both outputs to include the ems-esp measurement (all ems-esp/* topics fold into one measurement via topic_parsing).