### PR TITLE
config(influxdb): enable Processing Engine package manager

### DIFF
--- a/kubernetes/applications/influxdb/base/kustomization.yaml
+++ b/kubernetes/applications/influxdb/base/kustomization.yaml
@@ -59,7 +59,7 @@ patches:
         value: "exec influxdb3 \\\n  serve \\\n  --mode=ingest \\\n  --node-id=$(hostname)\n"
       - op: replace
         path: /spec/template/spec/containers/0/command/2
-        value: "exec influxdb3 \\\n  serve \\\n  --node-id=$(hostname) \\\n  --plugin-dir=/plugins \\\n  --package-manager=disabled\n"
+        value: "exec influxdb3 \\\n  serve \\\n  --node-id=$(hostname) \\\n  --plugin-dir=/plugins\n"
 
   # Rename influxdb3-ingester → influxdb3 since the single node runs all roles.
   - target:


### PR DESCRIPTION
## Summary

Remove \`--package-manager=disabled\` from the \`influxdb3 serve\` command so that \`influxdb3 install package <name>\` works at runtime.

## Why

Required for installing the upstream [influxdata/import](https://github.com/influxdata/influxdb3_plugins/blob/main/influxdata/import/README.md) plugin, which depends on the Python \`requests\` package. We plan to use that plugin for the Influx 2 → 3 historical backfill (homelab_1h covering 2022-07 onwards).

## Test plan

- [ ] ArgoCD sync → pod rolls without the \`--package-manager=disabled\` flag
- [ ] \`kubectl -n influxdb exec influxdb3-0 -- influxdb3 install package requests\` succeeds
- [ ] Existing \`downsample_1h\` trigger keeps working (plugin execution unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)