### PR TITLE
feat(external-services): support dev domain via PLACEHOLDER + overlay…

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -10,7 +10,7 @@
 ## Infrastructure
 
 - [ ] **Omni**: Use secrets for sensitive data.
-- [ ] **external-services dev domain**: Certificates in [kubernetes/applications/external-services/base/certificate.yaml](kubernetes/applications/external-services/base/certificate.yaml) only cover `*.zimmermann.sh` — add counterparts for the dev domain `*.zimmermann.phd`.
+- [ ] **External-DNS target dev domain**: All apps annotate their IngressRoutes with `external-dns.alpha.kubernetes.io/target: udm-pro.zimmermann.sh` — including in `overlays/dev`. In the dev cluster the `*.zimmermann.phd` CNAMEs should point to `udm-pro.zimmermann.phd` instead. Extend the dev overlays so the target is rewritten via `replacements` (affects homepage, grafana, alloy, authentik, external-services, node-red, nats, rustfs, prometheus, gatus, …).
 - [ ] **Restore Task**: Add `task k8s:restore` that replays Velero backups into DBs and PVCs after a bootstrap (e.g. Homepage images PVC).
 - [ ] **CNPG cluster PG16 → PG18 migration**: `authentik-db`, `wiki-js-db`, `crowdsec-db`, `gatus-db` are currently on PG 16.1. CNPG operator 1.28.x already supports PG 18 (in-place major upgrade via `imageName` bump + `pg_upgrade` orchestrated by the operator). New `timescaledb-db` runs on PG 18.3 / TimescaleDB 2.23 — keeping the others on 16.1 means two Postgres major versions in parallel. Plan a coordinated bump (one cluster at a time, verify backup + app reconnect after each) to land them all on PG 18.x.
 - [ ] **Split Ingress Architecture**: Dual Traefik strategy with UDM VLAN/DMZ separation.

--- a/kubernetes/applications/external-services/base/certificate.yaml
+++ b/kubernetes/applications/external-services/base/certificate.yaml
@@ -11,7 +11,7 @@ spec:
     name: letsencrypt-dns01-issuer
     kind: ClusterIssuer
   dnsNames:
-    - proxmox.zimmermann.sh
+    - PLACEHOLDER
 
 ---
 apiVersion: cert-manager.io/v1
@@ -27,7 +27,7 @@ spec:
     name: letsencrypt-dns01-issuer
     kind: ClusterIssuer
   dnsNames:
-    - backup.zimmermann.sh
+    - PLACEHOLDER
 
 ---
 apiVersion: cert-manager.io/v1
@@ -43,7 +43,7 @@ spec:
     name: letsencrypt-dns01-issuer
     kind: ClusterIssuer
   dnsNames:
-    - omni.zimmermann.sh
+    - PLACEHOLDER
 
 ---
 apiVersion: cert-manager.io/v1
@@ -59,7 +59,7 @@ spec:
     name: letsencrypt-dns01-issuer
     kind: ClusterIssuer
   dnsNames:
-    - ai-pro-1.zimmermann.sh
+    - PLACEHOLDER
 
 ---
 apiVersion: cert-manager.io/v1
@@ -75,7 +75,7 @@ spec:
     name: letsencrypt-dns01-issuer
     kind: ClusterIssuer
   dnsNames:
-    - ai-pro-2.zimmermann.sh
+    - PLACEHOLDER
 
 ---
 apiVersion: cert-manager.io/v1
@@ -91,7 +91,7 @@ spec:
     name: letsencrypt-dns01-issuer
     kind: ClusterIssuer
   dnsNames:
-    - ai-pro-3.zimmermann.sh
+    - PLACEHOLDER
 
 ---
 apiVersion: cert-manager.io/v1
@@ -107,7 +107,7 @@ spec:
     name: letsencrypt-dns01-issuer
     kind: ClusterIssuer
   dnsNames:
-    - ai-pro-4.zimmermann.sh
+    - PLACEHOLDER
 
 ---
 apiVersion: cert-manager.io/v1
@@ -123,7 +123,7 @@ spec:
     name: letsencrypt-dns01-issuer
     kind: ClusterIssuer
   dnsNames:
