### PR TITLE
fix(timescaledb): move shared_preload_libraries to top-level field

### DIFF
--- a/kubernetes/applications/timescaledb/base/database.yaml
+++ b/kubernetes/applications/timescaledb/base/database.yaml
@@ -32,6 +32,10 @@ spec:
             key: bootstrap.sql
 
   postgresql:
+    # Load TimescaleDB extension at server start
+    shared_preload_libraries:
+      - timescaledb
+
     parameters:
       # Memory settings — sized for write-heavy time-series workload
       shared_buffers: "256MB"
@@ -47,8 +51,7 @@ spec:
       wal_keep_size: "128MB"
       wal_compression: "on"
 
-      # TimescaleDB
-      shared_preload_libraries: "timescaledb"
+      # TimescaleDB worker settings
       max_worker_processes: "16"
       timescaledb.max_background_workers: "8"
 


### PR DESCRIPTION
## Summary

ArgoCD sync of `timescaledb-prod` failed with:

\`\`\`
admission webhook "vcluster.cnpg.io" denied the request:
Cluster.postgresql.cnpg.io "timescaledb-db" is invalid:
spec.postgresql.parameters.shared_preload_libraries:
  Invalid value: "timescaledb": Can't set fixed configuration parameter
\`\`\`

CNPG manages \`shared_preload_libraries\` itself; the dedicated way to add an extension is the top-level list \`spec.postgresql.shared_preload_libraries\`. Move TimescaleDB there.

## Test plan

- [ ] Merge → ArgoCD re-syncs timescaledb-prod
- [ ] Cluster reaches "Cluster in healthy state"
- [ ] \`SELECT extversion FROM pg_extension WHERE extname='timescaledb';\` returns 2.26.x

🤖 Generated with [Claude Code](https://claude.com/claude-code)