### PR TITLE
revert(influxdb): drop gen1-lookback=2000d override (breaks gen2 compaction)

### DIFF
--- a/kubernetes/applications/influxdb/base/values.yaml
+++ b/kubernetes/applications/influxdb/base/values.yaml
@@ -33,12 +33,6 @@ security:
 extraEnv:
   - name: INFLUXDB3_ADMIN_TOKEN_FILE
     value: /etc/influxdb3/tokens/admin-token.json
-  # Extend the gen1 index lookback window (default 24h) so historical
-  # writes (backfills, imports of pre-24h data) get indexed at startup
-  # and become visible to the Gen1 compactor. Without this the compactor
-  # ignores older-than-24h files and they pile up as tiny parquets forever.
-  - name: INFLUXDB3_GEN1_LOOKBACK_DURATION
-    value: 2000d
 
 # At-Home license allows only ONE node. Run the ingester as the sole component —
 # Kustomize patches strip --mode=ingest so it starts in combined mode


### PR DESCRIPTION
## Summary

- The `INFLUXDB3_GEN1_LOOKBACK_DURATION=2000d` set in #608 appears to be the cause of our silent gen2 compaction failure (GitHub issue [influxdata/influxdb#27301](https://github.com/influxdata/influxdb/issues/27301))
- Revert to the 24h default and verify whether the compactor actually starts merging files

## Background

After yesterday's recovery work the compactor persists summaries every ~2h (`sequence_number=378` now, +22 over 8h) but never produces merge plans. `system.parquet_files` grew from 24k → 29k in `homelab` overnight with zero consolidation. `compaction_details` is already clean (only the 16 active tables — no ghost load).

Research findings (see #27301 and [at-home license doc](https://docs.influxdata.com/influxdb3/enterprise/admin/license/)):
- At-Home license does NOT restrict compaction
- Issue #27301 is open, zero engagement, no public workaround
- The only non-default flag in our deployment is `INFLUXDB3_GEN1_LOOKBACK_DURATION=2000d`
- A very long lookback forces the producer to scan every gen1 file in the window when building a plan — at 30k files + 2 GiB memory this can fail silently and persist an empty summary

## What this PR does

- Removes the `INFLUXDB3_GEN1_LOOKBACK_DURATION` env var from `values.yaml` → back to the chart/server default of 24h
- Nothing else changes

## Test plan

- [ ] Merge → ArgoCD syncs → pod rolls with env var removed
- [ ] `kubectl exec influxdb3-0 -- env | grep GEN1_LOOKBACK` → not present
- [ ] After 2–3 hours: check whether `system.parquet_files` count starts dropping (compaction actively consolidating)
- [ ] If yes: revert plan was correct, keep default, plan next round of backfill with smaller batches
- [ ] If no: next step is upgrade to 3.9.1 per the release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)