-    - dali-1.zimmermann.sh
+    - PLACEHOLDER
 
 ---
 apiVersion: cert-manager.io/v1
@@ -139,7 +139,7 @@ spec:
     name: letsencrypt-dns01-issuer
     kind: ClusterIssuer
   dnsNames:
-    - dali-2.zimmermann.sh
+    - PLACEHOLDER
 
 ---
 apiVersion: cert-manager.io/v1
@@ -155,7 +155,7 @@ spec:
     name: letsencrypt-dns01-issuer
     kind: ClusterIssuer
   dnsNames:
-    - ems-esp.zimmermann.sh
+    - PLACEHOLDER
 
 ---
 apiVersion: cert-manager.io/v1
@@ -171,7 +171,7 @@ spec:
     name: letsencrypt-dns01-issuer
     kind: ClusterIssuer
   dnsNames:
-    - fritzbox.zimmermann.sh
+    - PLACEHOLDER
 
 ---
 apiVersion: cert-manager.io/v1
@@ -187,7 +187,7 @@ spec:
     name: letsencrypt-dns01-issuer
     kind: ClusterIssuer
   dnsNames:
-    - knx-ip.zimmermann.sh
+    - PLACEHOLDER
 
 ---
 apiVersion: cert-manager.io/v1
@@ -203,7 +203,7 @@ spec:
     name: letsencrypt-dns01-issuer
     kind: ClusterIssuer
   dnsNames:
-    - verso.zimmermann.sh
+    - PLACEHOLDER
 
 ---
 apiVersion: cert-manager.io/v1
@@ -219,4 +219,4 @@ spec:
     name: letsencrypt-dns01-issuer
     kind: ClusterIssuer
   dnsNames:
-    - warp.zimmermann.sh
+    - PLACEHOLDER

--- a/kubernetes/applications/external-services/base/ingress-route.yaml
+++ b/kubernetes/applications/external-services/base/ingress-route.yaml
@@ -12,7 +12,7 @@ metadata:
     gatus.home-operations.com/enabled: "true"
     gatus.home-operations.com/endpoint: |
       group: Infrastructure
-      url: https://proxmox.zimmermann.sh/_gatus
+      url: https://PLACEHOLDER/_gatus
       interval: 60s
       client:
         headers:
@@ -29,7 +29,7 @@ spec:
     - websecure
   routes:
     - kind: Rule
-      match: Host(`proxmox.zimmermann.sh`)
+      match: Host(`PLACEHOLDER`)
       priority: 10
       middlewares:
         - name: chain-mfa-auth
@@ -41,7 +41,7 @@ spec:
           scheme: https
     # Gatus bypass route — matches only requests that went through Cloudflare Access (JWT header set by CF)
     - kind: Rule
-      match: Host(`proxmox.zimmermann.sh`) && PathPrefix(`/_gatus`) && HeadersRegexp(`Cf-Access-Jwt-Assertion`, `.+`)
+      match: Host(`PLACEHOLDER`) && PathPrefix(`/_gatus`) && HeadersRegexp(`Cf-Access-Jwt-Assertion`, `.+`)
       priority: 20
       services:
         - kind: Service
@@ -66,7 +66,7 @@ metadata:
     gatus.home-operations.com/enabled: "true"
     gatus.home-operations.com/endpoint: |
       group: Infrastructure
-      url: https://backup.zimmermann.sh/_gatus
+      url: https://PLACEHOLDER/_gatus
       interval: 60s
       client:
         headers:
@@ -82,7 +82,7 @@ spec:
     - websecure
   routes:
     - kind: Rule
-      match: Host(`backup.zimmermann.sh`)
+      match: Host(`PLACEHOLDER`)
       middlewares:
         - name: chain-mfa-auth
           namespace: ingress-controller
@@ -92,7 +92,7 @@ spec:
           scheme: https
     # Gatus bypass route — matches only requests that went through Cloudflare Access (JWT header set by CF)
     - kind: Rule
