### PR TITLE
test(influxdb): upgrade image to 3.9.1-enterprise (test gen2 compaction fix)

### DIFF
--- a/kubernetes/applications/influxdb/base/values.yaml
+++ b/kubernetes/applications/influxdb/base/values.yaml
@@ -1,6 +1,13 @@
 # Stable resource name for all rendered objects
 fullnameOverride: influxdb3
 
+# Override the chart's pinned appVersion (3.8.4-enterprise) to test whether
+# 3.9.1-enterprise fixes the gen2 compactor "empty plans" issue (#27301).
+# The chart only bumps appVersion on chart releases (currently 0.2.0);
+# the image tag can be overridden without a chart version bump.
+image:
+  tag: 3.9.1-enterprise
+
 cluster:
   id: homelab-cluster
 


### PR DESCRIPTION
## Summary

- Override \`image.tag\` to \`3.9.1-enterprise\` to test whether the newer binary fixes the gen2 compactor bug from #27301 (our production symptom: producer persists summaries, \`plans_ran:[]\`, files pile up forever)
- The Helm chart is still pinned at appVersion 3.8.4 (chart 0.2.0, no newer release) so Renovate can't offer this bump — we override manually

## Why this is worth trying

- #612 (gen1-lookback revert) is our other active experiment; it doesn't change the binary. If compaction is still broken after that, the bug is in 3.8.4 itself
- InfluxDB release notes for 3.9.x explicitly mention "compaction scheduling fixes" (no issue number linked, but relevant)
- Issue #27301 reporter exhausted every compaction-specific flag with no success on 3.8.4 — a binary bump is the remaining lever

## Risks

- Image tag is ahead of chart appVersion — template behavior for the newer binary is untested on this chart
- Roll-back is trivial: drop this PR's changes via a revert PR, image tag falls back to \`<appVersion>-enterprise\` = \`3.8.4-enterprise\`

## Test plan

- [ ] Merge → ArgoCD syncs → pod pulls new image
- [ ] \`kubectl -n influxdb get pod influxdb3-0 -o jsonpath='{.spec.containers[0].image}'\` shows \`influxdb:3.9.1-enterprise\`
- [ ] Pod reaches Ready within the usual ~2 min startup
- [ ] No crashloop, WAL replay completes
- [ ] Within 1–2 hours: check \`system.parquet_files\` count — if it starts falling, 3.9.1 fixed it
- [ ] If not, comment on #27301 with our 3.9.1 repro and either revert or wait on upstream

🤖 Generated with [Claude Code](https://claude.com/claude-code)