### PR TITLE
chore(redpanda-connect): enable warp_charge_tracker backfill (POC)

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/kustomization.yaml
+++ b/kubernetes/applications/redpanda-connect/base/kustomization.yaml
@@ -25,6 +25,9 @@ configMapGenerator:
       - streams/warp_charge_manager.yaml
       - streams/warp_charge_tracker.yaml
       - streams/warp_meter.yaml
+      # One-shot historical backfill (InfluxDB → migration.warp_charge_tracker).
+      # Removed from this list after merge into public.warp_charge_tracker.
+      - streams/migrate_warp_charge_tracker.yaml
 
 labels:
   - includeSelectors: false


### PR DESCRIPTION
Wires the existing migrate_warp_charge_tracker.yaml into the streams ConfigMap. Smallest source set (~38 rows) — POC for the generate→http→unarchive→sql_raw migration pattern. After merge into public.warp_charge_tracker is verified, this kustomization entry + the stream file are removed in a follow-up commit.