### PR TITLE
fix(influxdb): raise memory to 4Gi request / 8Gi limit

### DIFF
--- a/kubernetes/applications/influxdb/overlays/prod/kustomization.yaml
+++ b/kubernetes/applications/influxdb/overlays/prod/kustomization.yaml
@@ -31,10 +31,10 @@ patches:
         value:
           requests:
             cpu: 50m
-            memory: 2Gi
+            memory: 4Gi
           limits:
             cpu: 500m
-            memory: 4Gi
+            memory: 8Gi
 
   # Extend startup grace so WAL replay can complete on first boot after
   # a backlog built up; extend liveness timeout to absorb persist/GC spikes.


### PR DESCRIPTION
4Gi limit still OOMed — hourly downsample plugin scanning 328 tables over the expanded (post-backfill) Parquet set pushes working set above 4Gi, pod crashed repeatedly in normal operation. Raising to 4Gi/8Gi both so the plugin has room and so the K8s scheduler moves the pod to a less-loaded data node (talos-dp-01 was sitting at 85% RAM).