### PR TITLE
refactor(backfill): chunk by days with inter-chunk sleep, not by month

### DIFF
--- a/scripts/backfill-influx2-to-influx3/README.md
+++ b/scripts/backfill-influx2-to-influx3/README.md
@@ -4,14 +4,20 @@ One-shot manual migration of the hourly-downsampled history.
 
 ## What it does
 
-For each calendar month in the requested range:
+For each N-day chunk (default 7d) in the requested month range:
 
 1. Runs the same Flux query the legacy `downsample_telegraf_1h` task used
    (filter numeric fields only, `aggregateWindow(every: 1h, fn: mean)`).
 2. Streams the annotated CSV response row-by-row (no big in-memory buffer).
 3. Writes line protocol to InfluxDB 3 in 5 000-line batches via `/api/v3/write_lp`.
+4. Sleeps `--sleep-between-chunks` seconds (default 30s) before the next chunk
+   so the pod's compactor can flush pending per-(table, hour) Parquet persists.
 
-Expected wall-clock: ~53 min for 2022-07 through 2026-04. Memory stays flat.
+Expected wall-clock for the full 2022-07 … 2026-04 range: ~2.5h (dominated by
+the inter-chunk sleeps, which keep the pod safe). Smaller `--chunk-days` →
+more, safer bursts; default of 7 is the tested safe setting against a 4Gi
+pod. A whole-month chunk tips the pod over because ~200 tables × 720 hours
+produces ~144k pending per-(table, hour) chunks that can't flush in time.
 
 Skips bool and string fields automatically — the `types.isType(float|int)` Flux
 filter is the whole reason the legacy task didn't crash on heterogeneous
@@ -39,6 +45,7 @@ instead of localhost.
 # 1. Sanity check — single month, no writes
 ./backfill.py \
   --from 2024-06 --to 2024-06 \
+  --chunk-days 7 --sleep-between-chunks 30 \
   --influx2-url http://localhost:8086 \
   --influx2-org zimmermann.eu.com \
   --influx2-bucket telegraf/autogen \
