### PR TITLE
chore: remove completed KNX→NATS TODO + auto-merge bridge images

### DIFF
--- a/.renovate/autoMerge.json5
+++ b/.renovate/autoMerge.json5
@@ -44,6 +44,15 @@
       "matchUpdateTypes": ["minor", "patch", "digest"],
       "minimumReleaseAge": "1 minute",
       "ignoreTests": true
+    },
+    {
+      "description": "Auto-merge own first-party bridge images",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["ghcr.io/alexander-zimmermann/knx-nats-bridge"],
+      "automerge": true,
+      "automergeType": "pr",
+      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "ignoreTests": false
     }
   ]
 }

--- a/TODO.md
+++ b/TODO.md
@@ -25,7 +25,6 @@
 
 - [ ] **stakater/application Chart**: Migrate apps with raw Deployment manifests to [stakater/application](https://github.com/stakater/application) (same pattern as Gatus). Start with `smtprelay` and `fritz-exporter` (simplest cases), then evaluate `solaredge2mqtt` (two releases), `homepage` (RBAC/PVC needs check), and `node-red` (initContainer + PVC support needed).
 - [ ] **Cilium**: Implement network policies.
-- [ ] **KNX → NATS via Telegraf**: Expose KNX events on NATS for future AI/home-automation consumers. Add `outputs.nats` to Telegraf so the existing `inputs.knx_listener` data is published on subjects like `knx.<a>.<b>.<c>` alongside the current InfluxDB write. No separate KNX→MQTT bridge, no MQTT gateway involved. Today only InfluxDB 3 gets the data — nothing else on NATS does.
 
 ## GitOps
 


### PR DESCRIPTION
Two small cleanups now that the bridge is in prod:

1. Removes the now-completed `KNX → NATS via Telegraf` TODO entry. The actual implementation went a different direction (xknx-based service in [knx-nats-bridge](https://github.com/alexander-zimmermann/knx-nats-bridge), not Telegraf), but it covers the same goal — and is live.
2. Adds a Renovate autoMerge rule for `ghcr.io/alexander-zimmermann/knx-nats-bridge` so patch/minor/digest bumps land automatically (with CI gating). Major bumps still need a manual review.