### PR TITLE
Revert "config(influxdb): enable Processing Engine package manager"

### DIFF
--- a/kubernetes/applications/influxdb/base/kustomization.yaml
+++ b/kubernetes/applications/influxdb/base/kustomization.yaml
@@ -59,7 +59,7 @@ patches:
         value: "exec influxdb3 \\\n  serve \\\n  --mode=ingest \\\n  --node-id=$(hostname)\n"
       - op: replace
         path: /spec/template/spec/containers/0/command/2
-        value: "exec influxdb3 \\\n  serve \\\n  --node-id=$(hostname) \\\n  --plugin-dir=/plugins\n"
+        value: "exec influxdb3 \\\n  serve \\\n  --node-id=$(hostname) \\\n  --plugin-dir=/plugins \\\n  --package-manager=disabled\n"
 
   # Rename influxdb3-ingester → influxdb3 since the single node runs all roles.
   - target:


### PR DESCRIPTION
Reverts #620.

The server fails to start with \`--package-manager\` not set to \`disabled\` because it then tries to create a Python virtualenv under \`/plugins/.venv/\`, which is a read-only ConfigMap mount.

```
Serve command failed: Python environment initialization failed:
Virtual environment error: Failed to initialize virtualenv:
Activation script not found at "/plugins/.venv/bin/activate"
```

Enabling the package manager requires plugin-dir to be writable. That is a larger change (emptyDir + initContainer to seed the plugin files from the ConfigMap) than warranted for our current goal. We'll use the self-built stdlib-only backfill script for the Influx 2 → 3 import instead of the upstream import plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)