### PR TITLE
fix(telegraf): cast KNX bool alarms to 0.0/1.0 so writes don't 400

### DIFF
--- a/kubernetes/applications/telegraf/base/processors/processor.knx.conf
+++ b/kubernetes/applications/telegraf/base/processors/processor.knx.conf
@@ -25,6 +25,14 @@ def apply(metric):
         metric.tags["knx_middle"] = parts[1]
         metric.tags["knx_sub"] = parts[2]
 
+    # The `value` field arrives as a float for DPT 9.*/13.*/14.* sensors and
+    # as a bool for DPT 1.001 alarms. Since all group addresses now share a
+    # single `knx` measurement, the `value` column has to be one concrete
+    # type — cast the bools to 0.0/1.0 so InfluxDB 3 accepts the writes.
+    v = metric.fields.get("value")
+    if type(v) == "bool":
+        metric.fields["value"] = 1.0 if v else 0.0
+
     # Collapse into one measurement.
     metric.name = "knx"
     return metric


### PR DESCRIPTION
After the KNX consolidation (PR #…), all group addresses share a single `knx` measurement. DPT 9.*/13.*/14.* sensors emit a float `value`, so the `value` column was created as Float64. DPT 1.001 alarms emit a bool, which InfluxDB 3 then rejects with `partial write of line protocol` — the column type is fixed on first-write.

Cast bools to 0.0/1.0 in the starlark processor. Grafana interprets both forms identically (0 = inactive, 1 = active), and a single numeric column keeps the measurement schema clean.