-      match: Host(`backup.zimmermann.sh`) && PathPrefix(`/_gatus`) && HeadersRegexp(`Cf-Access-Jwt-Assertion`, `.+`)
+      match: Host(`PLACEHOLDER`) && PathPrefix(`/_gatus`) && HeadersRegexp(`Cf-Access-Jwt-Assertion`, `.+`)
       priority: 20
       services:
         - name: backup
@@ -116,7 +116,7 @@ metadata:
     gatus.home-operations.com/enabled: "true"
     gatus.home-operations.com/endpoint: |
       group: Infrastructure
-      url: https://omni.zimmermann.sh/_gatus
+      url: https://PLACEHOLDER/_gatus
       interval: 60s
       client:
         headers:
@@ -132,7 +132,7 @@ spec:
     - websecure
   routes:
     - kind: Rule
-      match: Host(`omni.zimmermann.sh`)
+      match: Host(`PLACEHOLDER`)
       middlewares:
         - name: chain-mfa-auth
           namespace: ingress-controller
@@ -143,7 +143,7 @@ spec:
           serversTransport: insecure-transport
     # Gatus bypass route — matches only requests that went through Cloudflare Access (JWT header set by CF)
     - kind: Rule
-      match: Host(`omni.zimmermann.sh`) && PathPrefix(`/_gatus`) && HeadersRegexp(`Cf-Access-Jwt-Assertion`, `.+`)
+      match: Host(`PLACEHOLDER`) && PathPrefix(`/_gatus`) && HeadersRegexp(`Cf-Access-Jwt-Assertion`, `.+`)
       priority: 20
       services:
         - name: omni
@@ -169,7 +169,7 @@ spec:
   entryPoints:
     - websecure
   routes:
-    - match: Host(`ai-pro-1.zimmermann.sh`)
+    - match: Host(`PLACEHOLDER`)
       kind: Rule
       middlewares:
         - name: chain-basic-auth
@@ -198,7 +198,7 @@ spec:
   entryPoints:
     - websecure
   routes:
-    - match: Host(`ai-pro-2.zimmermann.sh`)
+    - match: Host(`PLACEHOLDER`)
       kind: Rule
       middlewares:
         - name: chain-basic-auth
@@ -227,7 +227,7 @@ spec:
   entryPoints:
     - websecure
   routes:
-    - match: Host(`ai-pro-3.zimmermann.sh`)
+    - match: Host(`PLACEHOLDER`)
       kind: Rule
       middlewares:
         - name: chain-basic-auth
@@ -256,7 +256,7 @@ spec:
   entryPoints:
     - websecure
   routes:
-    - match: Host(`ai-pro-4.zimmermann.sh`)
+    - match: Host(`PLACEHOLDER`)
       kind: Rule
       middlewares:
         - name: chain-basic-auth
@@ -285,7 +285,7 @@ spec:
   entryPoints:
     - websecure
   routes:
-    - match: Host(`dali-1.zimmermann.sh`)
+    - match: Host(`PLACEHOLDER`)
       kind: Rule
       middlewares:
         - name: chain-standard
@@ -313,7 +313,7 @@ spec:
   entryPoints:
     - websecure
   routes:
-    - match: Host(`dali-2.zimmermann.sh`)
+    - match: Host(`PLACEHOLDER`)
       kind: Rule
       middlewares:
         - name: chain-mfa-auth
@@ -342,7 +342,7 @@ metadata:
     gatus.home-operations.com/enabled: "true"
     gatus.home-operations.com/endpoint: |
       group: Smart Home Integration
-      url: https://ems-esp.zimmermann.sh/_gatus
+      url: https://PLACEHOLDER/_gatus
       interval: 60s
       client:
         headers:
@@ -357,7 +357,7 @@ spec:
   entryPoints:
     - websecure
   routes:
-    - match: Host(`ems-esp.zimmermann.sh`)
+    - match: Host(`PLACEHOLDER`)
       kind: Rule
       middlewares:
         - name: chain-mfa-auth
@@ -368,7 +368,7 @@ spec:
           passHostHeader: false
     # Gatus bypass route — matches only requests that went through Cloudflare Access (JWT header set by CF)
     - kind: Rule
