### PR TITLE
fix(redpanda-connect): SMALLINT/INTEGER casts in backfill streams

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/streams/migrate_ems_esp.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/migrate_ems_esp.yaml
@@ -44,11 +44,11 @@ pipeline:
           "flowtemphc":    $evt.flowtemphc,
           "settemp":       $evt.settemp,
           "curburnpow":    $evt.curburnpow,
-          "charging":      if $evt.charging != null { $evt.charging.int64() } else { null },
-          "heatingactive": if $evt.heatingactive != null { $evt.heatingactive.int64() } else { null },
-          "heatingpump":   if $evt.heatingpump != null { $evt.heatingpump.int64() } else { null },
-          "valvestatus":   if $evt.valvestatus != null { $evt.valvestatus.int64() } else { null },
-          "pumpstatus":    if $evt.pumpstatus != null { $evt.pumpstatus.int64() } else { null },
+          "charging":      $evt.charging,
+          "heatingactive": $evt.heatingactive,
+          "heatingpump":   $evt.heatingpump,
+          "valvestatus":   $evt.valvestatus,
+          "pumpstatus":    $evt.pumpstatus,
           "raw":           $evt,
         }
 
@@ -59,6 +59,7 @@ output:
     init_statement: |
       SET timezone = 'UTC';
     query: |
+      -- Cast Float64 → SMALLINT via numeric for the boolean-flag columns.
       INSERT INTO migration.ems_esp (
         time, topic,
         curflowtemp, rettemp, outdoortemp, switchtemp, syspress,
@@ -67,7 +68,10 @@ output:
         charging, heatingactive, heatingpump, valvestatus, pumpstatus,
         raw
       )
-      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14,
+              ($15::numeric)::smallint, ($16::numeric)::smallint,
+              ($17::numeric)::smallint, ($18::numeric)::smallint,
+              ($19::numeric)::smallint, $20)
       ON CONFLICT DO NOTHING
     args_mapping: |
       root = [

--- a/kubernetes/applications/redpanda-connect/base/streams/migrate_knx.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/migrate_knx.yaml
@@ -52,8 +52,9 @@ output:
     init_statement: |
       SET timezone = 'UTC';
     query: |
+      -- Cast Bloblang-numeric → SMALLINT via numeric for knx_main/middle/sub.
       INSERT INTO migration.knx (time, ga, knx_main, knx_middle, knx_sub, knx_name, dpt, value, raw)
-      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+      VALUES ($1, $2, ($3::numeric)::smallint, ($4::numeric)::smallint, ($5::numeric)::smallint, $6, $7, $8, $9)
       ON CONFLICT (time, ga) DO NOTHING
     args_mapping: |
       root = [

--- a/kubernetes/applications/redpanda-connect/base/streams/migrate_warp_charge_tracker.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/migrate_warp_charge_tracker.yaml
@@ -33,7 +33,7 @@ pipeline:
           "user_id":         if $evt.user_id != null { $evt.user_id.string() } else { null },
           "charge_duration": null,
           "energy_charged":  null,
-          "tracked_charges": if $evt.tracked_charges != null { $evt.tracked_charges.int64() } else { null },
+          "tracked_charges": $evt.tracked_charges,
           "raw":             $evt,
         }
 
@@ -44,10 +44,12 @@ output:
     init_statement: |
       SET timezone = 'UTC';
     query: |
+      -- Influx returns numeric fields as Float64; cast via numeric to satisfy
+      -- INTEGER target without driver-side stringification artefacts ("256.0").
       INSERT INTO migration.warp_charge_tracker (
         time, sub_topic, user_id, charge_duration, energy_charged, tracked_charges, raw
       )
-      VALUES ($1, $2, $3, $4, $5, $6, $7)
+      VALUES ($1, $2, $3, $4, $5, ($6::numeric)::integer, $7)
       ON CONFLICT DO NOTHING
     args_mapping: |
       root = [

--- a/kubernetes/applications/redpanda-connect/base/streams/migrate_warp_evse.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/migrate_warp_evse.yaml
@@ -29,10 +29,10 @@ pipeline:
         root = {
           "time":                   $evt.time,
           "sub_topic":              $parts.slice(1).join("."),
-          "charger_state":          if $evt.charger_state != null { $evt.charger_state.int64() } else { null },
-          "error_state":            if $evt.error_state != null { $evt.error_state.int64() } else { null },
-          "contactor_error":        if $evt.contactor_error != null { $evt.contactor_error.int64() } else { null },
-          "dc_fault_current_state": if $evt.dc_fault_current_state != null { $evt.dc_fault_current_state.int64() } else { null },
+          "charger_state":          $evt.charger_state,
+          "error_state":            $evt.error_state,
+          "contactor_error":        $evt.contactor_error,
+          "dc_fault_current_state": $evt.dc_fault_current_state,
           "raw":                    $evt,
         }
 
@@ -43,10 +43,11 @@ output:
     init_statement: |
       SET timezone = 'UTC';
     query: |
+      -- Cast Float64 → SMALLINT via numeric to handle "X.0" stringification.
       INSERT INTO migration.warp_evse (
         time, sub_topic, charger_state, error_state, contactor_error, dc_fault_current_state, raw
       )
-      VALUES ($1, $2, $3, $4, $5, $6, $7)
+      VALUES ($1, $2, ($3::numeric)::smallint, ($4::numeric)::smallint, ($5::numeric)::smallint, ($6::numeric)::smallint, $7)
       ON CONFLICT DO NOTHING
     args_mapping: |
       root = [


### PR DESCRIPTION
InfluxDB stores boolean flags + bounded counters as Float64. When pgx serialises them for SQL parameters, integer-target columns reject the ".0" string ("invalid input syntax for type integer: \"256.0\""). Move the cast from Bloblang (.int64() didn't survive driver round-trip) to the SQL VALUES clause via ($N::numeric)::smallint / ::integer:

- migrate_warp_charge_tracker: tracked_charges → integer (16 /state rows were silently failing)
- migrate_warp_evse: charger_state, error_state, contactor_error, dc_fault_current_state → smallint
- migrate_ems_esp: charging, heatingactive, heatingpump, valvestatus, pumpstatus → smallint
- migrate_knx: knx_main/middle/sub → smallint