### PR TITLE
fix(redpanda-connect): bump memory limit to 2Gi for backfill phase

### DIFF
--- a/kubernetes/applications/redpanda-connect/overlays/prod/kustomization.yaml
+++ b/kubernetes/applications/redpanda-connect/overlays/prod/kustomization.yaml
@@ -17,7 +17,11 @@ patches:
         value:
           requests:
             cpu: 50m
-            memory: 128Mi
+            memory: 256Mi
           limits:
-            cpu: 200m
-            memory: 512Mi
+            cpu: 500m
+            # Temporarily bumped from 512Mi for one-shot historical
+            # backfill streams (migrate_*.yaml) that pull large InfluxDB
+            # responses into memory before unarchiving. Revert to 512Mi
+            # after the migrate_* streams are removed from kustomization.
+            memory: 2Gi


### PR DESCRIPTION
Pod was OOMKilled with 512Mi while migrate_warp_meter held the full ~189k-row InfluxDB response in memory. Bump the limit to 2Gi (and the request to 256Mi) for the duration of the historical backfill. Once the migrate_*.yaml streams are removed from kustomization, revert to the original 512Mi limit — note left inline.

Also bumps CPU limit 200m → 500m so the one-shot insert burst doesn't get throttled mid-batch.