### PR TITLE
chore(redpanda-connect): enable warp_evse backfill, fix user_id format

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/kustomization.yaml
+++ b/kubernetes/applications/redpanda-connect/base/kustomization.yaml
@@ -25,9 +25,10 @@ configMapGenerator:
       - streams/warp_charge_manager.yaml
       - streams/warp_charge_tracker.yaml
       - streams/warp_meter.yaml
-      # One-shot historical backfill (InfluxDB → migration.warp_charge_tracker).
-      # Removed from this list after merge into public.warp_charge_tracker.
+      # One-shot historical backfills (InfluxDB → migration.<table>).
+      # Removed from this list after merge into public.<table>.
       - streams/migrate_warp_charge_tracker.yaml
+      - streams/migrate_warp_evse.yaml
 
 labels:
   - includeSelectors: false

--- a/kubernetes/applications/redpanda-connect/base/streams/migrate_warp_charge_tracker.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/migrate_warp_charge_tracker.yaml
@@ -30,7 +30,9 @@ pipeline:
         root = {
           "time":            $evt.time,
           "sub_topic":       $parts.slice(1).join("."),
-          "user_id":         if $evt.user_id != null { $evt.user_id.string() } else { null },
+          # Influx stores user_id as Float64; live stream stores int-as-string ("-1", "0").
+          # Truncate decimal to match.
+          "user_id":         if $evt.user_id != null { $evt.user_id.string().split(".").index(0) } else { null },
           "charge_duration": null,
           "energy_charged":  null,
           "tracked_charges": $evt.tracked_charges,


### PR DESCRIPTION
- Wire migrate_warp_evse.yaml (3653 rows) into the streams ConfigMap.
- Bloblang user_id mapping in warp_charge_tracker now truncates the decimal off Influx's Float64 representation ("-1.0" → "-1") to match the live stream's int-string format. POC staging rows already patched in-place via SQL; this commit aligns the source of truth so a future re-run produces identical output.