### PR TITLE
feat(telegraf): migrate knx metrics to in-cluster InfluxDB 3

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -21,6 +21,7 @@
 - [ ] **InfluxDB**: Configure data retention policies.
 - [ ] **Cilium**: Implement network policies.
 - [ ] **Telegraf NATS native**: Migrate Telegraf from MQTT protocol (`inputs.mqtt_consumer`) to native NATS protocol (`inputs.nats_consumer`) for solaredge topics. Enables direct JetStream access (replay, persistence).
+- [ ] **KNX → NATS via Telegraf**: Expose KNX events on NATS for future AI/home-automation consumers. Add `outputs.nats` to Telegraf so the existing `inputs.knx_listener` data is published on subjects like `knx.<a>.<b>.<c>` alongside the current InfluxDB write. No separate KNX→MQTT bridge, no MQTT gateway involved. Today only InfluxDB 3 gets the data — nothing else on NATS does.
 
 ## GitOps
 

--- a/kubernetes/applications/telegraf/base/values.yaml
+++ b/kubernetes/applications/telegraf/base/values.yaml
@@ -30,13 +30,15 @@ config:
         token: "$INFLUXDB_TOKEN"
         organization: "zimmermann.eu.com"
         bucket: "telegraf/autogen"
-        namedrop: ["solaredge.*", "ems-esp", "warp"]
+        namedrop: ["solaredge.*", "ems-esp", "warp",
+                   "Versorgungstechnik.*", "Sensorik.*", "Strom.*", "Heizung.*"]
     # In-cluster InfluxDB 3 Enterprise — receives metrics as they are migrated over.
     - influxdb_v3:
         urls: ["http://influxdb3.influxdb.svc.cluster.local:8181"]
         token: "$INFLUXDB_V3_TOKEN"
         database: "homelab"
-        namepass: ["solaredge.*", "ems-esp", "warp"]
+        namepass: ["solaredge.*", "ems-esp", "warp",
+                   "Versorgungstechnik.*", "Sensorik.*", "Strom.*", "Heizung.*"]
     - prometheus_client:
         listen: ":9273"
   inputs: []


### PR DESCRIPTION
Fourth and final step of the gradual InfluxDB migration. KNX uses inputs.knx_listener (not MQTT) so no NATS bridge work is required for the InfluxDB cutover — only the output filters change.

All 388 KNX measurements start with one of four German prefixes (Heizung, Sensorik, Strom, Versorgungstechnik), so four glob patterns cover everything on both the v2 namedrop and the v3 namepass lists.

Also note the deferred KNX → NATS publishing work in TODO.md. When we want the data on NATS (for future AI/home-automation consumers), we add outputs.nats to Telegraf on top of the existing knx_listener input — no external bridge, no MQTT gateway detour.