### PR TITLE
fix(renovate): revert to numeric app-id

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -42,7 +42,10 @@ jobs:
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
         id: app-token
         with:
-          client-id: ${{ secrets.RENOVATE_APP_CLIENT_ID }}
+          # NOTE: 'app-id' is marked deprecated by the action, but GitHub's
+          # installation-token endpoint still rejects string client-id values
+          # with 'iss must be an Integer' (HTTP 401). Staying on numeric App ID.
+          app-id: ${{ secrets.RENOVATE_APP_ID }}
           private-key: ${{ secrets.RENOVATE_PRIVATE_KEY }}
 
       - name: Run Renovate


### PR DESCRIPTION
## Summary
Reverts the client-id switch from #629. GitHub's installation-token endpoint rejects the JWT with `'Issuer' claim ('iss') must be an Integer` (HTTP 401) when the action generates a token using the string Client ID. The deprecation warning on `app-id` is cosmetic; the `client-id` path is actually broken end-to-end.

## Prerequisite
The repo secret `RENOVATE_APP_ID` (numeric App ID from the Renovate GitHub App settings page) must be restored; it was deleted after #629.

## Test plan
- [ ] Set `RENOVATE_APP_ID` repo secret (numeric App ID)
- [ ] Manually trigger the Renovate workflow (Actions → Maintenance: Renovate → Run workflow) with `dryRun: true`
- [ ] Confirm "Generate Token" step succeeds and Renovate runs