### PR TITLE
docs(readme): restructure into three-layer narrative with sub-READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,207 @@
+<div align="center">
+
+<img src="https://cdn.simpleicons.org/kubernetes/326CE5" height="32" alt="Kubernetes" />
+&nbsp;
+<img src="https://cdn.simpleicons.org/talos/FF7300" height="32" alt="Talos" />
+&nbsp;
+<img src="https://cdn.simpleicons.org/argo/EF7B4D" height="32" alt="Argo CD" />
+&nbsp;
+<img src="https://cdn.simpleicons.org/sidero/FF7300" height="32" alt="Omni" />
+&nbsp;
+<img src="https://cdn.simpleicons.org/proxmox/E57000" height="32" alt="Proxmox" />
+&nbsp;
+<img src="https://cdn.simpleicons.org/opentofu/844FBA" height="32" alt="OpenTofu" />
+
 # homelab
 
-## Bootstrap Proxmox
+_Three independent layers — infrastructure, cluster, apps — that compose into a full stack._
 
-1. Install Proxmox 9.0
-2. Configure API Key for root
+</div>
+
+**Cluster**
+&nbsp;
+[![Talos](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.zimmermann.sh%2Ftalos_version&style=flat-square&logo=talos&logoColor=white&color=blue&label=Talos)](https://talos.dev)
+[![Kubernetes](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.zimmermann.sh%2Fkubernetes_version&style=flat-square&logo=kubernetes&logoColor=white&color=blue&label=Kubernetes)](https://kubernetes.io)
+[![Nodes](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.zimmermann.sh%2Fcluster_node_count&style=flat-square&logo=kubernetes&logoColor=white&label=Nodes)](https://github.com/kashalls/kromgo)
+[![Pods](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.zimmermann.sh%2Fcluster_pod_count&style=flat-square&logo=kubernetes&logoColor=white&label=Pods)](https://github.com/kashalls/kromgo)
+[![Alerts](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.zimmermann.sh%2Fcluster_alert_count&style=flat-square&logo=prometheus&logoColor=white&label=Alerts)](https://github.com/kashalls/kromgo)
+
+**Repo**
+&nbsp;
+[![License](https://img.shields.io/github/license/alexander-zimmermann/homelab?style=flat-square&color=blue)](./LICENSE)
+[![Last Commit](https://img.shields.io/github/last-commit/alexander-zimmermann/homelab?style=flat-square&logo=github&logoColor=white)](https://github.com/alexander-zimmermann/homelab/commits/main)
+[![Renovate](https://img.shields.io/badge/Renovate-enabled-brightgreen?style=flat-square&logo=renovatebot&logoColor=white)](https://docs.renovatebot.com/)
+[![GitOps](https://img.shields.io/badge/GitOps-Argo%20CD-EF7B4D?style=flat-square&logo=argo&logoColor=white)](https://argo-cd.readthedocs.io/)
+[![Provisioned by Omni](https://img.shields.io/badge/Provisioned%20by-Omni-ff7300?style=flat-square&logo=sidero&logoColor=white)](https://omni.siderolabs.com/)
+
+---
+
+## About
+
+This is my personal homelab — a single [Proxmox VE](https://www.proxmox.com/) box tucked under the desk, running a [Talos Linux](https://www.talos.dev/) Kubernetes cluster that hosts everything from Grafana and Authentik down to the service that scrapes my solar inverter. It's my playground, my production, and the place where I try things before I recommend them to colleagues.
+
+What I care about most is that **everything is declarative end-to-end.** A git push is the only way state reaches the cluster. There is no `kubectl apply`, no `tofu apply` at 2 a.m. from my laptop, no snowflake tweaks. [Renovate](https://docs.renovatebot.com/) opens PRs when new versions drop, I merge them, [Argo CD](https://argo-cd.readthedocs.io/) rolls them out. It's boring. Boring is the point.
+
+The part I'm most proud of is how the repo is **split into three independent layers** — `infrastructure/`, `cluster/`, `kubernetes/`. Each one solves a single problem, speaks a single tool's language, and could be lifted out and reused in isolation. Together they form the stack; apart they're still useful on their own.
+
+## The three layers
+
+### 🧱 Layer 1 — `infrastructure/` · Proxmox IaC
+
+[![OpenTofu](https://img.shields.io/badge/OpenTofu-1.11+-844FBA?style=flat-square&logo=opentofu&logoColor=white)](https://opentofu.org/)
+[![Proxmox](https://img.shields.io/badge/Proxmox%20VE-9.0-E57000?style=flat-square&logo=proxmox&logoColor=white)](https://www.proxmox.com/)
+
+[OpenTofu](https://opentofu.org/) with the [`bpg/proxmox`](https://github.com/bpg/terraform-provider-proxmox) provider, driven by split YAML manifests. Manages the Proxmox cluster settings, node config, OS images, templates, and the entire VM/LXC fleet — including Windows 11 VMs with TPM/Secure Boot and a dedicated management VM that hosts Omni.
+
+**This layer has nothing to do with Kubernetes.** I could throw away everything above it and still have a clean, reproducible "Proxmox managed by code" setup.
+
+**Swap-out**: any IaC for any hypervisor. Replace `bpg/proxmox` with `libvirt`, `vsphere`, or a cloud provider and rewrite the `pve_*` modules. The manifest structure and cloud-init plumbing stay.
+
+→ [Full docs](infrastructure/README.md)
+
+### 🚀 Layer 2 — `cluster/` · Omni + Talos
+
+[![Talos](https://img.shields.io/badge/Talos-v1.12.6-blue?style=flat-square&logo=talos&logoColor=white)](https://www.talos.dev/)
+[![Omni](https://img.shields.io/badge/Managed%20by-Omni-ff7300?style=flat-square&logo=sidero&logoColor=white)](https://omni.siderolabs.com/)
+
+Three YAML files describe the cluster: versions, machine shapes, system extensions. [Omni](https://omni.siderolabs.com/) does the rest — hands out Talos configs, bootstraps etcd, rotates certificates, tunnels the API server past my dynamic IP.
+
+Machine classes ([`homelab-machine-classes.yaml`](cluster/homelab-machine-classes.yaml)) are auto-provisioned: **3× control plane** (4 vCPU, 4 GB) and **3× worker** (6 vCPU, 10 GB, extra storage disk). Omni picks fresh VMs, assigns roles, done.
+
+**Swap-out**: Omni supports [many infrastructure providers](https://docs.siderolabs.com/omni/infrastructure-and-extensions/infrastructure-providers) — libvirt, vSphere, AWS, Hetzner, bare-metal PXE. Only two fields (`providerid`, `providerdata`) are Proxmox-specific.
+
+→ [Full docs](cluster/README.md)
+
+### ☸️ Layer 3 — `kubernetes/` · Argo CD + Manifests
+
+[![Argo CD](https://img.shields.io/badge/Argo%20CD-GitOps-EF7B4D?style=flat-square&logo=argo&logoColor=white)](https://argo-cd.readthedocs.io/)
+[![Kustomize](https://img.shields.io/badge/Kustomize-1A73E8?style=flat-square&logo=kubernetes&logoColor=white)](https://kustomize.io/)
+
+Standard CNCF Kubernetes manifests, grouped into `bootstrap/` (day-zero), `components/` (shared infra — ingress, cert-manager, CSI, sealed-secrets, …), and `applications/` (25+ end-user apps). Two Argo CD `ApplicationSet`s auto-discover new folders by convention; I never hand-write an `Application` resource.
+
+**Swap-out**: this tree is vanilla Kubernetes. Strip the `talos-ccm` bootstrap folder and it runs on k3s, kind, EKS, whatever. No Talos lock-in above the control-plane layer.
+
+→ [Full docs](kubernetes/README.md)
+
+> **Why I like this split:** each layer has exactly one job, exactly one tool, and a clean escape hatch. If tomorrow I fall out of love with Proxmox, I rewrite one layer. If I want to move off Omni, I rewrite another. Nothing cascades.
+
+## Architecture
+
+```mermaid
+flowchart TB
+    subgraph L3["Layer 3: Apps — Argo CD + Manifests"]
+        direction LR
+        argo[Argo CD]
+        apps[25+ Applications]
+        components[Shared Components]
+        argo --> apps
+        argo --> components
+    end
+    subgraph L2["Layer 2: Cluster — Omni + Talos"]
+        direction LR
+        omni[Omni SaaS]
+        talos[Talos Cluster<br/>3× CP · 3× Worker]
+        omni --> talos
+    end
+    subgraph L1["Layer 1: Infrastructure — Proxmox + OpenTofu"]
+        direction LR
+        tofu[OpenTofu]
+        pve[Proxmox VE]
+        mgmt[Omni Mgmt VM]
+        tofu --> pve
+        pve --> mgmt
+    end
+
+    L1 -- VMs --> L2
+    L2 -- kubeconfig --> L3
+
+    renovate[Renovate Bot]
+    me[Me]
+    repo[(GitHub: main)]
+
+    me -- commits --> repo
+    renovate -- PRs --> repo
+    repo -- watched --> argo
+    mgmt -- hosts --> omni
+```
+
+## Hardware
+
+### Compute
+
+| Component  | Spec                                                           |
+| ---------- | -------------------------------------------------------------- |
+| Chassis    | Lenovo ThinkStation P3 Tiny Gen 2                              |
+| CPU        | Intel® Core™ Ultra 5 235T vPro® (14 cores, Arrow Lake-S, 35 W) |
+| Memory     | 64 GB DDR5-6400 (2× Kingston ValueRAM 32 GB)                   |
+| Storage    | 1 TB WD Black SN8100 NVMe (ZFS, `local-zfs`)                   |
+| Hypervisor | Proxmox VE 9                                                   |
+
+### Talos VMs
+
+Six VMs on the one Proxmox host, auto-provisioned by Omni — see [`cluster/homelab-machine-classes.yaml`](cluster/homelab-machine-classes.yaml).
+
+| Role          | Count | vCPU | RAM   | Root  | Extra disks                    |
+| ------------- | ----- | ---- | ----- | ----- | ------------------------------ |
+| Control plane | 3     | 4    | 4 GB  | 32 GB | —                              |
+| Worker        | 3     | 6    | 10 GB | 64 GB | 128 GB (storage) + 4 GB (swap) |
+
+### Network
+
+All-Ubiquiti stack — one uplink per tier, 10 GbE between switches, PoE on the edge.
+
+| Device                                                    | Role                                                 |
+| --------------------------------------------------------- | ---------------------------------------------------- |
+| EDPNET Belgium                                            | ISP (WAN)                                            |
+| [UDM-Pro](https://ui.com/cloud-gateways/udm-pro)          | Gateway / firewall / Network controller              |
+| [USW Pro HD 24](https://ui.com/switching/usw-pro-hd-24)   | Core switch (10 GbE uplink to UDM-Pro)               |
+| [USW Pro Max 48](https://ui.com/switching/usw-pro-max-48) | Aggregation switch (10 GbE uplink to USW Pro HD 24)  |
+| [USW Pro 48 PoE](https://ui.com/switching/usw-pro-48-poe) | Access switch (10 GbE uplink, PoE for APs & cameras) |
+| [USP-RPS](https://ui.com/power-backup/usp-rps)            | Redundant power supply for the rack                  |
+| 2× [U7 Pro](https://ui.com/wifi/flagship/u7-pro)          | Wi-Fi 7 APs (1× floor)                               |
+| 3× [U6-LR](https://ui.com/wifi/long-range/u6-long-range)  | Wi-Fi 6 long-range APs (ground floor + basement)     |
+
+### Storage (shared)
+
+| Device                                      | Role                                                                  |
+| ------------------------------------------- | --------------------------------------------------------------------- |
+| [UNAS Pro](https://ui.com/storage/unas-pro) | 4-bay NAS — bulk storage, backups, S3 targets for PITR/object storage |
+
+## Highlights
+
+A quick taste of what's running — full catalog in [`kubernetes/README.md`](kubernetes/README.md#catalog):
+
+- **GitOps everywhere** — [Argo CD](https://argo-cd.readthedocs.io/) reconciles the cluster, [Renovate](https://docs.renovatebot.com/) opens PRs for every dependency bump.
+- **Immutable OS** — [Talos Linux](https://www.talos.dev/) with disk encryption, managed by [Omni](https://omni.siderolabs.com/).
+- **Identity & edge** — [Authentik](https://goauthentik.io/) SSO/forward-auth, [Traefik](https://traefik.io/) with pre/post-auth middleware chains, [CrowdSec](https://www.crowdsec.net/) behavior-based IPS, [Cloudflare](https://www.cloudflare.com/) WAF.
+- **Data plane** — [CloudNativePG](https://cloudnative-pg.io/) with Barman S3 PITR backups, [Redis](https://redis.io/), [NATS](https://nats.io/), [InfluxDB](https://www.influxdata.com/), [RustFS](https://github.com/rustfs/rustfs) for S3-compatible object storage.
+- **Observability** — [Prometheus](https://prometheus.io/), [Grafana](https://grafana.com/), [Loki](https://grafana.com/oss/loki/), [Alloy](https://grafana.com/docs/alloy/), [Gatus](https://gatus.io/), plus [kromgo](https://github.com/kashalls/kromgo) powering the badges above.
+
+## Repository structure
+
+```
+homelab/
+├── infrastructure/   # Layer 1 — Proxmox IaC (OpenTofu + bpg/proxmox)
+├── cluster/          # Layer 2 — Omni cluster templates + machine classes
+├── kubernetes/       # Layer 3 — Argo CD-reconciled manifests
+│
+├── tasks/            # Taskfile includes (cluster/, infra/, kubernetes/)
+└── Taskfile.yaml     # Top-level entry point — `task --list`
+```
+
+Each of the three layer directories has its own detailed README:
+
+- [**infrastructure/README.md**](infrastructure/README.md)
+- [**cluster/README.md**](cluster/README.md)
+- [**kubernetes/README.md**](kubernetes/README.md)
+
+## Acknowledgements
+
+Standing on the shoulders of giants. This setup borrows patterns and inspiration from:
+
+- [buroa/k8s-gitops](https://github.com/buroa/k8s-gitops) — the kromgo badge idea and a lot of stylistic cues.
+- The [home-operations](https://github.com/home-operations) community.
 
 ## License
 
-See `LICENSE`.
+See [LICENSE](LICENSE).

--- a/TODO.md
+++ b/TODO.md
@@ -34,5 +34,3 @@
 ## Productivity
 
 - [ ] **Migrate TODO.md to GitHub**: Move this list to GitHub Issues + a Project (v2) board with labels/milestones instead of a flat markdown file.
-- [ ] **Readme**: Update project readme — see [buroa/k8s-gitops](https://github.com/buroa/k8s-gitops/tree/main) as reference.
-- [ ] **Kromgo README badges**: Add a scheduled GitHub Actions workflow that fetches the [kromgo](kubernetes/applications/kromgo/base/config/kromgo.yaml) endpoints at `kromgo.zimmermann.sh` using the Cloudflare Access Service Token (stored as GH repo secrets `CF_ACCESS_CLIENT_ID` / `CF_ACCESS_CLIENT_SECRET`) and rewrites the static shields.io badges in `README.md`. Needed because GitHub's image proxy (Camo) can't forward custom headers, so a direct shields.io → kromgo request would be blocked by CF Access.

--- a/cluster/README.md
+++ b/cluster/README.md
@@ -1,0 +1,85 @@
+# Cluster — Omni + Talos
+
+[![Talos](https://img.shields.io/badge/Talos-v1.12.6-blue?style=flat-square&logo=talos&logoColor=white)](https://www.talos.dev/)
+[![Kubernetes](https://img.shields.io/badge/Kubernetes-v1.34.6-blue?style=flat-square&logo=kubernetes&logoColor=white)](https://kubernetes.io/)
+[![Omni](https://img.shields.io/badge/Managed%20by-Omni-ff7300?style=flat-square&logo=sidero&logoColor=white)](https://omni.siderolabs.com/)
+
+> **Layer 2 of [the homelab stack](../README.md).** This is just cluster definition — machine shapes and Talos/Kubernetes versions. It has no opinion on what runs underneath (any infra provider works) or on top (standard Kubernetes manifests).
+
+## What this directory does
+
+I let [Omni](https://omni.siderolabs.com/) run my Talos control plane. All I do here is describe the cluster I want — Omni figures out the rest: it hands out bootstrap configs, issues certificates, upgrades nodes one-by-one, and keeps the API servers reachable via its tunnel even when my home IP rotates.
+
+The whole cluster state lives in three YAML files, reconciled into Omni with `omnictl`. No manual `talosctl bootstrap` dance, no per-node config sprawl.
+
+## Files
+
+| File                                                           | Purpose                                                                                     |
+| -------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| [`homelab-cluster-prod.yaml`](homelab-cluster-prod.yaml)       | Production Omni Cluster Template — Talos/k8s versions, 3× CP + 3× Worker, system extensions |
+| [`homelab-cluster-dev.yaml`](homelab-cluster-dev.yaml)         | Dev-cluster variant (smaller footprint, same shape)                                         |
+| [`homelab-machine-classes.yaml`](homelab-machine-classes.yaml) | Auto-provisioning shapes — what a "control plane" or "worker" VM looks like on Proxmox      |
+| [`patches/`](patches/)                                         | Omni patches (global settings, CP/DP tuning, extra manifests)                               |
+
+### Cluster shape (prod)
+
+Defined in [`homelab-cluster-prod.yaml`](homelab-cluster-prod.yaml):
+
+- **Talos** v1.12.6, **Kubernetes** v1.34.6
+- **Disk encryption** enabled (LUKS)
+- **3× control plane**, **3× worker** — all auto-provisioned via machine classes
+- **System extensions**: `qemu-guest-agent`, `i915` (Intel iGPU), `intel-ucode`, `nvidia-open-gpu-kernel-modules-lts`, `iscsi-tools`, `zfs`
+
+### Machine classes
+
+Defined in [`homelab-machine-classes.yaml`](homelab-machine-classes.yaml). Each class tells Omni's infra provider how to spin up a VM.
+
+| Role                 | vCPU | RAM   | Root  | Extra disks                    |
+| -------------------- | ---- | ----- | ----- | ------------------------------ |
+| `control-plane-prod` | 4    | 4 GB  | 32 GB | —                              |
+| `data-plane-prod`    | 6    | 10 GB | 64 GB | 128 GB (storage) + 4 GB (swap) |
+
+All go to `local-zfs` on my Proxmox host; NUMA, `host` CPU type, `q35` machine, `io_uring` async I/O.
+
+## Swapping the infra provider
+
+The interesting bit: **this layer has one line of Proxmox-specific config**. In every machine class, `spec.autoprovision.providerid: proxmox-infra` pins it. Change that (and the `providerdata` block) and you're on a different hypervisor without touching anything else.
+
+Omni ships [infrastructure providers](https://docs.siderolabs.com/omni/infrastructure-and-extensions/infrastructure-providers) for:
+
+- **libvirt** — for KVM-on-Linux homelabs
+- **vSphere** — for corporate-y setups
+- **AWS / Hetzner / GCP / Azure** — cloud-backed clusters
+- **Bare metal (PXE)** — physical fleet via iPXE + Talos factory images
+
+Each provider has its own `providerdata` schema (see their docs). The rest of the `Cluster` / `ControlPlane` / `Workers` / `MachineClasses` kinds stays identical.
+
+## Usage
+
+From the repo root (uses [go-task](https://taskfile.dev)):
+
+| Task                              | What it does                                                          |
+| --------------------------------- | --------------------------------------------------------------------- |
+| `task cluster:init`               | Register machine classes in Omni (run once, or after editing classes) |
+| `task cluster:create [dev\|prod]` | Sync the cluster template to Omni (default: `prod`)                   |
+| `task cluster:status [dev\|prod]` | Print current cluster status from Omni                                |
+| `task cluster:show [dev\|prod]`   | Download `kubeconfig` + `talosconfig` for the cluster                 |
+
+Underlying command for `create` is `omnictl cluster template sync --file homelab-cluster-prod.yaml`.
+
+## Bootstrap sequence
+
+This only makes sense in combination with [Layer 1 (infrastructure)](../infrastructure/README.md):
+
+1. **Infra up** — `task infra:create` brings the Proxmox VMs online. They boot a Talos image pre-baked with the Omni join token.
+2. **Omni sees them** — Machines register automatically and land in Omni as unassigned.
+3. **Register classes** — `task cluster:init` pushes [`homelab-machine-classes.yaml`](homelab-machine-classes.yaml) to Omni.
+4. **Create the cluster** — `task cluster:create` syncs the template. Omni assigns machines to roles based on their specs matching the classes, hands out Talos configs, bootstraps etcd, signs certs.
+5. **Omni applies day-zero manifests** — via `extraManifests` in [`patches/extraManifests-prod.yaml`](patches/extraManifests-prod.yaml), Omni pulls the rendered Cilium, Argo CD, and Talos-CCM manifests from the [`bootstrap` branch](https://github.com/alexander-zimmermann/homelab/tree/bootstrap) and applies them to the new cluster. No manual `kubectl apply -k` required.
+6. **Fetch kubeconfig** — `task cluster:show` writes `kubeconfig` / `talosconfig` locally. Done.
+
+At this point [Layer 3 (kubernetes)](../kubernetes/README.md) takes over — `task k8s:init` seeds the sealed-secrets master key and Argo CD reconciles the rest.
+
+## License
+
+See [../LICENSE](../LICENSE).

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -1,208 +1,123 @@
-# Homelab Infrastructure - Proxmox Orchestration with OpenTofu
+# Infrastructure — Proxmox IaC
 
-A comprehensive infrastructure-as-code solution for managing Proxmox VE environments using OpenTofu, featuring automated VM provisioning, Talos Kubernetes clusters, and streamlined cloud-init management.
+[![OpenTofu](https://img.shields.io/badge/OpenTofu-1.11+-844FBA?style=flat-square&logo=opentofu&logoColor=white)](https://opentofu.org/)
+[![Proxmox](https://img.shields.io/badge/Proxmox%20VE-9.0-E57000?style=flat-square&logo=proxmox&logoColor=white)](https://www.proxmox.com/)
+[![Provider](https://img.shields.io/badge/Provider-bpg%2Fproxmox-blue?style=flat-square)](https://github.com/bpg/terraform-provider-proxmox)
 
-## Overview
+> **Layer 1 of [the homelab stack](../README.md).** Pure Proxmox IaC — manages cluster-wide settings, nodes, images, templates, and the VM/LXC fleet. It has zero dependency on Kubernetes. I could rip out everything above this layer and still have a perfectly usable "IaC for Proxmox" setup.
 
-This project orchestrates a complete homelab infrastructure on Proxmox VE using OpenTofu (Terraform fork). It provides:
+## What this does
 
-- **Declarative Infrastructure**: YAML-based manifest for defining all infrastructure components
-- **Automated VM/Container Provisioning**: Streamlined creation of VMs and LXC containers
-- **Talos Kubernetes Integration**: Automated Talos cluster deployment via Sidero Omni
-- **Cloud-Init Management**: Modular cloud-init configuration system
-- **Image Management**: Automated download and checksum verification of OS images
-- **Windows VM Support**: UEFI, TPM 2.0, and Secure Boot configuration for Windows 11
+I describe my Proxmox setup in YAML manifests, `locals.tf` stitches them together, and [OpenTofu](https://opentofu.org/) plus the [`bpg/proxmox`](https://github.com/bpg/terraform-provider-proxmox) provider make it happen. That covers:
 
-## Architecture
+- **Cluster-wide config** — ACME for PVE UI certs, backup jobs to PBS, hardware mappings (USB), users.
+- **Per-node config** — repositories, network, optional subscription keys.
+- **OS images** — declarative download + SHA-512 verification (Debian Trixie, Ubuntu Noble/Plucky, Windows 11 25H2 + virtio).
+- **Cloud-init modules** — reusable blocks for users, vendor bootstrap, network.
+- **Templates** — VM and LXC templates (hardware shapes, OS type).
+- **Fleet** — actual VMs and containers instantiated from templates.
 
-### Core Components
+Specials worth calling out:
 
-- **OpenTofu 1.11.1**: Infrastructure orchestration engine
-- **Proxmox VE 9.0**: Virtualization platform
-- **Talos Linux**: Kubernetes-focused OS for container workloads
-- **Sidero Omni**: Management platform for Talos clusters
-- **Ubuntu 24.04 Noble**: General-purpose VM workloads
-- **Windows 11 25H2**: Windows workloads with modern security features
+- **Deterministic MAC addresses** — `02:01:00:XX:XX:XX` for VMs, `02:02:00:XX:XX:XX` for LXCs (derived from their IDs). Stable DHCP leases across rebuilds.
+- **Windows 11 support** — UEFI, TPM 2.0, Secure Boot with pre-enrolled keys, Q35, VirtIO driver ISO.
+- **Omni host VM** — one of the VMs (`management-01`) runs [Omni](https://omni.siderolabs.com/) in Docker Compose via cloud-init. Talos VMs themselves are **not** provisioned here — Omni creates and manages them through its own Proxmox infra provider ([Layer 2](../cluster/README.md)).
 
-### Project Structure
+## Directory layout
 
-```bash
+```
 infrastructure/
-├── main.tf                     # Primary configuration
-├── locals.tf                   # Logic & Manifest loading
-├── variables.tf                # Input variables definitions
-├── outputs.tf                  # Output values definitions
-├── versions.tf                 # Provider & Terraform versions
-├── terraform.tfvars.example    # Example variable values
-├── manifest/                   # YAML definitions (The "Source of Truth")
-│   ├── 00-cluster/             # Cluster-wide settings (PVE connection)
-│   ├── 10-pve-node/            # Node configurations (Core, Network)
-│   ├── 20-image/               # OS Image definitions
-│   ├── 30-cloud-init/          # Cloud-Init config (users, vendor, net)
-│   ├── 40-template/            # VM/LXC Templates
-│   └── 50-fleet/               # Virtual Machines & Containers
-├── modules/                    # Reusable OpenTofu modules
-│   ├── 10-pve-node-core/       # Proxmox Node Core Config
-│   ├── 30-cloud-init/          # Cloud-Init Generation
-│   └── ... (others)
-└── templates/                  # Templates for Cloud-Init & Provisioning
-    └── 30-cloud-init/          # Secret injection templates (.tftpl)
+├── main.tf                 # Module wiring
+├── locals.tf               # Manifest merging + computed defaults
+├── variables.tf            # Input variables (credentials, secrets)
+├── outputs.tf
+├── versions.tf             # OpenTofu + provider versions
+├── terraform.tfvars.example
+├── manifest/               # YAML — the source of truth
+│   ├── 00-cluster/         #   PVE connection, ACME, backup jobs, PBS storage, users
+│   ├── 10-pve-node/        #   Node core settings, repos, network
+│   ├── 20-image/           #   OS images with checksums
+│   ├── 30-cloud-init/      #   Reusable cloud-init modules
+│   ├── 40-template/        #   VM / LXC templates
+│   └── 50-fleet/           #   Actual VM / container instances
+├── modules/                # Reusable OpenTofu modules
+│   ├── 00-pve-cluster-*    #   cluster-scope
+│   ├── 10-pve-node-*       #   node-scope
+│   ├── 20-image
+│   ├── 30-cloud-init
+│   ├── 40-template-{vm,lxc}
+│   └── 50-fleet-{vm,lxc}
+└── templates/              # .tftpl files rendered into cloud-init (env files, scripts)
 ```
 
-## Infrastructure Workflow
+The numeric prefixes (`00-` through `50-`) match between `manifest/` and `modules/` so the data flow is obvious — a `50-fleet` YAML references a `40-template` which references a `20-image`, etc.
 
-### 1. Task-Based Automation
-
-The project uses `go-task` with organized sub-taskfiles.
-
-#### Infrastructure (`infra:*`)
-
-These tasks manage the Proxmox infrastructure via OpenTofu.
-
-- `task infra:init`: Initialize OpenTofu (`tofu init`), download plugins.
-- `task infra:status`: Generate an execution plan (`tofu plan`). Checks for drift.
-- `task infra:create`: Apply changes to Proxmox (`tofu apply`). **Zero-to-Hero infra command.**
-- `task infra:delete`: Tear down all managed infrastructure.
-- `task infra:show`: Show Terraform outputs.
-
-### 2. Infrastructure Definition
-
-Infrastructure is defined in a **split manifest structure** located in `infrastructure/manifest/*.yaml`. This allows for better organization and maintainability.
-
-The configuration is loaded and merged by `locals.tf`.
-
-#### Manifest Directories
-
-- **`00-cluster/`**: Cluster-wide configurations (PVE connection, ACME, Users).
-- **`10-pve-node/`**: Node-specific configurations (Core settings, Repositories, Network).
-- **`20-image/`**: Operating System images (Debian, Talos, Windows) with checksums.
-- **`30-cloud-init/`**: Reusable Cloud-Init modules (Users, Vendor, Network).
-- **`40-template/`**: VM and LXC Templates (Hardware specs, OS type).
-- **`50-fleet/`**: Actual Virtual Machine and Container instances.
-
-#### Example: Image Specifications (`20-image/`)
+## Example: declaring an OS image
 
 ```yaml
+# manifest/20-image/image.yaml
 image:
-  # Debian Cloud Image
   vm_debian_trixie:
     image_type: import
+    image_url: https://cloud.debian.org/images/cloud/trixie/20260327-2429/debian-13-genericcloud-amd64-20260327-2429.qcow2
     image_filename: debian-13-genericcloud-amd64.qcow2
-    image_url: https://cloud.debian.org/images/cloud/trixie/latest/debian-13-genericcloud-amd64.qcow2
-    image_checksum: "e5563c7bb388eebf7df385e99ee36c83cd16ba8fad4bd07f4c3fd725a6f1cf1cb9f54c6673d4274a856974327a5007a69ff24d44f9b21f7f920e1938a19edf7e"
-    image_checksum_algorithm: "sha512"
-
-  # Talos Linux (Factory build)
-  vm_talos_1_12_0:
-    image_type: import
-    image_filename: talos-1.12.0-nocloud-amd64.raw
-    image_url: https://factory.talos.dev/image/.../nocloud-amd64.raw
-    image_checksum: "b106e0b4a6644045e895552877c68c5094d1eb77633a37d900ddfaeefdb8e29b"
+    image_checksum: 09559ec27d263997827dd8cddf76e97ea8e0f1803380aa501ea7eaa4b4968cd76ffef4ec7eb07ef1a9ccbeb0925a5020492ea9ed53eb167d62f3a2285039912c
+    image_checksum_algorithm: sha512
 ```
 
-#### Templates Directory (`templates/`)
+`locals.tf` pulls every `manifest/20-image/*.yaml` in, merges them, and passes the map to the `20-image` module which handles the actual download + verification. Renovate keeps the `image_url` and `image_checksum` fresh via PRs — see [`image.yaml`](manifest/20-image/image.yaml) for the live catalog.
 
-Contains text-based templates (`.tftpl`) used by OpenTofu's `templatefile()` function:
+## Usage
 
-- **`30-cloud-init/`**: Environment files and scripts injected into VMs via Cloud-Init. Supports secret injection.
+From the repo root (uses [go-task](https://taskfile.dev)):
 
-### 3. Cloud-Init Configuration System
-
-Modular cloud-init configuration supporting:
-
-- **User Configuration**: SSH keys, passwords, user creation
-- **Vendor Configuration**: Package installation, system commands
-- **Network Configuration**: Static/DHCP networking, DNS settings
-- **Meta Configuration**: Hostname and metadata
-- **Snap Configuration**: Native support for Snap packages (used for `lego` and `task`)
-
-### 4. Management VM & Omni Setup
-
-A dedicated management VM (`management-01` / `cluster-mgmt`) hosts the **Omni** platform.
-
-- **Storage**: Persistent data on `/mnt/omni`.
-- **Config**: Ephemeral managed config in `/opt/omni` (Docker Compose, Envs).
-- **Bootstrap**: Cloud-Init Native:
-  - Cloud-Init injects `omni-compose.yaml` and `.env` files directly.
-  - `omni-bootstrap.sh` handles Init (Certificates, GPG) and Startup.
-  - No external git clone required during boot.
-
-### 5. Talos Kubernetes Cluster
-
-The project includes automated Talos Kubernetes cluster deployment via **Sidero Omni**.
-
-1.  **Infrastructure Provisioning**: OpenTofu creates the VMs (`infra:create`).
-2.  **Omni Registration**: VMs boot custom images (generated via `cluster:init`) and register with Omni.
-3.  **Machine Classes**: Defined in Omni (via `cluster:create`) to automatically assign roles (Control Plane / Worker) based on generic hardware or labels.
-
-### 5. Advanced Features
-
-#### Deterministic MAC Address Generation
-
-All VMs and containers receive deterministic MAC addresses based on their ID:
-
-- **VMs**: `02:01:00:XX:XX:XX` format (based on VM ID)
-- **Containers**: `02:02:00:XX:XX:XX` format (based on Container ID)
-- **Benefits**: Stable DHCP IP assignments across reboots and redeployments
-
-#### Windows 11 Support
-
-Full support for modern Windows VMs:
-
-- **UEFI Boot**: `bios: ovmf` for modern boot process
-- **TPM 2.0**: Hardware security module for BitLocker and Windows 11 requirements
-- **Secure Boot**: Pre-enrolled keys for secure boot validation
-- **Q35 Machine Type**: Modern chipset emulation
-- **VirtIO Drivers**: Automated ISO attachment for optimal performance
-
-## Provider Configuration
-
-### Proxmox Provider (bpg/proxmox)
-
-- **Primary Management**: VM/container lifecycle management
-- **API Communication**: RESTful API integration with Proxmox VE
+| Task | What it does |
+| --- | --- |
+| `task infra:init` | `tofu init` — download providers. Run once or after provider updates. |
+| `task infra:status` | `tofu plan` — dry-run, drift check. |
+| `task infra:create` | `tofu apply` — zero-to-hero. Builds everything declared in the manifests. |
+| `task infra:delete` | `tofu destroy` — tears everything down. |
+| `task infra:show` | Print OpenTofu outputs. |
 
 ## Prerequisites
 
-### Infrastructure Requirements
+- **Proxmox VE 9.0+**, API reachable on port 8006.
+- **DHCP** on the VM network (MAC addresses are deterministic, IPs come from your router).
+- **OpenTofu** ≥ 1.11, **omnictl**, **talosctl** on your workstation.
+- **`terraform.tfvars`** with:
 
-- **Proxmox VE 9.0+**: Accessible via API (port 8006)
-- **Network**: DHCP server for VM/container IP assignment
+  ```hcl
+  pve_cluster_token_id     = "…"
+  pve_cluster_token_secret = "…"
+  pve_cluster_password     = "…"  # optional, for console access
+  pve_node_core_subscription_keys = {
+    pve-1 = "…"
+  }
+  ```
 
-### Development Environment
+  See [`terraform.tfvars.example`](terraform.tfvars.example) for the full shape.
 
-- **OpenTofu 1.11.1+**: Infrastructure orchestration
-- **Talosctl**: Talos cluster management CLI
-- **Omnictl**: Sidero Omni CLI
+## Swapping the hypervisor
 
-### Authentication and Access
+The Proxmox-specific bits are confined to the `bpg/proxmox` provider and the `pve_*` module namespaces. Everything else (cloud-init generation, image catalog, manifest merging) is generic Terraform/OpenTofu. Swapping to another hypervisor means:
 
-Configure Proxmox credentials and subscription keys in `terraform.tfvars`:
+1. Replace `bpg/proxmox` in [`versions.tf`](versions.tf) with your provider of choice (libvirt, vsphere, …).
+2. Rewrite the `10-pve-node-*`, `40-template-{vm,lxc}`, `50-fleet-{vm,lxc}` modules against the new provider's resources.
+3. Keep `20-image`, `30-cloud-init`, `locals.tf`, and the manifest structure — they're portable.
 
-```hcl
-# Proxmox API Authentication
-pve_cluster_token_id     = "YOUR_PVE_TOKEN_ID"
-pve_cluster_token_secret = "YOUR_PVE_TOKEN_SECRET"
-pve_cluster_password     = "YOUR_PVE_PASSWORD" # Optional (Console Access)
-
-# Proxmox Subscription Keys (Optional)
-pve_node_core_subscription_keys = {
-  pve-1 = "YOUR_SUBSCRIPTION_KEY"
-}
-```
+Is it a weekend project? Yes. Is it doable? Also yes.
 
 ## Troubleshooting
 
-### Common Issues
+**Talos nodes show up as `NotReady`.**
+Check the [Omni dashboard](https://omni.siderolabs.com/). Probably machine classes aren't registered yet — run `task cluster:init`.
 
-**Issue**: Talos nodes are `NotReady`.
+**`tofu taint` doesn't trigger a rebuild.**
+`task infra:status` generates a plan file (`tfplan`). `task infra:create` applies that file. If you ran `taint` after generating the plan, rerun `task infra:status` first.
 
-- **Solution**: Check Sidero Omni dashboard. Ensure Machine Classes are registered (`task cluster:create`).
-
-**Issue**: `tofu taint` doesn't trigger rebuild.
-
-- **Solution**: `task infra:status` (Plan) checks for state changes. Ensure `task infra:create` applies the plan (`tofu apply tfplan`).
+**A secret in cloud-init needs to change without rebuilding the VM.**
+Cloud-init values are embedded at VM creation time. For post-boot secret rotation, use a real config-management path (Ansible, SSM, etc.) — this layer isn't the right tool.
 
 ## License
 
-See LICENSE file for details.
+See [../LICENSE](../LICENSE).

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -1,0 +1,195 @@
+# Kubernetes — Argo CD + Manifests
+
+[![Argo CD](https://img.shields.io/badge/Argo%20CD-GitOps-EF7B4D?style=flat-square&logo=argo&logoColor=white)](https://argo-cd.readthedocs.io/)
+[![Kustomize](https://img.shields.io/badge/Kustomize-1A73E8?style=flat-square&logo=kubernetes&logoColor=white)](https://kustomize.io/)
+[![Sealed Secrets](https://img.shields.io/badge/Sealed%20Secrets-encrypted-2F855A?style=flat-square&logo=kubernetes&logoColor=white)](https://github.com/bitnami-labs/sealed-secrets)
+
+> **Layer 3 of [the homelab stack](../README.md).** Standard CNCF-compatible Kubernetes manifests, reconciled by Argo CD. Nothing Talos- or Proxmox-specific lives in here (except a tiny `talos-ccm` bootstrap bit). Drop this directory into k3s, kind, EKS, or whatever — it'll work.
+
+## What this directory does
+
+Argo CD watches `main` and syncs everything under here into the cluster. I never `kubectl apply` anything by hand — a push to `main` is the only way state changes.
+
+Two `ApplicationSet`s (defined in [`bootstrap/gitops-controller/base/`](bootstrap/gitops-controller/base/)) auto-generate Argo `Application`s by scanning directory conventions:
+
+- One scans `components/*/base/kustomization.yaml` → shared infra
+- One scans `applications/*/base/kustomization.yaml` → end-user apps
+
+Add a folder that matches the convention and Argo picks it up on the next reconcile. No manual `Application` wiring per app.
+
+## Directory layout
+
+```
+kubernetes/
+├── bootstrap/          # Day-zero manifests (applied before Argo takes over)
+│   ├── cilium/         #   eBPF CNI (kube-proxy replacement, L2 announcements)
+│   ├── gitops-controller/  # Argo CD itself + the ApplicationSets that drive everything else
+│   └── talos-ccm/      #   Talos cloud-controller-manager (node provider integration)
+│
+├── components/         # Shared infra used by many apps
+│   ├── admission-controller/   # Kyverno (secret replication, admission policies)
+│   ├── cert-manager/           # TLS via Cloudflare DNS-01
+│   ├── cilium/                 # Cilium CRDs + overlays
+│   ├── csi-block-storage-controller/
+│   ├── csi-nfs-controller/
+│   ├── external-dns/           # Syncs ingress hostnames → Cloudflare
+│   ├── gitops-controller/      # Argo CD overlays
+│   ├── ingress-controller/     # Traefik + middleware chains (pre/post-auth)
+│   ├── metrics-server/
+│   ├── prometheus-crds/
+│   ├── sealed-secrets-controller/
+│   └── talos-ccm/
+│
+└── applications/       # End-user apps (each with base/ + overlays/{dev,prod})
+    ├── authentik/      #   SSO / OIDC
+    ├── grafana/        #   Dashboards
+    ├── homepage/       #   Service start page
+    ├── kromgo/         #   Cluster-stats badges (see top-level README)
+    ├── prometheus/     #   Metrics & alerting
+    ├── loki/           #   Logs
+    ├── cloudnative-pg/ #   Postgres operator
+    ├── crowdsec/       #   IPS
+    ├── wiki-js/        #   Personal wiki
+    └── …               #   (25+ in total)
+```
+
+## GitOps flow
+
+```mermaid
+flowchart LR
+    me[Me]
+    renovate[Renovate]
+    git[(GitHub: main)]
+    appset[ApplicationSets]
+    argo[Argo CD]
+    cluster[(Cluster)]
+
+    me -- PR + merge --> git
+    renovate -- PRs --> git
+    git -- polled every 3m --> appset
+    appset -- generates --> argo
+    argo -- reconciles --> cluster
+```
+
+Secrets are encrypted with [Sealed Secrets](https://github.com/bitnami-labs/sealed-secrets) — the master key lives in `components/sealed-secrets-controller/base/master-key.yaml` and is **not** in git (it's seeded once per cluster via `task k8s:init`). Every `secret.yaml` in the tree has a matching `sealed-secret.yaml` that Argo applies; the controller decrypts it in-cluster.
+
+## Usage
+
+From the repo root (uses [go-task](https://taskfile.dev)):
+
+| Task                                         | What it does                                                                                                |
+| -------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `task k8s:init`                              | Bootstrap sealed-secrets master key + DHI registry credentials. Run once, right after the cluster comes up. |
+| `task k8s:status`                            | Show nodes, pods (all namespaces), and Cilium status.                                                       |
+| `task k8s:show`                              | Print the Argo CD admin password.                                                                           |
+| `task k8s:seal path/to/secret.yaml`          | Encrypt a plain secret for git. Writes `sealed-secret.yaml` next to it.                                     |
+| `task k8s:unseal path/to/sealed-secret.yaml` | Decrypt back to `secret.yaml` (needs local master key).                                                     |
+| `task k8s:delete`                            | **Wipe every managed namespace** (prompted). Useful before re-bootstrapping.                                |
+
+## Adding a new app
+
+1. `mkdir -p kubernetes/applications/<name>/base` and drop your manifests in.
+2. Create `base/kustomization.yaml` with `namespace: <name>` and list the resources.
+3. Create `overlays/{dev,prod}/kustomization.yaml` that reference `../../base` and apply env-specific patches (hostnames, replicas).
+4. Commit, push. The `applications` ApplicationSet picks it up within one sync interval.
+
+If your app needs secrets: write them as plain `secret.yaml`, then `task k8s:seal kubernetes/applications/<name>/base/secret.yaml`, commit only the `sealed-secret.yaml`.
+
+## Catalog
+
+All components grouped by what they do. Icons via [Simple Icons](https://simpleicons.org/).
+
+### Platform
+
+|                                                                           | Component                                                        | Purpose                                                           |
+| ------------------------------------------------------------------------- | ---------------------------------------------------------------- | ----------------------------------------------------------------- |
+| <img src="https://cdn.simpleicons.org/talos/FF7300" height="16" />        | [Talos Linux](https://www.talos.dev/)                            | Immutable, API-managed Kubernetes OS                              |
+| <img src="https://cdn.simpleicons.org/sidero/FF7300" height="16" />       | [Omni](https://omni.siderolabs.com/)                             | SaaS control plane for Talos (auto-provisioning, machine classes) |
+| <img src="https://cdn.simpleicons.org/cilium/F8C517" height="16" />       | [Cilium](https://cilium.io/)                                     | eBPF CNI (kube-proxy replacement, L2 announcements)               |
+| <img src="https://cdn.simpleicons.org/traefikproxy/24A1C1" height="16" /> | [Traefik](https://traefik.io/)                                   | Ingress with pre/post-auth middleware chains                      |
+| <img src="https://cdn.simpleicons.org/letsencrypt/003A70" height="16" />  | [cert-manager](https://cert-manager.io/)                         | Automated TLS via Cloudflare DNS-01                               |
+| <img src="https://cdn.simpleicons.org/cloudflare/F38020" height="16" />   | [external-dns](https://github.com/kubernetes-sigs/external-dns)  | Syncs ingress hostnames to Cloudflare                             |
+| <img src="https://cdn.simpleicons.org/kubernetes/326CE5" height="16" />   | [Kyverno](https://kyverno.io/)                                   | Policy engine (secret replication, admission)                     |
+| <img src="https://cdn.simpleicons.org/bitwarden/175DDC" height="16" />    | [Sealed Secrets](https://github.com/bitnami-labs/sealed-secrets) | Git-safe, cluster-decryptable secrets                             |
+
+### GitOps & Automation
+
+|                                                                          | Component                                  | Purpose                                       |
+| ------------------------------------------------------------------------ | ------------------------------------------ | --------------------------------------------- |
+| <img src="https://cdn.simpleicons.org/argo/EF7B4D" height="16" />        | [Argo CD](https://argo-cd.readthedocs.io/) | Declarative sync of `kubernetes/applications` |
+| <img src="https://cdn.simpleicons.org/renovatebot/1A1F6C" height="16" /> | [Renovate](https://docs.renovatebot.com/)  | Automated dependency PRs                      |
+
+### Security & Identity
+
+|                                                                         | Component                                 | Purpose                                 |
+| ----------------------------------------------------------------------- | ----------------------------------------- | --------------------------------------- |
+| <img src="https://cdn.simpleicons.org/auth0/EB5424" height="16" />      | [Authentik](https://goauthentik.io/)      | SSO / OIDC / forward-auth               |
+| <img src="https://cdn.simpleicons.org/crowdsec/F24D1F" height="16" />   | [CrowdSec](https://www.crowdsec.net/)     | Behavior-based IPS on ingress           |
+| <img src="https://cdn.simpleicons.org/cloudflare/F38020" height="16" /> | [Cloudflare](https://www.cloudflare.com/) | WAF, rate-limiting, edge TLS, tunneling |
+
+### Storage & Data
+
+|                                                                         | Component                                                                     | Purpose                                |
+| ----------------------------------------------------------------------- | ----------------------------------------------------------------------------- | -------------------------------------- |
+| <img src="https://cdn.simpleicons.org/kubernetes/326CE5" height="16" /> | CSI Block + NFS                                                               | Persistent volumes for workloads       |
+| <img src="https://cdn.simpleicons.org/rust/000000" height="16" />       | [RustFS](https://github.com/rustfs/rustfs)                                    | S3-compatible object storage           |
+| <img src="https://cdn.simpleicons.org/postgresql/4169E1" height="16" /> | [CloudNativePG](https://cloudnative-pg.io/) + [Barman](https://pgbarman.org/) | Postgres operator with S3 PITR backups |
+| <img src="https://cdn.simpleicons.org/redis/DC382D" height="16" />      | [Redis](https://redis.io/)                                                    | In-memory cache                        |
+| <img src="https://cdn.simpleicons.org/natsdotio/27AAE1" height="16" />  | [NATS](https://nats.io/)                                                      | Lightweight messaging                  |
+| <img src="https://cdn.simpleicons.org/influxdb/22ADF6" height="16" />   | [InfluxDB](https://www.influxdata.com/)                                       | Time-series DB for IoT telemetry       |
+
+### Observability
+
+|                                                                           | Component                                    | Purpose                                     |
+| ------------------------------------------------------------------------- | -------------------------------------------- | ------------------------------------------- |
+| <img src="https://cdn.simpleicons.org/prometheus/E6522C" height="16" />   | [Prometheus](https://prometheus.io/)         | Metrics & alerting                          |
+| <img src="https://cdn.simpleicons.org/grafana/F46800" height="16" />      | [Grafana](https://grafana.com/) + Operator   | Dashboards, dashboards-as-code              |
+| <img src="https://cdn.simpleicons.org/grafana/F46800" height="16" />      | [Loki](https://grafana.com/oss/loki/)        | Log aggregation                             |
+| <img src="https://cdn.simpleicons.org/grafana/F46800" height="16" />      | [Alloy](https://grafana.com/docs/alloy/)     | Unified telemetry collector                 |
+| <img src="https://cdn.simpleicons.org/statuspage/172B4D" height="16" />   | [Gatus](https://gatus.io/)                   | Status page / synthetic probes              |
+| <img src="https://cdn.simpleicons.org/shieldsdotio/000000" height="16" /> | [kromgo](https://github.com/kashalls/kromgo) | PromQL → shields.io bridge (cluster badges) |
+
+### Applications
+
+|                                                                        | Component                            | Purpose                                   |
+| ---------------------------------------------------------------------- | ------------------------------------ | ----------------------------------------- |
+| <img src="https://cdn.simpleicons.org/homepage/14B8A6" height="16" />  | [Homepage](https://gethomepage.dev/) | Service start page                        |
+| <img src="https://cdn.simpleicons.org/wikidotjs/1976D2" height="16" /> | [Wiki.js](https://js.wiki/)          | Knowledge base                            |
+| <img src="https://cdn.simpleicons.org/nodered/8F0000" height="16" />   | [Node-RED](https://nodered.org/)     | Flow-based automation                     |
+| <img src="https://cdn.simpleicons.org/solaredge/00AC4F" height="16" /> | SolarEdge2MQTT                       | PV inverter → MQTT / InfluxDB             |
+| <img src="https://cdn.simpleicons.org/maildotru/005FF9" height="16" /> | SMTPRelay                            | Outbound mail relay for cluster workloads |
+
+## Portability note
+
+The whole `kubernetes/` tree is standard CNCF Kubernetes. Point a k3s or kind cluster at it and it'll largely just run — the only real Talos-isms are:
+
+- `bootstrap/talos-ccm/` — only makes sense on Talos; strip it on other distros.
+- A handful of `securityContext` tweaks tuned for Talos's strict defaults.
+- `storageClass` names assuming the Talos CSI drivers.
+
+Everything else (ingress, certs, DNS, Argo CD, all 25+ apps) is portable.
+
+## Bootstrap sequence
+
+### With Omni (this repo's default)
+
+Omni applies Cilium, Argo CD, and Talos-CCM automatically via [`extraManifests`](../cluster/patches/extraManifests-prod.yaml) during cluster creation — see [Layer 2 (cluster)](../cluster/README.md#bootstrap-sequence). The rendered manifests are continuously published to the [`bootstrap` branch](https://github.com/alexander-zimmermann/homelab/tree/bootstrap) by the [`cd-render-bootstrap.yaml`](../.github/workflows/cd-render-bootstrap.yaml) workflow — that's what Omni pulls.
+
+So once the cluster is up and `kubeconfig` is on your machine, there's only one step left:
+
+1. `task k8s:init` — seeds the sealed-secrets master key + DHI registry credentials.
+
+That's it. Argo CD is already running and starts reconciling the components / applications trees.
+
+### Without Omni (plain Kubernetes)
+
+If you're running this tree on a different cluster without Omni's `extraManifests` mechanism, apply the bootstrap manifests yourself:
+
+1. `kubectl apply -k kubernetes/bootstrap/cilium/overlays/prod` — CNI online.
+2. `kubectl apply -k kubernetes/bootstrap/talos-ccm/overlays/prod` — nodes get proper labels. *(Skip on non-Talos clusters.)*
+3. `kubectl apply -k kubernetes/bootstrap/gitops-controller/overlays/prod` — Argo CD + the two ApplicationSets land, reconciliation starts.
+4. `task k8s:init` — seed the sealed-secrets master key + DHI registry credentials.
+
+## License
+
+See [../LICENSE](../LICENSE).


### PR DESCRIPTION
- README.md rewritten around the three-layer pitch (infrastructure / cluster / kubernetes) with first-person tone, tech-icon hero grid, cluster + repo badge rows, Mermaid stack diagram, compute + UniFi network hardware tables, Talos VM table, and a compact highlights section that links to the moved component catalog.
- cluster/README.md added: Omni cluster templates, machine classes, infra-provider swap-out, tasks, and a bootstrap sequence that describes how Omni applies day-zero manifests via extraManifests.
- kubernetes/README.md added: directory layout, GitOps flow, tasks, adding-a-new-app recipe, portability note, full component catalog (platform / GitOps / security / storage / observability / applications), and a bootstrap sequence split into With-Omni and Without-Omni paths.
- infrastructure/README.md restyled to match: Layer 1 context, first-person tone, corrected image example (Debian Trixie, since Talos is no longer provisioned via OpenTofu), clarified that Omni creates Talos VMs itself, and a hypervisor swap-out note.
- TODO.md: removed the completed "Readme" and "Kromgo README badges" entries.