### PR TITLE
config(influxdb): TEMP re-enable gen1-lookback=1460d for backfill phase

### DIFF
--- a/kubernetes/applications/influxdb/base/values.yaml
+++ b/kubernetes/applications/influxdb/base/values.yaml
@@ -40,6 +40,13 @@ security:
 extraEnv:
   - name: INFLUXDB3_ADMIN_TOKEN_FILE
     value: /etc/influxdb3/tokens/admin-token.json
+  # TEMP: extend the gen1 index lookback window (default 24h) so the Gen1
+  # compactor sees historical writes (Influx 2 → 3 backfill covering
+  # 2022-07 onwards) while they are being written, rather than leaving
+  # them as tiny uncompacted 10-min buckets forever. Revisit after the
+  # backfill is complete.
+  - name: INFLUXDB3_GEN1_LOOKBACK_DURATION
+    value: 1460d
 
 # At-Home license allows only ONE node. Run the ingester as the sole component —
 # Kustomize patches strip --mode=ingest so it starts in combined mode


### PR DESCRIPTION
## Summary

Re-enable \`INFLUXDB3_GEN1_LOOKBACK_DURATION=1460d\` before the Influx 2 → 3 historical backfill starts. Without this, files written with historical timestamps (2022-07 onwards) would be outside the default 24h lookback window → invisible to the Gen1 compactor → pile up forever as tiny 10-minute-bucket parquets.

## Context

- Last attempt at a long lookback (#608, 2000d) was reverted (#612) because the compactor planner errored with \`Unexpected(table definition is missing)\`.
- Yesterday we tracked the real cause of that error to **ghost catalog entries from soft-deleted DB generations**, not the lookback flag. A full rebuild (fresh RustFS bucket, purged S3 object versions, clean catalog) eliminated the planner errors completely — we've confirmed zero errors for the last ~10 h on the current 3.9.1-enterprise instance.
- Marked \`TEMP\` so it is revisited once the backfill is complete and the steady-state lookback can be decided.

## Order matters

Merging this PR first, then running the import via [\`influxdata/import\`](https://github.com/influxdata/influxdb3_plugins/blob/main/influxdata/import/README.md). If we imported first and extended the lookback afterwards we'd already have billions of tiny uncompacted files to chew through.

## Test plan

- [ ] Merge → ArgoCD syncs → pod rolls with new env var
- [ ] \`kubectl exec influxdb3-0 -- env | grep GEN1_LOOKBACK\` shows \`1460d\`
- [ ] No \`table definition is missing\` errors in the log after startup
- [ ] Compactor keeps persisting compaction summaries on schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)