### PR TITLE
ci(mirror-charts): skip upstream tags whose manifest is unresolvable

### DIFF
--- a/.github/workflows/cd-mirror-charts.yaml
+++ b/.github/workflows/cd-mirror-charts.yaml
@@ -112,5 +112,15 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          SRC_REF="${{ matrix.src }}:${{ matrix.tag }}"
+          DST_REF="${{ matrix.dst }}:${{ matrix.tag }}"
           # '-r': also copy referrers (e.g., signatures/SBOM attestations) if present
-          oras cp -r "${{ matrix.src }}:${{ matrix.tag }}" "${{ matrix.dst }}:${{ matrix.tag }}"
+          if ! ERR="$(oras cp -r "$SRC_REF" "$DST_REF" 2>&1)"; then
+            printf '%s\n' "$ERR"
+            # Tolerate upstream tags listed but not resolvable (manifest withdrawn).
+            if grep -qiE 'failed to resolve|not found|manifest unknown' <<< "$ERR"; then
+              echo "::warning::Skipping unresolvable upstream tag $SRC_REF"
+              exit 0
+            fi
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- The nightly `CD: Mirror OCI Charts` workflow has been failing since 2026-04-16.
- Root cause: `dhi.io` lists phantom tags for `cert-manager-chart` (`1` and `1.20.2`) in its tag index, but their manifests are not resolvable (`failed to resolve ...: not found`). `helm pull` on existing tags like `1.19.4` works fine — only these specific entries are broken upstream.
- Fix: in the `mirror-charts` matrix step, catch `oras cp` resolve/not-found errors and emit a `::warning::` instead of failing the job. The phantom tag stays absent on GHCR and will be retried on the next run once upstream fixes it.

## Test plan
- [ ] Manually trigger the workflow (`workflow_dispatch`) and confirm that the `cert-manager-chart:1` / `:1.20.2` matrix legs emit a warning and finish green.
- [ ] Verify that the other charts (sealed-secrets, metrics-server, external-dns, cloudnative-pg) still mirror new tags successfully.
- [ ] Confirm a truly broken copy (e.g. auth failure) would still fail the job — grep filter only matches resolve/not-found messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)