### PR TITLE
feat(kromgo): add Prometheus-backed public metrics proxy

### DIFF
--- a/kubernetes/applications/kromgo/base/certificate.yaml
+++ b/kubernetes/applications/kromgo/base/certificate.yaml
@@ -1,0 +1,14 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+
+metadata:
+  name: kromgo-tls
+  namespace: kromgo
+
+spec:
+  secretName: kromgo-tls
+  issuerRef:
+    name: letsencrypt-dns01-issuer
+    kind: ClusterIssuer
+  dnsNames:
+    - PLACEHOLDER

--- a/kubernetes/applications/kromgo/base/config/kromgo.yaml
+++ b/kubernetes/applications/kromgo/base/config/kromgo.yaml
@@ -1,0 +1,73 @@
+# kromgo metric catalog — each entry becomes a `GET /<name>` endpoint.
+# Queries are executed read-only against PROMETHEUS_URL; colors map the scalar result to a badge color.
+metrics:
+  # Versions
+  - name: talos_version
+    query: label_replace(node_os_info{name="Talos"}, "version_id", "$1", "version_id", "v(.+)")
+    label: version_id
+    title: Talos
+
+  - name: kubernetes_version
+    query: label_replace(kubernetes_build_info{service="kubernetes"}, "git_version", "$1", "git_version", "v(.+)")
+    label: git_version
+    title: Kubernetes
+
+  # Cluster size
+  - name: cluster_node_count
+    query: count(count by (node) (kube_node_status_condition{condition="Ready"}))
+    colors:
+      - { color: green, min: 0, max: 9999 }
+    title: Nodes
+
+  - name: cluster_pod_count
+    query: sum(kube_pod_status_phase{phase="Running"})
+    colors:
+      - { color: green, min: 0, max: 9999 }
+    title: Pods
+
+  # Resource usage
+  - name: cluster_cpu_usage
+    query: round(avg(instance:node_cpu_utilisation:rate5m{pod!=""}) * 100, 0.1)
+    suffix: "%"
+    colors:
+      - { color: green, min: 0, max: 35 }
+      - { color: orange, min: 36, max: 75 }
+      - { color: red, min: 76, max: 9999 }
+    title: CPU
+
+  - name: cluster_memory_usage
+    query: round(sum(node_memory_MemTotal_bytes{pod!=""} - node_memory_MemAvailable_bytes{pod!=""}) / sum(node_memory_MemTotal_bytes{pod!=""}) * 100, 0.1)
+    suffix: "%"
+    colors:
+      - { color: green, min: 0, max: 35 }
+      - { color: orange, min: 36, max: 75 }
+      - { color: red, min: 76, max: 9999 }
+    title: Memory
+
+  # Lifetime
+  - name: cluster_age_days
+    query: round((time() - min(kube_node_created)) / 86400)
+    suffix: d
+    colors:
+      - { color: green, min: 0, max: 180 }
+      - { color: orange, min: 181, max: 360 }
+      - { color: red, min: 361, max: 9999 }
+    title: Age
+
+  - name: cluster_uptime_days
+    query: round(avg(node_time_seconds{pod!=""} - node_boot_time_seconds{pod!=""}) / 86400)
+    suffix: d
+    colors:
+      - { color: green, min: 0, max: 180 }
+      - { color: orange, min: 181, max: 360 }
+      - { color: red, min: 361, max: 9999 }
+    title: Uptime
+
+  # Health
+  - name: cluster_alert_count
+    # Subtract 1 to ignore the always-firing Watchdog alert
+    query: alertmanager_alerts{state="active"} - 1
+    colors:
+      - { color: green, min: 0, max: 0 }
+      - { color: red, min: 1, max: 9999 }
+    title: Alerts

--- a/kubernetes/applications/kromgo/base/ingress-route.yaml
+++ b/kubernetes/applications/kromgo/base/ingress-route.yaml
@@ -1,0 +1,27 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+
+metadata:
+  name: kromgo
+  namespace: kromgo
+  annotations:
+    # ExternalDNS configuration for Cloudflare
+    external-dns.alpha.kubernetes.io/target: udm-pro.zimmermann.sh
+    external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
+    kubernetes.io/ingress.class: traefik
+
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - kind: Rule
+      match: Host(`PLACEHOLDER`)
+      middlewares:
+        - name: chain-standard
+          namespace: ingress-controller
+      services:
+        - kind: Service
+          name: kromgo
+          port: 80
+  tls:
+    secretName: kromgo-tls

--- a/kubernetes/applications/kromgo/base/kustomization.yaml
+++ b/kubernetes/applications/kromgo/base/kustomization.yaml
@@ -1,0 +1,31 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: kromgo
+resources:
+  - ./namespace.yaml
+  - ./certificate.yaml
+  - ./ingress-route.yaml
+
+helmCharts:
+  - name: application
+    repo: https://stakater.github.io/stakater-charts
+    releaseName: kromgo
+    version: 6.16.1
+    valuesFile: values.yaml
+    namespace: kromgo
+    apiVersions:
+      - monitoring.coreos.com/v1
+
+configMapGenerator:
+  - name: kromgo-config
+    files:
+      - config.yaml=config/kromgo.yaml
+
+labels:
+  - includeSelectors: false
+    pairs:
+      homelab.app: kromgo
+
+commonAnnotations:
+  argocd.argoproj.io/sync-wave: "10"

--- a/kubernetes/applications/kromgo/base/namespace.yaml
+++ b/kubernetes/applications/kromgo/base/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+
+metadata:
+  name: kromgo

