### PR TITLE
chore(gatus): set explicit endpoint names for consistent capitalization

### DIFF
--- a/kubernetes/applications/authentik/base/ingress-route.yaml
+++ b/kubernetes/applications/authentik/base/ingress-route.yaml
@@ -24,6 +24,7 @@ metadata:
     # Gatus — automated status page discovery (probes via /_gatus path with CF Access Service Token)
     gatus.home-operations.com/enabled: "true"
     gatus.home-operations.com/endpoint: |
+      name: Authentik
       group: Security & Identity
       url: https://PLACEHOLDER/_gatus
       interval: 60s

--- a/kubernetes/applications/external-services/base/ingress-route.yaml
+++ b/kubernetes/applications/external-services/base/ingress-route.yaml
@@ -11,6 +11,7 @@ metadata:
     # Gatus — automated status page discovery (probes via /_gatus path with CF Access Service Token)
     gatus.home-operations.com/enabled: "true"
     gatus.home-operations.com/endpoint: |
+      name: Proxmox
       group: Infrastructure
       url: https://PLACEHOLDER/_gatus
       interval: 60s
@@ -65,6 +66,7 @@ metadata:
     # Gatus — automated status page discovery (probes via /_gatus path with CF Access Service Token)
     gatus.home-operations.com/enabled: "true"
     gatus.home-operations.com/endpoint: |
+      name: Backup
       group: Infrastructure
       url: https://PLACEHOLDER/_gatus
       interval: 60s
@@ -115,6 +117,7 @@ metadata:
     # Gatus — automated status page discovery (probes via /_gatus path with CF Access Service Token)
     gatus.home-operations.com/enabled: "true"
     gatus.home-operations.com/endpoint: |
+      name: Omni
       group: Infrastructure
       url: https://PLACEHOLDER/_gatus
       interval: 60s
@@ -341,6 +344,7 @@ metadata:
     # higher failure tolerance for flaky ESP32 devices)
     gatus.home-operations.com/enabled: "true"
     gatus.home-operations.com/endpoint: |
+      name: EMS-ESP
       group: Smart Home Integration
       url: https://PLACEHOLDER/_gatus
       interval: 60s
@@ -392,6 +396,7 @@ metadata:
     # higher failure tolerance for flaky ESP32 devices)
     gatus.home-operations.com/enabled: "true"
     gatus.home-operations.com/endpoint: |
+      name: FRITZ!Box
       group: Networking
       url: https://PLACEHOLDER/_gatus
       interval: 60s
@@ -442,6 +447,7 @@ metadata:
     # higher failure tolerance for flaky ESP32 devices)
     gatus.home-operations.com/enabled: "true"
     gatus.home-operations.com/endpoint: |
+      name: KNX-IP
       group: Smart Home Integration
       url: https://PLACEHOLDER/_gatus
       interval: 60s

--- a/kubernetes/applications/grafana/base/ingress-route.yaml
+++ b/kubernetes/applications/grafana/base/ingress-route.yaml
@@ -25,6 +25,7 @@ metadata:
     # Gatus — automated status page discovery (probes via /_gatus path with CF Access Service Token)
     gatus.home-operations.com/enabled: "true"
     gatus.home-operations.com/endpoint: |
+      name: Grafana
       group: Observability
       url: https://PLACEHOLDER/_gatus
       interval: 60s

--- a/kubernetes/applications/homepage/base/ingress-route.yaml
+++ b/kubernetes/applications/homepage/base/ingress-route.yaml
@@ -19,6 +19,7 @@ metadata:
     # Gatus — automated status page discovery (probes via /_gatus path with CF Access Service Token)
     gatus.home-operations.com/enabled: "true"
     gatus.home-operations.com/endpoint: |
+      name: Homepage
       group: Productivity
       url: https://PLACEHOLDER/_gatus
       interval: 60s

--- a/kubernetes/applications/wiki-js/base/ingress-route.yaml
+++ b/kubernetes/applications/wiki-js/base/ingress-route.yaml
@@ -20,6 +20,7 @@ metadata:
     # Gatus — automated status page discovery (probes via /_gatus path with CF Access Service Token)
     gatus.home-operations.com/enabled: "true"
     gatus.home-operations.com/endpoint: |
+      name: Wiki.js
       group: Productivity
       url: https://PLACEHOLDER/_gatus
       interval: 60s

--- a/kubernetes/components/gitops-controller/base/ingress-route.yaml
+++ b/kubernetes/components/gitops-controller/base/ingress-route.yaml
@@ -22,6 +22,7 @@ metadata:
     # Gatus — automated status page discovery (probes via /_gatus path with CF Access Service Token)
     gatus.home-operations.com/enabled: "true"
     gatus.home-operations.com/endpoint: |
+      name: ArgoCD
       group: GitOps
       url: https://PLACEHOLDER/_gatus
       interval: 60s


### PR DESCRIPTION
Add `name:` to gatus.home-operations.com/endpoint annotations so the Gatus UI shows Title Case names (Authentik, ArgoCD, Proxmox, ...) instead of falling back to lowercase IngressRoute resource names.