### PR TITLE
feat(redpanda-connect): route streams through PgBouncer Pooler

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/streams/knx.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/knx.yaml
@@ -45,7 +45,7 @@ pipeline:
 output:
   sql_raw:
     driver: postgres
-    dsn: postgres://${PGUSER}:${PGPASSWORD}@timescaledb-db-rw.timescaledb.svc.cluster.local:5432/homelab?sslmode=disable
+    dsn: postgres://${PGUSER}:${PGPASSWORD}@timescaledb-db-pooler.timescaledb.svc.cluster.local:5432/homelab?sslmode=disable
     init_statement: |
       SET timezone = 'UTC';
     query: |

--- a/kubernetes/applications/redpanda-connect/base/streams/solaredge_inverter.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/solaredge_inverter.yaml
@@ -37,7 +37,7 @@ pipeline:
 output:
   sql_raw:
     driver: postgres
-    dsn: postgres://${PGUSER}:${PGPASSWORD}@timescaledb-db-rw.timescaledb.svc.cluster.local:5432/homelab?sslmode=disable
+    dsn: postgres://${PGUSER}:${PGPASSWORD}@timescaledb-db-pooler.timescaledb.svc.cluster.local:5432/homelab?sslmode=disable
     init_statement: |
       SET timezone = 'UTC';
     query: |

--- a/kubernetes/applications/redpanda-connect/base/streams/solaredge_powerflow.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/solaredge_powerflow.yaml
@@ -38,7 +38,7 @@ pipeline:
 output:
   sql_raw:
     driver: postgres
-    dsn: postgres://${PGUSER}:${PGPASSWORD}@timescaledb-db-rw.timescaledb.svc.cluster.local:5432/homelab?sslmode=disable
+    dsn: postgres://${PGUSER}:${PGPASSWORD}@timescaledb-db-pooler.timescaledb.svc.cluster.local:5432/homelab?sslmode=disable
     init_statement: |
       SET timezone = 'UTC';
     query: |


### PR DESCRIPTION
Switch the sql_raw DSN host from timescaledb-db-rw to timescaledb-db-pooler so the knx/solaredge_* streams multiplex onto ~25 backend connections instead of holding ~30 each. Frees the remaining slots for the upcoming warp + ems-esp streams. User, password, port, db and sslmode are unchanged; CNPG's auth_query authenticates the connect role through the pooler.