### PR TITLE
fix(redpanda-connect): correct DPT-1 detection + skip non-numeric DPTs

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/streams/knx.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/knx.yaml
@@ -15,22 +15,30 @@ pipeline:
     - mapping: |
         let evt = this
         let parts = $evt.ga.split("/")
-        # bool coercion for DPT-1 (true/false → 1.0/0.0); other DPTs are already numbers
-        let v = if $evt.dpt.has_prefix("DPT-1") {
-          if $evt.value == true { 1.0 } else { 0.0 }
+        # DPT format is "<major>.<minor>" (e.g. "1.001", "9.008", "14.058")
+        let dpt_major = $evt.dpt.split(".").index(0)
+        let value_type = $evt.value.type()
+
+        # DPT-1.x is bool; other DPTs publish numbers. DPT-19 (datetime) and
+        # other non-numeric payloads are skipped — raw is lost too, accept that.
+        root = if $dpt_major != "1" && $value_type != "number" {
+          deleted()
         } else {
-          $evt.value.number()
-        }
-        root = {
-          "time":       $evt.ts,
-          "ga":         $evt.ga,
-          "knx_main":   $parts.index(0).number(),
-          "knx_middle": $parts.index(1).number(),
-          "knx_sub":    $parts.index(2).number(),
-          "knx_name":   $evt.name,
-          "dpt":        $evt.dpt,
-          "value":      $v,
-          "raw":        $evt,
+          {
+            "time":       $evt.ts,
+            "ga":         $evt.ga,
+            "knx_main":   $parts.index(0).number(),
+            "knx_middle": $parts.index(1).number(),
+            "knx_sub":    $parts.index(2).number(),
+            "knx_name":   $evt.name,
+            "dpt":        $evt.dpt,
+            "value":      if $dpt_major == "1" {
+                            if $evt.value == true { 1.0 } else { 0.0 }
+                          } else {
+                            $evt.value
+                          },
+            "raw":        $evt,
+          }
         }
 
 output:


### PR DESCRIPTION
## Summary

Connect's bloblang mapping was wrong about the DPT format. The KNX-bridge sends `dpt: "1.001"`, `"9.008"`, `"14.058"` — `<major>.<minor>` numbers. My `has_prefix("DPT-1")` never matched, so DPT-1 booleans went into the else branch and `.number()` failed on the bool. Postgres then rejected the literal `"false"`/`"true"` against the `DOUBLE PRECISION` column, and Connect couldn't ack — the backlog stalled at 22/449k.

Fix:
- Split `dpt` on `.` and check the major component for `1`.
- For non-DPT-1 events whose value isn't a number (e.g. DPT-19 datetime represented as `KNXDateTime(...)`), drop the message via `deleted()` so the consumer acks. Raw is lost for those — acceptable, ≪1% of traffic.

## Test plan

- [ ] Merge → ArgoCD `redpanda-connect-prod` syncs → pod restarts → ConfigMap updated.
- [ ] Connect logs no longer spam "expected number value, got bool".
- [ ] `nats consumer info KNX redpanda-connect-knx` shows `ack_floor` advancing rapidly, `num_pending` going down.
- [ ] `SELECT count(*) FROM knx WHERE time > now() - interval '1 minute';` ≥ 10.
- [ ] Sample row: `SELECT time, knx_name, dpt, value FROM knx WHERE dpt LIKE '1.%' ORDER BY time DESC LIMIT 5;` shows DPT-1 values as 0.0/1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)