### PR TITLE
revert(rustfs): TEMP 2Gi memory → back to 512Mi

### DIFF
--- a/kubernetes/applications/rustfs/overlays/prod/kustomization.yaml
+++ b/kubernetes/applications/rustfs/overlays/prod/kustomization.yaml
@@ -48,9 +48,6 @@ replacements:
 
 patches:
   # RustFS server manages distributed storage and API access.
-  # TEMP: memory limit bumped 512Mi → 2Gi during the InfluxDB 3 backfill /
-  # recovery phase (2026-04-23). 512Mi got the pod OOMKilled under the
-  # Telegraf-retry-buffer write spike; revisit once backfill is complete.
   - target:
       kind: Deployment
       name: rustfs
@@ -66,7 +63,7 @@ patches:
             memory: 128Mi
           limits:
             cpu: 200m
-            memory: 2Gi
+            memory: 512Mi
 
   # RustFS API service with static IP and BGP advertisement
   - target:


### PR DESCRIPTION
## Summary

Revert the TEMP 2Gi memory bump from #618. That was only needed during the InfluxDB 3 backfill phase to handle a write spike; with the backfill parked (upstream architectural issue per influxdata/influxdb#27301), RustFS is back to its steady-state workload and 512Mi is plenty.

## Test plan

- [ ] ArgoCD sync rolls the deployment onto 512Mi
- [ ] RustFS pod stable (no OOM) for 24–48h under live load

🤖 Generated with [Claude Code](https://claude.com/claude-code)