### PR TITLE
feat(prometheus): Gatus dead-man-switch for Watchdog alert

### DIFF
--- a/kubernetes/applications/prometheus/base/ingress-route.yaml
+++ b/kubernetes/applications/prometheus/base/ingress-route.yaml
@@ -22,7 +22,7 @@ metadata:
     # fails (and pages Pushover) if Prometheus is unreachable or the rule stops firing.
     gatus.home-operations.com/enabled: "true"
     gatus.home-operations.com/endpoint: |
-      name: Watchdog
+      name: Prometheus Watchdog
       group: Observability
       url: http://prometheus-prometheus.prometheus.svc.cluster.local:9090/api/v1/query?query=ALERTS%7Balertname%3D%22Watchdog%22%2Calertstate%3D%22firing%22%7D
       interval: 1m

--- a/kubernetes/applications/prometheus/base/ingress-route.yaml
+++ b/kubernetes/applications/prometheus/base/ingress-route.yaml
@@ -18,6 +18,19 @@ metadata:
     gethomepage.dev/href: "https://PLACEHOLDER"
     gethomepage.dev/widget.type: "prometheus"
     gethomepage.dev/widget.url: "http://prometheus-operated.prometheus.svc.cluster.local:9090"
+    # Gatus dead-man-switch: queries the Prometheus API for the Watchdog alert;
+    # fails (and pages Pushover) if Prometheus is unreachable or the rule stops firing.
+    gatus.home-operations.com/enabled: "true"
+    gatus.home-operations.com/endpoint: |
+      name: Watchdog
+      group: Observability
+      url: http://prometheus-prometheus.prometheus.svc.cluster.local:9090/api/v1/query?query=ALERTS%7Balertname%3D%22Watchdog%22%2Calertstate%3D%22firing%22%7D
+      interval: 1m
+      conditions:
+        - "[STATUS] == 200"
+        - "[BODY].data.result[0].value[1] == 1"
+      alerts:
+        - type: pushover
 
 spec:
   entryPoints:


### PR DESCRIPTION
## Summary
- Adds `gatus.home-operations.com/enabled` + `gatus.home-operations.com/endpoint` annotations on the Prometheus IngressRoute
- Gatus queries `ALERTS{alertname="Watchdog",alertstate="firing"}` against the cluster-internal Prometheus API every minute
- Fails on either Prometheus being unreachable or the rule no longer firing — pages Pushover after 3 consecutive failures (~3min)

## Why
Pairs with #671 (silent Watchdog Pushover heartbeat). The Alertmanager-side ping confirms the alerting pipeline is alive day-to-day; this Gatus check is the dead-man-switch that loudly notifies if the pipeline breaks. Uses the project's existing gatus-sidecar pattern (annotation on the IngressRoute) so the config lives next to the resource it monitors.

## Test plan
- [ ] After merge, `gatus.zimmermann.sh` shows a "Watchdog" entry in the Observability group, green
- [ ] `kubectl -n prometheus scale --replicas=0 statefulset/prometheus-prometheus` triggers Pushover after ~3min
- [ ] Scaling back up resolves the alert and sends a Pushover resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)