### PR TITLE
feat(redpanda-connect): solaredge inverter + powerflow pipelines (Schritt F-1)

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/kustomization.yaml
+++ b/kubernetes/applications/redpanda-connect/base/kustomization.yaml
@@ -17,6 +17,8 @@ configMapGenerator:
   - name: redpanda-connect-streams
     files:
       - streams/knx.yaml
+      - streams/solaredge_inverter.yaml
+      - streams/solaredge_powerflow.yaml
 
 labels:
   - includeSelectors: false

--- a/kubernetes/applications/redpanda-connect/base/streams/solaredge_inverter.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/solaredge_inverter.yaml
@@ -1,0 +1,66 @@
+input:
+  nats_jetstream:
+    urls: ["nats://nats.nats.svc:4222"]
+    auth:
+      user: redpanda-connect
+      password: ${NATS_PASSWORD}
+    subject: "*.modbus.inverter"
+    durable: redpanda-connect-solaredge-inverter
+    deliver: all
+    ack_wait: 30s
+    max_ack_pending: 256
+
+pipeline:
+  processors:
+    - mapping: |
+        let evt = this
+        # Subject is "solaredge-N.modbus.inverter"; pull N for inverter_id.
+        let subj = meta("nats_subject")
+        let inv_id = $subj.split(".").index(0).split("-").index(1).number()
+        root = {
+          "time":               $evt.timestamp,
+          "inverter_id":        $inv_id,
+          "ac_power_actual":    $evt.ac.power.actual,
+          "ac_current_actual":  $evt.ac.current.actual,
+          "ac_voltage_l1":      $evt.ac.voltage.l1,
+          "ac_frequency":       $evt.ac.frequency,
+          "dc_power":           $evt.dc.power,
+          "dc_current":         $evt.dc.current,
+          "dc_voltage":         $evt.dc.voltage,
+          "energytotal":        $evt.energytotal,
+          "temperature":        $evt.temperature,
+          "status":             $evt.status,
+          "raw":                $evt,
+        }
+
+output:
+  sql_raw:
+    driver: postgres
+    dsn: postgres://${PGUSER}:${PGPASSWORD}@timescaledb-db-rw.timescaledb.svc.cluster.local:5432/homelab?sslmode=disable
+    init_statement: |
+      SET timezone = 'UTC';
+    query: |
+      INSERT INTO solaredge_inverter (
+        time, inverter_id,
+        ac_power_actual, ac_current_actual, ac_voltage_l1, ac_frequency,
+        dc_power, dc_current, dc_voltage,
+        energytotal, temperature, status, raw
+      )
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+      ON CONFLICT (time, inverter_id) DO NOTHING
+    args_mapping: |
+      root = [
+        this.time,
+        this.inverter_id,
+        this.ac_power_actual,
+        this.ac_current_actual,
+        this.ac_voltage_l1,
+        this.ac_frequency,
+        this.dc_power,
+        this.dc_current,
+        this.dc_voltage,
+        this.energytotal,
+        this.temperature,
+        this.status,
+        this.raw.string(),
+      ]

--- a/kubernetes/applications/redpanda-connect/base/streams/solaredge_powerflow.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/solaredge_powerflow.yaml
@@ -1,0 +1,70 @@
+input:
+  nats_jetstream:
+    urls: ["nats://nats.nats.svc:4222"]
+    auth:
+      user: redpanda-connect
+      password: ${NATS_PASSWORD}
+    subject: "*.powerflow"
+    durable: redpanda-connect-solaredge-powerflow
+    deliver: all
+    ack_wait: 30s
+    max_ack_pending: 256
+
+pipeline:
+  processors:
+    - mapping: |
+        let evt = this
+        # Subject is "solaredge-N.powerflow"; pull N for inverter_id.
+        let subj = meta("nats_subject")
+        let inv_id = $subj.split(".").index(0).split("-").index(1).number()
+        root = {
+          "time":               $evt.timestamp,
+          "inverter_id":        $inv_id,
+          "pv_production":      $evt.pv_production,
+          "grid_power":         $evt.grid.power,
+          "grid_consumption":   $evt.grid.consumption,
+          "grid_delivery":      $evt.grid.delivery,
+          "battery_charge":     $evt.battery.charge,
+          "battery_discharge":  $evt.battery.discharge,
+          "consumer_total":     $evt.consumer.total,
+          "consumer_house":     $evt.consumer.house,
+          "consumer_evcharger": $evt.consumer.evcharger,
+          "inverter_power":     $evt.inverter.power,
+          "inverter_dc_power":  $evt.inverter.dc_power,
+          "raw":                $evt,
+        }
+
+output:
+  sql_raw:
+    driver: postgres
+    dsn: postgres://${PGUSER}:${PGPASSWORD}@timescaledb-db-rw.timescaledb.svc.cluster.local:5432/homelab?sslmode=disable
+    init_statement: |
+      SET timezone = 'UTC';
+    query: |
+      INSERT INTO solaredge_powerflow (
+        time, inverter_id,
+        pv_production,
+        grid_power, grid_consumption, grid_delivery,
+        battery_charge, battery_discharge,
+        consumer_total, consumer_house, consumer_evcharger,
+        inverter_power, inverter_dc_power, raw
+      )
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+      ON CONFLICT (time, inverter_id) DO NOTHING
+    args_mapping: |
+      root = [
+        this.time,
+        this.inverter_id,
+        this.pv_production,
+        this.grid_power,
+        this.grid_consumption,
+        this.grid_delivery,
+        this.battery_charge,
+        this.battery_discharge,
+        this.consumer_total,
+        this.consumer_house,
+        this.consumer_evcharger,
+        this.inverter_power,
+        this.inverter_dc_power,
+        this.raw.string(),
+      ]


### PR DESCRIPTION
## Summary

Schritt F-1 — adds two new Connect streams for the SolarEdge sources:

- `streams/solaredge_inverter.yaml` — subject `*.modbus.inverter` → `solaredge_inverter` hypertable. Parses inverter_id from the subject (`solaredge-1.…` → 1).
- `streams/solaredge_powerflow.yaml` — subject `*.powerflow` → `solaredge_powerflow`. Same inverter_id trick.

Both use durable consumers on the existing SOLAREDGE JetStream and write hot-path typed columns (the dashboard fields) plus the full payload as `raw JSONB`.

## Test plan

- [ ] Merge → ArgoCD `redpanda-connect-prod` syncs → ConfigMap content hash flips → pod auto-rolls (Recreate) → both new durables register on SOLAREDGE.
- [ ] `nats consumer info SOLAREDGE redpanda-connect-solaredge-inverter` shows `ack_floor` advancing, `num_pending` going down. Same for `redpanda-connect-solaredge-powerflow`.
- [ ] `psql … "SELECT count(*) FROM solaredge_inverter WHERE time > now() - interval '5 minutes';"` ≥ 1 (inverter publishes every ~5s).
- [ ] `psql … "SELECT count(*) FROM solaredge_powerflow WHERE time > now() - interval '5 minutes';"` ≥ 1.
- [ ] `psql … "SELECT inverter_id, count(*) FROM solaredge_inverter WHERE time > now() - interval '5 minutes' GROUP BY 1;"` shows both `1` and `2` if both inverters publish.
- [ ] Sample row sanity: `psql … "SELECT time, inverter_id, ac_power_actual, dc_power, energytotal FROM solaredge_inverter ORDER BY time DESC LIMIT 5;"` shows real values matching the live NATS stream.
- [ ] Connect logs no error spam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)