### PR TITLE
feat(redpanda-connect): add ems-esp pipeline (Schritt F-2)

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/kustomization.yaml
+++ b/kubernetes/applications/redpanda-connect/base/kustomization.yaml
@@ -19,6 +19,7 @@ configMapGenerator:
       - streams/knx.yaml
       - streams/solaredge_inverter.yaml
       - streams/solaredge_powerflow.yaml
+      - streams/ems_esp.yaml
 
 labels:
   - includeSelectors: false

--- a/kubernetes/applications/redpanda-connect/base/streams/ems_esp.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/ems_esp.yaml
@@ -1,0 +1,84 @@
+input:
+  nats_jetstream:
+    urls: ["nats://nats.nats.svc:4222"]
+    auth:
+      user: redpanda-connect
+      password: ${NATS_PASSWORD}
+    stream: EMS_ESP
+    subject: ems-esp.>
+    durable: redpanda-connect-ems-esp
+    deliver: all
+    ack_wait: 30s
+    max_ack_pending: 256
+
+pipeline:
+  processors:
+    - mapping: |
+        let evt = this
+        # Subject is "ems-esp.<topic>"; pull the topic suffix.
+        let topic = meta("nats_subject").split(".").index(1)
+        # ems-esp payloads carry no timestamp field — use the JetStream-server
+        # receive time, falling back to now() if metadata is missing.
+        let ts = meta("nats_timestamp").or(now().ts_format("2006-01-02T15:04:05.999999Z"))
+        root = {
+          "time":          $ts,
+          "topic":         $topic,
+          "curflowtemp":   $evt.curflowtemp,
+          "rettemp":       $evt.rettemp,
+          "outdoortemp":   $evt.outdoortemp,
+          "switchtemp":    $evt.switchtemp,
+          "syspress":      $evt.syspress,
+          "curtemp":       $evt.curtemp,
+          "curflow":       $evt.curflow,
+          "setflowtemp":   $evt.setflowtemp,
+          "flowsettemp":   $evt.flowsettemp,
+          "flowtemphc":    $evt.flowtemphc,
+          "settemp":       $evt.settemp,
+          "curburnpow":    $evt.curburnpow,
+          "charging":      $evt.charging,
+          "heatingactive": $evt.heatingactive,
+          "heatingpump":   $evt.heatingpump,
+          "valvestatus":   $evt.valvestatus,
+          "pumpstatus":    $evt.pumpstatus,
+          "raw":           $evt,
+        }
+
+output:
+  sql_raw:
+    driver: pgx
+    dsn: postgres://${PGUSER}:${PGPASSWORD}@timescaledb-db-pooler.timescaledb.svc.cluster.local:5432/homelab?sslmode=disable
+    init_statement: |
+      SET timezone = 'UTC';
+    query: |
+      INSERT INTO ems_esp (
+        time, topic,
+        curflowtemp, rettemp, outdoortemp, switchtemp, syspress,
+        curtemp, curflow, setflowtemp, flowsettemp, flowtemphc, settemp,
+        curburnpow,
+        charging, heatingactive, heatingpump, valvestatus, pumpstatus,
+        raw
+      )
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)
+    args_mapping: |
+      root = [
+        this.time,
+        this.topic,
+        this.curflowtemp,
+        this.rettemp,
+        this.outdoortemp,
+        this.switchtemp,
+        this.syspress,
+        this.curtemp,
+        this.curflow,
+        this.setflowtemp,
+        this.flowsettemp,
+        this.flowtemphc,
+        this.settemp,
+        this.curburnpow,
+        this.charging,
+        this.heatingactive,
+        this.heatingpump,
+        this.valvestatus,
+        this.pumpstatus,
+        this.raw.string(),
+      ]


### PR DESCRIPTION
## Summary

Schritt F-2 — adds the ems-esp ingest pipeline.

- New `streams/ems_esp.yaml` consumes `ems-esp.>` from the EMS_ESP JetStream and INSERTs into the `ems_esp` hypertable.
- Six topics share one stream (boiler_data, boiler_data_dhw, thermostat_data, thermostat_data_hc1, thermostat_data_dhw, mixer_data_hc1). The topic suffix is parsed from the NATS subject and stored as the `topic` column alongside the typed dashboard fields and `raw JSONB`.
- Per row only the source topic's fields are populated; everything else stays `NULL` (cheap in Postgres).
- Payloads carry no timestamp field. Time is taken from `nats_timestamp` metadata (JetStream-server receive time) with `now()` fallback.
- Driver + DSN match the existing knx / solaredge streams: pgx through the `timescaledb-db-pooler` PgBouncer service.

## Test plan

- [ ] Merge → ConfigMap hash flips → pod auto-rolls (Recreate).
- [ ] `nats consumer info EMS_ESP redpanda-connect-ems-esp` shows ack_floor advancing.
- [ ] `psql … "SELECT topic, count(*) FROM ems_esp WHERE time > now() - interval '5 minutes' GROUP BY 1 ORDER BY 1;"` shows all 6 topics with non-zero counts.
- [ ] Sample row sanity for boiler: `psql … "SELECT time, curflowtemp, rettemp, outdoortemp FROM ems_esp WHERE topic='boiler_data' ORDER BY time DESC LIMIT 5;"` shows real temperatures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)