### PR TITLE
revert(redpanda-connect): disable migrate_* streams — TS primary OOM

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/kustomization.yaml
+++ b/kubernetes/applications/redpanda-connect/base/kustomization.yaml
@@ -26,10 +26,11 @@ configMapGenerator:
       - streams/warp_charge_tracker.yaml
       - streams/warp_meter.yaml
       # One-shot historical backfills (InfluxDB → migration.<table>).
-      # Removed from this list after merge into public.<table>.
-      - streams/migrate_warp_charge_tracker.yaml
-      - streams/migrate_warp_evse.yaml
-      - streams/migrate_warp_meter.yaml
+      # All currently disabled while we redesign the throughput/memory
+      # profile — see incident notes on the branch that introduced them.
+      # The 7 migrate_*.yaml files remain in the streams/ directory for
+      # re-enable once TimescaleDB resources have been bumped and the
+      # streams use a slower, gentler batching pattern.
 
 labels:
   - includeSelectors: false


### PR DESCRIPTION
migrate_warp_meter pushed enough load (189k rows × multi-row INSERT through pgx) to OOMKill the TimescaleDB primary (1Gi memory limit). The primary then crashlooped, the pgbouncer pooler cached the failed backend logins, and ALL live streams (knx, warp_evse, warp_system, warp_charge_manager, ems_esp, solaredge_*) started failing too.

Disable all three currently-listed migrate_*.yaml entries until:
  1. TimescaleDB memory limit is raised (currently 1Gi, way under what a multi-row INSERT burst needs).
  2. Backfill streams adopt a gentler shape — smaller batches, sleep between batches, or chunked HTTP fetches against InfluxDB.

The stream YAMLs themselves stay in streams/ for the upcoming retry. Already-staged data (38 warp_charge_tracker + 3653 warp_evse + ~31k warp_meter rows in migration.*) is preserved.