### PR TITLE
feat(telegraf): migrate warp wallbox metrics to in-cluster InfluxDB 3

### DIFF
--- a/kubernetes/applications/telegraf/base/values.yaml
+++ b/kubernetes/applications/telegraf/base/values.yaml
@@ -30,13 +30,13 @@ config:
         token: "$INFLUXDB_TOKEN"
         organization: "zimmermann.eu.com"
         bucket: "telegraf/autogen"
-        namedrop: ["solaredge.*", "ems-esp"]
+        namedrop: ["solaredge.*", "ems-esp", "warp"]
     # In-cluster InfluxDB 3 Enterprise — receives metrics as they are migrated over.
     - influxdb_v3:
         urls: ["http://influxdb3.influxdb.svc.cluster.local:8181"]
         token: "$INFLUXDB_V3_TOKEN"
         database: "homelab"
-        namepass: ["solaredge.*", "ems-esp"]
+        namepass: ["solaredge.*", "ems-esp", "warp"]
     - prometheus_client:
         listen: ":9273"
   inputs: []


### PR DESCRIPTION
Third step of the gradual InfluxDB migration. All WARP charger topics (evse/state, charge_tracker/*, meters/0/values) fold into the single "warp" measurement via topic_parsing, so a single namepass entry catches them.