### PR TITLE
fix(alertmanager): use admin@ alias to fit iCloud's 3-alias cap

### DIFF
--- a/kubernetes/applications/prometheus/base/values.yaml
+++ b/kubernetes/applications/prometheus/base/values.yaml
@@ -15,8 +15,8 @@ alertmanager:
       resolve_timeout: 5m
       # Internal smtprelay (no auth, accepts mail from cluster CIDR)
       smtp_smarthost: smtprelay.smtprelay.svc.cluster.local:25
-      # FROM must use zimmermann.sh — iCloud only accepts addresses tied to the relay account's aliases
-      smtp_from: alertmanager@zimmermann.sh
+      # iCloud caps custom-domain aliases at 3, so all in-cluster services share the `admin` alias
+      smtp_from: admin@zimmermann.sh
       smtp_require_tls: false
     route:
       # Group by job to avoid alert storms when multiple alerts fire together


### PR DESCRIPTION
## Summary
- Changes Alertmanager `smtp_from` from `alertmanager@zimmermann.sh` to `admin@zimmermann.sh`

## Why
After #650 merged, mail was still rejected by iCloud — the `alertmanager@` alias was never configured. iCloud caps custom-domain aliases at 3 per account, so all in-cluster services must share a single alias: `admin@zimmermann.sh` (the same one Authentik already uses for `admin@zimmermann.sh`).

The dev cluster will FROM the same `.sh` address rather than `.phd`, since the alertmanager config lives base64-encoded in a Helm-rendered Secret and per-overlay PLACEHOLDER replacement isn't trivial. iCloud accepts it (same account); only the visible FROM domain differs in dev mail. We can revisit if dev volume warrants restructuring.

## Test plan
- [ ] After merge, confirm `AlertmanagerFailedToSendAlerts` resolves
- [ ] Confirm a Watchdog email arrives from `admin@zimmermann.sh`
- [ ] Check smtprelay logs show successful delivery (no 550)

🤖 Generated with [Claude Code](https://claude.com/claude-code)