### PR TITLE
refactor(influxdb): rightsize resources after 11h of monitoring

### DIFF
--- a/kubernetes/applications/influxdb/overlays/dev/kustomization.yaml
+++ b/kubernetes/applications/influxdb/overlays/dev/kustomization.yaml
@@ -28,7 +28,7 @@ patches:
         value:
           requests:
             cpu: 25m
-            memory: 64Mi
+            memory: 128Mi
           limits:
             cpu: 250m
-            memory: 256Mi
+            memory: 512Mi

--- a/kubernetes/applications/influxdb/overlays/prod/kustomization.yaml
+++ b/kubernetes/applications/influxdb/overlays/prod/kustomization.yaml
@@ -30,10 +30,10 @@ patches:
         value:
           requests:
             cpu: 50m
-            memory: 1Gi
+            memory: 512Mi
           limits:
             cpu: 500m
-            memory: 2Gi
+            memory: 1Gi
 
   # Extend startup grace so WAL replay can complete on first boot after
   # a backlog built up; extend liveness timeout to absorb persist/GC spikes.
@@ -43,7 +43,7 @@ patches:
     patch: |-
       - op: replace
         path: /spec/template/spec/containers/0/startupProbe/failureThreshold
-        value: 60
+        value: 30
       - op: replace
         path: /spec/template/spec/containers/0/livenessProbe/timeoutSeconds
         value: 10


### PR DESCRIPTION
Observed steady-state ~300 MiB and 6h peak ~513 MiB on the prod node, so 1Gi memory limit gives ~2× headroom over peak without wasting RAM. Drop startup failureThreshold from 60 to 30 (= 2.5 min) — still 2.5× the chart default, enough buffer for one-time WAL replay incidents.

Bump dev floor to 128Mi/512Mi: the previous 64Mi/256Mi was below InfluxDB's ~150 MiB startup footprint and would have hit the same crashloop trap as prod.