### PR TITLE
fix(knx-nats-bridge): bump image to v0.1.2 (nkeys runtime dep)

### DIFF
--- a/kubernetes/applications/knx-nats-bridge/base/values.yaml
+++ b/kubernetes/applications/knx-nats-bridge/base/values.yaml
@@ -5,7 +5,7 @@ deployment:
   enabled: true
   image:
     repository: ghcr.io/alexander-zimmermann/knx-nats-bridge
-    tag: 0.1.1
+    tag: 0.1.2
     pullPolicy: IfNotPresent
 
   # KNX tunnel allows only one connection per credential; never run two replicas.


### PR DESCRIPTION
Bumps the bridge image tag from 0.1.1 → 0.1.2. The v0.1.1 release crashed at startup with `ModuleNotFoundError: No module named 'nkeys'` because nats-py imports nkeys lazily and we hadn't pulled in the optional dep. v0.1.2 (knx-nats-bridge#17) switches to `nats-py[nkeys]` so runtime works.

Once merged, ArgoCD should pick up the new image and the bridge pod will start cleanly.