### PR TITLE
config(influxdb): extend gen1 lookback to 2000d so historical writes are compacted

### DIFF
--- a/kubernetes/applications/influxdb/base/values.yaml
+++ b/kubernetes/applications/influxdb/base/values.yaml
@@ -33,6 +33,12 @@ security:
 extraEnv:
   - name: INFLUXDB3_ADMIN_TOKEN_FILE
     value: /etc/influxdb3/tokens/admin-token.json
+  # Extend the gen1 index lookback window (default 24h) so historical
+  # writes (backfills, imports of pre-24h data) get indexed at startup
+  # and become visible to the Gen1 compactor. Without this the compactor
+  # ignores older-than-24h files and they pile up as tiny parquets forever.
+  - name: INFLUXDB3_GEN1_LOOKBACK_DURATION
+    value: 2000d
 
 # At-Home license allows only ONE node. Run the ingester as the sole component —
 # Kustomize patches strip --mode=ingest so it starts in combined mode


### PR DESCRIPTION
## Summary

- Default \`--gen1-lookback-duration\` is **24h** → compactor ignores any parquet file older than 24h at startup (invisible to the Gen1 compactor's index)
- Our historical backfill produced thousands of tiny 10-minute-bucket parquets; they never got merged, driving up metadata-cache RAM and file count
- Setting lookback to **2000d** covers the full Influx 2 → 3 migration range + any future multi-year backfill; no downside for live data

## Context

Finding from today: \`homelab\` + \`homelab_1h\` held ~39k parquet files across ~40 tables, avg file size 8–16 KB. Primary cause is missing compaction on historical files. This PR is the pre-flight config before the backfill retry.

Do NOT merge yet — the backfill Phase A (export existing live data) runs first, otherwise ~4 days of unique live data is lost on the pod restart that ArgoCD triggers.

## Test plan

- [ ] Phase A export done (data safely dumped)
- [ ] Merge → ArgoCD syncs → pod rolls with new env var
- [ ] Pod reaches Ready
- [ ] \`kubectl exec influxdb3-0 -- env | grep GEN1_LOOKBACK\` shows \`2000d\`
- [ ] After backfill runs: parquet file count per table stays bounded (hundreds, not thousands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)