### PR TITLE
chore(knx-nats-bridge): bump image to v0.1.4

### DIFF
--- a/kubernetes/applications/knx-nats-bridge/base/values.yaml
+++ b/kubernetes/applications/knx-nats-bridge/base/values.yaml
@@ -5,7 +5,7 @@ deployment:
   enabled: true
   image:
     repository: ghcr.io/alexander-zimmermann/knx-nats-bridge
-    tag: 0.1.3
+    tag: 0.1.4
     pullPolicy: IfNotPresent
 
   # KNX tunnel allows only one connection per credential; never run two replicas.


### PR DESCRIPTION
Bumps bridge image 0.1.3 → 0.1.4. Splits receive counter into received/decoded/unmapped so bus traffic shows up in /metrics independent of mapping coverage. See [knx-nats-bridge#19](https://github.com/alexander-zimmermann/knx-nats-bridge/pull/19).