### PR TITLE
feat(rustfs): add timescaledb-backups bucket

### DIFF
--- a/kubernetes/applications/rustfs/base/initialize-buckets-job.yaml
+++ b/kubernetes/applications/rustfs/base/initialize-buckets-job.yaml
@@ -45,7 +45,7 @@ spec:
             - name: RUSTFS_URL
               value: "http://rustfs-svc.rustfs.svc.cluster.local:9000"
             - name: BUCKETS
-              value: "authentik-backups longhorn-backups influxdb3"
+              value: "authentik-backups longhorn-backups influxdb3 timescaledb-backups"
             - name: ACCESS_KEY
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Summary

Adds `timescaledb-backups` to the `BUCKETS` env var of the [initialize-rustfs-buckets PostSync Job](kubernetes/applications/rustfs/base/initialize-buckets-job.yaml). The Job uses `mc mb` and is idempotent — existing buckets are skipped, so this is safe to roll out anytime. Must be merged + synced before the TimescaleDB app (Schritt 3 of the migration plan) lands, otherwise Barman-Cloud's WAL archiver errors on first write.

## Test plan

- [ ] Merge → ArgoCD syncs `rustfs` app → PostSync Job runs
- [ ] `mc ls rustfs/timescaledb-backups` from inside the rustfs namespace returns success (empty bucket)
- [ ] Existing buckets (`authentik-backups`, `longhorn-backups`, `influxdb3`) untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)