### PR TITLE
fix(telegraf): cast KNX int-typed values (DPT 5/6/7/8/12/13) to float

### DIFF
--- a/kubernetes/applications/telegraf/base/processors/processor.knx.conf
+++ b/kubernetes/applications/telegraf/base/processors/processor.knx.conf
@@ -25,13 +25,18 @@ def apply(metric):
         metric.tags["knx_middle"] = parts[1]
         metric.tags["knx_sub"] = parts[2]
 
-    # The `value` field arrives as a float for DPT 9.*/13.*/14.* sensors and
-    # as a bool for DPT 1.001 alarms. Since all group addresses now share a
-    # single `knx` measurement, the `value` column has to be one concrete
-    # type — cast the bools to 0.0/1.0 so InfluxDB 3 accepts the writes.
+    # `value` arrives in three different Python types depending on the DPT:
+    # DPT 9.*/14.* emit float, DPT 5.*/6.*/7.*/8.*/12.*/13.* emit int (e.g.
+    # energy-meter readings), DPT 1.001 emit bool. Since all group addresses
+    # now share a single `knx` measurement, the column has to be one concrete
+    # type — cast bool and int to float so InfluxDB 3's Float64 column accepts
+    # every telegram.
     v = metric.fields.get("value")
-    if type(v) == "bool":
+    t = type(v)
+    if t == "bool":
         metric.fields["value"] = 1.0 if v else 0.0
+    elif t == "int":
+        metric.fields["value"] = float(v)
 
     # Collapse into one measurement.
     metric.name = "knx"


### PR DESCRIPTION
The starlark processor only cast bools to float. DPT 13.013 energy-meter readings (and other int-typed DPTs) slipped through as Int, which the consolidated `knx` Float64 column rejects. Extend the cast to cover int values as well.