### PR TITLE
config(rustfs): TEMP bump memory limit 512Mi → 2Gi for backfill phase

### DIFF
--- a/kubernetes/applications/rustfs/overlays/prod/kustomization.yaml
+++ b/kubernetes/applications/rustfs/overlays/prod/kustomization.yaml
@@ -47,7 +47,10 @@ replacements:
           - spec.resources.requests.storage
 
 patches:
-  # RustFS server manages distributed storage and API access
+  # RustFS server manages distributed storage and API access.
+  # TEMP: memory limit bumped 512Mi → 2Gi during the InfluxDB 3 backfill /
+  # recovery phase (2026-04-23). 512Mi got the pod OOMKilled under the
+  # Telegraf-retry-buffer write spike; revisit once backfill is complete.
   - target:
       kind: Deployment
       name: rustfs

--- a/kubernetes/applications/rustfs/overlays/prod/kustomization.yaml
+++ b/kubernetes/applications/rustfs/overlays/prod/kustomization.yaml
@@ -63,7 +63,7 @@ patches:
             memory: 128Mi
           limits:
             cpu: 200m
-            memory: 512Mi
+            memory: 2Gi
 
   # RustFS API service with static IP and BGP advertisement
   - target:


### PR DESCRIPTION
## Summary

Temporarily bump RustFS memory limit from 512Mi to 2Gi to keep it stable under the current InfluxDB 3 backfill / recovery load.

## Context

During yesterday's InfluxDB 3 nuclear rebuild the pod flushed a backlogged Telegraf retry buffer (~1M writes in a few minutes) to the object store. RustFS at 512Mi got OOMKilled and entered CrashLoopBackOff, which in turn left InfluxDB unable to reach its object store. A live kubectl patch to 2Gi stabilised it (steady ~250 MiB, peak ~950 MiB during the write spike) — this PR makes that change durable in Git.

Node headroom is fine: DP-nodes currently at ~48–54 % memory, ~4 GiB free each.

Marked TEMP (same convention as the InfluxDB overlay) — revisit once the Influx 2 → 3 backfill is complete and steady-state memory is known.

## Test plan

- [ ] ArgoCD sync → Deployment rolled
- [ ] `kubectl -n rustfs get deploy rustfs -o jsonpath='{.spec.template.spec.containers[0].resources.limits.memory}'` → `2Gi`
- [ ] RustFS pod stable under write load (no OOMKilled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)