### PR TITLE
feat(redpanda-connect): add warp pipelines (5 streams, Schritt F-3)

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/kustomization.yaml
+++ b/kubernetes/applications/redpanda-connect/base/kustomization.yaml
@@ -20,6 +20,11 @@ configMapGenerator:
       - streams/solaredge_inverter.yaml
       - streams/solaredge_powerflow.yaml
       - streams/ems_esp.yaml
+      - streams/warp_system.yaml
+      - streams/warp_evse.yaml
+      - streams/warp_charge_manager.yaml
+      - streams/warp_charge_tracker.yaml
+      - streams/warp_meter.yaml
 
 labels:
   - includeSelectors: false

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_charge_manager.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_charge_manager.yaml
@@ -1,0 +1,39 @@
+input:
+  nats_jetstream:
+    urls: ["nats://nats.nats.svc:4222"]
+    auth:
+      user: redpanda-connect
+      password: ${NATS_PASSWORD}
+    stream: WARP
+    subject: warp.charge_manager.>
+    durable: redpanda-connect-warp-charge-manager
+    deliver: all
+    ack_wait: 30s
+    max_ack_pending: 256
+
+pipeline:
+  processors:
+    - mapping: |
+        let evt = this
+        let parts = meta("nats_subject").split(".")
+        root = {
+          "time":      meta("nats_timestamp").or(now().ts_format("2006-01-02T15:04:05.999999Z")),
+          "sub_topic": $parts.slice(1).join("."),
+          "raw":       $evt,
+        }
+
+output:
+  sql_raw:
+    driver: pgx
+    dsn: postgres://${PGUSER}:${PGPASSWORD}@timescaledb-db-pooler.timescaledb.svc.cluster.local:5432/homelab?sslmode=disable
+    init_statement: |
+      SET timezone = 'UTC';
+    query: |
+      INSERT INTO warp_charge_manager (time, sub_topic, raw)
+      VALUES ($1, $2, $3)
+    args_mapping: |
+      root = [
+        this.time,
+        this.sub_topic,
+        this.raw.string(),
+      ]

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_charge_tracker.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_charge_tracker.yaml
@@ -1,0 +1,51 @@
+input:
+  nats_jetstream:
+    urls: ["nats://nats.nats.svc:4222"]
+    auth:
+      user: redpanda-connect
+      password: ${NATS_PASSWORD}
+    stream: WARP
+    subject: warp.charge_tracker.>
+    durable: redpanda-connect-warp-charge-tracker
+    deliver: all
+    ack_wait: 30s
+    max_ack_pending: 256
+
+pipeline:
+  processors:
+    - mapping: |
+        let evt = this
+        let parts = meta("nats_subject").split(".")
+        root = {
+          "time":            meta("nats_timestamp").or(now().ts_format("2006-01-02T15:04:05.999999Z")),
+          "sub_topic":       $parts.slice(1).join("."),
+          "user_id":         $evt.user_id.or(null),
+          "charge_duration": $evt.charge_duration.or(null),
+          "energy_charged":  $evt.energy_charged.or(null),
+          "tracked_charges": $evt.tracked_charges.or(null),
+          "raw":             $evt,
+        }
+
+output:
+  sql_raw:
+    driver: pgx
+    dsn: postgres://${PGUSER}:${PGPASSWORD}@timescaledb-db-pooler.timescaledb.svc.cluster.local:5432/homelab?sslmode=disable
+    init_statement: |
+      SET timezone = 'UTC';
+    query: |
+      INSERT INTO warp_charge_tracker (
+        time, sub_topic,
+        user_id, charge_duration, energy_charged, tracked_charges,
+        raw
+      )
+      VALUES ($1, $2, $3, $4, $5, $6, $7)
+    args_mapping: |
+      root = [
+        this.time,
+        this.sub_topic,
+        this.user_id,
+        this.charge_duration,
+        this.energy_charged,
+        this.tracked_charges,
+        this.raw.string(),
+      ]

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_evse.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_evse.yaml
@@ -1,0 +1,51 @@
+input:
+  nats_jetstream:
+    urls: ["nats://nats.nats.svc:4222"]
+    auth:
+      user: redpanda-connect
+      password: ${NATS_PASSWORD}
+    stream: WARP
+    subject: warp.evse.>
+    durable: redpanda-connect-warp-evse
+    deliver: all
+    ack_wait: 30s
+    max_ack_pending: 256
+
+pipeline:
+  processors:
+    - mapping: |
+        let evt = this
+        let parts = meta("nats_subject").split(".")
+        root = {
+          "time":                   meta("nats_timestamp").or(now().ts_format("2006-01-02T15:04:05.999999Z")),
+          "sub_topic":              $parts.slice(1).join("."),
+          "charger_state":          $evt.charger_state.or(null),
+          "error_state":            $evt.error_state.or(null),
+          "contactor_error":        $evt.contactor_error.or(null),
+          "dc_fault_current_state": $evt.dc_fault_current_state.or(null),
+          "raw":                    $evt,
+        }
+
+output:
+  sql_raw:
+    driver: pgx
+    dsn: postgres://${PGUSER}:${PGPASSWORD}@timescaledb-db-pooler.timescaledb.svc.cluster.local:5432/homelab?sslmode=disable
+    init_statement: |
+      SET timezone = 'UTC';
+    query: |
+      INSERT INTO warp_evse (
+        time, sub_topic,
+        charger_state, error_state, contactor_error, dc_fault_current_state,
+        raw
+      )
+      VALUES ($1, $2, $3, $4, $5, $6, $7)
+    args_mapping: |
+      root = [
+        this.time,
+        this.sub_topic,
+        this.charger_state,
+        this.error_state,
+        this.contactor_error,
+        this.dc_fault_current_state,
+        this.raw.string(),
+      ]

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_meter.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_meter.yaml
@@ -1,0 +1,78 @@
+input:
+  nats_jetstream:
+    urls: ["nats://nats.nats.svc:4222"]
+    auth:
+      user: redpanda-connect
+      password: ${NATS_PASSWORD}
+    stream: WARP
+    subject: warp.>
+    durable: redpanda-connect-warp-meter
+    deliver: all
+    ack_wait: 30s
+    max_ack_pending: 256
+
+pipeline:
+  processors:
+    - mapping: |
+        let evt = this
+        let parts = meta("nats_subject").split(".")
+        let root = $parts.index(1)
+        # Forward only meter / meters subjects; everything else handled by
+        # other warp_* streams.
+        root = if $root != "meter" && $root != "meters" {
+          deleted()
+        } else {
+          # Phase columns only meaningful for "warp.meters.<N>.values"
+          # (4 tokens, second is "meters", fourth is "values"). Indices
+          # 0..8 of the array map to V/A/W per phase per Telegraf XPath.
+          let is_indexed_values = $root == "meters" && $parts.length() == 4 && $parts.index(3) == "values"
+          let meter_id = if $is_indexed_values { $parts.index(2).number() } else { null }
+          let v = $evt
+          {
+            "time":       meta("nats_timestamp").or(now().ts_format("2006-01-02T15:04:05.999999Z")),
+            "sub_topic":  $parts.slice(1).join("."),
+            "meter_id":   $meter_id,
+            "voltage_l1": if $is_indexed_values { $v.index(0) } else { null },
+            "voltage_l2": if $is_indexed_values { $v.index(1) } else { null },
+            "voltage_l3": if $is_indexed_values { $v.index(2) } else { null },
+            "current_l1": if $is_indexed_values { $v.index(3) } else { null },
+            "current_l2": if $is_indexed_values { $v.index(4) } else { null },
+            "current_l3": if $is_indexed_values { $v.index(5) } else { null },
+            "power_l1":   if $is_indexed_values { $v.index(6) } else { null },
+            "power_l2":   if $is_indexed_values { $v.index(7) } else { null },
+            "power_l3":   if $is_indexed_values { $v.index(8) } else { null },
+            "raw":        $evt,
+          }
+        }
+
+output:
+  sql_raw:
+    driver: pgx
+    dsn: postgres://${PGUSER}:${PGPASSWORD}@timescaledb-db-pooler.timescaledb.svc.cluster.local:5432/homelab?sslmode=disable
+    init_statement: |
+      SET timezone = 'UTC';
+    query: |
+      INSERT INTO warp_meter (
+        time, sub_topic, meter_id,
+        voltage_l1, voltage_l2, voltage_l3,
+        current_l1, current_l2, current_l3,
+        power_l1, power_l2, power_l3,
+        raw
+      )
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+    args_mapping: |
+      root = [
+        this.time,
+        this.sub_topic,
+        this.meter_id,
+        this.voltage_l1,
+        this.voltage_l2,
+        this.voltage_l3,
+        this.current_l1,
+        this.current_l2,
+        this.current_l3,
+        this.power_l1,
+        this.power_l2,
+        this.power_l3,
+        this.raw.string(),
+      ]

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_system.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_system.yaml
@@ -1,0 +1,45 @@
+input:
+  nats_jetstream:
+    urls: ["nats://nats.nats.svc:4222"]
+    auth:
+      user: redpanda-connect
+      password: ${NATS_PASSWORD}
+    stream: WARP
+    subject: warp.>
+    durable: redpanda-connect-warp-system
+    deliver: all
+    ack_wait: 30s
+    max_ack_pending: 256
+
+pipeline:
+  processors:
+    - mapping: |
+        let evt = this
+        # Subject: warp.<root>.<rest> — only forward rtc/esp32/ntp into warp_system.
+        let parts = meta("nats_subject").split(".")
+        let root = $parts.index(1)
+        root = if $root != "rtc" && $root != "esp32" && $root != "ntp" {
+          deleted()
+        } else {
+          {
+            "time":      meta("nats_timestamp").or(now().ts_format("2006-01-02T15:04:05.999999Z")),
+            "sub_topic": $parts.slice(1).join("."),
+            "raw":       $evt,
+          }
+        }
+
+output:
+  sql_raw:
+    driver: pgx
+    dsn: postgres://${PGUSER}:${PGPASSWORD}@timescaledb-db-pooler.timescaledb.svc.cluster.local:5432/homelab?sslmode=disable
+    init_statement: |
+      SET timezone = 'UTC';
+    query: |
+      INSERT INTO warp_system (time, sub_topic, raw)
+      VALUES ($1, $2, $3)
+    args_mapping: |
+      root = [
+        this.time,
+        this.sub_topic,
+        this.raw.string(),
+      ]


