### PR TITLE
fix(renovate): use client-id instead of deprecated app-id

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
         id: app-token
         with:
-          app-id: ${{ secrets.RENOVATE_APP_ID }}
+          client-id: ${{ secrets.RENOVATE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RENOVATE_PRIVATE_KEY }}
 
       - name: Run Renovate


### PR DESCRIPTION
## Summary
- `app-id` on `actions/create-github-app-token` is deprecated; switches to the new `client-id` input to silence the warning.

## Prerequisite
The repo secret `RENOVATE_APP_CLIENT_ID` must be set with the Client ID from the Renovate GitHub App settings page (Settings → Developer settings → GitHub Apps → your Renovate app → General → Client ID, looks like \`Iv23…\`). The existing `RENOVATE_PRIVATE_KEY` is reused unchanged. Old `RENOVATE_APP_ID` can be deleted after this PR is merged.

## Test plan
- [ ] Set `RENOVATE_APP_CLIENT_ID` repo secret
- [ ] Manually trigger the Renovate workflow (Actions → Maintenance: Renovate → Run workflow) with `dryRun: true`
- [ ] Confirm no deprecation warning appears and "Generate Token" step succeeds