### PR TITLE
feat(timescaledb): staging schema + token sync for InfluxDB backfill

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/streams/migrate_ems_esp.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/migrate_ems_esp.yaml
@@ -1,0 +1,94 @@
+# One-shot historical backfill: InfluxDB iox."ems-esp" → migration.ems_esp
+# Cutover: MIN(time) public.ems_esp = 2026-04-29 16:32:24.121308+00
+# Influx data: ~578k rows across 6 topics (boiler_data, boiler_data_dhw, mixer_data_hc1,
+#   thermostat_data, thermostat_data_hc1, thermostat_data_dhw).
+# Topic prefix `ems-esp/` is stripped to match live convention.
+# All ~88 Influx-only fields (burner stats, energy counters, service codes) preserved in raw.
+input:
+  generate:
+    count: 1
+    interval: 0s
+    mapping: |
+      root = {}
+
+pipeline:
+  processors:
+    - mapping: |
+        root.db = "homelab"
+        root.q = "SELECT * FROM \"ems-esp\" WHERE time < '2026-04-29 16:32:24.121308' ORDER BY time"
+        root.format = "json"
+    - http:
+        url: http://influxdb3.influxdb.svc:8181/api/v3/query_sql
+        verb: POST
+        headers:
+          Authorization: Bearer ${INFLUXDB_TOKEN}
+          Content-Type: application/json
+    - unarchive:
+        format: json_array
+    - mapping: |
+        let evt = this
+        # Influx topic = "ems-esp/<topic>"; strip prefix to match live stream's `topic` value.
+        let topic_parts = $evt.topic.split("/")
+        root = {
+          "time":          $evt.time,
+          "topic":         $topic_parts.index(1),
+          "curflowtemp":   $evt.curflowtemp,
+          "rettemp":       $evt.rettemp,
+          "outdoortemp":   $evt.outdoortemp,
+          "switchtemp":    $evt.switchtemp,
+          "syspress":      $evt.syspress,
+          "curtemp":       $evt.curtemp,
+          "curflow":       $evt.curflow,
+          "setflowtemp":   $evt.setflowtemp,
+          "flowsettemp":   $evt.flowsettemp,
+          "flowtemphc":    $evt.flowtemphc,
+          "settemp":       $evt.settemp,
+          "curburnpow":    $evt.curburnpow,
+          "charging":      if $evt.charging != null { $evt.charging.int64() } else { null },
+          "heatingactive": if $evt.heatingactive != null { $evt.heatingactive.int64() } else { null },
+          "heatingpump":   if $evt.heatingpump != null { $evt.heatingpump.int64() } else { null },
+          "valvestatus":   if $evt.valvestatus != null { $evt.valvestatus.int64() } else { null },
+          "pumpstatus":    if $evt.pumpstatus != null { $evt.pumpstatus.int64() } else { null },
+          "raw":           $evt,
+        }
+
+output:
+  sql_raw:
+    driver: pgx
+    dsn: postgres://${PGUSER}:${PGPASSWORD}@timescaledb-db-pooler.timescaledb.svc.cluster.local:5432/homelab?sslmode=disable
+    init_statement: |
+      SET timezone = 'UTC';
+    query: |
+      INSERT INTO migration.ems_esp (
+        time, topic,
+        curflowtemp, rettemp, outdoortemp, switchtemp, syspress,
+        curtemp, curflow, setflowtemp, flowsettemp, flowtemphc, settemp,
+        curburnpow,
+        charging, heatingactive, heatingpump, valvestatus, pumpstatus,
+        raw
+      )
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)
+      ON CONFLICT DO NOTHING
+    args_mapping: |
+      root = [
+        this.time,
+        this.topic,
+        this.curflowtemp,
+        this.rettemp,
+        this.outdoortemp,
+        this.switchtemp,
+        this.syspress,
+        this.curtemp,
+        this.curflow,
+        this.setflowtemp,
+        this.flowsettemp,
+        this.flowtemphc,
+        this.settemp,
+        this.curburnpow,
+        this.charging,
+        this.heatingactive,
+        this.heatingpump,
+        this.valvestatus,
+        this.pumpstatus,
+        this.raw.string(),
+      ]

