### PR TITLE
fix(influxdb): correct CLI syntax in init jobs so they stop backing off

### DIFF
--- a/kubernetes/applications/influxdb/base/initialize-influxdb-triggers-job.yaml
+++ b/kubernetes/applications/influxdb/base/initialize-influxdb-triggers-job.yaml
@@ -53,10 +53,13 @@ spec:
               value: "homelab"
             # Hourly at :05 — the 5-minute offset mirrors the legacy Flux task
             # and gives late writes from the previous hour time to flush.
+            # 6-field cron (second minute hour day month weekday).
             - name: TRIGGER_SPEC
-              value: "cron:5 * * * *"
-            - name: PLUGIN_PATH
-              value: "/plugins/downsample_1h.py"
+              value: "cron:0 5 * * * *"
+            # Relative to the server's --plugin-dir (mounted at /plugins on
+            # the ingester via values.yaml), not an absolute path.
+            - name: PLUGIN_FILENAME
+              value: "downsample_1h.py"
           resources:
             requests:
               cpu: 10m
@@ -67,14 +70,8 @@ spec:
           volumeMounts:
             - name: scripts
               mountPath: /scripts
-            - name: plugins
-              mountPath: /plugins
       volumes:
         - name: scripts
           configMap:
             name: influxdb-triggers-init-script
             defaultMode: 0555
-        - name: plugins
-          configMap:
-            name: influxdb-plugins
-            defaultMode: 0444

--- a/kubernetes/applications/influxdb/base/scripts/initialize-influxdb-databases.sh
+++ b/kubernetes/applications/influxdb/base/scripts/initialize-influxdb-databases.sh
@@ -27,7 +27,7 @@ for entry in $DATABASES; do
   if db_exists "$name"; then
     echo "Database '$name' already exists — updating retention to '$retention'"
     # shellcheck disable=SC2086
-    influxdb3 update database --host "$INFLUXDB_URL" --token "$INFLUXDB3_AUTH_TOKEN" $retention_args "$name"
+    influxdb3 update database --host "$INFLUXDB_URL" --token "$INFLUXDB3_AUTH_TOKEN" --database "$name" $retention_args
   else
     # shellcheck disable=SC2086
     influxdb3 create database --host "$INFLUXDB_URL" --token "$INFLUXDB3_AUTH_TOKEN" $retention_args "$name"

--- a/kubernetes/applications/influxdb/base/scripts/initialize-influxdb-triggers.sh
+++ b/kubernetes/applications/influxdb/base/scripts/initialize-influxdb-triggers.sh
@@ -3,15 +3,21 @@
 # Inputs (environment):
 #   INFLUXDB_URL         — InfluxDB 3 base URL
 #   INFLUXDB3_AUTH_TOKEN — admin token
-#   PLUGIN_PATH          — absolute path to the plugin file (mounted ConfigMap)
+#   PLUGIN_FILENAME      — filename of the plugin inside the server's plugin-dir
+#                          (mounted at /plugins via values.yaml extraVolumes)
 #   TRIGGER_NAME         — name of the trigger (e.g. downsample_1h)
 #   TRIGGER_DATABASE     — database the trigger runs against (source: homelab)
-#   TRIGGER_SPEC         — CLI trigger spec (e.g. "cron:5 * * * *")
+#   TRIGGER_SPEC         — CLI trigger spec (6-field cron, e.g. "cron:0 5 * * * *")
 set -eu
 
+# Triggers live in a per-database system table, so we check existence via SQL.
 trigger_exists() {
-  influxdb3 show triggers --host "$INFLUXDB_URL" --token "$INFLUXDB3_AUTH_TOKEN" \
-    --database "$TRIGGER_DATABASE" | grep -q " $TRIGGER_NAME "
+  influxdb3 query \
+    --host "$INFLUXDB_URL" \
+    --token "$INFLUXDB3_AUTH_TOKEN" \
+    --database "$TRIGGER_DATABASE" \
+    "SELECT trigger_name FROM system.processing_engine_triggers WHERE trigger_name = '$TRIGGER_NAME'" \
+    | grep -q "$TRIGGER_NAME"
 }
 
 if trigger_exists; then
@@ -25,7 +31,6 @@ influxdb3 create trigger \
   --token "$INFLUXDB3_AUTH_TOKEN" \
   --database "$TRIGGER_DATABASE" \
   --trigger-spec "$TRIGGER_SPEC" \
-  --path "$PLUGIN_PATH" \
-  --upload \
+  --path "$PLUGIN_FILENAME" \
   "$TRIGGER_NAME"
 echo "Trigger '$TRIGGER_NAME' created"


### PR DESCRIPTION
Three real-cluster bugs the first sync surfaced:

- `influxdb3 update database` takes `--database <name>`, not a positional argument. The script was passing the name positionally, the CLI rejected it, and the whole DATABASES loop bailed before `homelab_1h` was created.
- `influxdb3 show` has no `triggers` subcommand. Triggers live in a per-db system table, so existence is checked via `SELECT trigger_name FROM system.processing_engine_triggers`.
- `create trigger --trigger-spec` requires 6-field cron (seconds first); `cron:5 * * * *` was rejected. Changed to `cron:0 5 * * * *`.
- `create trigger --path` rejects absolute paths as path-traversal. The plugin is already mounted at the server's `--plugin-dir` via values.yaml, so `--upload` is dropped and the relative filename `downsample_1h.py` is used. The plugins volume-mount on the Job is removed since the Job no longer ships the file.