### PR TITLE
fix(redpanda-connect): warp_meter — guard against partial-array payloads

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/streams/warp_meter.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_meter.yaml
@@ -20,20 +20,27 @@ pipeline:
         # (4 tokens, fourth is "values"). Indices 0..8 of the array map
         # to V/A/W per phase per Telegraf XPath. warp.meters.<N>.update
         # also lands here but with non-array payloads — typed cols stay NULL.
+        # Phase typed columns require both:
+        #  - subject `warp.meters.<N>.values` (4 tokens, 4th is "values"), AND
+        #  - payload is an array with at least 9 elements (V/A/W per phase).
+        # Some warp.meters.<N>.values messages carry partial / 1-element arrays;
+        # without the length guard, $evt.index(1) errors and aborts the whole
+        # root mapping → time + sub_topic + raw never get set → NULL-time INSERT.
         let is_indexed_values = $parts.length() == 4 && $parts.index(3) == "values"
+        let is_full_array = $is_indexed_values && $evt.type() == "array" && $evt.length() >= 9
         root = {
           "time":       meta("nats_timestamp").or(now().ts_format("2006-01-02T15:04:05.999999Z")),
           "sub_topic":  $parts.slice(1).join("."),
           "meter_id":   $parts.index(2).number(),
-          "voltage_l1": if $is_indexed_values { $evt.index(0) } else { null },
-          "voltage_l2": if $is_indexed_values { $evt.index(1) } else { null },
-          "voltage_l3": if $is_indexed_values { $evt.index(2) } else { null },
-          "current_l1": if $is_indexed_values { $evt.index(3) } else { null },
-          "current_l2": if $is_indexed_values { $evt.index(4) } else { null },
-          "current_l3": if $is_indexed_values { $evt.index(5) } else { null },
-          "power_l1":   if $is_indexed_values { $evt.index(6) } else { null },
-          "power_l2":   if $is_indexed_values { $evt.index(7) } else { null },
-          "power_l3":   if $is_indexed_values { $evt.index(8) } else { null },
+          "voltage_l1": if $is_full_array { $evt.index(0) } else { null },
+          "voltage_l2": if $is_full_array { $evt.index(1) } else { null },
+          "voltage_l3": if $is_full_array { $evt.index(2) } else { null },
+          "current_l1": if $is_full_array { $evt.index(3) } else { null },
+          "current_l2": if $is_full_array { $evt.index(4) } else { null },
+          "current_l3": if $is_full_array { $evt.index(5) } else { null },
+          "power_l1":   if $is_full_array { $evt.index(6) } else { null },
+          "power_l2":   if $is_full_array { $evt.index(7) } else { null },
+          "power_l3":   if $is_full_array { $evt.index(8) } else { null },
           "raw":        $evt,
         }
 


### PR DESCRIPTION
Some warp.meters.<N>.values messages carry a 1-element array instead of the expected 9-element [V1,V2,V3,A1,A2,A3,W1,W2,W3]. The old is_indexed_values check only validated the subject; once that was true, $evt.index(1) ran unconditionally and threw "index out of bounds for array size: 1". A Bloblang error inside the root mapping aborts the whole assignment — time, sub_topic, raw never get set — and the downstream INSERT fails with "NULL value in column time".

Add an is_full_array guard that also checks the payload type and length. Partial-array messages now fall through with typed phase cols NULL but time/sub_topic/raw populated, so the row still INSERTs and the DB doesn't see a flood of NULL-time errors.

Recurring root cause of the just-resolved outage: the NULL-time constraint failures looped through pgx + pgbouncer and hammered PG hard enough to OOM the 1Gi primary, which then crashlooped and broke the pooler for every other consumer.