--- a/kubernetes/applications/redpanda-connect/base/streams/migrate_knx.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/migrate_knx.yaml
@@ -1,0 +1,69 @@
+# One-shot historical backfill: InfluxDB iox.knx → migration.knx
+# Cutover: MIN(time) public.knx = 2026-04-26 15:26:14.273504+00
+# Influx data: ~2.19M rows.
+# Schema gaps:
+#   - Influx column `groupaddress` (Timescale: ga). 1:1 rename.
+#   - knx_main/middle/sub are Utf8 strings in Influx, SMALLINT in Timescale → cast via .number().
+#   - Influx has NO dpt field; backfill rows use 'unknown' as placeholder.
+#     Optional cleanup AFTER staging insert, BEFORE merge into public:
+#       UPDATE migration.knx m SET dpt = src.dpt
+#         FROM (SELECT DISTINCT ga, dpt FROM public.knx) src
+#         WHERE m.ga = src.ga AND m.dpt = 'unknown';
+#   - value column already Float64 in Influx (DPT-1 booleans were 0/1 at write time).
+input:
+  generate:
+    count: 1
+    interval: 0s
+    mapping: |
+      root = {}
+
+pipeline:
+  processors:
+    - mapping: |
+        root.db = "homelab"
+        root.q = "SELECT * FROM knx WHERE time < '2026-04-26 15:26:14.273504' ORDER BY time"
+        root.format = "json"
+    - http:
+        url: http://influxdb3.influxdb.svc:8181/api/v3/query_sql
+        verb: POST
+        headers:
+          Authorization: Bearer ${INFLUXDB_TOKEN}
+          Content-Type: application/json
+    - unarchive:
+        format: json_array
+    - mapping: |
+        let evt = this
+        root = {
+          "time":       $evt.time,
+          "ga":         $evt.groupaddress,
+          "knx_main":   $evt.knx_main.number(),
+          "knx_middle": $evt.knx_middle.number(),
+          "knx_sub":    $evt.knx_sub.number(),
+          "knx_name":   $evt.knx_name,
+          "dpt":        "unknown",
+          "value":      $evt.value,
+          "raw":        $evt,
+        }
+
+output:
+  sql_raw:
+    driver: pgx
+    dsn: postgres://${PGUSER}:${PGPASSWORD}@timescaledb-db-pooler.timescaledb.svc.cluster.local:5432/homelab?sslmode=disable
+    init_statement: |
+      SET timezone = 'UTC';
+    query: |
+      INSERT INTO migration.knx (time, ga, knx_main, knx_middle, knx_sub, knx_name, dpt, value, raw)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+      ON CONFLICT (time, ga) DO NOTHING
+    args_mapping: |
+      root = [
+        this.time,
+        this.ga,
+        this.knx_main,
+        this.knx_middle,
+        this.knx_sub,
+        this.knx_name,
+        this.dpt,
+        this.value,
+        this.raw.string(),
+      ]

