### PR TITLE
chore(gatus): group endpoints by section in the UI

### DIFF
--- a/kubernetes/applications/gatus/base/config/endpoints.yaml
+++ b/kubernetes/applications/gatus/base/config/endpoints.yaml
@@ -9,6 +9,8 @@ metrics: true
 ui:
   title: "Home Lab Status"
   header: "Home Lab Status"
+  # Group endpoints into collapsible sections (Observability, Infrastructure, etc.) instead of a flat list
+  default-sort-by: group
 
 alerting:
   pushover:


### PR DESCRIPTION
Sets ui.default-sort-by: group so the dashboard renders endpoints as collapsible sections (Observability, Infrastructure, Productivity, …) instead of a flat grid — matches the buroa/k8s-gitops pattern.