### PR TITLE
chore(gitignore): ignore .claude/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ build/
 !.vscode/settings.json
 !.vscode/extensions.json
 *.code-workspace
+
+# --- KI ---
+.claude/


### PR DESCRIPTION
## Summary

Adds `.claude/` to `.gitignore`. Claude Code creates a per-project `.claude/` folder (session transcripts, auto-memory references) at the repo root — none of it is meant to be committed.

## Test plan

- [ ] `git status` no longer flags `.claude/` as untracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)