### PR TITLE
refactor(helm): drop includeCRDs flag where the chart ships no CRDs

### DIFF
--- a/kubernetes/applications/authentik/base/kustomization.yaml
+++ b/kubernetes/applications/authentik/base/kustomization.yaml
@@ -16,7 +16,6 @@ helmCharts:
     version: 2026.2.2
     valuesFile: values.yaml
     namespace: authentik
-    includeCRDs: true
     apiVersions:
       - monitoring.coreos.com/v1
 

--- a/kubernetes/applications/crowdsec/base/kustomization.yaml
+++ b/kubernetes/applications/crowdsec/base/kustomization.yaml
@@ -14,7 +14,6 @@ helmCharts:
     version: 0.23.0
     valuesFile: values.yaml
     namespace: crowdsec
-    includeCRDs: true
     apiVersions:
       - monitoring.coreos.com/v1
 

--- a/kubernetes/applications/gatus/base/kustomization.yaml
+++ b/kubernetes/applications/gatus/base/kustomization.yaml
@@ -17,7 +17,6 @@ helmCharts:
     version: 6.16.1
     valuesFile: values.yaml
     namespace: gatus
-    includeCRDs: true
     apiVersions:
       - monitoring.coreos.com/v1
 

--- a/kubernetes/applications/grafana/base/kustomization.yaml
+++ b/kubernetes/applications/grafana/base/kustomization.yaml
@@ -19,7 +19,6 @@ helmCharts:
     version: 10.5.15
     valuesFile: values.yaml
     namespace: grafana
-    includeCRDs: true
 
 patches:
   # Service Patch - Fix Selector Collision

--- a/kubernetes/applications/redis/base/kustomization.yaml
+++ b/kubernetes/applications/redis/base/kustomization.yaml
@@ -13,7 +13,6 @@ helmCharts:
     version: 23.0.5
     valuesFile: values.yaml
     namespace: redis
-    includeCRDs: true
 
 labels:
   - includeSelectors: true


### PR DESCRIPTION
Verified via `kustomize build --enable-helm` that removing the flag leaves the rendered output identical for authentik, crowdsec, gatus, grafana, and redis — none of those charts ship their own CRDs, so the flag was a no-op copied across new apps. Kept on alloy, grafana-operator and nats-operator which do ship CRDs (1, 13 and 6 respectively).