### PR TITLE
chore(renovate): enable pre-commit manager

### DIFF
--- a/.renovate/groups.json5
+++ b/.renovate/groups.json5
@@ -2,6 +2,11 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "packageRules": [
     {
+      "description": "pre-commit hooks grouping",
+      "matchManagers": ["pre-commit"],
+      "groupName": "pre-commit"
+    },
+    {
       "description": "Kubernetes components grouping",
       "groupName": "kubernetes",
       "matchDatasources": ["docker"],

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -26,6 +26,9 @@
   "flux": {
     "managerFilePatterns": ["/\\.yaml$/"]
   },
+  "pre-commit": {
+    "enabled": true
+  },
   "packageRules": [
     {
       "matchFileNames": ["infrastructure/manifest/20-image/image.yaml"],


### PR DESCRIPTION
## Summary

- Enables Renovate's `pre-commit` manager so `rev:` pins in `.pre-commit-config.yaml` (gitleaks, actionlint, pre-commit-hooks, ...) get updated alongside the rest of the managed dependencies.
- Adds a grouping rule in `.renovate/groups.json5` to bundle all hook bumps into a single weekly PR.
- Brings homelab in line with `knx-nats-bridge` and the new `cnpg-postgres-timescaledb` repo, which both already have this config.

## Test plan

- [ ] Merge + wait for next hourly Renovate run
- [ ] Verify Renovate Dashboard issue lists pending `.pre-commit-config.yaml` updates
- [ ] First combined pre-commit bump PR lands with group name `pre-commit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)