### PR TITLE
chore(redpanda-connect): enable warp_meter backfill

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/kustomization.yaml
+++ b/kubernetes/applications/redpanda-connect/base/kustomization.yaml
@@ -29,6 +29,7 @@ configMapGenerator:
       # Removed from this list after merge into public.<table>.
       - streams/migrate_warp_charge_tracker.yaml
       - streams/migrate_warp_evse.yaml
+      - streams/migrate_warp_meter.yaml
 
 labels:
   - includeSelectors: false


### PR DESCRIPTION
Wire migrate_warp_meter.yaml (~189k rows) into the streams ConfigMap. Influx-side data is already shaped as voltage_L*/current_L*/power_L* columns (no array indexing needed, unlike the live NATS stream).