### PR TITLE
fix(redpanda-connect): narrow warp_meter + warp_system subjects

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/streams/warp_meter.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_meter.yaml
@@ -5,7 +5,7 @@ input:
       user: redpanda-connect
       password: ${NATS_PASSWORD}
     stream: WARP
-    subject: warp.>
+    subject: warp.meters.>
     durable: redpanda-connect-warp-meter
     deliver: all
     ack_wait: 30s
@@ -16,33 +16,25 @@ pipeline:
     - mapping: |
         let evt = this
         let parts = meta("nats_subject").split(".")
-        let root_token = $parts.index(1)
-        # Forward only meter / meters subjects; everything else handled by
-        # other warp_* streams.
-        let keep = $root_token == "meter" || $root_token == "meters"
         # Phase columns only meaningful for "warp.meters.<N>.values"
-        # (4 tokens, second is "meters", fourth is "values"). Indices
-        # 0..8 of the array map to V/A/W per phase per Telegraf XPath.
-        let is_indexed_values = $root_token == "meters" && $parts.length() == 4 && $parts.index(3) == "values"
-        let meter_id = if $is_indexed_values { $parts.index(2).number() } else { null }
-        root = if !$keep {
-          deleted()
-        } else {
-          {
-            "time":       meta("nats_timestamp").or(now().ts_format("2006-01-02T15:04:05.999999Z")),
-            "sub_topic":  $parts.slice(1).join("."),
-            "meter_id":   $meter_id,
-            "voltage_l1": if $is_indexed_values { $evt.index(0) } else { null },
-            "voltage_l2": if $is_indexed_values { $evt.index(1) } else { null },
-            "voltage_l3": if $is_indexed_values { $evt.index(2) } else { null },
-            "current_l1": if $is_indexed_values { $evt.index(3) } else { null },
-            "current_l2": if $is_indexed_values { $evt.index(4) } else { null },
-            "current_l3": if $is_indexed_values { $evt.index(5) } else { null },
-            "power_l1":   if $is_indexed_values { $evt.index(6) } else { null },
-            "power_l2":   if $is_indexed_values { $evt.index(7) } else { null },
-            "power_l3":   if $is_indexed_values { $evt.index(8) } else { null },
-            "raw":        $evt,
-          }
+        # (4 tokens, fourth is "values"). Indices 0..8 of the array map
+        # to V/A/W per phase per Telegraf XPath. warp.meters.<N>.update
+        # also lands here but with non-array payloads — typed cols stay NULL.
+        let is_indexed_values = $parts.length() == 4 && $parts.index(3) == "values"
+        root = {
+          "time":       meta("nats_timestamp").or(now().ts_format("2006-01-02T15:04:05.999999Z")),
+          "sub_topic":  $parts.slice(1).join("."),
+          "meter_id":   $parts.index(2).number(),
+          "voltage_l1": if $is_indexed_values { $evt.index(0) } else { null },
+          "voltage_l2": if $is_indexed_values { $evt.index(1) } else { null },
+          "voltage_l3": if $is_indexed_values { $evt.index(2) } else { null },
+          "current_l1": if $is_indexed_values { $evt.index(3) } else { null },
+          "current_l2": if $is_indexed_values { $evt.index(4) } else { null },
+          "current_l3": if $is_indexed_values { $evt.index(5) } else { null },
+          "power_l1":   if $is_indexed_values { $evt.index(6) } else { null },
+          "power_l2":   if $is_indexed_values { $evt.index(7) } else { null },
+          "power_l3":   if $is_indexed_values { $evt.index(8) } else { null },
+          "raw":        $evt,
         }
 
 output:

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_system.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_system.yaml
@@ -1,32 +1,49 @@
 input:
-  nats_jetstream:
-    urls: ["nats://nats.nats.svc:4222"]
-    auth:
-      user: redpanda-connect
-      password: ${NATS_PASSWORD}
-    stream: WARP
-    subject: warp.>
-    durable: redpanda-connect-warp-system
-    deliver: all
-    ack_wait: 30s
-    max_ack_pending: 256
+  broker:
+    inputs:
+      - nats_jetstream:
+          urls: ["nats://nats.nats.svc:4222"]
+          auth:
+            user: redpanda-connect
+            password: ${NATS_PASSWORD}
+          stream: WARP
+          subject: warp.rtc.>
+          durable: redpanda-connect-warp-system-rtc
+          deliver: all
+          ack_wait: 30s
+          max_ack_pending: 256
+      - nats_jetstream:
+          urls: ["nats://nats.nats.svc:4222"]
+          auth:
+            user: redpanda-connect
+            password: ${NATS_PASSWORD}
+          stream: WARP
+          subject: warp.esp32.>
+          durable: redpanda-connect-warp-system-esp32
+          deliver: all
+          ack_wait: 30s
+          max_ack_pending: 256
+      - nats_jetstream:
+          urls: ["nats://nats.nats.svc:4222"]
+          auth:
+            user: redpanda-connect
+            password: ${NATS_PASSWORD}
+          stream: WARP
+          subject: warp.ntp.>
+          durable: redpanda-connect-warp-system-ntp
+          deliver: all
+          ack_wait: 30s
+          max_ack_pending: 256
 
 pipeline:
   processors:
     - mapping: |
         let evt = this
-        # Subject: warp.<root>.<rest> — only forward rtc/esp32/ntp into warp_system.
         let parts = meta("nats_subject").split(".")
-        let root_token = $parts.index(1)
-        let keep = $root_token == "rtc" || $root_token == "esp32" || $root_token == "ntp"
-        root = if !$keep {
-          deleted()
-        } else {
-          {
-            "time":      meta("nats_timestamp").or(now().ts_format("2006-01-02T15:04:05.999999Z")),
-            "sub_topic": $parts.slice(1).join("."),
-            "raw":       $evt,
-          }
+        root = {
+          "time":      meta("nats_timestamp").or(now().ts_format("2006-01-02T15:04:05.999999Z")),
+          "sub_topic": $parts.slice(1).join("."),
+          "raw":       $evt,
         }
 
 output:


### PR DESCRIPTION
## Summary

Two warp streams subscribed to `warp.>` and discarded most messages via `deleted()` in the mapping. `warp-meter` couldn't keep ack-rate up and accumulated **2.2M pending** messages; `warp-system` happened to keep up but was equally wasteful.

Tighten both at the JetStream consumer level:

- **warp_meter** — subject `warp.>` → `warp.meters.>`. Mapping simplified (no keep guard). `warp.meter.all_values` 3-token aggregate is no longer captured — redundant with per-meter values; can be re-added as a separate stream if needed.
- **warp_system** — single `nats_jetstream` input with `warp.>` → `broker` input with three narrow children (`warp.rtc.>`, `warp.esp32.>`, `warp.ntp.>`). Three durables feed one shared INSERT into `warp_system`.

The other three warp streams (`warp_evse`, `warp_charge_manager`, `warp_charge_tracker`) already use specific narrow subjects, no change.

## Operator note

NATS may not auto-update an existing consumer's `filter_subject`. After merge, force-recreate so Connect picks up the new filters cleanly:

```
nats consumer rm WARP redpanda-connect-warp-meter -f
nats consumer rm WARP redpanda-connect-warp-system -f
```

Connect re-creates `redpanda-connect-warp-meter` (new filter) and the three `redpanda-connect-warp-system-*` durables on the next reconcile.

## Test plan

- [ ] Merge → pod rolls.
- [ ] Manual consumer recreate (above commands).
- [ ] `nats consumer info WARP redpanda-connect-warp-meter` shows `num_pending` close to 0 within minutes.
- [ ] All three `redpanda-connect-warp-system-*` consumers exist and advance.
- [ ] `psql … "SELECT count(*) FROM warp_meter WHERE time > now() - interval '5 minutes' AND voltage_l1 IS NOT NULL;"` ≥ 1.
- [ ] `psql … "SELECT count(*) FROM warp_system WHERE time > now() - interval '5 minutes';"` ≥ 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)