### PR TITLE
fix(redpanda-connect): switch sql_raw to pgx driver for Pooler compat

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/streams/knx.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/knx.yaml
@@ -44,7 +44,7 @@ pipeline:
 
 output:
   sql_raw:
-    driver: postgres
+    driver: pgx
     dsn: postgres://${PGUSER}:${PGPASSWORD}@timescaledb-db-pooler.timescaledb.svc.cluster.local:5432/homelab?sslmode=disable
     init_statement: |
       SET timezone = 'UTC';

--- a/kubernetes/applications/redpanda-connect/base/streams/solaredge_inverter.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/solaredge_inverter.yaml
@@ -36,7 +36,7 @@ pipeline:
 
 output:
   sql_raw:
-    driver: postgres
+    driver: pgx
     dsn: postgres://${PGUSER}:${PGPASSWORD}@timescaledb-db-pooler.timescaledb.svc.cluster.local:5432/homelab?sslmode=disable
     init_statement: |
       SET timezone = 'UTC';

--- a/kubernetes/applications/redpanda-connect/base/streams/solaredge_powerflow.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/solaredge_powerflow.yaml
@@ -37,7 +37,7 @@ pipeline:
 
 output:
   sql_raw:
-    driver: postgres
+    driver: pgx
     dsn: postgres://${PGUSER}:${PGPASSWORD}@timescaledb-db-pooler.timescaledb.svc.cluster.local:5432/homelab?sslmode=disable
     init_statement: |
       SET timezone = 'UTC';


### PR DESCRIPTION
The postgres driver in Bento is lib/pq, which uses unnamed prepared statements that PgBouncer's transaction-mode multiplexer cannot route correctly across streams with different parameter counts (solaredge_* collide constantly). Switching to pgx makes Connect emit named cached prepared statements, which PgBouncer 1.21+ handles transparently via max_prepared_statements=100 (already set on the Pooler).