-      match: Host(`ems-esp.zimmermann.sh`) && PathPrefix(`/_gatus`) && HeadersRegexp(`Cf-Access-Jwt-Assertion`, `.+`)
+      match: Host(`PLACEHOLDER`) && PathPrefix(`/_gatus`) && HeadersRegexp(`Cf-Access-Jwt-Assertion`, `.+`)
       priority: 20
       services:
         - name: ems-esp
@@ -393,7 +393,7 @@ metadata:
     gatus.home-operations.com/enabled: "true"
     gatus.home-operations.com/endpoint: |
       group: Networking
-      url: https://fritzbox.zimmermann.sh/_gatus
+      url: https://PLACEHOLDER/_gatus
       interval: 60s
       client:
         headers:
@@ -409,7 +409,7 @@ spec:
   entryPoints:
     - websecure
   routes:
-    - match: Host(`fritzbox.zimmermann.sh`)
+    - match: Host(`PLACEHOLDER`)
       kind: Rule
       middlewares:
         - name: chain-mfa-auth
@@ -419,7 +419,7 @@ spec:
           port: 80
     # Gatus bypass route — matches only requests that went through Cloudflare Access (JWT header set by CF)
     - kind: Rule
-      match: Host(`fritzbox.zimmermann.sh`) && PathPrefix(`/_gatus`) && HeadersRegexp(`Cf-Access-Jwt-Assertion`, `.+`)
+      match: Host(`PLACEHOLDER`) && PathPrefix(`/_gatus`) && HeadersRegexp(`Cf-Access-Jwt-Assertion`, `.+`)
       priority: 20
       services:
         - name: fritzbox
@@ -443,7 +443,7 @@ metadata:
     gatus.home-operations.com/enabled: "true"
     gatus.home-operations.com/endpoint: |
       group: Smart Home Integration
-      url: https://knx-ip.zimmermann.sh/_gatus
+      url: https://PLACEHOLDER/_gatus
       interval: 60s
       client:
         headers:
@@ -459,7 +459,7 @@ spec:
   entryPoints:
     - websecure
   routes:
-    - match: Host(`knx-ip.zimmermann.sh`)
+    - match: Host(`PLACEHOLDER`)
       kind: Rule
       middlewares:
         - name: chain-mfa-auth
@@ -470,7 +470,7 @@ spec:
           passHostHeader: false
     # Gatus bypass route — matches only requests that went through Cloudflare Access (JWT header set by CF)
     - kind: Rule
-      match: Host(`knx-ip.zimmermann.sh`) && PathPrefix(`/_gatus`) && HeadersRegexp(`Cf-Access-Jwt-Assertion`, `.+`)
+      match: Host(`PLACEHOLDER`) && PathPrefix(`/_gatus`) && HeadersRegexp(`Cf-Access-Jwt-Assertion`, `.+`)
       priority: 20
       services:
         - name: knx-ip
@@ -495,7 +495,7 @@ spec:
   entryPoints:
     - websecure
   routes:
-    - match: Host(`verso.zimmermann.sh`)
+    - match: Host(`PLACEHOLDER`)
       kind: Rule
       middlewares:
         - name: chain-mfa-auth
@@ -524,7 +524,7 @@ spec:
   entryPoints:
     - websecure
   routes:
-    - match: Host(`warp.zimmermann.sh`)
+    - match: Host(`PLACEHOLDER`)
       kind: Rule
       middlewares:
         - name: chain-mfa-auth

--- a/kubernetes/applications/external-services/overlays/dev/kustomization.yaml
+++ b/kubernetes/applications/external-services/overlays/dev/kustomization.yaml
@@ -3,3 +3,296 @@ kind: Kustomization
 
 resources:
   - ../../base