@@ -54,6 +61,10 @@ instead of localhost.
 # 3. Full history. Break into 1–2 year chunks if you want to resume safely.
 ./backfill.py --from 2022-07 --to 2026-04 [... same args]
 ```
+
+Monitor `kubectl top pod -n influxdb influxdb3-0` during the run. Values
+under ~3 GiB on a 4 GiB pod are fine. If memory climbs past ~3.5 GiB,
+drop `--chunk-days` to 3 and bump `--sleep-between-chunks` to 60.
 
 ## Tokens
 

--- a/scripts/backfill-influx2-to-influx3/backfill.py
+++ b/scripts/backfill-influx2-to-influx3/backfill.py
@@ -4,8 +4,11 @@ Backfill hourly downsampled data from the legacy InfluxDB 2 Docker instance
 into the in-cluster InfluxDB 3 database `homelab_1h`.
 
 Runs the same Flux aggregation that the legacy task used (mean over 1h,
-numeric-only filter via types.isType), chunked by calendar month to keep
-memory usage bounded. Writes results as line-protocol to InfluxDB 3.
+numeric-only filter via types.isType). Chunks by N days (default 7) so
+InfluxDB 3 doesn't end up with thousands of pending per-(table, hour)
+Parquet persists in memory at once — a full month in one go crashloops the
+pod. Writes results as line-protocol to InfluxDB 3 and sleeps between
+chunks so the compactor can flush.
 
 Meant to be run ONCE, manually, from the Linux host that owns the Docker
 InfluxDB 2 (so localhost:8086 works for the source) with a kubectl
@@ -15,6 +18,7 @@ Usage example:
 
   ./backfill.py \\
     --from 2022-07 --to 2026-04 \\
+    --chunk-days 7 --sleep-between-chunks 30 \\
     --influx2-url http://localhost:8086 \\
     --influx2-org zimmermann.eu.com \\
     --influx2-bucket telegraf/autogen \\
@@ -47,13 +51,17 @@ def parse_month(value: str) -> datetime.date:
     return datetime.datetime.strptime(value, "%Y-%m").date().replace(day=1)
 
 
-def month_chunks(start: datetime.date, end: datetime.date) -> Iterator[Tuple[datetime.date, datetime.date]]:
+def month_after(d: datetime.date) -> datetime.date:
+    return d.replace(year=d.year + 1, month=1) if d.month == 12 else d.replace(month=d.month + 1)
+
+
+def day_chunks(
+    start: datetime.date, end_exclusive: datetime.date, days: int
+) -> Iterator[Tuple[datetime.date, datetime.date]]:
     cur = start
-    while cur <= end:
-        if cur.month == 12:
-            nxt = cur.replace(year=cur.year + 1, month=1)
-        else:
-            nxt = cur.replace(month=cur.month + 1)
+    step = datetime.timedelta(days=days)
+    while cur < end_exclusive:
+        nxt = min(cur + step, end_exclusive)
         yield cur, nxt
         cur = nxt
 
@@ -175,11 +183,12 @@ def write_batch(url: str, db: str, token: str, lines: List[str]) -> None:
             raise RuntimeError(f"InfluxDB 3 write failed: HTTP {resp.status}")
 
 
-def backfill_month(args, start: datetime.date, stop: datetime.date) -> int:
+def backfill_chunk(args, start: datetime.date, stop: datetime.date) -> int:
+    label = f"{start} .. {stop}"
     flux = FLUX_QUERY_TEMPLATE.format(
         bucket=args.influx2_bucket, start=iso(start), stop=iso(stop)
     )
-    print(f"[{start:%Y-%m}] querying InfluxDB 2 ({iso(start)} .. {iso(stop)})", flush=True)
+    print(f"[{label}] querying InfluxDB 2", flush=True)
     t0 = time.monotonic()
     resp = query_influx2(args.influx2_url, args.influx2_org, args.influx2_token, flux)
 
@@ -202,7 +211,7 @@ def backfill_month(args, start: datetime.date, stop: datetime.date) -> int:
 
     dt = time.monotonic() - t0
     tag = " (dry-run)" if args.dry_run else ""
-    print(f"[{start:%Y-%m}] wrote {total} points in {dt:.1f}s{tag}", flush=True)
+    print(f"[{label}] wrote {total} points in {dt:.1f}s{tag}", flush=True)
     return total
 
 
@@ -218,18 +227,37 @@ def main() -> int:
     p.add_argument("--influx3-db", required=True)
     p.add_argument("--influx3-token", required=True)
     p.add_argument("--batch-size", type=int, default=5000)
+    p.add_argument(
+        "--chunk-days",
+        type=int,
+        default=7,
+        help="Days per backfill chunk (default: 7). Smaller = more pending persists bounded, safer for the pod.",
+    )
+    p.add_argument(
+        "--sleep-between-chunks",
+        type=int,
+        default=30,
+        help="Seconds to pause between chunks so InfluxDB 3 can snapshot/compact (default: 30).",
+    )
     p.add_argument("--dry-run", action="store_true", help="Query source but skip writes")
     args = p.parse_args()
 
     start = parse_month(args.from_month)
-    end = parse_month(args.to_month)
-    if start > end:
+    end_month_first = parse_month(args.to_month)
+    end_exclusive = month_after(end_month_first)
+    if start >= end_exclusive:
         print("error: --from must be <= --to", file=sys.stderr)
         return 2
 
+    chunks = list(day_chunks(start, end_exclusive, args.chunk_days))
+    print(f"backfilling {len(chunks)} chunks of ~{args.chunk_days}d from {start} to {end_exclusive}", flush=True)
+
     grand_total = 0
-    for mstart, mstop in month_chunks(start, end):
-        grand_total += backfill_month(args, mstart, mstop)
+    for idx, (cstart, cstop) in enumerate(chunks):
+        grand_total += backfill_chunk(args, cstart, cstop)
+        if args.sleep_between_chunks > 0 and idx < len(chunks) - 1:
+            print(f"--- sleeping {args.sleep_between_chunks}s ({idx + 1}/{len(chunks)} done) ---", flush=True)
+            time.sleep(args.sleep_between_chunks)
     print(f"done. total points: {grand_total}", flush=True)
     return 0
 


### PR DESCRIPTION
One month in a single go (~144k pending per-(table, hour) Parquet persists) tipped the 4Gi pod into OOM/crashloop during WAL replay. Split into N-day chunks (default 7) with a 30s sleep between chunks so the compactor can flush before the next burst. The chunks are smaller bursts (~34k pending each) that Influx can absorb comfortably; full backfill runs ~2.5h instead of the unsafe 53min of month-blasts.

Replaces --sleep-between-months with --chunk-days + --sleep-between-chunks. README documents the memory-watch guidance (drop --chunk-days if RSS exceeds ~3.5Gi on a 4Gi pod).