### PR TITLE
fix(nats): bump JetStream storage (prod 5Gi, dev 1Gi)

### DIFF
--- a/kubernetes/applications/nats/overlays/dev/kustomization.yaml
+++ b/kubernetes/applications/nats/overlays/dev/kustomization.yaml
@@ -28,7 +28,7 @@ replacements:
           - metadata.annotations.[coredns.io/hostname]
 
   # Inject JetStream storage size
-  - sourceValue: 256Mi
+  - sourceValue: 1Gi
     targets:
       - select:
           kind: StatefulSet
@@ -63,4 +63,4 @@ patches:
         path: /spec/template/spec/containers/0/env/-
         value:
           name: JETSTREAM_MAX_STORE
-          value: "256Mi"
+          value: "1Gi"

--- a/kubernetes/applications/nats/overlays/prod/kustomization.yaml
+++ b/kubernetes/applications/nats/overlays/prod/kustomization.yaml
@@ -28,7 +28,7 @@ replacements:
           - metadata.annotations.[coredns.io/hostname]
 
   # Inject JetStream storage size
-  - sourceValue: 1Gi
+  - sourceValue: 5Gi
     targets:
       - select:
           kind: StatefulSet
@@ -63,7 +63,7 @@ patches:
         path: /spec/template/spec/containers/0/env/-
         value:
           name: JETSTREAM_MAX_STORE
-          value: "1Gi"
+          value: "5Gi"
 
   # NATS service with static IP
   - target:


### PR DESCRIPTION
## Summary

Prod NATS JetStream PVC hit 100% (4 streams × 5 days × 7d retention ≈ 953 MiB on a 1Gi PVC). Redpanda Connect couldn't register its `redpanda-connect-knx` consumer — NATS server returned `error creating store for consumer: ... no space left on device`.

- **prod**: 1Gi → 5Gi (PVC + `JETSTREAM_MAX_STORE`).
- **dev**: 256Mi → 1Gi (symmetric headroom for ad-hoc dev publishes).

Longhorn supports online resize — no NATS pod restart required.

## Test plan

- [ ] Merge → ArgoCD `nats-prod` syncs.
- [ ] `kubectl -n nats get pvc nats-js-nats-0` shows `5Gi` capacity.
- [ ] `kubectl -n nats exec nats-0 -c nats -- df -h /data` shows ~5Gi capacity, current usage ~1Gi.
- [ ] Redpanda Connect pod becomes Ready, consumer registers, KNX backlog drains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)