### PR TITLE
feat(redpanda-connect): add app with knx → timescaledb pipeline (Schritt C-3)

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/kustomization.yaml
+++ b/kubernetes/applications/redpanda-connect/base/kustomization.yaml
@@ -13,7 +13,6 @@ helmCharts:
     valuesFile: values.yaml
     namespace: redpanda-connect
 
-# Pipelines: one stream per source.
 configMapGenerator:
   - name: redpanda-connect-streams
     options:
@@ -26,6 +25,5 @@ labels:
     pairs:
       homelab.app: redpanda-connect
 
-# Wave 4: TimescaleDB (wave 3) + NATS (wave 2) + Kyverno-cloned secrets must be ready first.
 commonAnnotations:
   argocd.argoproj.io/sync-wave: "4"

--- a/kubernetes/applications/redpanda-connect/base/kustomization.yaml
+++ b/kubernetes/applications/redpanda-connect/base/kustomization.yaml
@@ -1,0 +1,31 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: redpanda-connect
+resources:
+  - ./namespace.yaml
+
+helmCharts:
+  - name: connect
+    repo: https://charts.redpanda.com
+    releaseName: redpanda-connect
+    version: 3.2.4
+    valuesFile: values.yaml
+    namespace: redpanda-connect
+
+# Pipelines: one stream per source.
+configMapGenerator:
+  - name: redpanda-connect-streams
+    options:
+      disableNameSuffixHash: true
+    files:
+      - streams/knx.yaml
+
+labels:
+  - includeSelectors: false
+    pairs:
+      homelab.app: redpanda-connect
+
+# Wave 4: TimescaleDB (wave 3) + NATS (wave 2) + Kyverno-cloned secrets must be ready first.
+commonAnnotations:
+  argocd.argoproj.io/sync-wave: "4"

--- a/kubernetes/applications/redpanda-connect/base/namespace.yaml
+++ b/kubernetes/applications/redpanda-connect/base/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+
+metadata:
+  name: redpanda-connect

--- a/kubernetes/applications/redpanda-connect/base/streams/knx.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/knx.yaml
@@ -1,0 +1,57 @@
+input:
+  nats_jetstream:
+    urls: ["nats://nats.nats.svc:4222"]
+    auth:
+      user: redpanda-connect
+      password: ${NATS_PASSWORD}
+    subject: knx.>
+    durable: redpanda-connect-knx
+    deliver: all
+    ack_wait: 30s
+    max_ack_pending: 256
+
+pipeline:
+  processors:
+    - mapping: |
+        let evt = this
+        let parts = $evt.ga.split("/")
+        # bool coercion for DPT-1 (true/false → 1.0/0.0); other DPTs are already numbers
+        let v = if $evt.dpt.has_prefix("DPT-1") {
+          if $evt.value == true { 1.0 } else { 0.0 }
+        } else {
+          $evt.value.number()
+        }
+        root = {
+          "time":       $evt.ts,
+          "ga":         $evt.ga,
+          "knx_main":   $parts.index(0).number(),
+          "knx_middle": $parts.index(1).number(),
+          "knx_sub":    $parts.index(2).number(),
+          "knx_name":   $evt.name,
+          "dpt":        $evt.dpt,
+          "value":      $v,
+          "raw":        $evt,
+        }
+
+output:
+  sql_raw:
+    driver: postgres
+    dsn: postgres://${PGUSER}:${PGPASSWORD}@timescaledb-db-rw.timescaledb.svc.cluster.local:5432/homelab?sslmode=disable
+    init_statement: |
+      SET timezone = 'UTC';
+    query: |
+      INSERT INTO knx (time, ga, knx_main, knx_middle, knx_sub, knx_name, dpt, value, raw)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+      ON CONFLICT (time, ga) DO NOTHING
+    args_mapping: |
+      root = [
+        this.time,
+        this.ga,
+        this.knx_main,
+        this.knx_middle,
+        this.knx_sub,
+        this.knx_name,
+        this.dpt,
+        this.value,
+        this.raw.string(),
+      ]

