### PR TITLE
fix(argocd): use zimmermann.sh FROM so iCloud accepts deploy emails

### DIFF
--- a/kubernetes/bootstrap/gitops-controller/base/values.yaml
+++ b/kubernetes/bootstrap/gitops-controller/base/values.yaml
@@ -91,7 +91,7 @@ notifications:
     service.email.smtp: |
       host: smtprelay.smtprelay.svc.cluster.local
       port: 25
-      from: argocd@zimmermann.eu.com
+      from: argocd@zimmermann.sh
 
   # Notification content per event type
   templates:


### PR DESCRIPTION
## Summary
- Changes ArgoCD's notifications email service `from` from `argocd@zimmermann.eu.com` to `argocd@zimmermann.sh`

## Why
Same root cause as the Alertmanager issue (#650): the smtprelay forwards to iCloud authenticated as `dr.azimmermann@icloud.com`, and iCloud only accepts FROM addresses that are aliases of that account. `zimmermann.sh` is the configured custom-domain alias — Authentik already uses `admin@zimmermann.sh` for the same reason. Without this, every successful sync's email is rejected with `550 5.7.0 From address is not one of your addresses`.

## Test plan
- [ ] After merge, trigger a sync on a small app and confirm the deploy email arrives
- [ ] Check smtprelay logs show successful delivery (no 550)
- [ ] Confirm Pushover behavior is unchanged for failures/degraded health

🤖 Generated with [Claude Code](https://claude.com/claude-code)