### PR TITLE
fix(redpanda-connect): bind solaredge streams to SOLAREDGE explicitly

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/streams/knx.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/knx.yaml
@@ -4,6 +4,7 @@ input:
     auth:
       user: redpanda-connect
       password: ${NATS_PASSWORD}
+    stream: KNX
     subject: knx.>
     durable: redpanda-connect-knx
     deliver: all

--- a/kubernetes/applications/redpanda-connect/base/streams/solaredge_inverter.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/solaredge_inverter.yaml
@@ -4,6 +4,7 @@ input:
     auth:
       user: redpanda-connect
       password: ${NATS_PASSWORD}
+    stream: SOLAREDGE
     subject: "*.modbus.inverter"
     durable: redpanda-connect-solaredge-inverter
     deliver: all

--- a/kubernetes/applications/redpanda-connect/base/streams/solaredge_powerflow.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/solaredge_powerflow.yaml
@@ -4,6 +4,7 @@ input:
     auth:
       user: redpanda-connect
       password: ${NATS_PASSWORD}
+    stream: SOLAREDGE
     subject: "*.powerflow"
     durable: redpanda-connect-solaredge-powerflow
     deliver: all


### PR DESCRIPTION
## Summary

PR #706's solaredge streams used `subject: "*.modbus.inverter"` and `subject: "*.powerflow"`. NATS couldn't auto-discover the JetStream — no stream's subject definition exactly matches the wildcard pattern (SOLAREDGE has `solaredge-{1,2}.>`, not `*.modbus.inverter`). Connect logs spammed "nats: no stream matches subject" and the pod stayed not-ready, which dragged the existing knx pipeline down.

Add explicit `stream: SOLAREDGE` so Connect binds the consumer to the stream directly; the subject becomes a filter inside it.

## Test plan

- [ ] Merge → ConfigMap hash flips → pod auto-rolls.
- [ ] Pod becomes Ready (knx pipeline back online).
- [ ] `nats consumer info SOLAREDGE redpanda-connect-solaredge-inverter` shows ack_floor advancing.
- [ ] `nats consumer info SOLAREDGE redpanda-connect-solaredge-powerflow` likewise.
- [ ] `psql … "SELECT count(*) FROM solaredge_inverter WHERE time > now() - interval '5 minutes';"` ≥ 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)