### PR TITLE
chore(grafana): drop unused InfluxQL datasources for InfluxDB 3

### DIFF
--- a/kubernetes/applications/grafana/base/datasources.yaml
+++ b/kubernetes/applications/grafana/base/datasources.yaml
@@ -42,7 +42,7 @@ spec:
       homelab.app: grafana
 
 ---
-# InfluxDB 3 Enterprise — SQL (native, Flight SQL over gRPC/HTTP2)
+# InfluxDB 3 Enterprise — raw telemetry
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDatasource
 
@@ -73,40 +73,7 @@ spec:
       homelab.app: grafana
 
 ---
-# InfluxDB 3 Enterprise — InfluxQL (v1 compatibility, plain HTTP/1.1)
-apiVersion: grafana.integreatly.org/v1beta1
-kind: GrafanaDatasource
-
-metadata:
-  name: influxdb-influxql
-  namespace: grafana
-
-spec:
-  valuesFrom:
-    - targetPath: secureJsonData.password
-      valueFrom:
-        secretKeyRef:
-          name: influxdb-credentials
-          key: admin-token
-  datasource:
-    name: InfluxDB (InfluxQL)
-    type: influxdb
-    access: proxy
-    url: http://influxdb3.influxdb.svc.cluster.local:8181
-    isDefault: false
-    editable: false
-    database: homelab
-    user: ignored
-    jsonData:
-      version: InfluxQL
-      dbName: homelab
-      httpMode: POST
-  instanceSelector:
-    matchLabels:
-      homelab.app: grafana
-
----
-# InfluxDB 3 Enterprise — 1h downsampled (SQL)
+# InfluxDB 3 Enterprise — 1h downsampled aggregates
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDatasource
 
@@ -130,39 +97,6 @@ spec:
     editable: false
     jsonData:
       version: SQL
-      dbName: homelab_1h
-      httpMode: POST
-  instanceSelector:
-    matchLabels:
-      homelab.app: grafana
-
----
-# InfluxDB 3 Enterprise — 1h downsampled (InfluxQL)
-apiVersion: grafana.integreatly.org/v1beta1
-kind: GrafanaDatasource
-
-metadata:
-  name: influxdb-1h-influxql
-  namespace: grafana
-
-spec:
-  valuesFrom:
-    - targetPath: secureJsonData.password
-      valueFrom:
-        secretKeyRef:
-          name: influxdb-credentials
-          key: admin-token
-  datasource:
-    name: InfluxDB 1h (InfluxQL)
-    type: influxdb
-    access: proxy
-    url: http://influxdb3.influxdb.svc.cluster.local:8181
-    isDefault: false
-    editable: false
-    database: homelab_1h
-    user: ignored
-    jsonData:
-      version: InfluxQL
       dbName: homelab_1h
       httpMode: POST
   instanceSelector:


### PR DESCRIPTION
Neither `homelab` nor `homelab_1h` has a concrete migration plan that requires keeping legacy dashboards on InfluxQL syntax — new panels will target the SQL datasource directly. Removing the dead weight, and tighten the header comments since the SQL vs. InfluxQL contrast no longer exists.