### PR TITLE
fix(influxdb): raise memory to 4Gi so WAL replay survives backfill bu…

### DIFF
--- a/kubernetes/applications/influxdb/overlays/prod/kustomization.yaml
+++ b/kubernetes/applications/influxdb/overlays/prod/kustomization.yaml
@@ -16,7 +16,8 @@ replacements:
 
 patches:
   # Combined node: handles ingest + query + compact in a single process.
-  # Memory sized so regular snapshots keep the WAL drained — too little memory
+  # Memory sized to cover bursty workloads (hourly downsample + one-off
+  # legacy-v2 backfills) on top of steady-state ingest — too little memory
   # caused WAL backlog and startup-probe-triggered crashloops.
   - target:
       kind: StatefulSet
@@ -30,10 +31,10 @@ patches:
         value:
           requests:
             cpu: 50m
-            memory: 512Mi
+            memory: 2Gi
           limits:
             cpu: 500m
-            memory: 1Gi
+            memory: 4Gi
 
   # Extend startup grace so WAL replay can complete on first boot after
   # a backlog built up; extend liveness timeout to absorb persist/GC spikes.


### PR DESCRIPTION
…rsts

The first backfill run from legacy InfluxDB 2 into homelab_1h (~108k points per month) produced enough WAL traffic that the combined node OOM-killed on the 1Gi limit during startup WAL replay, landing in a crashloop.

Bumping the overlay to 2Gi request / 4Gi limit gives room for the hourly downsample plugin + any remaining backfill months on top of steady-state ingest. Homelab cluster has the headroom.