### PR TITLE
docs(readme): switch icons from Simple Icons to Homarr dashboard-icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,14 @@
 <div align="center">
 
-<img src="https://cdn.simpleicons.org/kubernetes/326CE5" height="32" alt="Kubernetes" />
+<img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/kubernetes.svg" height="40" alt="Kubernetes" />
 &nbsp;
-<img src="https://cdn.simpleicons.org/talos/FF7300" height="32" alt="Talos" />
+<img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/talos.svg" height="40" alt="Talos" />
 &nbsp;
-<img src="https://cdn.simpleicons.org/argo/EF7B4D" height="32" alt="Argo CD" />
+<img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/argo-cd.svg" height="40" alt="Argo CD" />
 &nbsp;
-<img src="https://cdn.simpleicons.org/sidero/FF7300" height="32" alt="Omni" />
+<img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/proxmox.svg" height="40" alt="Proxmox" />
 &nbsp;
-<img src="https://cdn.simpleicons.org/proxmox/E57000" height="32" alt="Proxmox" />
-&nbsp;
-<img src="https://cdn.simpleicons.org/opentofu/844FBA" height="32" alt="OpenTofu" />
+<img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/opentofu.svg" height="40" alt="OpenTofu" />
 
 # homelab
 

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -97,67 +97,67 @@ If your app needs secrets: write them as plain `secret.yaml`, then `task k8s:sea
 
 ## Catalog
 
-All components grouped by what they do. Icons via [Simple Icons](https://simpleicons.org/).
+All components grouped by what they do. Icons via [homarr-labs/dashboard-icons](https://github.com/homarr-labs/dashboard-icons), served through jsDelivr. Rows without an icon are for projects that don't have a curated brand-icon (yet).
 
 ### Platform
 
-|                                                                           | Component                                                        | Purpose                                                           |
-| ------------------------------------------------------------------------- | ---------------------------------------------------------------- | ----------------------------------------------------------------- |
-| <img src="https://cdn.simpleicons.org/talos/FF7300" height="16" />        | [Talos Linux](https://www.talos.dev/)                            | Immutable, API-managed Kubernetes OS                              |
-| <img src="https://cdn.simpleicons.org/sidero/FF7300" height="16" />       | [Omni](https://omni.siderolabs.com/)                             | SaaS control plane for Talos (auto-provisioning, machine classes) |
-| <img src="https://cdn.simpleicons.org/cilium/F8C517" height="16" />       | [Cilium](https://cilium.io/)                                     | eBPF CNI (kube-proxy replacement, L2 announcements)               |
-| <img src="https://cdn.simpleicons.org/traefikproxy/24A1C1" height="16" /> | [Traefik](https://traefik.io/)                                   | Ingress with pre/post-auth middleware chains                      |
-| <img src="https://cdn.simpleicons.org/letsencrypt/003A70" height="16" />  | [cert-manager](https://cert-manager.io/)                         | Automated TLS via Cloudflare DNS-01                               |
-| <img src="https://cdn.simpleicons.org/cloudflare/F38020" height="16" />   | [external-dns](https://github.com/kubernetes-sigs/external-dns)  | Syncs ingress hostnames to Cloudflare                             |
-| <img src="https://cdn.simpleicons.org/kubernetes/326CE5" height="16" />   | [Kyverno](https://kyverno.io/)                                   | Policy engine (secret replication, admission)                     |
-| <img src="https://cdn.simpleicons.org/bitwarden/175DDC" height="16" />    | [Sealed Secrets](https://github.com/bitnami-labs/sealed-secrets) | Git-safe, cluster-decryptable secrets                             |
+|                                                                                                        | Component                                                        | Purpose                                                           |
+| ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------- | ----------------------------------------------------------------- |
+| <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/talos.svg" height="18" />        | [Talos Linux](https://www.talos.dev/)                            | Immutable, API-managed Kubernetes OS                              |
+|                                                                                                        | [Omni](https://omni.siderolabs.com/)                             | SaaS control plane for Talos (auto-provisioning, machine classes) |
+| <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/cilium.svg" height="18" />       | [Cilium](https://cilium.io/)                                     | eBPF CNI (kube-proxy replacement, L2 announcements)               |
+| <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/traefik.svg" height="18" />      | [Traefik](https://traefik.io/)                                   | Ingress with pre/post-auth middleware chains                      |
+| <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/cert-manager.svg" height="18" /> | [cert-manager](https://cert-manager.io/)                         | Automated TLS via Cloudflare DNS-01                               |
+|                                                                                                        | [external-dns](https://github.com/kubernetes-sigs/external-dns)  | Syncs ingress hostnames to Cloudflare                             |
+|                                                                                                        | [Kyverno](https://kyverno.io/)                                   | Policy engine (secret replication, admission)                     |
+|                                                                                                        | [Sealed Secrets](https://github.com/bitnami-labs/sealed-secrets) | Git-safe, cluster-decryptable secrets                             |
 
 ### GitOps & Automation
 
-|                                                                          | Component                                  | Purpose                                       |
-| ------------------------------------------------------------------------ | ------------------------------------------ | --------------------------------------------- |
-| <img src="https://cdn.simpleicons.org/argo/EF7B4D" height="16" />        | [Argo CD](https://argo-cd.readthedocs.io/) | Declarative sync of `kubernetes/applications` |
-| <img src="https://cdn.simpleicons.org/renovatebot/1A1F6C" height="16" /> | [Renovate](https://docs.renovatebot.com/)  | Automated dependency PRs                      |
+|                                                                                                    | Component                                  | Purpose                                       |
+| -------------------------------------------------------------------------------------------------- | ------------------------------------------ | --------------------------------------------- |
+| <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/argo-cd.svg" height="18" />  | [Argo CD](https://argo-cd.readthedocs.io/) | Declarative sync of `kubernetes/applications` |
+| <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/renovate.svg" height="18" /> | [Renovate](https://docs.renovatebot.com/)  | Automated dependency PRs                      |
 
 ### Security & Identity
 
-|                                                                         | Component                                 | Purpose                                 |
-| ----------------------------------------------------------------------- | ----------------------------------------- | --------------------------------------- |
-| <img src="https://cdn.simpleicons.org/auth0/EB5424" height="16" />      | [Authentik](https://goauthentik.io/)      | SSO / OIDC / forward-auth               |
-| <img src="https://cdn.simpleicons.org/crowdsec/F24D1F" height="16" />   | [CrowdSec](https://www.crowdsec.net/)     | Behavior-based IPS on ingress           |
-| <img src="https://cdn.simpleicons.org/cloudflare/F38020" height="16" /> | [Cloudflare](https://www.cloudflare.com/) | WAF, rate-limiting, edge TLS, tunneling |
+|                                                                                                      | Component                                 | Purpose                                 |
+| ---------------------------------------------------------------------------------------------------- | ----------------------------------------- | --------------------------------------- |
+| <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/authentik.svg" height="18" />  | [Authentik](https://goauthentik.io/)      | SSO / OIDC / forward-auth               |
+| <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/crowdsec.svg" height="18" />   | [CrowdSec](https://www.crowdsec.net/)     | Behavior-based IPS on ingress           |
+| <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/cloudflare.svg" height="18" /> | [Cloudflare](https://www.cloudflare.com/) | WAF, rate-limiting, edge TLS, tunneling |
 
 ### Storage & Data
 
-|                                                                         | Component                                                                     | Purpose                                |
-| ----------------------------------------------------------------------- | ----------------------------------------------------------------------------- | -------------------------------------- |
-| <img src="https://cdn.simpleicons.org/kubernetes/326CE5" height="16" /> | CSI Block + NFS                                                               | Persistent volumes for workloads       |
-| <img src="https://cdn.simpleicons.org/rust/000000" height="16" />       | [RustFS](https://github.com/rustfs/rustfs)                                    | S3-compatible object storage           |
-| <img src="https://cdn.simpleicons.org/postgresql/4169E1" height="16" /> | [CloudNativePG](https://cloudnative-pg.io/) + [Barman](https://pgbarman.org/) | Postgres operator with S3 PITR backups |
-| <img src="https://cdn.simpleicons.org/redis/DC382D" height="16" />      | [Redis](https://redis.io/)                                                    | In-memory cache                        |
-| <img src="https://cdn.simpleicons.org/natsdotio/27AAE1" height="16" />  | [NATS](https://nats.io/)                                                      | Lightweight messaging                  |
-| <img src="https://cdn.simpleicons.org/influxdb/22ADF6" height="16" />   | [InfluxDB](https://www.influxdata.com/)                                       | Time-series DB for IoT telemetry       |
+|                                                                                                      | Component                                                                     | Purpose                                |
+| ---------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- | -------------------------------------- |
+| <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/kubernetes.svg" height="18" /> | CSI Block + NFS                                                               | Persistent volumes for workloads       |
+| <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/rustfs.svg" height="18" />     | [RustFS](https://github.com/rustfs/rustfs)                                    | S3-compatible object storage           |
+| <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/postgresql.svg" height="18" /> | [CloudNativePG](https://cloudnative-pg.io/) + [Barman](https://pgbarman.org/) | Postgres operator with S3 PITR backups |
+| <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/redis.svg" height="18" />      | [Redis](https://redis.io/)                                                    | In-memory cache                        |
+|                                                                                                      | [NATS](https://nats.io/)                                                      | Lightweight messaging                  |
+| <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/influxdb.svg" height="18" />   | [InfluxDB](https://www.influxdata.com/)                                       | Time-series DB for IoT telemetry       |
 
 ### Observability
 
-|                                                                           | Component                                    | Purpose                                     |
-| ------------------------------------------------------------------------- | -------------------------------------------- | ------------------------------------------- |
-| <img src="https://cdn.simpleicons.org/prometheus/E6522C" height="16" />   | [Prometheus](https://prometheus.io/)         | Metrics & alerting                          |
-| <img src="https://cdn.simpleicons.org/grafana/F46800" height="16" />      | [Grafana](https://grafana.com/) + Operator   | Dashboards, dashboards-as-code              |
-| <img src="https://cdn.simpleicons.org/grafana/F46800" height="16" />      | [Loki](https://grafana.com/oss/loki/)        | Log aggregation                             |
-| <img src="https://cdn.simpleicons.org/grafana/F46800" height="16" />      | [Alloy](https://grafana.com/docs/alloy/)     | Unified telemetry collector                 |
-| <img src="https://cdn.simpleicons.org/statuspage/172B4D" height="16" />   | [Gatus](https://gatus.io/)                   | Status page / synthetic probes              |
-| <img src="https://cdn.simpleicons.org/shieldsdotio/000000" height="16" /> | [kromgo](https://github.com/kashalls/kromgo) | PromQL → shields.io bridge (cluster badges) |
+|                                                                                                      | Component                                    | Purpose                                     |
+| ---------------------------------------------------------------------------------------------------- | -------------------------------------------- | ------------------------------------------- |
+| <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/prometheus.svg" height="18" /> | [Prometheus](https://prometheus.io/)         | Metrics & alerting                          |
+| <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/grafana.svg" height="18" />    | [Grafana](https://grafana.com/) + Operator   | Dashboards, dashboards-as-code              |
+| <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/loki.svg" height="18" />       | [Loki](https://grafana.com/oss/loki/)        | Log aggregation                             |
+| <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/alloy.svg" height="18" />      | [Alloy](https://grafana.com/docs/alloy/)     | Unified telemetry collector                 |
+| <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/gatus.svg" height="18" />      | [Gatus](https://gatus.io/)                   | Status page / synthetic probes              |
+|                                                                                                      | [kromgo](https://github.com/kashalls/kromgo) | PromQL → shields.io bridge (cluster badges) |
 
 ### Applications
 
-|                                                                        | Component                            | Purpose                                   |
-| ---------------------------------------------------------------------- | ------------------------------------ | ----------------------------------------- |
-| <img src="https://cdn.simpleicons.org/homepage/14B8A6" height="16" />  | [Homepage](https://gethomepage.dev/) | Service start page                        |
-| <img src="https://cdn.simpleicons.org/wikidotjs/1976D2" height="16" /> | [Wiki.js](https://js.wiki/)          | Knowledge base                            |
-| <img src="https://cdn.simpleicons.org/nodered/8F0000" height="16" />   | [Node-RED](https://nodered.org/)     | Flow-based automation                     |
-| <img src="https://cdn.simpleicons.org/solaredge/00AC4F" height="16" /> | SolarEdge2MQTT                       | PV inverter → MQTT / InfluxDB             |
-| <img src="https://cdn.simpleicons.org/maildotru/005FF9" height="16" /> | SMTPRelay                            | Outbound mail relay for cluster workloads |
+|                                                                                                    | Component                            | Purpose                                   |
+| -------------------------------------------------------------------------------------------------- | ------------------------------------ | ----------------------------------------- |
+|                                                                                                    | [Homepage](https://gethomepage.dev/) | Service start page                        |
+| <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/wikijs.svg" height="18" />   | [Wiki.js](https://js.wiki/)          | Knowledge base                            |
+| <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/node-red.svg" height="18" /> | [Node-RED](https://nodered.org/)     | Flow-based automation                     |
+|                                                                                                    | SolarEdge2MQTT                       | PV inverter → MQTT / InfluxDB             |
+|                                                                                                    | SMTPRelay                            | Outbound mail relay for cluster workloads |
 
 ## Portability note
 
@@ -186,7 +186,7 @@ That's it. Argo CD is already running and starts reconciling the components / ap
 If you're running this tree on a different cluster without Omni's `extraManifests` mechanism, apply the bootstrap manifests yourself:
 
 1. `kubectl apply -k kubernetes/bootstrap/cilium/overlays/prod` — CNI online.
-2. `kubectl apply -k kubernetes/bootstrap/talos-ccm/overlays/prod` — nodes get proper labels. *(Skip on non-Talos clusters.)*
+2. `kubectl apply -k kubernetes/bootstrap/talos-ccm/overlays/prod` — nodes get proper labels. _(Skip on non-Talos clusters.)_
 3. `kubectl apply -k kubernetes/bootstrap/gitops-controller/overlays/prod` — Argo CD + the two ApplicationSets land, reconciliation starts.
 4. `task k8s:init` — seed the sealed-secrets master key + DHI registry credentials.
 


### PR DESCRIPTION
Many homelab-specific tools (Authentik, Gatus, CrowdSec, RustFS, Alloy, Loki, Node-RED, Wiki.js, cert-manager, Kromgo-via-shields, …) don't exist in Simple Icons, so the catalog used placeholder logos (auth0 for Authentik, bitwarden for Sealed Secrets, grafana for Loki/Alloy, etc.). Homarr's dashboard-icons set is curated for homelab dashboards and has most of them natively — served via jsDelivr for CDN caching and correct SVG content-type.

- README.md hero: replace 6 Simple-Icons logos with 5 Homarr logos (Kubernetes, Talos, Argo CD, Proxmox, OpenTofu); dropped Sidero because Homarr doesn't have it and Talos already represents the ecosystem.
- kubernetes/README.md catalog: swap all Simple-Icons <img> tags for Homarr URLs where available. Icon cells left empty for projects without a curated Homarr entry (Omni, external-dns, Kyverno, Sealed Secrets, NATS, kromgo, Homepage, SolarEdge2MQTT, SMTPRelay).
- Shields.io badges still use Simple Icons via &logo=... (that is shields.io's own integration, not a catalog icon).

All Homarr URLs verified to return 200 image/svg+xml.