### PR TITLE
fix(redpanda-connect): Recreate strategy + auto-hashed streams ConfigMap

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/kustomization.yaml
+++ b/kubernetes/applications/redpanda-connect/base/kustomization.yaml
@@ -15,8 +15,6 @@ helmCharts:
 
 configMapGenerator:
   - name: redpanda-connect-streams
-    options:
-      disableNameSuffixHash: true
     files:
       - streams/knx.yaml
 

--- a/kubernetes/applications/redpanda-connect/base/values.yaml
+++ b/kubernetes/applications/redpanda-connect/base/values.yaml
@@ -3,6 +3,10 @@ streams:
   enabled: true
   streamsConfigMap: redpanda-connect-streams
 
+# JetStream durable consumer can only bind one subscription — Recreate avoids "already bound" loop
+updateStrategy:
+  type: Recreate
+
 env:
   # NATS user (cloned from nats namespace by Kyverno)
   - name: NATS_PASSWORD


### PR DESCRIPTION
## Summary

Two related rollout fixes after observing the live pipeline:

1. **`updateStrategy.type: Recreate`** — JetStream durable consumers can only be bound to one subscription. RollingUpdate kept the old pod alive while the new one tried to bind → "consumer is already bound" loop, rollout stuck.
2. **Drop `disableNameSuffixHash`** on `redpanda-connect-streams` — content changes now bump the ConfigMap name, kustomize auto-rewrites the rendered Deployment's volume reference, and Argo triggers a rollout. Future stream edits no longer require manual `kubectl rollout restart`.

## Test plan

- [ ] Merge → ArgoCD `redpanda-connect-prod` syncs → old pod terminates → new pod binds the durable consumer cleanly (no "already bound" log spam).
- [ ] After next stream change (e.g. Schritt F adds solaredge.yaml), pod auto-rolls without manual intervention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)