### PR TITLE
chore(security): allowlist SealedSecret blobs in gitleaks

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,11 @@
+# Extend gitleaks' default ruleset; only add an allowlist for files that
+# legitimately contain high-entropy strings.
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Bitnami SealedSecret encrypted blobs are not plaintext leaks"
+paths = [
+    '''.*sealed-secret\.yaml$''',
+    '''.*sealed-secret-.*\.yaml$''',
+]


### PR DESCRIPTION
## Summary

Adds a repo-root \`.gitleaks.toml\` that allowlists Bitnami SealedSecret files (\`sealed-secret.yaml\` and \`sealed-secret-*.yaml\`).

The encrypted base64 payloads inside SealedSecret resources have high entropy and can match the default \`generic-api-key\` rule, but they are AES-encrypted and unusable without the cluster's master key — they are not actual plaintext leaks. Without this allowlist, any new SealedSecret entry blocks the pre-commit gitleaks hook, forcing \`--no-verify\` workarounds.

The allowlist extends gitleaks' default ruleset (\`extend.useDefault = true\`), so all other detection rules continue to apply.

## Test plan
- [ ] Existing pre-commit run on a no-op edit still scans the rest of the repo
- [ ] A modified \`sealed-secret.yaml\` no longer triggers the gitleaks hook