--- a/kubernetes/applications/redpanda-connect/base/streams/migrate_solaredge_inverter.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/migrate_solaredge_inverter.yaml
@@ -1,0 +1,77 @@
+# One-shot historical backfill: InfluxDB iox."solaredge.inverter" → migration.solaredge_inverter
+# Cutover: MIN(time) public.solaredge_inverter = 2026-04-23 20:32:50.480246+00
+# Influx data: ~385k rows across both inverters (topic = solaredge-{1,2}/modbus/inverter)
+# Influx-only fields (ac_current_l2/l3, ac_voltage_l2/l3, ac_power_apparent/reactive, power_factor) preserved in raw.
+# Timescale-only field `status` not in Influx → stays NULL.
+input:
+  generate:
+    count: 1
+    interval: 0s
+    mapping: |
+      root = {}
+
+pipeline:
+  processors:
+    - mapping: |
+        root.db = "homelab"
+        root.q = "SELECT * FROM \"solaredge.inverter\" WHERE time < '2026-04-23 20:32:50.480246' ORDER BY time"
+        root.format = "json"
+    - http:
+        url: http://influxdb3.influxdb.svc:8181/api/v3/query_sql
+        verb: POST
+        headers:
+          Authorization: Bearer ${INFLUXDB_TOKEN}
+          Content-Type: application/json
+    - unarchive:
+        format: json_array
+    - mapping: |
+        let evt = this
+        # topic = solaredge-N/modbus/inverter → inverter_id = N
+        let inv_id = $evt.topic.split("/").index(0).split("-").index(1).number()
+        root = {
+          "time":              $evt.time,
+          "inverter_id":       $inv_id,
+          "ac_power_actual":   $evt.ac_power_actual,
+          "ac_current_actual": $evt.ac_current_actual,
+          "ac_voltage_l1":     $evt.ac_voltage_l1,
+          "ac_frequency":      $evt.ac_frequency,
+          "dc_power":          $evt.dc_power,
+          "dc_current":        $evt.dc_current,
+          "dc_voltage":        $evt.dc_voltage,
+          "energytotal":       $evt.energytotal,
+          "temperature":       $evt.temperature,
+          "status":            null,
+          "raw":               $evt,
+        }
+
+output:
+  sql_raw:
+    driver: pgx
+    dsn: postgres://${PGUSER}:${PGPASSWORD}@timescaledb-db-pooler.timescaledb.svc.cluster.local:5432/homelab?sslmode=disable
+    init_statement: |
+      SET timezone = 'UTC';
+    query: |
+      INSERT INTO migration.solaredge_inverter (
+        time, inverter_id,
+        ac_power_actual, ac_current_actual, ac_voltage_l1, ac_frequency,
+        dc_power, dc_current, dc_voltage,
+        energytotal, temperature, status, raw
+      )
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+      ON CONFLICT (time, inverter_id) DO NOTHING
+    args_mapping: |
+      root = [
+        this.time,
+        this.inverter_id,
+        this.ac_power_actual,
+        this.ac_current_actual,
+        this.ac_voltage_l1,
+        this.ac_frequency,
+        this.dc_power,
+        this.dc_current,
+        this.dc_voltage,
+        this.energytotal,
+        this.temperature,
+        this.status,
+        this.raw.string(),
+      ]

--- a/kubernetes/applications/redpanda-connect/base/streams/migrate_solaredge_powerflow.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/migrate_solaredge_powerflow.yaml
@@ -1,0 +1,89 @@
+# One-shot historical backfill: InfluxDB iox."solaredge.powerflow" → migration.solaredge_powerflow
+# Cutover: MIN(time) public.solaredge_powerflow = 2026-04-23 20:32:50.480471+00
+# Influx data: ~385k rows across both inverters (topic = solaredge-{1,2}/powerflow)
+# Influx has battery_power (signed) and battery_discharge but NO battery_charge.
+# Reconstruction: solaredge2mqtt convention is battery_power = charge - discharge,
+# so charge = max(battery_power + battery_discharge, 0). Use Influx columns where present, fall through to raw.
+# Influx-only fields (consumer_inverter, consumer_used_*_production, inverter_*_production) preserved in raw.
+input:
+  generate:
+    count: 1
+    interval: 0s
+    mapping: |
+      root = {}
+
+pipeline:
+  processors:
+    - mapping: |
+        root.db = "homelab"
+        root.q = "SELECT * FROM \"solaredge.powerflow\" WHERE time < '2026-04-23 20:32:50.480471' ORDER BY time"
+        root.format = "json"
+    - http:
+        url: http://influxdb3.influxdb.svc:8181/api/v3/query_sql
+        verb: POST
+        headers:
+          Authorization: Bearer ${INFLUXDB_TOKEN}
+          Content-Type: application/json
+    - unarchive:
+        format: json_array
+    - mapping: |
+        let evt = this
+        let inv_id = $evt.topic.split("/").index(0).split("-").index(1).number()
+        # battery_charge reconstruction: solaredge2mqtt publishes battery_power as net flow
+        # (negative = discharge to house, positive = charge from PV/grid). When power > 0,
+        # the charge component equals power + discharge (discharge is reported separately).
+        let bp = $evt.battery_power.or(0)
+        let bd = $evt.battery_discharge.or(0)
+        let computed_charge = $bp + $bd
+        let charge = if $computed_charge > 0 { $computed_charge } else { 0 }
+        root = {
+          "time":               $evt.time,
+          "inverter_id":        $inv_id,
+          "pv_production":      $evt.pv_production,
+          "grid_power":         $evt.grid_power,
+          "grid_consumption":   $evt.grid_consumption,
+          "grid_delivery":      $evt.grid_delivery,
+          "battery_charge":     $charge,
+          "battery_discharge":  $evt.battery_discharge,
+          "consumer_total":     $evt.consumer_total,
+          "consumer_house":     $evt.consumer_house,
+          "consumer_evcharger": $evt.consumer_evcharger,
+          "inverter_power":     $evt.inverter_power,
+          "inverter_dc_power":  $evt.inverter_dc_power,
+          "raw":                $evt,
+        }
+
+output:
+  sql_raw:
+    driver: pgx
+    dsn: postgres://${PGUSER}:${PGPASSWORD}@timescaledb-db-pooler.timescaledb.svc.cluster.local:5432/homelab?sslmode=disable
+    init_statement: |
+      SET timezone = 'UTC';
+    query: |
+      INSERT INTO migration.solaredge_powerflow (
+        time, inverter_id,
+        pv_production,
+        grid_power, grid_consumption, grid_delivery,
+        battery_charge, battery_discharge,
+        consumer_total, consumer_house, consumer_evcharger,
+        inverter_power, inverter_dc_power, raw
+      )
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+      ON CONFLICT (time, inverter_id) DO NOTHING
+    args_mapping: |
+      root = [
+        this.time,
+        this.inverter_id,
+        this.pv_production,
+        this.grid_power,
+        this.grid_consumption,
+        this.grid_delivery,
+        this.battery_charge,
+        this.battery_discharge,
+        this.consumer_total,
+        this.consumer_house,
+        this.consumer_evcharger,
+        this.inverter_power,
+        this.inverter_dc_power,
+        this.raw.string(),
+      ]

