### PR TITLE
feat(alertmanager): route Watchdog to email instead of Pushover

### DIFF
--- a/kubernetes/applications/prometheus/base/values.yaml
+++ b/kubernetes/applications/prometheus/base/values.yaml
@@ -13,6 +13,10 @@ alertmanager:
   config:
     global:
       resolve_timeout: 5m
+      # Internal smtprelay (no auth, accepts mail from cluster CIDR)
+      smtp_smarthost: smtprelay.smtprelay.svc.cluster.local:25
+      smtp_from: alertmanager@zimmermann.eu.com
+      smtp_require_tls: false
     route:
       # Group by job to avoid alert storms when multiple alerts fire together
       group_by: ["alertname", "job"]
@@ -21,10 +25,10 @@ alertmanager:
       repeat_interval: 6h
       receiver: "endpoints"
       routes:
-        # Watchdog heartbeat: fires continuously so we know alerting works
+        # Watchdog heartbeat: routine signal, route to email only (no Pushover noise)
         - matchers:
             - alertname = "Watchdog"
-          receiver: "endpoints"
+          receiver: "watchdog-email"
           repeat_interval: 12h
     receivers:
       - name: "endpoints"
@@ -36,6 +40,10 @@ alertmanager:
         # Node-RED endpoint for container status events
         webhook_configs:
           - url: "http://node-red.zimmermann.eu.com:1880/container-status"
+            send_resolved: true
+      - name: "watchdog-email"
+        email_configs:
+          - to: alexander@zimmermann.eu.com
             send_resolved: true
 
   alertmanagerSpec:


### PR DESCRIPTION
## Summary
- Adds an SMTP smarthost to Alertmanager's `global` config pointing at the in-cluster smtprelay (`smtprelay.smtprelay.svc.cluster.local:25`, no TLS, no auth — relay accepts cluster CIDR)
- New `watchdog-email` receiver that emails `alexander@zimmermann.eu.com` with `send_resolved: true`
- Watchdog route now targets `watchdog-email` instead of `endpoints`, so the heartbeat no longer hits Pushover or the Node-RED webhook

## Why
Watchdog is a continuous heartbeat alert (`expr: vector(1)`) used to verify the alerting pipeline end-to-end. Pushing it to Pushover means a mobile push every 12h for something that, by design, isn't actionable — pure noise. Real alerts continue to use the `endpoints` receiver (Pushover + Node-RED).

## Test plan
- [ ] After merge, confirm an email arrives within 12h titled with the Watchdog alert
- [ ] Confirm no Pushover push for Watchdog
- [ ] Trigger a real alert (e.g. silence/unsilence a test rule) and confirm Pushover + Node-RED still fire
- [ ] Check smtprelay logs show the inbound mail from the prometheus namespace

🤖 Generated with [Claude Code](https://claude.com/claude-code)