+
+replacements:
+  # Inject domain name into Certificate, IngressRoute, and Gatus annotation
+  - sourceValue: proxmox.zimmermann.phd
+    targets:
+      - select:
+          kind: Certificate
+          name: proxmox-tls-cert
+        fieldPaths:
+          - spec.dnsNames.0
+      - select:
+          kind: IngressRoute
+          name: proxmox
+        fieldPaths:
+          - spec.routes.0.match
+          - spec.routes.1.match
+        options:
+          delimiter: "`"
+          index: 1
+      - select:
+          kind: IngressRoute
+          name: proxmox
+        fieldPaths:
+          - metadata.annotations.[gatus.home-operations.com/endpoint]
+        options:
+          delimiter: "/"
+          index: 2
+
+  # Inject domain name into Certificate, IngressRoute, and Gatus annotation
+  - sourceValue: backup.zimmermann.phd
+    targets:
+      - select:
+          kind: Certificate
+          name: backup-tls-cert
+        fieldPaths:
+          - spec.dnsNames.0
+      - select:
+          kind: IngressRoute
+          name: backup
+        fieldPaths:
+          - spec.routes.0.match
+          - spec.routes.1.match
+        options:
+          delimiter: "`"
+          index: 1
+      - select:
+          kind: IngressRoute
+          name: backup
+        fieldPaths:
+          - metadata.annotations.[gatus.home-operations.com/endpoint]
+        options:
+          delimiter: "/"
+          index: 2
+
+  # Inject domain name into Certificate, IngressRoute, and Gatus annotation
+  - sourceValue: omni.zimmermann.phd
+    targets:
+      - select:
+          kind: Certificate
+          name: omni-tls-cert
+        fieldPaths:
+          - spec.dnsNames.0
+      - select:
+          kind: IngressRoute
+          name: omni
+        fieldPaths:
+          - spec.routes.0.match
+          - spec.routes.1.match
+        options:
+          delimiter: "`"
+          index: 1
+      - select:
+          kind: IngressRoute
+          name: omni
+        fieldPaths:
+          - metadata.annotations.[gatus.home-operations.com/endpoint]
+        options:
+          delimiter: "/"
+          index: 2
+
+  # Inject domain name into Certificate and IngressRoute
+  - sourceValue: ai-pro-1.zimmermann.phd
+    targets:
+      - select:
+          kind: Certificate
+          name: ai-pro-1-tls-cert
+        fieldPaths:
+          - spec.dnsNames.0
+      - select:
+          kind: IngressRoute
+          name: ai-pro-1
+        fieldPaths:
+          - spec.routes.0.match
+        options:
+          delimiter: "`"
+          index: 1
+
+  # Inject domain name into Certificate and IngressRoute
+  - sourceValue: ai-pro-2.zimmermann.phd
+    targets:
+      - select:
+          kind: Certificate
+          name: ai-pro-2-tls-cert
+        fieldPaths:
+          - spec.dnsNames.0
+      - select:
+          kind: IngressRoute
+          name: ai-pro-2
+        fieldPaths:
+          - spec.routes.0.match
+        options:
+          delimiter: "`"
+          index: 1
+
+  # Inject domain name into Certificate and IngressRoute
+  - sourceValue: ai-pro-3.zimmermann.phd
+    targets:
+      - select:
+          kind: Certificate
+          name: ai-pro-3-tls-cert
+        fieldPaths:
+          - spec.dnsNames.0
+      - select:
+          kind: IngressRoute
+          name: ai-pro-3
+        fieldPaths:
+          - spec.routes.0.match
+        options:
+          delimiter: "`"
+          index: 1
+
+  # Inject domain name into Certificate and IngressRoute
+  - sourceValue: ai-pro-4.zimmermann.phd
+    targets:
+      - select:
+          kind: Certificate
+          name: ai-pro-4-tls-cert
+        fieldPaths:
+          - spec.dnsNames.0
+      - select:
+          kind: IngressRoute
+          name: ai-pro-4
+        fieldPaths:
+          - spec.routes.0.match
+        options:
+          delimiter: "`"
+          index: 1
+
+  # Inject domain name into Certificate and IngressRoute
+  - sourceValue: dali-1.zimmermann.phd
+    targets:
+      - select:
+          kind: Certificate
+          name: dali-1-tls-cert
+        fieldPaths:
+          - spec.dnsNames.0
+      - select:
+          kind: IngressRoute
+          name: dali-1
+        fieldPaths:
+          - spec.routes.0.match
+        options:
+          delimiter: "`"
+          index: 1
+
+  # Inject domain name into Certificate and IngressRoute
+  - sourceValue: dali-2.zimmermann.phd
+    targets:
+      - select:
+          kind: Certificate
+          name: dali-2-tls-cert
+        fieldPaths:
+          - spec.dnsNames.0
+      - select:
+          kind: IngressRoute
+          name: dali-2
+        fieldPaths:
+          - spec.routes.0.match
+        options:
+          delimiter: "`"
+          index: 1
+
+  # Inject domain name into Certificate, IngressRoute, and Gatus annotation
+  - sourceValue: ems-esp.zimmermann.phd
+    targets:
+      - select:
+          kind: Certificate
+          name: ems-esp-tls-cert
+        fieldPaths:
+          - spec.dnsNames.0
+      - select:
+          kind: IngressRoute
+          name: ems-esp
+        fieldPaths:
+          - spec.routes.0.match
+          - spec.routes.1.match
+        options:
+          delimiter: "`"
+          index: 1
+      - select:
+          kind: IngressRoute
+          name: ems-esp
+        fieldPaths:
+          - metadata.annotations.[gatus.home-operations.com/endpoint]
+        options:
+          delimiter: "/"
+          index: 2
+
+  # Inject domain name into Certificate, IngressRoute, and Gatus annotation
+  - sourceValue: fritzbox.zimmermann.phd
+    targets:
+      - select:
+          kind: Certificate
+          name: fritzbox-tls-cert
+        fieldPaths:
+          - spec.dnsNames.0
+      - select:
+          kind: IngressRoute
+          name: fritzbox
+        fieldPaths:
+          - spec.routes.0.match
+          - spec.routes.1.match
+        options:
+          delimiter: "`"
+          index: 1
+      - select:
+          kind: IngressRoute
+          name: fritzbox
+        fieldPaths:
+          - metadata.annotations.[gatus.home-operations.com/endpoint]
+        options:
+          delimiter: "/"
+          index: 2
+
+  # Inject domain name into Certificate, IngressRoute, and Gatus annotation
+  - sourceValue: knx-ip.zimmermann.phd
+    targets:
+      - select:
+          kind: Certificate
+          name: knx-ip-tls-cert
+        fieldPaths:
+          - spec.dnsNames.0
+      - select:
+          kind: IngressRoute
+          name: knx-ip
+        fieldPaths:
+          - spec.routes.0.match
+          - spec.routes.1.match
+        options:
+          delimiter: "`"
+          index: 1
+      - select:
+          kind: IngressRoute
+          name: knx-ip
+        fieldPaths:
+          - metadata.annotations.[gatus.home-operations.com/endpoint]
+        options:
+          delimiter: "/"
+          index: 2
+
+  # Inject domain name into Certificate and IngressRoute
+  - sourceValue: verso.zimmermann.phd
+    targets:
+      - select:
+          kind: Certificate
+          name: verso-tls-cert
+        fieldPaths:
+          - spec.dnsNames.0
+      - select:
+          kind: IngressRoute
+          name: verso
+        fieldPaths:
+          - spec.routes.0.match
+        options:
+          delimiter: "`"
+          index: 1
+
+  # Inject domain name into Certificate and IngressRoute
+  - sourceValue: warp.zimmermann.phd
+    targets:
+      - select:
+          kind: Certificate
+          name: warp-tls-cert
+        fieldPaths:
+          - spec.dnsNames.0
+      - select:
+          kind: IngressRoute
+          name: warp
+        fieldPaths:
+          - spec.routes.0.match
+        options:
+          delimiter: "`"
+          index: 1