--- a/kubernetes/applications/redpanda-connect/base/streams/migrate_warp_charge_tracker.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/migrate_warp_charge_tracker.yaml
@@ -1,0 +1,61 @@
+# One-shot historical backfill: InfluxDB iox.warp (charge_tracker topics) → migration.warp_charge_tracker
+# Cutover: MIN(time) public.warp_charge_tracker = 2026-04-29 19:46:39.414754+00
+# Influx data: ~38 rows for warp/charge_tracker/{state,current_charge}
+# After successful merge into public, this file + kustomization entry are removed.
+input:
+  generate:
+    count: 1
+    interval: 0s
+    mapping: |
+      root = {}
+
+pipeline:
+  processors:
+    - mapping: |
+        root.db = "homelab"
+        root.q = "SELECT * FROM warp WHERE topic LIKE 'warp/charge_tracker/%' AND time < '2026-04-29 19:46:39.414754' ORDER BY time"
+        root.format = "json"
+    - http:
+        url: http://influxdb3.influxdb.svc:8181/api/v3/query_sql
+        verb: POST
+        headers:
+          Authorization: Bearer ${INFLUXDB_TOKEN}
+          Content-Type: application/json
+    - unarchive:
+        format: json_array
+    - mapping: |
+        let evt = this
+        let parts = $evt.topic.split("/")
+        # warp/charge_tracker/<sub> → sub_topic = charge_tracker.<sub> (matches live stream convention)
+        root = {
+          "time":            $evt.time,
+          "sub_topic":       $parts.slice(1).join("."),
+          "user_id":         if $evt.user_id != null { $evt.user_id.string() } else { null },
+          "charge_duration": null,
+          "energy_charged":  null,
+          "tracked_charges": if $evt.tracked_charges != null { $evt.tracked_charges.int64() } else { null },
+          "raw":             $evt,
+        }
+
+output:
+  sql_raw:
+    driver: pgx
+    dsn: postgres://${PGUSER}:${PGPASSWORD}@timescaledb-db-pooler.timescaledb.svc.cluster.local:5432/homelab?sslmode=disable
+    init_statement: |
+      SET timezone = 'UTC';
+    query: |
+      INSERT INTO migration.warp_charge_tracker (
+        time, sub_topic, user_id, charge_duration, energy_charged, tracked_charges, raw
+      )
+      VALUES ($1, $2, $3, $4, $5, $6, $7)
+      ON CONFLICT DO NOTHING
+    args_mapping: |
+      root = [
+        this.time,
+        this.sub_topic,
+        this.user_id,
+        this.charge_duration,
+        this.energy_charged,
+        this.tracked_charges,
+        this.raw.string(),
+      ]

