### PR TITLE
revert(rustfs): chart 0.0.95 → 0.0.94 due to FaultyDisk regression

### DIFF
--- a/kubernetes/applications/rustfs/base/kustomization.yaml
+++ b/kubernetes/applications/rustfs/base/kustomization.yaml
@@ -13,7 +13,7 @@ helmCharts:
   - name: rustfs
     repo: https://rustfs.github.io/helm
     releaseName: rustfs
-    version: 0.0.95
+    version: 0.0.94
     valuesFile: values.yaml
     namespace: rustfs
 


### PR DESCRIPTION
After the 0.0.94 → 0.0.95 bump (PR #579, deployed 2026-04-19 13:20) rustfs throws persistent `FaultyDisk` / `erasure write quorum` errors on a single-volume (RUSTFS_VOLUMES=/data) setup immediately after pod start, returning HTTP 500 for every S3 op. InfluxDB fails to init its catalog and crash-loops.

The fsGroup fix (PR #584) was unrelated — the same errors appear on a fresh pod before any chown. Rolling back to 0.0.94 / alpha.94 until the regression is understood.