### PR DESCRIPTION
## Summary

Schritt F-3 — five Connect streams that ingest the WARP JetStream into the warp_* hypertables.

| stream | NATS subject | output table | typed columns |
|---|---|---|---|
| `warp_system.yaml` | `warp.>` filtered to `rtc/esp32/ntp` | `warp_system` | sub_topic + raw |
| `warp_evse.yaml` | `warp.evse.>` | `warp_evse` | charger_state, error_state, contactor_error, dc_fault_current_state |
| `warp_charge_manager.yaml` | `warp.charge_manager.>` | `warp_charge_manager` | sub_topic + raw |
| `warp_charge_tracker.yaml` | `warp.charge_tracker.>` | `warp_charge_tracker` | user_id, charge_duration, energy_charged, tracked_charges |
| `warp_meter.yaml` | `warp.>` filtered to `meter/meters` | `warp_meter` | meter_id + voltage/current/power L1-L3 (only for `warp.meters.<N>.values` 39-float arrays) |

All use `nats_timestamp` metadata for the row time (warp payloads carry no timestamp field), pgx driver, and route through the `timescaledb-db-pooler` service.

## Test plan

- [ ] Merge → ConfigMap hash flips → pod auto-rolls.
- [ ] All 5 consumers register on WARP: `for c in redpanda-connect-warp-{system,evse,charge-manager,charge-tracker,meter}; do nats consumer info WARP $c; done` shows ack_floor advancing.
- [ ] `psql … "SELECT 'sys: '||count(*) FROM warp_system WHERE time > now() - interval '5 minutes' UNION ALL SELECT 'evse: '||count(*) FROM warp_evse WHERE time > now() - interval '5 minutes' UNION ALL SELECT 'cm: '||count(*) FROM warp_charge_manager WHERE time > now() - interval '5 minutes' UNION ALL SELECT 'ct: '||count(*) FROM warp_charge_tracker WHERE time > now() - interval '5 minutes' UNION ALL SELECT 'meter: '||count(*) FROM warp_meter WHERE time > now() - interval '5 minutes';"`
  shows non-zero counts in at least system, evse, charge_manager, meter.
- [ ] Phase columns populated: `psql … "SELECT time, meter_id, voltage_l1, current_l1, power_l1 FROM warp_meter WHERE meter_id IS NOT NULL ORDER BY time DESC LIMIT 5;"` shows real values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)