--- a/kubernetes/applications/redpanda-connect/base/streams/migrate_warp_evse.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/migrate_warp_evse.yaml
@@ -1,0 +1,60 @@
+# One-shot historical backfill: InfluxDB iox.warp (evse topic) → migration.warp_evse
+# Cutover: MIN(time) public.warp_evse = 2026-04-29 19:46:39.276491+00
+# Influx data: ~3653 rows for warp/evse/state
+# Influx-only fields (allowed_charging_current, iec61851_state, lock_state) preserved in raw.
+input:
+  generate:
+    count: 1
+    interval: 0s
+    mapping: |
+      root = {}
+
+pipeline:
+  processors:
+    - mapping: |
+        root.db = "homelab"
+        root.q = "SELECT * FROM warp WHERE topic LIKE 'warp/evse/%' AND time < '2026-04-29 19:46:39.276491' ORDER BY time"
+        root.format = "json"
+    - http:
+        url: http://influxdb3.influxdb.svc:8181/api/v3/query_sql
+        verb: POST
+        headers:
+          Authorization: Bearer ${INFLUXDB_TOKEN}
+          Content-Type: application/json
+    - unarchive:
+        format: json_array
+    - mapping: |
+        let evt = this
+        let parts = $evt.topic.split("/")
+        root = {
+          "time":                   $evt.time,
+          "sub_topic":              $parts.slice(1).join("."),
+          "charger_state":          if $evt.charger_state != null { $evt.charger_state.int64() } else { null },
+          "error_state":            if $evt.error_state != null { $evt.error_state.int64() } else { null },
+          "contactor_error":        if $evt.contactor_error != null { $evt.contactor_error.int64() } else { null },
+          "dc_fault_current_state": if $evt.dc_fault_current_state != null { $evt.dc_fault_current_state.int64() } else { null },
+          "raw":                    $evt,
+        }
+
+output:
+  sql_raw:
+    driver: pgx
+    dsn: postgres://${PGUSER}:${PGPASSWORD}@timescaledb-db-pooler.timescaledb.svc.cluster.local:5432/homelab?sslmode=disable
+    init_statement: |
+      SET timezone = 'UTC';
+    query: |
+      INSERT INTO migration.warp_evse (
+        time, sub_topic, charger_state, error_state, contactor_error, dc_fault_current_state, raw
+      )
+      VALUES ($1, $2, $3, $4, $5, $6, $7)
+      ON CONFLICT DO NOTHING
+    args_mapping: |
+      root = [
+        this.time,
+        this.sub_topic,
+        this.charger_state,
+        this.error_state,
+        this.contactor_error,
+        this.dc_fault_current_state,
+        this.raw.string(),
+      ]

--- a/kubernetes/applications/redpanda-connect/base/streams/migrate_warp_meter.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/migrate_warp_meter.yaml
@@ -1,0 +1,77 @@
+# One-shot historical backfill: InfluxDB iox.warp (meters topic) → migration.warp_meter
+# Cutover: MIN(time) public.warp_meter = 2026-04-29 19:46:39.376863+00
+# Influx data: ~189296 rows for warp/meters/0/values
+# Influx already has parsed phase columns (voltage_L1/L2/L3 etc.); no array indexing needed.
+input:
+  generate:
+    count: 1
+    interval: 0s
+    mapping: |
+      root = {}
+
+pipeline:
+  processors:
+    - mapping: |
+        root.db = "homelab"
+        root.q = "SELECT * FROM warp WHERE topic LIKE 'warp/meters/%' AND time < '2026-04-29 19:46:39.376863' ORDER BY time"
+        root.format = "json"
+    - http:
+        url: http://influxdb3.influxdb.svc:8181/api/v3/query_sql
+        verb: POST
+        headers:
+          Authorization: Bearer ${INFLUXDB_TOKEN}
+          Content-Type: application/json
+    - unarchive:
+        format: json_array
+    - mapping: |
+        let evt = this
+        let parts = $evt.topic.split("/")
+        # warp/meters/<id>/values → meter_id from parts[2]
+        root = {
+          "time":       $evt.time,
+          "sub_topic":  $parts.slice(1).join("."),
+          "meter_id":   $parts.index(2).number(),
+          "voltage_l1": $evt.voltage_L1,
+          "voltage_l2": $evt.voltage_L2,
+          "voltage_l3": $evt.voltage_L3,
+          "current_l1": $evt.current_L1,
+          "current_l2": $evt.current_L2,
+          "current_l3": $evt.current_L3,
+          "power_l1":   $evt.power_L1,
+          "power_l2":   $evt.power_L2,
+          "power_l3":   $evt.power_L3,
+          "raw":        $evt,
+        }
+
+output:
+  sql_raw:
+    driver: pgx
+    dsn: postgres://${PGUSER}:${PGPASSWORD}@timescaledb-db-pooler.timescaledb.svc.cluster.local:5432/homelab?sslmode=disable
+    init_statement: |
+      SET timezone = 'UTC';
+    query: |
+      INSERT INTO migration.warp_meter (
+        time, sub_topic, meter_id,
+        voltage_l1, voltage_l2, voltage_l3,
+        current_l1, current_l2, current_l3,
+        power_l1, power_l2, power_l3,
+        raw
+      )
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+      ON CONFLICT DO NOTHING
+    args_mapping: |
+      root = [
+        this.time,
+        this.sub_topic,
+        this.meter_id,
+        this.voltage_l1,
+        this.voltage_l2,
+        this.voltage_l3,
+        this.current_l1,
+        this.current_l2,
+        this.current_l3,
+        this.power_l1,
+        this.power_l2,
+        this.power_l3,
+        this.raw.string(),
+      ]

