### PR TITLE
chore(github): let issue-labeler run on Renovate-authored issues

### DIFF
--- a/.github/workflows/issue-labeler.yaml
+++ b/.github/workflows/issue-labeler.yaml
@@ -15,11 +15,6 @@ jobs:
   label-issue:
     name: Label Issue
     runs-on: ubuntu-latest
-    # Skip for Renovate Dashboard and other Renovate-managed issues
-    if: |
-      github.event.issue.user.login != 'renovate[bot]' &&
-      !contains(github.event.issue.labels.*.name, 'renovate') &&
-      !contains(github.event.issue.title, 'Renovate')
     permissions:
       issues: write
     steps:


### PR DESCRIPTION
Removes the skip-clause that excluded Renovate-managed issues from the labeler. The existing area/renovate keyword rule (in issue-labeler.yaml config) now matches the Renovate Dashboard title and labels it, which lets the project auto-add filter exclude such issues via -label:"area/renovate".