### PR TITLE
fix(rustfs): skip fsGroup walk and only create missing buckets

### DIFF
--- a/kubernetes/applications/rustfs/base/scripts/initialize-rustfs-buckets.sh
+++ b/kubernetes/applications/rustfs/base/scripts/initialize-rustfs-buckets.sh
@@ -11,8 +11,9 @@ export MC_CONFIG_DIR=$(mktemp -d)
 mc alias set rustfs "$RUSTFS_URL" "$ACCESS_KEY" "$SECRET_KEY"
 
 for BUCKET in $BUCKETS; do
-  echo "Creating bucket: $BUCKET"
-  mc mb --ignore-existing "rustfs/$BUCKET"
+  if ! mc ls "rustfs/$BUCKET" >/dev/null 2>&1; then
+    mc mb "rustfs/$BUCKET"
+  fi
 done
 
 echo "Done"

--- a/kubernetes/applications/rustfs/base/values.yaml
+++ b/kubernetes/applications/rustfs/base/values.yaml
@@ -18,6 +18,11 @@ config:
     # Set log level to error to suppress verbose tracing warnings
     log_level: "error"
 
+# Skip recursive chown on PVC when root perms already match (avoids ~3 min
+# fsGroup walk over 100k+ files on NFS-backed PVC at every pod start)
+podSecurityContext:
+  fsGroupChangePolicy: OnRootMismatch
+
 # Ingress is managed outside of the chart (Traefik IngressRoute manifests)
 ingress:
   enabled: false


### PR DESCRIPTION
- Set fsGroupChangePolicy: OnRootMismatch to avoid ~3 min recursive chown over 100k+ files on the NFS-backed PVC at every pod restart.
- Check bucket existence before mc mb so RustFS no longer logs VolumeExists errors on every PostSync run.