### PR TITLE
fix(argocd): use admin@ alias with per-env domain

### DIFF
--- a/kubernetes/bootstrap/gitops-controller/base/values.yaml
+++ b/kubernetes/bootstrap/gitops-controller/base/values.yaml
@@ -91,7 +91,7 @@ notifications:
     service.email.smtp: |
       host: smtprelay.smtprelay.svc.cluster.local
       port: 25
-      from: argocd@zimmermann.sh
+      from: admin@PLACEHOLDER
 
   # Notification content per event type
   templates:

--- a/kubernetes/bootstrap/gitops-controller/overlays/dev/kustomization.yaml
+++ b/kubernetes/bootstrap/gitops-controller/overlays/dev/kustomization.yaml
@@ -30,6 +30,17 @@ replacements:
           delimiter: "/"
           index: 2
 
+  - sourceValue: "zimmermann.phd"
+    targets:
+      - select:
+          kind: ConfigMap
+          name: argocd-notifications-cm
+        fieldPaths:
+          - data.[service.email.smtp]
+        options:
+          delimiter: "@"
+          index: 1
+
   # Append environment ('dev') into ApplicationSet paths and names
   - sourceValue: "dev"
     targets:

--- a/kubernetes/bootstrap/gitops-controller/overlays/prod/kustomization.yaml
+++ b/kubernetes/bootstrap/gitops-controller/overlays/prod/kustomization.yaml
@@ -30,6 +30,17 @@ replacements:
           delimiter: "/"
           index: 2
 
+  - sourceValue: "zimmermann.sh"
+    targets:
+      - select:
+          kind: ConfigMap
+          name: argocd-notifications-cm
+        fieldPaths:
+          - data.[service.email.smtp]
+        options:
+          delimiter: "@"
+          index: 1
+
   # Append environment ('prod') into ApplicationSet paths and names
   - sourceValue: "prod"
     targets:


### PR DESCRIPTION
## Summary
- Base notifier `from` is now `admin@PLACEHOLDER`
- Prod overlay replaces the FROM domain with `zimmermann.sh`
- Dev overlay replaces with `zimmermann.phd`

## Why
After #651 merged, mail was still rejected by iCloud — the `argocd@` alias was never configured. iCloud caps custom-domain aliases at 3 per account, so all in-cluster services must share the `admin@` alias (already used by Authentik). This PR also gives dev its own FROM domain via the existing PLACEHOLDER + replacements pattern that the rest of the overlay already uses.

## Test plan
- [ ] After merge, trigger a sync on a small app and confirm a deploy email arrives from `admin@zimmermann.sh`
- [ ] Check smtprelay logs show successful delivery (no 550)
- [ ] Confirm Pushover behavior unchanged for failures/degraded health

🤖 Generated with [Claude Code](https://claude.com/claude-code)