### PR TITLE
feat(nats): add JetStream streams for KNX, SolarEdge, EMS-ESP, Warp

### DIFF
--- a/kubernetes/applications/nats/base/kustomization.yaml
+++ b/kubernetes/applications/nats/base/kustomization.yaml
@@ -6,6 +6,10 @@ resources:
   - ./certificate.yaml
   - ./ingress-route-tcp.yaml
   - ./sealed-secret.yaml
+  - ./streams/knx.yaml
+  - ./streams/solaredge.yaml
+  - ./streams/ems-esp.yaml
+  - ./streams/warp.yaml
 
 helmCharts:
   - name: nats

--- a/kubernetes/applications/nats/base/streams/ems-esp.yaml
+++ b/kubernetes/applications/nats/base/streams/ems-esp.yaml
@@ -1,0 +1,15 @@
+# EMS-ESP heating system data published via MQTT (topic prefix `ems-esp/…`).
+# The NATS MQTT adapter maps to `ems-esp.>` NATS subjects.
+apiVersion: jetstream.nats.io/v1beta2
+kind: Stream
+metadata:
+  name: ems-esp
+  namespace: nats
+spec:
+  name: EMS_ESP
+  subjects:
+    - ems-esp.>
+  storage: file
+  retention: limits
+  maxAge: 168h
+  replicas: 1

--- a/kubernetes/applications/nats/base/streams/knx.yaml
+++ b/kubernetes/applications/nats/base/streams/knx.yaml
@@ -1,0 +1,16 @@
+# KNX events published by the xknx-NATS bridge on `knx.<main>.<middle>.<sub>`.
+# Retention 7d is the safety puffer if a downstream consumer (Redpanda Connect
+# → TimescaleDB) is offline for a while — KNX bus itself does not buffer.
+apiVersion: jetstream.nats.io/v1beta2
+kind: Stream
+metadata:
+  name: knx
+  namespace: nats
+spec:
+  name: KNX
+  subjects:
+    - knx.>
+  storage: file
+  retention: limits
+  maxAge: 168h
+  replicas: 1

--- a/kubernetes/applications/nats/base/streams/solaredge.yaml
+++ b/kubernetes/applications/nats/base/streams/solaredge.yaml
@@ -1,0 +1,17 @@
+# SolarEdge inverters published by solaredge2mqtt via MQTT (port 1883). The NATS
+# MQTT adapter maps `solaredge-1/*` and `solaredge-2/*` MQTT topics to
+# `solaredge-1.>` / `solaredge-2.>` NATS subjects. One stream covers both.
+apiVersion: jetstream.nats.io/v1beta2
+kind: Stream
+metadata:
+  name: solaredge
+  namespace: nats
+spec:
+  name: SOLAREDGE
+  subjects:
+    - solaredge-1.>
+    - solaredge-2.>
+  storage: file
+  retention: limits
+  maxAge: 168h
+  replicas: 1

--- a/kubernetes/applications/nats/base/streams/warp.yaml
+++ b/kubernetes/applications/nats/base/streams/warp.yaml
@@ -1,0 +1,15 @@
+# Tinkerforge Warp wallbox data published via MQTT (topic prefix `warp/…`).
+# The NATS MQTT adapter maps to `warp.>` NATS subjects.
+apiVersion: jetstream.nats.io/v1beta2
+kind: Stream
+metadata:
+  name: warp
+  namespace: nats
+spec:
+  name: WARP
+  subjects:
+    - warp.>
+  storage: file
+  retention: limits
+  maxAge: 168h
+  replicas: 1


### PR DESCRIPTION
## Summary

Define four JetStream Stream CRDs (managed by the already-installed \`nack\` operator) so that publishes on the respective subjects are **persisted with a 7-day retention buffer**. Without this, NATS is plain pub/sub and any consumer outage means data loss.

## Streams

| Name | Subjects | Source |
|---|---|---|
| KNX | \`knx.>\` | xknx bridge (coming soon, Schritt A of migration) |
| SOLAREDGE | \`solaredge-1.>\`, \`solaredge-2.>\` | solaredge2mqtt via NATS's MQTT adapter |
| EMS_ESP | \`ems-esp.>\` | ems-esp via NATS's MQTT adapter |
| WARP | \`warp.>\` | Tinkerforge wallbox via NATS's MQTT adapter |

All: \`storage=file\`, \`retention=limits\`, \`maxAge=168h\` (7 days), \`replicas=1\`.

## Context

This is **Schritt 0** of the migration away from InfluxDB 3 to TimescaleDB + Redpanda Connect, as captured in the parallel plan [handoff-influxdb-2-tranquil-haven.md](/Users/alexander/.claude/plans/handoff-influxdb-2-tranquil-haven.md). No consumer (KNX bridge, Redpanda Connect, future AI) can reliably subscribe to these subjects without a persistent stream behind them.

After this merges: existing MQTT producers continue unchanged (solaredge2mqtt, ems-esp, warp all talk MQTT → NATS adapter → now JetStream persists the messages for 7 days).

## Test plan

- [ ] ArgoCD sync creates 4 \`Stream\` resources in \`nats\` namespace
- [ ] \`kubectl get streams.jetstream.nats.io -n nats\` shows all 4
- [ ] MQTT producer (e.g. solaredge2mqtt) writes still arrive as before (verified via \`nats sub "solaredge-1.>"\`)
- [ ] Server-side \`nats stream info SOLAREDGE\` shows incoming message count > 0 after a few minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)