### PR TITLE
fix(smtprelay): align pod labels with service selector

### DIFF
--- a/kubernetes/applications/smtprelay/base/deployment.yaml
+++ b/kubernetes/applications/smtprelay/base/deployment.yaml
@@ -12,11 +12,11 @@ spec:
   selector:
     # Must match `.spec.template.metadata.labels`.
     matchLabels:
-      app: smtprelay
+      app.kubernetes.io/name: smtprelay
   template:
     metadata:
       labels:
-        app: smtprelay
+        app.kubernetes.io/name: smtprelay
     spec:
       containers:
         - name: smtprelay


### PR DESCRIPTION
The Deployment used `app: smtprelay` while the Service selects on `app.kubernetes.io/name: smtprelay`, leaving the EndpointSlice empty and causing the LoadBalancer (192.168.10.25:25) to reset connections. Switch the Deployment selector/template labels to the repo-wide `app.kubernetes.io/name` convention used by node-red, homepage, fritz-exporter and solaredge2mqtt.

Note: `.spec.selector.matchLabels` is immutable — the Deployment must be recreated on sync (e.g. ArgoCD Replace=true or manual delete).