### PR TITLE
docs(telegraf): cite the knx-go DPT package in the starlark comment

### DIFF
--- a/kubernetes/applications/telegraf/base/processors/processor.knx.conf
+++ b/kubernetes/applications/telegraf/base/processors/processor.knx.conf
@@ -25,12 +25,10 @@ def apply(metric):
         metric.tags["knx_middle"] = parts[1]
         metric.tags["knx_sub"] = parts[2]
 
-    # `value` arrives in three different Python types depending on the DPT:
-    # DPT 9.*/14.* emit float, DPT 5.*/6.*/7.*/8.*/12.*/13.* emit int (e.g.
-    # energy-meter readings), DPT 1.001 emit bool. Since all group addresses
-    # now share a single `knx` measurement, the column has to be one concrete
-    # type — cast bool and int to float so InfluxDB 3's Float64 column accepts
-    # every telegram.
+    # Telegraf's knx-go decoder emits bool, int or float depending on the
+    # DPT (see pkg.go.dev/github.com/vapourismo/knx-go/knx/dpt). All group
+    # addresses share the `knx` measurement — cast to float so the Float64
+    # column accepts every telegram.
     v = metric.fields.get("value")
     t = type(v)
     if t == "bool":


### PR DESCRIPTION
The telegraf knx_listener plugin decodes datapoints via the `github.com/vapourismo/knx-go/knx/dpt` package, so that's the canonical reference for which DPTs yield which Python type.