### PR TITLE
chore(renovate): expand trusted auto-merge list

### DIFF
--- a/.renovate/autoMerge.json5
+++ b/.renovate/autoMerge.json5
@@ -10,19 +10,30 @@
       "ignoreTests": false
     },
     {
-      "description": "Auto-merge OCI Charts (Core Monitoring)",
+      "description": "Auto-merge trusted minor/patch container updates",
       "matchDatasources": ["docker"],
       "automerge": true,
       "automergeType": "pr",
       "matchUpdateTypes": ["minor", "patch"],
       "matchPackageNames": [
+        // Observability stack — strict semver, frequent CVE patches
         "/kube-prometheus-stack/",
+        "/prometheus-crds/",
         "/grafana/",
         "/alloy/",
         "/loki/",
+        // Networking + DNS — mature CNCF projects
         "/cilium/",
+        "/external-dns/",
+        "/traefik/",
+        // Security/policy/secrets — small, stable, security-relevant
         "/cert-manager/",
-        "/external-dns/"
+        "/kyverno/",
+        "/sealed-secrets/",
+        // Tiny built-in components
+        "/metrics-server/",
+        // First-party images (we own the build + CI)
+        "/knx-nats-bridge/"
       ],
       "ignoreTests": false
     },


### PR DESCRIPTION
## Summary
The trust-allowlist for Renovate auto-merge of minor/patch container updates hadn't been reviewed since several new components/apps landed. Adds six entries that meet the same bar as the existing seven (strict semver, frequent CVE patches, low blast radius):

| New entry | Reason |
|---|---|
| `prometheus-crds` | Should bump in lock-step with kube-prometheus-stack |
| `traefik` | Mature CNCF ingress, frequent CVE fixes |
| `kyverno` | Security-relevant policy/admission controller |
| `sealed-secrets` | Bitnami, very stable, crypto patches |
| `metrics-server` | Tiny, super-stable component |
| `knx-nats-bridge` | First-party image — we own the build + CI |

Renamed the rule from `Auto-merge OCI Charts (Core Monitoring)` to `Auto-merge trusted minor/patch container updates` to reflect the broader scope, and grouped the package list by category with comments.

## Explicitly NOT auto-merged (kept for manual review)
- **Data layer**: influxdb, timescaledb, cloudnative-pg, redis, rustfs (cf. 0.0.95 regression), nats, barman-cloud-plugin — storage/CRD migrations, data-loss risk
- **Operators with CRDs**: grafana-operator, nats-operator — silent CRD-schema drift
- **GitOps**: ArgoCD itself
- **Auth**: authentik — DB migrations, OIDC settings
- **Talos**: has its own `talos` group with `minimumGroupSize: 2`
- **User-facing apps**: gatus, kromgo, homepage, node-red, wiki-js — visual/functional regressions
- **Third-party services**: crowdsec, fritz-exporter, solaredge2mqtt, telegraf, unifi-poller, smtprelay
- **Storage CSIs**: csi-block-storage-controller, csi-nfs-controller — never auto

## Test plan
- [ ] CI passes
- [ ] Next Renovate run respects the rename + new entries