### PR TITLE
fix(knx-nats-bridge): bump image to v0.1.3 (sync callbacks)

### DIFF
--- a/kubernetes/applications/knx-nats-bridge/base/values.yaml
+++ b/kubernetes/applications/knx-nats-bridge/base/values.yaml
@@ -5,7 +5,7 @@ deployment:
   enabled: true
   image:
     repository: ghcr.io/alexander-zimmermann/knx-nats-bridge
-    tag: 0.1.2
+    tag: 0.1.3
     pullPolicy: IfNotPresent
 
   # KNX tunnel allows only one connection per credential; never run two replicas.


### PR DESCRIPTION
Bumps bridge from 0.1.2 to 0.1.3. v0.1.2 connected to NATS but silently dropped every KNX telegram (async callbacks weren't awaited by xknx — see [knx-nats-bridge#18](https://github.com/alexander-zimmermann/knx-nats-bridge/pull/18)). v0.1.3 fixes the callback contract.