### PR TITLE
debug(influxdb+telegraf): raise log verbosity + mirror telegraf batch…

### DIFF
--- a/kubernetes/applications/influxdb/base/values.yaml
+++ b/kubernetes/applications/influxdb/base/values.yaml
@@ -33,6 +33,10 @@ security:
 extraEnv:
   - name: INFLUXDB3_ADMIN_TOKEN_FILE
     value: /etc/influxdb3/tokens/admin-token.json
+  # Temporarily raised to surface details about HTTP 400 partial-write
+  # responses to Telegraf — remove once schema conflict is identified.
+  - name: INFLUXDB3_LOG_FILTER
+    value: "influxdb3=debug,influxdb3_write=debug,influxdb3_server=debug,info"
 
 # At-Home license allows only ONE node. Run the ingester as the sole component —
 # Kustomize patches strip --mode=ingest so it starts in combined mode

--- a/kubernetes/applications/telegraf/base/values.yaml
+++ b/kubernetes/applications/telegraf/base/values.yaml
@@ -30,6 +30,14 @@ config:
         database: "homelab"
     - prometheus_client:
         listen: ":9273"
+    # Temporary mirror of every outgoing batch to disk so we can inspect
+    # the exact line protocol that InfluxDB 3 rejects with HTTP 400.
+    # Path is inside the pod; rotation keeps disk use bounded.
+    - file:
+        files: ["/tmp/telegraf-batch.lp"]
+        data_format: "influx"
+        rotation_max_size: "10MB"
+        rotation_max_archives: 2
   inputs: []
 
 # Health endpoint for probes (port 8888)


### PR DESCRIPTION
…es to disk

To diagnose the ongoing `400 Bad Request: partial write of line protocol occurred` that Telegraf hits on every flush:

- influxdb: set INFLUXDB3_LOG_FILTER to debug for the HTTP/write paths so the server logs *why* a line is rejected (type mismatch, parse error, etc.), not just that the batch was partially rejected.
- telegraf: add outputs.file mirror of every batch to /tmp/telegraf-batch.lp (10 MB rotation, 2 archives) so we can grab the exact rejected line and replay it via curl if the Influx log still isn't specific enough.

Both intended to be reverted once the schema conflict is identified.