### PR TITLE
fix(kyverno): clone rustfs-admin-credentials into timescaledb namespace

### DIFF
--- a/kubernetes/components/admission-controller/base/clusterpolicy-secrets.yaml
+++ b/kubernetes/components/admission-controller/base/clusterpolicy-secrets.yaml
@@ -342,6 +342,25 @@ spec:
           namespace: rustfs
           name: rustfs-admin-credentials
 
+    # Syncs RustFS admin credentials from rustfs into timescaledb for WAL archiving/backup
+    - name: sync-rustfs-admin-credentials-timescaledb
+      match:
+        any:
+          - resources:
+              kinds:
+                - Namespace
+              names:
+                - timescaledb
+      generate:
+        apiVersion: v1
+        kind: Secret
+        name: rustfs-admin-credentials
+        namespace: timescaledb
+        synchronize: true
+        clone:
+          namespace: rustfs
+          name: rustfs-admin-credentials
+
     # Syncs KNX NATS Bridge credentials from nats into knx-nats-bridge for NATS authentication
     - name: sync-knx-nats-bridge-credentials
       match:


### PR DESCRIPTION
## Summary

Barman-Cloud-Plugin in the timescaledb-db Cluster keeps logging:

\`\`\`
Error while handling GRPC request ... while getting secret rustfs-admin-credentials:
secrets "rustfs-admin-credentials" not found
\`\`\`

Reason: the rustfs admin secret lives in the \`rustfs\` namespace, but the WAL archiver looks it up in the cluster's own namespace (\`timescaledb\`). The existing Kyverno ClusterPolicy already handles this for authentik, wiki-js and influxdb — add a matching rule for timescaledb.

## Test plan

- [ ] Merge → Kyverno generates \`Secret/rustfs-admin-credentials\` in \`timescaledb\` namespace
- [ ] Barman-Cloud sidecar logs no longer show "secret not found"
- [ ] \`kubectl -n timescaledb get cluster timescaledb-db -o jsonpath='{.status.firstRecoverabilityPoint}'\` populates after the next WAL switch

🤖 Generated with [Claude Code](https://claude.com/claude-code)