### PR TITLE
fix(influxdb): raise memory and extend startup/liveness probes

### DIFF
--- a/kubernetes/applications/influxdb/overlays/prod/kustomization.yaml
+++ b/kubernetes/applications/influxdb/overlays/prod/kustomization.yaml
@@ -15,7 +15,9 @@ replacements:
           - spec.volumeClaimTemplates.0.spec.resources.requests.storage
 
 patches:
-  # Combined node: handles ingest + query + compact in a single process
+  # Combined node: handles ingest + query + compact in a single process.
+  # Memory sized so regular snapshots keep the WAL drained — too little memory
+  # caused WAL backlog and startup-probe-triggered crashloops.
   - target:
       kind: StatefulSet
       name: influxdb3
@@ -28,7 +30,20 @@ patches:
         value:
           requests:
             cpu: 50m
-            memory: 128Mi
+            memory: 1Gi
           limits:
             cpu: 500m
-            memory: 512Mi
+            memory: 2Gi
+
+  # Extend startup grace so WAL replay can complete on first boot after
+  # a backlog built up; extend liveness timeout to absorb persist/GC spikes.
+  - target:
+      kind: StatefulSet
+      name: influxdb3
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/startupProbe/failureThreshold
+        value: 60
+      - op: replace
+        path: /spec/template/spec/containers/0/livenessProbe/timeoutSeconds
+        value: 10


### PR DESCRIPTION
Pod was crashlooping: 512Mi limit prevented regular WAL snapshots, backlog grew to 2500+ files, and the 60s startup probe killed the pod mid-replay — every restart replayed the same backlog.

Bump memory to 1Gi/2Gi, extend startup failureThreshold to 60 (5 min) to absorb the current one-time recovery, and raise liveness timeout to 10s to tolerate persist/GC spikes.