### PR TITLE
fix(grafana): correct prometheus datasource UID in dashboards

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3,6 +3,7 @@
 ## Observability
 
 - [ ] **RustFS Monitoring**: Enable OTLP metrics export via Alloy once RustFS exposes meaningful S3 metrics (bucket ops, disk status). Configure `otelcol.receiver.otlp` in Alloy and add `PrometheusRule` for RustFS.
+- [ ] **Grafana dashboards Flux → InfluxQL/SQL**: 17 dashboards (`energy-*`, `hvac-*`, `knx-*`) still contain Flux queries (`from(bucket:...)`) targeting stale InfluxDB v2 datasource UIDs. InfluxDB 3 dropped Flux — rewrite to InfluxQL or SQL and point to the `InfluxDB (InfluxQL)` / `InfluxDB (SQL)` datasources (UIDs `ab06323c-...` / `3b275c55-...`).
 - [ ] **Gatus**: Deploy uptime monitoring for external ingress endpoints (wallbox, SolarEdge etc.) with GitHub status badges. Decision pending: self-hosted vs. SaaS.
 
 ## Infrastructure

--- a/kubernetes/applications/grafana/base/dashboards/k8s-traefik.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/k8s-traefik.yaml
@@ -42,7 +42,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "YlZj266nz"
+            "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
           },
           "gridPos": {
             "h": 1,
@@ -55,7 +55,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "refId": "A"
             }
