### PR TITLE
fix(timescaledb): transfer table ownership to homelab in bootstrap

### DIFF
--- a/kubernetes/applications/timescaledb/base/scripts/bootstrap.sql
+++ b/kubernetes/applications/timescaledb/base/scripts/bootstrap.sql
@@ -277,3 +277,19 @@ SELECT add_continuous_aggregate_policy('ems_esp_dhw_1h',
 SELECT add_continuous_aggregate_policy('warp_meter_1h',
     start_offset => INTERVAL '2 days', end_offset => INTERVAL '1 hour',
     schedule_interval => INTERVAL '1 hour');
+
+-- =========================================================
+-- Transfer ownership from `postgres` (CNPG runs initdb as superuser)
+-- to the application user `homelab`, so it can issue table-level GRANTs.
+-- =========================================================
+DO $$
+DECLARE
+    r record;
+BEGIN
+    FOR r IN SELECT tablename FROM pg_tables WHERE schemaname = 'public' LOOP
+        EXECUTE format('ALTER TABLE public.%I OWNER TO homelab', r.tablename);
+    END LOOP;
+    FOR r IN SELECT view_name FROM timescaledb_information.continuous_aggregates LOOP
+        EXECUTE format('ALTER MATERIALIZED VIEW public.%I OWNER TO homelab', r.view_name);
+    END LOOP;
+END$$;


### PR DESCRIPTION
## Summary

Closes the gap that broke PR #695's apply-grants Job: CNPG runs `postInitApplicationSQL` as the postgres superuser, so every table + CAGG ended up owned by `postgres`. The Job runs as `homelab` and got `permission denied for table knx` on the GRANT.

Appends an ownership-transfer DO-block at the end of `bootstrap.sql`:
- Tables (9 hypertables) → `ALTER TABLE … OWNER TO homelab`
- CAGGs (6) → `ALTER MATERIALIZED VIEW … OWNER TO homelab` (TimescaleDB rejects plain `ALTER VIEW` for continuous aggregates)

The live cluster was altered manually (`kubectl exec psql -U postgres`); this commit only matters for DR / env-clone scenarios that re-run bootstrap.sql from scratch.

## Test plan

- [ ] Merge → ArgoCD `timescaledb-prod` syncs (no-op for the live DB).
- [ ] Next time the cluster is rebuilt from scratch: tables + CAGGs end up owned by `homelab`; apply-grants Job runs successfully on first try.

🤖 Generated with [Claude Code](https://claude.com/claude-code)