### PR TITLE
debug(telegraf): enable agent debug to surface InfluxDB 400 response …

### DIFF
--- a/kubernetes/applications/telegraf/base/values.yaml
+++ b/kubernetes/applications/telegraf/base/values.yaml
@@ -19,6 +19,9 @@ args:
 
 # Main telegraf.conf (chart converts YAML -> TOML)
 config:
+  # Temporarily enabled to capture InfluxDB 400 partial-write response body
+  agent:
+    debug: true
   processors: []
   outputs:
     - influxdb_v3:


### PR DESCRIPTION
…body

Telegraf is dropping every write batch with
`failed to write metric to homelab (will be dropped: 400 Bad Request): partial write of line protocol occurred`
but the response body is not logged at info level, making it impossible to tell which field/type is rejected by InfluxDB 3.

Flipping agent.debug to true temporarily — to be reverted once the offending input/measurement is identified.