--- a/kubernetes/applications/redpanda-connect/base/values.yaml
+++ b/kubernetes/applications/redpanda-connect/base/values.yaml
@@ -25,6 +25,12 @@ env:
       secretKeyRef:
         name: timescaledb-db-connect-secret
         key: password
+  # InfluxDB admin token for one-shot historical backfill streams (cloned from influxdb by Kyverno)
+  - name: INFLUXDB_TOKEN
+    valueFrom:
+      secretKeyRef:
+        name: influxdb-credentials
+        key: admin-token
 
 serviceMonitor:
   enabled: true

--- a/kubernetes/applications/timescaledb/base/scripts/migration_schema.sql
+++ b/kubernetes/applications/timescaledb/base/scripts/migration_schema.sql
@@ -1,0 +1,62 @@
+-- One-shot DDL for the InfluxDB 3 → TimescaleDB historical backfill.
+-- Run as superuser (postgres) on the primary; the migration schema mirrors
+-- the public hypertables minus the CAGG attachments. Streams in
+-- redpanda-connect write here; after verification each table is INSERT…SELECT'd
+-- into public and dropped.
+--
+-- Apply with:
+--   kubectl -n timescaledb exec -i timescaledb-db-1 -- psql -U postgres -d homelab < migration_schema.sql
+--
+-- Rollback: DROP SCHEMA migration CASCADE;
+
+CREATE SCHEMA IF NOT EXISTS migration AUTHORIZATION homelab;
+GRANT USAGE ON SCHEMA migration TO connect;
+
+-- ---------- knx (raw nullable already, dpt NOT NULL → backfill uses 'unknown') ----------
+CREATE TABLE migration.knx (LIKE public.knx INCLUDING DEFAULTS INCLUDING CONSTRAINTS);
+ALTER TABLE migration.knx OWNER TO homelab;
+SELECT create_hypertable('migration.knx', 'time', chunk_time_interval => INTERVAL '1 day');
+GRANT INSERT, SELECT ON migration.knx TO connect;
+
+-- ---------- solaredge_inverter (PK time,inverter_id; raw NOT NULL) ----------
+CREATE TABLE migration.solaredge_inverter (LIKE public.solaredge_inverter INCLUDING DEFAULTS INCLUDING CONSTRAINTS);
+ALTER TABLE migration.solaredge_inverter OWNER TO homelab;
+SELECT create_hypertable('migration.solaredge_inverter', 'time', chunk_time_interval => INTERVAL '1 day');
+GRANT INSERT, SELECT ON migration.solaredge_inverter TO connect;
+
+-- ---------- solaredge_powerflow (PK time,inverter_id; raw NOT NULL) ----------
+CREATE TABLE migration.solaredge_powerflow (LIKE public.solaredge_powerflow INCLUDING DEFAULTS INCLUDING CONSTRAINTS);
+ALTER TABLE migration.solaredge_powerflow OWNER TO homelab;
+SELECT create_hypertable('migration.solaredge_powerflow', 'time', chunk_time_interval => INTERVAL '1 day');
+GRANT INSERT, SELECT ON migration.solaredge_powerflow TO connect;
+
+-- ---------- ems_esp (no PK; raw NOT NULL) ----------
+CREATE TABLE migration.ems_esp (LIKE public.ems_esp INCLUDING DEFAULTS INCLUDING CONSTRAINTS);
+ALTER TABLE migration.ems_esp OWNER TO homelab;
+SELECT create_hypertable('migration.ems_esp', 'time', chunk_time_interval => INTERVAL '1 day');
+-- Re-run safety: dedup on (time, topic, raw)
+CREATE UNIQUE INDEX ON migration.ems_esp (time, topic, md5(raw::text));
+GRANT INSERT, SELECT ON migration.ems_esp TO connect;
+
+-- ---------- warp_evse (no PK; raw NOT NULL) ----------
+CREATE TABLE migration.warp_evse (LIKE public.warp_evse INCLUDING DEFAULTS INCLUDING CONSTRAINTS);
+ALTER TABLE migration.warp_evse OWNER TO homelab;
+SELECT create_hypertable('migration.warp_evse', 'time', chunk_time_interval => INTERVAL '1 day');
+CREATE UNIQUE INDEX ON migration.warp_evse (time, sub_topic, md5(raw::text));
+GRANT INSERT, SELECT ON migration.warp_evse TO connect;
+
+-- ---------- warp_charge_tracker (no PK; raw NOT NULL) ----------
+CREATE TABLE migration.warp_charge_tracker (LIKE public.warp_charge_tracker INCLUDING DEFAULTS INCLUDING CONSTRAINTS);
+ALTER TABLE migration.warp_charge_tracker OWNER TO homelab;
+SELECT create_hypertable('migration.warp_charge_tracker', 'time', chunk_time_interval => INTERVAL '1 day');
+CREATE UNIQUE INDEX ON migration.warp_charge_tracker (time, sub_topic, md5(raw::text));
+GRANT INSERT, SELECT ON migration.warp_charge_tracker TO connect;
+
+-- ---------- warp_meter (no PK; raw NOT NULL) ----------
+CREATE TABLE migration.warp_meter (LIKE public.warp_meter INCLUDING DEFAULTS INCLUDING CONSTRAINTS);
+ALTER TABLE migration.warp_meter OWNER TO homelab;
+SELECT create_hypertable('migration.warp_meter', 'time', chunk_time_interval => INTERVAL '1 day');
+CREATE UNIQUE INDEX ON migration.warp_meter (time, sub_topic, COALESCE(meter_id, -1), md5(raw::text));
+GRANT INSERT, SELECT ON migration.warp_meter TO connect;
+
+-- warp_system, warp_charge_manager: keine Influx-Daten → kein Staging-Mirror nötig.