--- a/kubernetes/applications/kromgo/base/values.yaml
+++ b/kubernetes/applications/kromgo/base/values.yaml
@@ -1,0 +1,102 @@
+# Override chart's default resource naming (`application`) — everything gets prefixed `kromgo`
+applicationName: kromgo
+
+deployment:
+  enabled: true
+  # Single instance is sufficient; kromgo is stateless and only proxies read-only Prometheus queries
+  replicas: 1
+  image:
+    repository: ghcr.io/kashalls/kromgo
+    tag: v0.9.1
+    pullPolicy: IfNotPresent
+
+  env:
+    # Health/metrics probe endpoint — separate port keeps /metrics off the public listener
+    HEALTH_PORT:
+      value: "8080"
+    # Public listener port (matches Service and IngressRoute target)
+    SERVER_PORT:
+      value: "80"
+    # In-cluster Prometheus Operator headless service — resolved from the `prometheus` namespace
+    PROMETHEUS_URL:
+      value: http://prometheus-operated.prometheus.svc.cluster.local:9090
+
+  # Single ConfigMap holds all metric definitions; generated via kustomize configMapGenerator
+  volumes:
+    kromgo-config:
+      configMap:
+        name: kromgo-config
+
+  volumeMounts:
+    # Mount the exporter config at the expected path
+    kromgo-config:
+      mountPath: /kromgo/config.yaml
+      subPath: config.yaml
+
+  ports:
+    - containerPort: 80
+      name: http
+      protocol: TCP
+    - containerPort: 8080
+      name: health
+      protocol: TCP
+
+  # kromgo exposes /-/ready on HEALTH_PORT (8080) — used for both liveness and readiness
+  livenessProbe:
+    enabled: true
+    httpGet:
+      path: /-/ready
+      port: health
+  readinessProbe:
+    enabled: true
+    httpGet:
+      path: /-/ready
+      port: health
+
+  resources:
+    # Ensure Burstable QoS (no BestEffort) and prevent runaway usage
+    requests:
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      cpu: 100m
+      memory: 64Mi
+
+  # Upstream image ships without a non-root USER — pin UID/GID explicitly so runAsNonRoot is satisfied
+  containerSecurityContext:
+    runAsUser: 1000
+    runAsGroup: 1000
+    runAsNonRoot: true
+    readOnlyRootFilesystem: true
+
+  # Pod-level fsGroup so the mounted ConfigMap subPath is group-readable by the non-root user
+  securityContext:
+    fsGroup: 1000
+
+# LoadBalancer with BGP advertisement via Cilium — static IP injected per environment via overlay
+service:
+  enabled: true
+  type: LoadBalancer
+  additionalLabels:
+    bgp.cilium.io/ip-pool: default
+    bgp.cilium.io/advertise-service: default
+  ports:
+    - port: 80
+      name: http
+      protocol: TCP
+      targetPort: http
+    - port: 8080
+      name: health
+      protocol: TCP
+      targetPort: health
+
+# Prometheus scrapes kromgo's own /metrics for operational visibility (request counts, latency)
+serviceMonitor:
+  enabled: true
+  additionalLabels:
+    # Prometheus Operator label (Opt-In)
+    release: prometheus
+  endpoints:
+    - port: health
+      interval: 60s
+      path: /metrics

--- a/kubernetes/applications/kromgo/overlays/dev/kustomization.yaml
+++ b/kubernetes/applications/kromgo/overlays/dev/kustomization.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+replacements:
+  # Inject domain name into Certificate and IngressRoute
+  - sourceValue: kromgo.zimmermann.phd
+    targets:
+      - select:
+          kind: Certificate
+          name: kromgo-tls
+        fieldPaths:
+          - spec.dnsNames.0
+      - select:
+          kind: IngressRoute
+          name: kromgo
+        fieldPaths:
+          - spec.routes.0.match
+        options:
+          delimiter: "`"
+          index: 1

--- a/kubernetes/applications/kromgo/overlays/prod/kustomization.yaml
+++ b/kubernetes/applications/kromgo/overlays/prod/kustomization.yaml
@@ -1,0 +1,36 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+replacements:
+  # Inject domain name into Certificate and IngressRoute
+  - sourceValue: kromgo.zimmermann.sh
+    targets:
+      - select:
+          kind: Certificate
+          name: kromgo-tls
+        fieldPaths:
+          - spec.dnsNames.0
+      - select:
+          kind: IngressRoute
+          name: kromgo
+        fieldPaths:
+          - spec.routes.0.match
+        options:
+          delimiter: "`"
+          index: 1
+
+patches:
+  # kromgo service with static IP and BGP advertisement
+  - target:
+      kind: Service
+      name: kromgo
+    patch: |-
+      - op: test
+        path: /spec/type
+        value: LoadBalancer
+      - op: add
+        path: /metadata/annotations/io.cilium~1lb-ipam-ips
+        value: "192.168.10.36"


### PR DESCRIPTION
Exposes a small, explicitly-configured set of Prometheus queries as HTTP endpoints at kromgo.zimmermann.sh so values (K8s/Talos version, node and pod counts, CPU/memory usage, cluster age/uptime, active alerts) can be consumed from outside the cluster by Discord bots, Home Assistant, or README badges.

- Deploys via the stakater/application chart (v6.16.1), matching the gatus/homepage pattern.
- Service is LoadBalancer with BGP advertisement; static IP 192.168.10.36 in prod, continuing the IP sequence after gatus (.35).
- IngressRoute uses chain-standard (CrowdSec, rate-limit, CF IP check, security headers) without Authentik — external auth is handled at the Cloudflare edge via Authenticated Origin Pulls plus a CF Access Service Token on the hostname.
- ServiceMonitor scrapes kromgo's own /metrics on the separate health port (8080) so the public listener (80) only serves configured metrics.
- Metric catalog is a ConfigMap (configMapGenerator, hash-suffixed); Stakater Reloader auto-rolls the pod on config changes.