### PR TITLE
fix(alertmanager): use zimmermann.sh FROM so iCloud accepts mail

### DIFF
--- a/kubernetes/applications/prometheus/base/values.yaml
+++ b/kubernetes/applications/prometheus/base/values.yaml
@@ -15,7 +15,8 @@ alertmanager:
       resolve_timeout: 5m
       # Internal smtprelay (no auth, accepts mail from cluster CIDR)
       smtp_smarthost: smtprelay.smtprelay.svc.cluster.local:25
-      smtp_from: alertmanager@zimmermann.eu.com
+      # FROM must use zimmermann.sh — iCloud only accepts addresses tied to the relay account's aliases
+      smtp_from: alertmanager@zimmermann.sh
       smtp_require_tls: false
     route:
       # Group by job to avoid alert storms when multiple alerts fire together


### PR DESCRIPTION
## Summary
- Changes Alertmanager's `smtp_from` from `alertmanager@zimmermann.eu.com` to `alertmanager@zimmermann.sh`

## Why
After #647 merged, `AlertmanagerFailedToSendAlerts` started firing. Logs show iCloud rejecting the mail:

```
delivery failure: 550 5.7.0 From address is not one of your addresses
```

The smtprelay forwards to iCloud authenticated as `dr.azimmermann@icloud.com`, and iCloud only accepts FROM addresses that are aliases of that account. `zimmermann.sh` is the configured custom-domain alias — Authentik already uses `admin@zimmermann.sh` for the same reason.

## Test plan
- [ ] After merge, confirm `AlertmanagerFailedToSendAlerts` resolves
- [ ] Confirm a Watchdog email arrives
- [ ] Check smtprelay logs show successful delivery (no 550)

🤖 Generated with [Claude Code](https://claude.com/claude-code)