--- a/kubernetes/components/admission-controller/base/clusterpolicy-secrets.yaml
+++ b/kubernetes/components/admission-controller/base/clusterpolicy-secrets.yaml
@@ -398,3 +398,22 @@ spec:
         clone:
           namespace: timescaledb
           name: timescaledb-db-connect-secret
+
+    # Syncs InfluxDB admin token into redpanda-connect for one-shot historical backfill streams
+    - name: sync-influxdb-credentials-redpanda-connect
+      match:
+        any:
+          - resources:
+              kinds:
+                - Namespace
+              names:
+                - redpanda-connect
+      generate:
+        apiVersion: v1
+        kind: Secret
+        name: influxdb-credentials
+        namespace: redpanda-connect
+        synchronize: true
+        clone:
+          namespace: influxdb
+          name: influxdb-credentials


### PR DESCRIPTION
Prep for one-shot historical migration of the ~12 days of data still in InfluxDB 3 (~04-18 → cutover) into TimescaleDB:

- New migration_schema.sql: mirror tables for the 7 hypertables that have Influx source data (warp_system + warp_charge_manager have none and are skipped). Hypertables, no CAGG attach; UNIQUE indexes on PK-less tables for re-run idempotency. Run manually via `kubectl exec ... psql`, rollback via DROP SCHEMA migration CASCADE.
- Kyverno: clone influxdb-credentials into redpanda-connect namespace so backfill streams can authenticate against /api/v3/query_sql.
- redpanda-connect values: surface INFLUXDB_TOKEN env from the cloned secret.

Backfill stream files follow in a separate commit per table.