### PR TITLE
fix(gatus): pin non-root UID/GID so runAsNonRoot is satisfied

### DIFF
--- a/kubernetes/applications/gatus/base/values.yaml
+++ b/kubernetes/applications/gatus/base/values.yaml
@@ -93,6 +93,17 @@ deployment:
       cpu: 200m
       memory: 256Mi
 
+  # Gatus image ships without a non-root USER — pin UID/GID explicitly so runAsNonRoot is satisfied
+  containerSecurityContext:
+    runAsUser: 65534
+    runAsGroup: 65534
+    runAsNonRoot: true
+    readOnlyRootFilesystem: true
+
+  # Pod-level fsGroup so mounted volumes (emptyDir + ConfigMap subPath) are group-readable by the non-root user
+  securityContext:
+    fsGroup: 65534
+
 # LoadBalancer with BGP advertisement via Cilium — static IP injected per environment via overlay
 service:
   enabled: true


### PR DESCRIPTION
The Gatus image ships without a non-root USER instruction, so the chart's containerSecurityContext.runAsNonRoot: true caused the pod to refuse startup:

  Error: container has runAsNonRoot and image will run as root

Set runAsUser/runAsGroup to 65534 (nobody) — matches the upstream TwiN Helm chart defaults — and add fsGroup: 65534 at pod level so the shared emptyDir + ConfigMap mounts are accessible.