### PR TITLE
feat(timescaledb): add PgBouncer Pooler in front of CNPG cluster

### DIFF
--- a/kubernetes/applications/timescaledb/base/kustomization.yaml
+++ b/kubernetes/applications/timescaledb/base/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ./namespace.yaml
   - ./sealed-secret.yaml
   - ./database.yaml
+  - ./pooler.yaml
   - ./apply-grants-job.yaml
 
 configMapGenerator:

--- a/kubernetes/applications/timescaledb/base/pooler.yaml
+++ b/kubernetes/applications/timescaledb/base/pooler.yaml
@@ -1,0 +1,35 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Pooler
+
+metadata:
+  name: timescaledb-db-pooler
+  namespace: timescaledb
+
+spec:
+  cluster:
+    name: timescaledb-db
+
+  instances: 1
+  type: rw
+
+  pgbouncer:
+    poolMode: transaction
+    parameters:
+      max_client_conn: "200"
+      default_pool_size: "25"
+      min_pool_size: "0"
+      # pgx (Redpanda Connect sql_raw driver) caches prepared statements;
+      # PgBouncer 1.21+ supports them in transaction mode via this setting.
+      max_prepared_statements: "100"
+
+  template:
+    spec:
+      containers:
+        - name: pgbouncer
+          resources:
+            requests:
+              cpu: 100m
+              memory: 64Mi
+            limits:
+              cpu: 300m
+              memory: 256Mi


### PR DESCRIPTION
Multiplex Redpanda Connect stream connections (knx, solaredge_*) onto a small backend pool (default_pool_size=25, transaction mode) so adding warp + ems-esp streams later does not exhaust the cluster's 100 conn slots. max_prepared_statements=100 lets pgx (sql_raw driver) keep its prepared-statement cache in transaction mode.

Streams still connect to timescaledb-db-rw directly; switching their DSN to the pooler service is a follow-up change.