--- a/kubernetes/applications/external-services/overlays/prod/kustomization.yaml
+++ b/kubernetes/applications/external-services/overlays/prod/kustomization.yaml
@@ -3,3 +3,296 @@ kind: Kustomization
 
 resources:
   - ../../base
+
+replacements:
+  # Inject domain name into Certificate, IngressRoute, and Gatus annotation
+  - sourceValue: proxmox.zimmermann.sh
+    targets:
+      - select:
+          kind: Certificate
+          name: proxmox-tls-cert
+        fieldPaths:
+          - spec.dnsNames.0
+      - select:
+          kind: IngressRoute
+          name: proxmox
+        fieldPaths:
+          - spec.routes.0.match
+          - spec.routes.1.match
+        options:
+          delimiter: "`"
+          index: 1
+      - select:
+          kind: IngressRoute
+          name: proxmox
+        fieldPaths:
+          - metadata.annotations.[gatus.home-operations.com/endpoint]
+        options:
+          delimiter: "/"
+          index: 2
+
+  # Inject domain name into Certificate, IngressRoute, and Gatus annotation
+  - sourceValue: backup.zimmermann.sh
+    targets:
+      - select:
+          kind: Certificate
+          name: backup-tls-cert
+        fieldPaths:
+          - spec.dnsNames.0
+      - select:
+          kind: IngressRoute
+          name: backup
+        fieldPaths:
+          - spec.routes.0.match
+          - spec.routes.1.match
+        options:
+          delimiter: "`"
+          index: 1
+      - select:
+          kind: IngressRoute
+          name: backup
+        fieldPaths:
+          - metadata.annotations.[gatus.home-operations.com/endpoint]
+        options:
+          delimiter: "/"
+          index: 2
+
+  # Inject domain name into Certificate, IngressRoute, and Gatus annotation
+  - sourceValue: omni.zimmermann.sh
+    targets:
+      - select:
+          kind: Certificate
+          name: omni-tls-cert
+        fieldPaths:
+          - spec.dnsNames.0
+      - select:
+          kind: IngressRoute
+          name: omni
+        fieldPaths:
+          - spec.routes.0.match
+          - spec.routes.1.match
+        options:
+          delimiter: "`"
+          index: 1
+      - select:
+          kind: IngressRoute
+          name: omni
+        fieldPaths:
+          - metadata.annotations.[gatus.home-operations.com/endpoint]
+        options:
+          delimiter: "/"
+          index: 2
+
+  # Inject domain name into Certificate and IngressRoute
+  - sourceValue: ai-pro-1.zimmermann.sh
+    targets:
+      - select:
+          kind: Certificate
+          name: ai-pro-1-tls-cert
+        fieldPaths:
+          - spec.dnsNames.0
+      - select:
+          kind: IngressRoute
+          name: ai-pro-1
+        fieldPaths:
+          - spec.routes.0.match
+        options:
+          delimiter: "`"
+          index: 1
+
+  # Inject domain name into Certificate and IngressRoute
+  - sourceValue: ai-pro-2.zimmermann.sh
+    targets:
+      - select:
+          kind: Certificate
+          name: ai-pro-2-tls-cert
+        fieldPaths:
+          - spec.dnsNames.0
+      - select:
+          kind: IngressRoute
+          name: ai-pro-2
+        fieldPaths:
+          - spec.routes.0.match
+        options:
+          delimiter: "`"
+          index: 1
+
+  # Inject domain name into Certificate and IngressRoute
+  - sourceValue: ai-pro-3.zimmermann.sh
+    targets:
+      - select:
+          kind: Certificate
+          name: ai-pro-3-tls-cert
+        fieldPaths:
+          - spec.dnsNames.0
+      - select:
+          kind: IngressRoute
+          name: ai-pro-3
+        fieldPaths:
+          - spec.routes.0.match
+        options:
+          delimiter: "`"
+          index: 1
+
+  # Inject domain name into Certificate and IngressRoute
+  - sourceValue: ai-pro-4.zimmermann.sh
+    targets:
+      - select:
+          kind: Certificate
+          name: ai-pro-4-tls-cert
+        fieldPaths:
+          - spec.dnsNames.0
+      - select:
+          kind: IngressRoute
+          name: ai-pro-4
+        fieldPaths:
+          - spec.routes.0.match
+        options:
+          delimiter: "`"
+          index: 1
+
+  # Inject domain name into Certificate and IngressRoute
+  - sourceValue: dali-1.zimmermann.sh
+    targets:
+      - select:
+          kind: Certificate
+          name: dali-1-tls-cert
+        fieldPaths:
+          - spec.dnsNames.0
+      - select:
+          kind: IngressRoute
+          name: dali-1
+        fieldPaths:
+          - spec.routes.0.match
+        options:
+          delimiter: "`"
+          index: 1
+
+  # Inject domain name into Certificate and IngressRoute
+  - sourceValue: dali-2.zimmermann.sh
+    targets:
+      - select:
+          kind: Certificate
+          name: dali-2-tls-cert
+        fieldPaths:
+          - spec.dnsNames.0
+      - select:
+          kind: IngressRoute
+          name: dali-2
+        fieldPaths:
+          - spec.routes.0.match
+        options:
+          delimiter: "`"
+          index: 1
+
+  # Inject domain name into Certificate, IngressRoute, and Gatus annotation
+  - sourceValue: ems-esp.zimmermann.sh
+    targets:
+      - select:
+          kind: Certificate
+          name: ems-esp-tls-cert
+        fieldPaths:
+          - spec.dnsNames.0
+      - select:
+          kind: IngressRoute
+          name: ems-esp
+        fieldPaths:
+          - spec.routes.0.match
+          - spec.routes.1.match
+        options:
+          delimiter: "`"
+          index: 1
+      - select:
+          kind: IngressRoute
+          name: ems-esp
+        fieldPaths:
+          - metadata.annotations.[gatus.home-operations.com/endpoint]
+        options:
+          delimiter: "/"
+          index: 2
+
+  # Inject domain name into Certificate, IngressRoute, and Gatus annotation
+  - sourceValue: fritzbox.zimmermann.sh
+    targets:
+      - select:
+          kind: Certificate
+          name: fritzbox-tls-cert
+        fieldPaths:
+          - spec.dnsNames.0
+      - select:
+          kind: IngressRoute
+          name: fritzbox
+        fieldPaths:
+          - spec.routes.0.match
+          - spec.routes.1.match
+        options:
+          delimiter: "`"
+          index: 1
+      - select:
+          kind: IngressRoute
+          name: fritzbox
+        fieldPaths:
+          - metadata.annotations.[gatus.home-operations.com/endpoint]
+        options:
+          delimiter: "/"
+          index: 2
+
+  # Inject domain name into Certificate, IngressRoute, and Gatus annotation
+  - sourceValue: knx-ip.zimmermann.sh
+    targets:
+      - select:
+          kind: Certificate
+          name: knx-ip-tls-cert
+        fieldPaths:
+          - spec.dnsNames.0
+      - select:
+          kind: IngressRoute
+          name: knx-ip
+        fieldPaths:
+          - spec.routes.0.match
+          - spec.routes.1.match
+        options:
+          delimiter: "`"
+          index: 1
+      - select:
+          kind: IngressRoute
+          name: knx-ip
+        fieldPaths:
+          - metadata.annotations.[gatus.home-operations.com/endpoint]
+        options:
+          delimiter: "/"
+          index: 2
+
+  # Inject domain name into Certificate and IngressRoute
+  - sourceValue: verso.zimmermann.sh
+    targets:
+      - select:
+          kind: Certificate
+          name: verso-tls-cert
+        fieldPaths:
+          - spec.dnsNames.0
+      - select:
+          kind: IngressRoute
+          name: verso
+        fieldPaths:
+          - spec.routes.0.match
+        options:
+          delimiter: "`"
+          index: 1
+
+  # Inject domain name into Certificate and IngressRoute
+  - sourceValue: warp.zimmermann.sh
+    targets:
+      - select:
+          kind: Certificate
+          name: warp-tls-cert
+        fieldPaths:
+          - spec.dnsNames.0
+      - select:
+          kind: IngressRoute
+          name: warp
+        fieldPaths:
+          - spec.routes.0.match
+        options:
+          delimiter: "`"
+          index: 1


### PR DESCRIPTION
… replacements

Refactor base manifests to use PLACEHOLDER for hostnames and inject the real domain in both overlays via kustomize replacements (matching the homepage/grafana/alloy/… convention). Dev overlay now renders all 14 services under `*.zimmermann.phd`; prod render is unchanged.

External-DNS target stays on `udm-pro.zimmermann.sh` in the dev overlay — that gap affects all apps and is captured as a follow-up in TODO.md.