@@ -70,7 +70,7 @@ spec:
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "YlZj266nz"
+            "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
           },
           "fieldConfig": {
             "defaults": {
@@ -118,7 +118,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum(traefik_service_request_duration_seconds_sum{}) by (service) / sum(traefik_service_request_duration_seconds_count{}) by (service)",
               "format": "time_series",
@@ -165,7 +165,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "YlZj266nz"
+            "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
           },
           "fieldConfig": {
             "defaults": {
@@ -220,7 +220,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum(rate(traefik_service_requests_total[5m])) by (service) ",
               "format": "time_series",
@@ -236,7 +236,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "YlZj266nz"
+            "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
           },
           "fieldConfig": {
             "defaults": {
@@ -291,7 +291,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum(rate(traefik_entrypoint_requests_total{entrypoint =~ \"$entrypoint\"}[5m])) by (entrypoint) ",
               "format": "time_series",
@@ -311,7 +311,7 @@ spec:
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "YlZj266nz"
+            "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
           },
           "fieldConfig": {
             "defaults": {
@@ -359,7 +359,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "rate(traefik_entrypoint_requests_total{entrypoint=~\"$entrypoint\",code=\"200\"}[5m])",
               "format": "time_series",
@@ -406,7 +406,7 @@ spec:
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "YlZj266nz"
+            "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
           },
           "fieldConfig": {
             "defaults": {
@@ -454,7 +454,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "rate(traefik_entrypoint_requests_total{entrypoint=~\"$entrypoint\",code!=\"200\"}[5m])",
               "format": "time_series",
@@ -497,7 +497,7 @@ spec:
           "collapsed": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "YlZj266nz"
+            "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
           },
           "gridPos": {
             "h": 1,
@@ -511,7 +511,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "refId": "A"
             }
@@ -522,7 +522,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "YlZj266nz"
+            "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
           },
           "fieldConfig": {
             "defaults": {
@@ -587,7 +587,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum(traefik_service_request_duration_seconds_sum{service=\"$service\"}) / sum(traefik_service_requests_total{service=\"$service\"}) * 1000",
               "format": "time_series",
@@ -603,7 +603,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "YlZj266nz"
+            "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
           },
           "fieldConfig": {
             "defaults": {
@@ -659,7 +659,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "traefik_service_requests_total{service=\"$service\"}",
               "format": "time_series",
@@ -679,7 +679,7 @@ spec:
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "YlZj266nz"
+            "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
           },
           "fieldConfig": {
             "defaults": {
@@ -727,7 +727,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum(rate(traefik_service_requests_total{service=\"$service\"}[5m]))",
               "format": "time_series",
@@ -782,7 +782,7 @@ spec:
             "current": {},
             "datasource": {
               "type": "prometheus",
-              "uid": "YlZj266nz"
+              "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
             },
             "definition": "label_values(service)",
             "hide": 0,
@@ -804,7 +804,7 @@ spec:
             "current": {},
             "datasource": {
               "type": "prometheus",
-              "uid": "YlZj266nz"
+              "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
             },
             "definition": "",
             "hide": 0,

--- a/kubernetes/applications/grafana/base/dashboards/network-unifi-ap.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/network-unifi-ap.yaml
@@ -98,7 +98,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "YlZj266nz"
+            "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
           },
           "description": "Visualize wireless channel usage w/ wired client counts.",
           "fieldConfig": {
@@ -149,7 +149,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "count by (channel) (unpoller_client_roam_count_total{site_name=~\"$Site\", ap_name=~\"$AP\"})\n",
               "instant": false,
@@ -165,7 +165,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "YlZj266nz"
+            "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
           },
           "description": "Visualize how many clients are connected to which radios/APs.",
           "fieldConfig": {
@@ -216,7 +216,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "count by (radio_desc) (unpoller_client_uptime_seconds{site_name=~\"$Site\", ap_name=~\"$AP\"})",
               "instant": false,
@@ -232,7 +232,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "YlZj266nz"
+            "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
           },
           "description": "This shows an OUI breakdown from Unifi's perspective.",
           "fieldConfig": {
@@ -283,7 +283,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "count by (oui) (unpoller_client_uptime_seconds{site_name=~\"$Site\", ap_name=~\"$AP\"})",
               "instant": false,
@@ -299,7 +299,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "YlZj266nz"
+            "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
           },
           "description": "",
           "fieldConfig": {
@@ -355,7 +355,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum(unpoller_device_stations{site_name=~\"$Site\", name=~\"$AP\", station_type=\"user\"})",
               "instant": true,
@@ -368,7 +368,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "YlZj266nz"
+            "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
           },
           "description": "",
           "fieldConfig": {
@@ -424,7 +424,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum(unpoller_device_stations{site_name=~\"$Site\", name=~\"$AP\", station_type=\"guest\"})",
               "instant": true,
@@ -437,7 +437,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "YlZj266nz"
+            "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
           },
           "fieldConfig": {
             "defaults": {
@@ -793,7 +793,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum by (ip,mac,model,name,serial,site_name,type,version) (unpoller_device_info{site_name=~\"$Site\", name=~\"$AP\"})",
               "format": "table",
@@ -805,7 +805,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum by (ip,mac,model,name,serial,site_name,type,version) (unpoller_device_uptime_seconds{site_name=~\"$Site\", name=~\"$AP\"})",
               "format": "table",
@@ -818,7 +818,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum by (ip,mac,model,name,serial,site_name,type,version) (unpoller_device_bytes_total{site_name=~\"$Site\", name=~\"$AP\"})",
               "format": "table",
@@ -835,7 +835,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "YlZj266nz"
+            "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
           },
           "description": "The counters in this table represent uptime totals and do not change with the time range selector. ",
           "fieldConfig": {
@@ -1472,7 +1472,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum by (bssid,essid,ap_name,name,radio,radio_name,vap_name,site_name,usage,source) (unpoller_device_vap_ccq_ratio{site_name=~\"$Site\", name=~\"$AP\"})",
               "format": "table",
@@ -1483,7 +1483,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum by (bssid,essid,ap_name,name,radio,radio_name,vap_name,site_name,usage,source) (unpoller_device_vap_average_client_signal{site_name=~\"$Site\", name=~\"$AP\"})",
               "format": "table",
@@ -1495,7 +1495,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum by (bssid,essid,ap_name,name,radio,radio_name,vap_name,site_name,usage,source) (unpoller_device_vap_receive_dropped_total{site_name=~\"$Site\", name=~\"$AP\"}) ",
               "format": "table",
@@ -1507,7 +1507,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum by (bssid,essid,ap_name,name,radio,radio_name,vap_name,site_name,usage,source) (unpoller_device_vap_transmit_dropped_total{site_name=~\"$Site\", name=~\"$AP\"}) ",
               "format": "table",
@@ -1519,7 +1519,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum by (bssid,essid,ap_name,name,radio,radio_name,vap_name,site_name,usage,source) (unpoller_device_vap_transmit_bytes_total{site_name=~\"$Site\", name=~\"$AP\"}) ",
               "format": "table",
@@ -1531,7 +1531,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum by (bssid,essid,ap_name,name,radio,radio_name,vap_name,site_name,usage,source) (unpoller_device_vap_receive_bytes_total{site_name=~\"$Site\", name=~\"$AP\"}) ",
               "format": "table",
@@ -1543,7 +1543,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum by (bssid,essid,ap_name,name,radio,radio_name,vap_name,site_name,usage,source) (unpoller_device_vap_receive_packets_total{site_name=~\"$Site\", name=~\"$AP\"}) ",
               "format": "table",
@@ -1555,7 +1555,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum by (bssid,essid,ap_name,name,radio,radio_name,vap_name,site_name,usage,source) (unpoller_device_vap_transmit_packets_total{site_name=~\"$Site\", name=~\"$AP\"}) ",
               "format": "table",
@@ -1572,7 +1572,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "YlZj266nz"
+            "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
           },
           "description": "",
           "fieldConfig": {
@@ -1710,7 +1710,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "unpoller_device_cpu_utilization_ratio{site_name=~\"$Site\",name=~\"$AP\"}",
               "interval": "$Smooth",
@@ -1724,7 +1724,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "YlZj266nz"
+            "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
           },
           "description": "",
           "fieldConfig": {
@@ -1862,7 +1862,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "unpoller_device_memory_utilization_ratio{site_name=~\"$Site\",name=~\"$AP\"}",
               "interval": "$Smooth",
@@ -1876,7 +1876,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "YlZj266nz"
+            "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
           },
           "fieldConfig": {
             "defaults": {
@@ -2083,7 +2083,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "unpoller_device_load_average_1{site_name=~\"$Site\",name=~\"$AP\"}",
               "interval": "$Smooth",
@@ -2093,7 +2093,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "unpoller_device_load_average_5{site_name=~\"$Site\",name=~\"$AP\"}",
               "hide": true,
@@ -2104,7 +2104,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "unpoller_device_load_average_15{site_name=~\"$Site\",name=~\"$AP\"}",
               "interval": "$Smooth",
@@ -2119,7 +2119,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "YlZj266nz"
+            "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
           },
           "fieldConfig": {
             "defaults": {
@@ -2228,7 +2228,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "unpoller_device_stations{site_name=~\"$Site\",name=~\"$AP\"}",
               "interval": "$Smooth",
@@ -2243,7 +2243,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "YlZj266nz"
+            "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
           },
           "description": "Devices TX / RX bytes per second grouped by OUI. RX on negative axis.",
           "fieldConfig": {
@@ -2365,7 +2365,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum (unpoller_client_receive_rate_bytes{site_name=~\"$Site\",ap_name=~\"$AP\"}) by (oui)",
               "interval": "$Smooth",
@@ -2375,7 +2375,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum (unpoller_client_transmit_rate_bytes{site_name=~\"$Site\",ap_name=~\"$AP\"}) by (oui)",
               "interval": "$Smooth",
@@ -2389,7 +2389,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "YlZj266nz"
+            "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
           },
           "fieldConfig": {
             "defaults": {
@@ -2518,7 +2518,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum (unpoller_device_radio_stations{radio=\"ng\", site_name=~\"$Site\",name=~\"$AP\", station_type=\"guest\"}) by  (radio,name)",
               "hide": false,
@@ -2529,7 +2529,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum (unpoller_device_radio_stations{radio=\"ng\", site_name=~\"$Site\",name=~\"$AP\", station_type=\"user\"}) by (radio,name)",
               "interval": "$Smooth",
@@ -2539,7 +2539,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum (unpoller_device_radio_stations{radio=\"na\", site_name=~\"$Site\",name=~\"$AP\", station_type=\"user\"}) by (radio,name)",
               "hide": false,
@@ -2550,7 +2550,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum (unpoller_device_radio_stations{radio=\"na\", site_name=~\"$Site\",name=~\"$AP\", station_type=\"guest\"}) by (radio,name)",
               "hide": false,
@@ -2565,7 +2565,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "YlZj266nz"
+            "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
           },
           "fieldConfig": {
             "defaults": {
@@ -2695,7 +2695,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "unpoller_device_vap_average_client_signal{name=~\"$AP\"}",
               "interval": "$Smooth",
@@ -2710,7 +2710,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "YlZj266nz"
+            "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
           },
           "fieldConfig": {
             "defaults": {
@@ -2840,7 +2840,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "avg(unpoller_client_rssi_db{ap_name=~\"$AP\"}) by (ap_name, radio_name)",
               "interval": "$Smooth",
@@ -2855,7 +2855,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "YlZj266nz"
+            "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
           },
           "fieldConfig": {
             "defaults": {
@@ -2984,7 +2984,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "unpoller_device_vap_ccq_ratio{site_name=~\"$Site\",name=~\"$AP\", radio=\"na\"}",
               "interval": "$Smooth",
@@ -2999,7 +2999,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "YlZj266nz"
+            "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
           },
           "fieldConfig": {
             "defaults": {
@@ -3128,7 +3128,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "unpoller_device_vap_ccq_ratio{site_name=~\"$Site\",name=~\"$AP\", radio=\"ng\"}",
               "interval": "1m",
@@ -3143,7 +3143,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "YlZj266nz"
+            "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
           },
           "fieldConfig": {
             "defaults": {
@@ -3251,7 +3251,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "unpoller_device_radio_channel_utilization_receive_ratio{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}",
               "interval": "$Smooth",
@@ -3261,7 +3261,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "unpoller_device_radio_channel_utilization_transmit_ratio{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}",
               "interval": "$Smooth",
@@ -3275,7 +3275,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "YlZj266nz"
+            "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
           },
           "description": "Displays 2.4GHz usage.",
           "fieldConfig": {
@@ -3383,7 +3383,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "unpoller_device_radio_channel_utilization_receive_ratio{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}",
               "interval": "$Smooth",
@@ -3393,7 +3393,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "unpoller_device_radio_channel_utilization_transmit_ratio{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}",
               "interval": "$Smooth",
@@ -3407,7 +3407,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "YlZj266nz"
+            "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
           },
           "description": "RX is on the negative Axis.",
           "fieldConfig": {
@@ -3527,7 +3527,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum (rate(unpoller_device_vap_transmit_bytes_total{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}[5m])) by (name)",
               "interval": "$Smooth",
@@ -3537,7 +3537,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum (rate(unpoller_device_vap_receive_bytes_total{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}[5m])) by (name)",
               "interval": "$Smooth",
@@ -3552,7 +3552,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "YlZj266nz"
+            "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
           },
           "description": "RX is on the negative Axis.",
           "fieldConfig": {
@@ -3672,7 +3672,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum (rate(unpoller_device_vap_transmit_bytes_total{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}[5m])) by (name)",
               "interval": "$Smooth",
@@ -3682,7 +3682,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum (rate(unpoller_device_vap_receive_bytes_total{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}[5m])) by (name)",
               "interval": "$Smooth",
@@ -3697,7 +3697,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "YlZj266nz"
+            "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
           },
           "description": "PPS on the na band. In is on the negative Axis.",
           "fieldConfig": {
@@ -3818,7 +3818,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum (rate(unpoller_device_vap_transmit_packets_total{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
               "hide": false,
@@ -3829,7 +3829,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum (rate(unpoller_device_vap_receive_packets_total{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
               "interval": "$Smooth",
@@ -3843,7 +3843,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "YlZj266nz"
+            "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
           },
           "description": "PPS on the ng band calculated in 30 second buckets. In is on the negative Axis.",
           "fieldConfig": {
@@ -3964,7 +3964,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum (rate(unpoller_device_vap_transmit_packets_total{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
               "interval": "$Smooth",
@@ -3974,7 +3974,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum (rate(unpoller_device_vap_receive_packets_total{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
               "interval": "$Smooth",
@@ -3988,7 +3988,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "YlZj266nz"
+            "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
           },
           "description": "Visualize packet errors (several types)  per second in the 5GHz band.",
           "fieldConfig": {
@@ -4109,7 +4109,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum (rate(unpoller_device_vap_receive_dropped_total{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
               "interval": "$Smooth",
@@ -4119,7 +4119,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum (rate(unpoller_device_vap_transmit_dropped_total{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
               "interval": "$Smooth",
@@ -4129,7 +4129,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum (rate(unpoller_device_vap_receive_errors_total{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
               "interval": "$Smooth",
@@ -4139,7 +4139,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum (rate(unpoller_device_vap_transmit_errors_total{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
               "interval": "$Smooth",
@@ -4149,7 +4149,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum (rate(unpoller_device_vap_receive_crypts_total{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
               "interval": "$Smooth",
@@ -4159,7 +4159,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum (rate(unpoller_device_vap_receive_frags_total{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
               "interval": "$Smooth",
@@ -4169,7 +4169,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum (rate(unpoller_device_vap_receive_nwids_total{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
               "interval": "$Smooth",
@@ -4179,7 +4179,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum (rate(unpoller_device_vap_transmit_retries_total{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
               "interval": "$Smooth",
@@ -4194,7 +4194,7 @@ spec:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "YlZj266nz"
+            "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
           },
           "description": "In is on the negative axis.",
           "fieldConfig": {
@@ -4315,7 +4315,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum (rate(unpoller_device_vap_receive_dropped_total{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
               "interval": "$Smooth",
@@ -4325,7 +4325,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum (rate(unpoller_device_vap_transmit_dropped_total{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
               "interval": "$Smooth",
@@ -4335,7 +4335,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum (rate(unpoller_device_vap_receive_errors_total{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
               "interval": "$Smooth",
@@ -4345,7 +4345,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum (rate(unpoller_device_vap_transmit_errors_total{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
               "interval": "$Smooth",
@@ -4355,7 +4355,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum (rate(unpoller_device_vap_receive_crypts_total{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
               "interval": "$Smooth",
@@ -4365,7 +4365,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum (rate(unpoller_device_vap_receive_frags_total{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
               "interval": "$Smooth",
@@ -4375,7 +4375,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum (rate(unpoller_device_vap_receive_nwids_total{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
               "interval": "$Smooth",
@@ -4385,7 +4385,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum (rate(unpoller_device_vap_transmit_retries_total{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
               "interval": "$Smooth",
@@ -4413,7 +4413,7 @@ spec:
             "current": {},
             "datasource": {
               "type": "prometheus",
-              "uid": "YlZj266nz"
+              "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
             },
             "definition": "label_values(unpoller_device_info{type=\"uap\"},source)",
             "hide": 2,
@@ -4431,7 +4431,7 @@ spec:
             "current": {},
             "datasource": {
               "type": "prometheus",
-              "uid": "YlZj266nz"
+              "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
             },
             "definition": "label_values(unpoller_device_info{source=~\"$Controller\", type=\"uap\"},site_name)",
             "includeAll": true,
@@ -4448,7 +4448,7 @@ spec:
             "current": {},
             "datasource": {
               "type": "prometheus",
-              "uid": "YlZj266nz"
+              "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
             },
             "definition": "label_values(unpoller_device_info{site_name=~\"$Site\", type=~\"uap|udm\",model!=\"UDMPRO\"},name)",
             "includeAll": true,

--- a/kubernetes/applications/grafana/base/dashboards/network-unifi-client.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/network-unifi-client.yaml
@@ -72,7 +72,7 @@ spec:
           "columns": [],
           "datasource": {
             "type": "prometheus",
-            "uid": "YlZj266nz"
+            "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
           },
           "description": "This table represents current (latest) data.\nBytes columns are lifetime totals.",
           "fontSize": "80%",
@@ -541,7 +541,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum by (channel,essid,ip,mac,name,network,oui,radio_desc,site_name,source) (\n unpoller_client_receive_bytes_total{wired!=\"true\", site_name=~\"$Site\", name=~\"$Wireless\"})",
               "format": "table",
@@ -553,7 +553,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum by (channel,essid,ip,mac,name,network,oui,radio_desc,site_name,source) (\n unpoller_client_transmit_bytes_total{wired!=\"true\",site_name=~\"$Site\", name=~\"$Wireless\"})",
               "format": "table",
@@ -565,7 +565,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum by (channel,essid,ip,mac,name,network,oui,radio_desc,site_name,source) (\n unpoller_client_uptime_seconds{wired!=\"true\",site_name=~\"$Site\", name=~\"$Wireless\"})",
               "format": "table",
@@ -583,7 +583,7 @@ spec:
           "columns": [],
           "datasource": {
             "type": "prometheus",
-            "uid": "YlZj266nz"
+            "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
           },
           "description": "This table represents current (latest) data.\nBytes columns are lifetime totals.",
           "fontSize": "80%",
@@ -934,7 +934,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum by (ap_name,ip,mac,name,network,oui,site_name,source,sw_port) (\n     unpoller_client_uptime_seconds{wired=\"true\", site_name=~\"$Site\", name=~\"$Wired\", sw_name=~\"$Switch\"})",
               "format": "table",
@@ -945,7 +945,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum by (ap_name,ip,mac,name,network,oui,site_name,source,sw_port) (\n     unpoller_client_receive_bytes_total{wired=\"true\", site_name=~\"$Site\", name=~\"$Wired\", sw_name=~\"$Switch\"})",
               "format": "table",
@@ -957,7 +957,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum by (ap_name,ip,mac,name,network,oui,site_name,source,sw_port) (\n     unpoller_client_transmit_bytes_total{wired=\"true\", site_name=~\"$Site\", name=~\"$Wired\", sw_name=~\"$Switch\"})",
               "format": "table",
@@ -980,7 +980,7 @@ spec:
           },
           "datasource": {
             "type": "prometheus",
-            "uid": "YlZj266nz"
+            "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
           },
           "decimals": 0,
           "description": "Visualize wireless channel usage w/ wired client counts.",
@@ -1044,7 +1044,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "count by (hostname) (unpoller_client_uptime_seconds{site_name=~\"$Site\", name=~\"$Wired\", sw_name=~\"$Switch\"})",
               "instant": true,
@@ -1054,7 +1054,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "count by (channel) (unpoller_client_roam_count_total{site_name=~\"$Site\", name=~\"$Wireless\", ap_name=~\"$AP\"})",
               "instant": true,
@@ -1077,7 +1077,7 @@ spec:
           },
           "datasource": {
             "type": "prometheus",
-            "uid": "YlZj266nz"
+            "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
           },
           "decimals": 0,
           "description": "Visualize how many clients are connected to which radios/APs.",
@@ -1141,7 +1141,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "count by (radio_proto) (unpoller_client_roam_count_total{site_name=~\"$Site\", name=~\"$Wireless\", ap_name=~\"$AP\"})",
               "instant": true,
@@ -1164,7 +1164,7 @@ spec:
           },
           "datasource": {
             "type": "prometheus",
-            "uid": "YlZj266nz"
+            "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
           },
           "decimals": 0,
           "description": "This shows an OUI breakdown from Unifi's perspective. e = wired, w = wireless",
@@ -1231,7 +1231,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "count by (oui) (unpoller_client_uptime_seconds{site_name=~\"$Site\", name=~\"$Wireless\", ap_name=~\"$AP\"})",
               "hide": false,
@@ -1243,7 +1243,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "count by (oui) (+unpoller_client_uptime_seconds{site_name=~\"$Site\", name=~\"$Wired\", sw_name=~\"$Switch\"})",
               "hide": false,
@@ -1265,7 +1265,7 @@ spec:
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "YlZj266nz"
+            "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
           },
           "description": "Bandwidth usage per wireless devices as reported by the UAPs. Rx is on the negative axis. Does not include amazon devices.",
           "fieldConfig": {
@@ -1324,7 +1324,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum by ($Identifier) (rate(unpoller_client_transmit_bytes_total{name!~\".*camera.*|.*cam(era)?$\", name=~\"$Wireless\", site_name=~\"$Site\", ap_name=~\"$AP\"}[$__interval]))",
               "instant": false,
@@ -1335,7 +1335,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum by ($Identifier) (rate(unpoller_client_receive_bytes_total{name!~\".*camera.*|.*cam(era)?$\", name=~\"$Wireless\", site_name=~\"$Site\", ap_name=~\"$AP\"}[$__interval]))",
               "instant": false,
@@ -1382,7 +1382,7 @@ spec:
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "YlZj266nz"
+            "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
           },
           "description": "Wired TX / RX bytes per second (calculated in 30 second buckets). Rx is on the negative axis. Does not include amazon and camera devices. Unaffected by the AP setting.",
           "fieldConfig": {
@@ -1440,7 +1440,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum by ($Identifier) (rate(unpoller_client_transmit_bytes_total{name!~\".*camera.*|.*cam(era)?$\", name=~\"$Wired\", site_name=~\"$Site\", sw_name=~\"$Switch\"}[$__interval]))",
               "interval": "$Smooth",
@@ -1450,7 +1450,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum by ($Identifier) (rate(unpoller_client_receive_bytes_total{name!~\".*camera.*|.*cam(era)?$\", name=~\"$Wired\", site_name=~\"$Site\", sw_name=~\"$Switch\"}[$__interval]))",
               "hide": false,
@@ -1499,7 +1499,7 @@ spec:
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "YlZj266nz"
+            "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
           },
           "description": "Amazon Devices TX / RX bytes per second. Rx is on the negative axis. My home network has a ton of Amazon devices, so I broke them out separately. If you don't have Amazon devices, or they have different names, you can edit the query to use a different name. e = wired, w = wireless",
           "fieldConfig": {
@@ -1556,7 +1556,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum by ($Identifier) (rate(unpoller_client_transmit_bytes_total{name=~\"^amazon.*\", name=~\"$Wireless\", site_name=~\"$Site\", ap_name=~\"$AP\"}[$__interval]))",
               "hide": false,
@@ -1567,7 +1567,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum by ($Identifier) (rate(unpoller_client_receive_bytes_total{name=~\"^amazon.*\", name=~\"$Wireless\", site_name=~\"$Site\", ap_name=~\"$AP\"}[$__interval]))",
               "hide": false,
@@ -1578,7 +1578,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum by ($Identifier) (rate(unpoller_client_transmit_bytes_total{name=~\"^amazon.*\", name=~\"$Wired\", site_name=~\"$Site\", sw_name=~\"$Switch\"}[$__interval]))",
               "hide": false,
@@ -1589,7 +1589,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum by ($Identifier) (rate(unpoller_client_receive_bytes_total{name=~\"^amazon.*\", name=~\"$Wired\", site_name=~\"$Site\", sw_name=~\"$Switch\"}[$__interval]))",
               "hide": false,
@@ -1636,7 +1636,7 @@ spec:
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "YlZj266nz"
+            "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
           },
           "description": "Cameras TX / RX bytes per second. Rx is on the negative axis. This graph shows any device with the word \"camera\" in its name and has nothing to do with UniFi Protect/video products. e = wired, w = wireless",
           "fieldConfig": {
@@ -1694,7 +1694,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum by ($Identifier) (rate(unpoller_client_transmit_bytes_total{ap_name=~\"$AP\", name=~\".*camera.*|.*cam$\", site_name=~\"$Site\"}[$__interval]))",
               "hide": false,
@@ -1706,7 +1706,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum by ($Identifier) (rate(unpoller_client_receive_bytes_total{ap_name=~\"$AP\", name=~\".*camera.*|.*cam$\", site_name=~\"$Site\"}[$__interval]))",
               "hide": false,
@@ -1717,7 +1717,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum by ($Identifier) (rate(unpoller_client_transmit_bytes_total{sw_name=~\"$Switch\", name=~\".*camera.*|.*cam$\", site_name=~\"$Site\"}[$__interval]))",
               "hide": false,
@@ -1728,7 +1728,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum by ($Identifier) (rate(unpoller_client_receive_bytes_total{sw_name=~\"$Switch\", name=~\".*camera.*|.*cam$\", site_name=~\"$Site\"}[$__interval]))",
               "hide": false,
@@ -1775,7 +1775,7 @@ spec:
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "YlZj266nz"
+            "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
           },
           "decimals": 0,
           "fieldConfig": {
@@ -1828,7 +1828,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum by ($Identifier) (unpoller_client_rssi_db{ap_name=~\"$AP\", site_name=~\"$Site\", name=~\"$Wireless\"})",
               "interval": "1m",
@@ -1876,7 +1876,7 @@ spec:
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "YlZj266nz"
+            "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
           },
           "decimals": 0,
           "fieldConfig": {
@@ -1929,7 +1929,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum by ($Identifier) (unpoller_client_radio_signal_db{ap_name=~\"$AP\", site_name=~\"$Site\", name=~\"$Wireless\"})",
               "instant": false,
@@ -1979,7 +1979,7 @@ spec:
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "YlZj266nz"
+            "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
           },
           "decimals": 0,
           "fieldConfig": {
@@ -2032,7 +2032,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum by ($Identifier) (unpoller_client_noise_db{ap_name=~\"$AP\", site_name=~\"$Site\", name=~\"$Wireless\"})",
               "instant": false,
@@ -2080,7 +2080,7 @@ spec:
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "YlZj266nz"
+            "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
           },
           "description": "Client reported transmit rate.",
           "fieldConfig": {
@@ -2131,7 +2131,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum by ($Identifier) (unpoller_client_radio_transmit_rate_bps{ap_name=~\"$AP\", site_name=~\"$Site\", name=~\"$Wireless\"})",
               "interval": "$Smooth",
@@ -2177,7 +2177,7 @@ spec:
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "YlZj266nz"
+            "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
           },
           "decimals": 0,
           "fieldConfig": {
@@ -2230,7 +2230,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "avg by ($Identifier) (rate(unpoller_client_wifi_attempts_transmit_total{ap_name=~\"$AP\", site_name=~\"$Site\", name=~\"$Wireless\"}[$__interval]))",
               "interval": "$Smooth",
@@ -2278,7 +2278,7 @@ spec:
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "YlZj266nz"
+            "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
           },
           "description": "Client reported receive rate.",
           "fieldConfig": {
@@ -2331,7 +2331,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum by ($Identifier) (unpoller_client_radio_receive_rate_bps{ap_name=~\"$AP\", site_name=~\"$Site\", name=~\"$Wireless\"})",
               "interval": "$Smooth",
@@ -2378,7 +2378,7 @@ spec:
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "YlZj266nz"
+            "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
           },
           "decimals": 0,
           "fieldConfig": {
@@ -2431,7 +2431,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum by ($Identifier) (rate(unpoller_client_transmit_retries_total{ap_name=~\"$AP\", site_name=~\"$Site\", name=~\"$Wireless\"}[$__interval]))",
               "interval": "$Smooth",
@@ -2478,7 +2478,7 @@ spec:
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "YlZj266nz"
+            "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
           },
           "decimals": 0,
           "fieldConfig": {
@@ -2531,7 +2531,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum by ($Identifier) (unpoller_client_radio_transmit_power_dbm{ap_name=~\"$AP\", site_name=~\"$Site\", name=~\"$Wireless\"})",
               "interval": "$Smooth",
@@ -2578,7 +2578,7 @@ spec:
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "YlZj266nz"
+            "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
           },
           "decimals": 0,
           "fieldConfig": {
@@ -2631,7 +2631,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum by ($Identifier) (unpoller_client_anomalies{ap_name=~\"$AP\", site_name=~\"$Site\", name=~\"$Wireless\"})",
               "interval": "$Smooth",
@@ -2679,7 +2679,7 @@ spec:
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "YlZj266nz"
+            "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
           },
           "decimals": 0,
           "fieldConfig": {
@@ -2732,7 +2732,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum by ($Identifier) (unpoller_client_satisfaction_ratio{ap_name=~\"$AP\", site_name=~\"$Site\", name=~\"$Wireless\"})",
               "interval": "$Smooth",
@@ -2782,7 +2782,7 @@ spec:
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "YlZj266nz"
+            "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
           },
           "decimals": 0,
           "fieldConfig": {
@@ -2835,7 +2835,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum by ($Identifier) (unpoller_client_roam_count_total{ap_name=~\"$AP\", site_name=~\"$Site\", name=~\"$Wireless\"})",
               "interval": "$Smooth",
@@ -2882,7 +2882,7 @@ spec:
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "YlZj266nz"
+            "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
           },
           "decimals": 0,
           "fieldConfig": {
@@ -2935,7 +2935,7 @@ spec:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "YlZj266nz"
+                "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
               },
               "expr": "sum by ($Identifier) (unpoller_client_ccq_ratio{ap_name=~\"$AP\", site_name=~\"$Site\", name=~\"$Wireless\"})",
               "interval": "$Smooth",
@@ -2990,7 +2990,7 @@ spec:
             "current": {},
             "datasource": {
               "type": "prometheus",
-              "uid": "YlZj266nz"
+              "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
             },
             "definition": "label_values(unpoller_client_uptime_seconds,source)",
             "hide": 2,
@@ -3013,7 +3013,7 @@ spec:
             "current": {},
             "datasource": {
               "type": "prometheus",
-              "uid": "YlZj266nz"
+              "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
             },
             "definition": "label_values(unpoller_client_uptime_seconds{source=~\"$Controller\"},site_name)",
             "hide": 0,
@@ -3036,7 +3036,7 @@ spec:
             "current": {},
             "datasource": {
               "type": "prometheus",
-              "uid": "YlZj266nz"
+              "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
             },
             "definition": "label_values(unpoller_client_uptime_seconds{site_name=~\"$Site\"},ap_name)",
             "hide": 0,
@@ -3059,7 +3059,7 @@ spec:
             "current": {},
             "datasource": {
               "type": "prometheus",
-              "uid": "YlZj266nz"
+              "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
             },
             "definition": "label_values(unpoller_client_uptime_seconds{site_name=~\"$Site\"},sw_name)",
             "hide": 0,
@@ -3082,7 +3082,7 @@ spec:
             "current": {},
             "datasource": {
               "type": "prometheus",
-              "uid": "YlZj266nz"
+              "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
             },
             "definition": "label_values(unpoller_client_uptime_seconds{site_name=~\"$Site\", ap_name=~\"$AP\", wired=\"false\"},name)",
             "hide": 0,
@@ -3105,7 +3105,7 @@ spec:
             "current": {},
             "datasource": {
               "type": "prometheus",
-              "uid": "YlZj266nz"
+              "uid": "454b7787-9ec4-42fc-9bf7-100716723e20"
             },
             "definition": "label_values(unpoller_client_uptime_seconds{site_name=~\"$Site\", sw_name=~\"$Switch\", wired=\"true\"},name)",
             "hide": 0,


### PR DESCRIPTION
Replace stale UID "YlZj266nz" with the actual Prometheus datasource UID from the running Grafana instance in three dashboards that were silently broken (panels returning "datasource not found"):

- k8s-traefik
- network-unifi-ap
- network-unifi-client

The 17 InfluxDB-based dashboards (energy/hvac/knx) remain broken: they carry Flux queries that InfluxDB 3 no longer supports. Tracked as a separate TODO for follow-up rewrite to InfluxQL/SQL.