--- a/kubernetes/applications/redpanda-connect/base/values.yaml
+++ b/kubernetes/applications/redpanda-connect/base/values.yaml
@@ -1,0 +1,29 @@
+# Pipeline definitions in streams/*.yaml, mounted via configMapGenerator
+streams:
+  enabled: true
+  streamsConfigMap: redpanda-connect-streams
+
+env:
+  # NATS user (cloned from nats namespace by Kyverno)
+  - name: NATS_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: redpanda-connect-credentials
+        key: NATS_PASSWORD
+  # CNPG-managed connect-role credentials (cloned from timescaledb namespace by Kyverno)
+  - name: PGUSER
+    valueFrom:
+      secretKeyRef:
+        name: timescaledb-db-connect-secret
+        key: username
+  - name: PGPASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: timescaledb-db-connect-secret
+        key: password
+
+serviceMonitor:
+  enabled: true
+  interval: 30s
+  labels:
+    release: prometheus

--- a/kubernetes/applications/redpanda-connect/overlays/dev/kustomization.yaml
+++ b/kubernetes/applications/redpanda-connect/overlays/dev/kustomization.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+patches:
+  - target:
+      kind: Deployment
+      name: redpanda-connect
+    patch: |-
+      - op: test
+        path: /spec/template/spec/containers/0/name
+        value: connect
+      - op: add
+        path: /spec/template/spec/containers/0/resources
+        value:
+          requests:
+            cpu: 25m
+            memory: 64Mi
+          limits:
+            cpu: 100m
+            memory: 256Mi

--- a/kubernetes/applications/redpanda-connect/overlays/prod/kustomization.yaml
+++ b/kubernetes/applications/redpanda-connect/overlays/prod/kustomization.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+patches:
+  - target:
+      kind: Deployment
+      name: redpanda-connect
+    patch: |-
+      - op: test
+        path: /spec/template/spec/containers/0/name
+        value: connect
+      - op: add
+        path: /spec/template/spec/containers/0/resources
+        value:
+          requests:
+            cpu: 50m
+            memory: 128Mi
+          limits:
+            cpu: 200m
+            memory: 512Mi


### PR DESCRIPTION
## Summary

Schritt C-3 — first Connect-based ingest pipeline reading `knx.>` from JetStream `KNX` and writing into the `knx` hypertable.

- **Helm chart**: `connect` 3.2.4 from `https://charts.redpanda.com` (no OCI upstream).
- **Pipeline** (`streams/knx.yaml`): NATS-JetStream durable consumer `redpanda-connect-knx` → bloblang mapping (GA split, DPT-1 bool coercion, raw JSONB preserved) → `sql_raw` insert with `ON CONFLICT DO NOTHING`.
- **Auth**: `NATS_PASSWORD` + `PGUSER`/`PGPASSWORD` from the secrets cloned by the Kyverno rules added in PR #696, against the dedicated CNPG `connect` role added in PR #695.
- **Overlays**: prod (200m/512Mi limits) + dev (smaller).

## Test plan

- [ ] Merge → ArgoCD `redpanda-connect-prod` syncs → pod 1/1 Running.
- [ ] Pod logs show `Pipeline started`, no auth errors against NATS or Postgres.
- [ ] `nats consumer info KNX redpanda-connect-knx --server=...` shows `ack_floor` advancing, `num_pending` going down (47k+ backlog).
- [ ] `psql … -d homelab -c "SELECT count(*) FROM knx;"` grows; `… "SELECT count(*) FROM knx WHERE time > now() - interval '1 minute';"` ≥ 10.
- [ ] Sample row sanity-checks: `… "SELECT time, ga, knx_name, value FROM knx ORDER BY time DESC LIMIT 5;"` shows real values, bool DPTs coerced to 0.0/1.0.
- [ ] After ~2h: `SELECT count(*) FROM knx_1h;` > 0 (continuous-aggregate refresh ran).
- [ ] PodMonitor scrape OK in Prometheus, Connect's `output_sent_total` and `input_received_total` ticking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)