### PR TITLE
chore(influxdb): revert backfill tuning + memory back to 1Gi

### DIFF
--- a/kubernetes/applications/influxdb/base/values.yaml
+++ b/kubernetes/applications/influxdb/base/values.yaml
@@ -42,24 +42,6 @@ ingester:
   persistence:
     storageClass: longhorn
     size: PLACEHOLDER
-  # Backfill tuning — sized for the one-off 2022..2026 history import into
-  # `homelab_1h`. Default (70% snapshot threshold, 600 WAL files/snapshot) let
-  # the snapshot sort/dedupe step OOM the pod under bulk-write load. Revert to
-  # chart defaults once the backfill is complete; steady-state ingest should
-  # not run with 30% threshold.
-  memory:
-    forceSnapshotMemThreshold: "30%"
-    execMemPoolBytes: "40%"
-  wal:
-    snapshotSize: 100
-    replayFailOnError: false
-
-# Gen1 compactor only looks 24h into the past by default — historical backfill
-# falls outside that window, leaving thousands of tiny Parquet files
-# uncompacted and blowing up memory. Cover the full 4-year range so backfilled
-# partitions compact normally.
-dataLifecycle:
-  gen1LookbackDuration: "1460d"
 
 # Disable separate querier/compactor — the single combined node handles all roles.
 querier:

--- a/kubernetes/applications/influxdb/overlays/prod/kustomization.yaml
+++ b/kubernetes/applications/influxdb/overlays/prod/kustomization.yaml
@@ -15,10 +15,11 @@ replacements:
           - spec.volumeClaimTemplates.0.spec.resources.requests.storage
 
 patches:
-  # Combined node: handles ingest + query + compact in a single process.
-  # Memory sized to cover bursty workloads (hourly downsample + one-off
-  # legacy-v2 backfills) on top of steady-state ingest — too little memory
-  # caused WAL backlog and startup-probe-triggered crashloops.
+  # Combined node: ingest + query + compact in one process. Sized from 11h
+  # of steady-state observation (~300 MiB idle, ~513 MiB peak), so 1 GiB
+  # limit gives ~2× headroom. Do NOT bulk-backfill into this pod — the
+  # Influx 3 partitioning (per table, per hour) OOMs on large historical
+  # writes regardless of memory.
   - target:
       kind: StatefulSet
       name: influxdb3
@@ -31,10 +32,10 @@ patches:
         value:
           requests:
             cpu: 50m
-            memory: 4Gi
+            memory: 512Mi
           limits:
             cpu: 500m
-            memory: 8Gi
+            memory: 1Gi
 
   # Extend startup grace so WAL replay can complete on first boot after
   # a backlog built up; extend liveness timeout to absorb persist/GC spikes.


### PR DESCRIPTION
The in-cluster bulk backfill into `homelab_1h` was abandoned — the per-(table, hour) partitioning combined with ~300 measurements would produce ~10M Parquet files for the full 4-year history, which no amount of tuning fits into an At-Home-sized ingester.

Drop the aggressive Helm values (`forceSnapshotMemThreshold: 30%`, `wal.snapshotSize: 100`, `gen1LookbackDuration: 1460d`, etc.) — they hurt steady-state ingest without solving the root schema issue.

Roll the prod memory limits all the way back to 512Mi request / 1Gi limit (the state settled in 4a4e152 after 11h of steady-state observation). The 4Gi/8Gi bump only made sense for the failed backfill.

Follow-up migration will happen out-of-cluster on a Docker Influx 3 with a redesigned schema (consolidate the KNX input's 388 measurements into a single `knx` table with the original name as a tag), then swap the data in. Tracked in TODO.md.