### PR TITLE
refactor(telegraf): drop influxdb v2 output and related legacy config

### DIFF
--- a/kubernetes/applications/telegraf/base/values.yaml
+++ b/kubernetes/applications/telegraf/base/values.yaml
@@ -1,15 +1,12 @@
-# Inject secrets as env vars from K8s Secrets
-envFromSecret: "telegraf-credentials"
-
 env:
   - name: NATS_MQTT_PASSWORD
     valueFrom:
       secretKeyRef:
         name: telegraf-mqtt-credentials
         key: NATS_MQTT_PASSWORD
-  # Admin token for the new in-cluster InfluxDB 3 Enterprise.
+  # Admin token for the in-cluster InfluxDB 3 Enterprise.
   # Secret is cloned from the influxdb namespace by Kyverno.
-  - name: INFLUXDB_V3_TOKEN
+  - name: INFLUXDB_TOKEN
     valueFrom:
       secretKeyRef:
         name: influxdb-credentials
@@ -24,21 +21,10 @@ args:
 config:
   processors: []
   outputs:
-    # Legacy Docker InfluxDB v2 — receives everything EXCEPT metrics already migrated to v3.
-    - influxdb_v2:
-        urls: ["http://influx.zimmermann.eu.com:8086"]
-        token: "$INFLUXDB_TOKEN"
-        organization: "zimmermann.eu.com"
-        bucket: "telegraf/autogen"
-        namedrop: ["solaredge.*", "ems-esp", "warp",
-                   "Versorgungstechnik.*", "Sensorik.*", "Strom.*", "Heizung.*"]
-    # In-cluster InfluxDB 3 Enterprise — receives metrics as they are migrated over.
     - influxdb_v3:
         urls: ["http://influxdb3.influxdb.svc.cluster.local:8181"]
-        token: "$INFLUXDB_V3_TOKEN"
+        token: "$INFLUXDB_TOKEN"
         database: "homelab"
-        namepass: ["solaredge.*", "ems-esp", "warp",
-                   "Versorgungstechnik.*", "Sensorik.*", "Strom.*", "Heizung.*"]
     - prometheus_client:
         listen: ":9273"
   inputs: []


### PR DESCRIPTION
All four inputs (solaredge, ems-esp, warp, knx) now flow to the in-cluster InfluxDB 3 Enterprise. The Docker-hosted InfluxDB v2 has received no new writes since the last input migration, so remove:

- influxdb_v2 output block (URL, org, bucket, token ref)
- namepass/namedrop filters on both outputs (no more split — v3 gets everything)
- envFromSecret reference to telegraf-credentials (its INFLUXDB_TOKEN was only for v2 and MQTT_PASSWORD was already dead after the earlier NATS migration)

Also rename INFLUXDB_V3_TOKEN → INFLUXDB_TOKEN now that v3 is the only InfluxDB Telegraf writes to.