### PR TITLE
fix(redpanda-connect): ems_esp — drop non-JSON payloads before mapping

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/streams/ems_esp.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/ems_esp.yaml
@@ -14,6 +14,14 @@ input:
 pipeline:
   processors:
     - mapping: |
+        # Some ems-esp.<topic> sub-topics publish bare strings (e.g. "off",
+        # "on", numeric scalars) instead of JSON objects. Accessing `this`
+        # as structured then errors with "parse as json: invalid character
+        # 'o' looking for beginning of value", which aborts the whole root
+        # mapping and produces a NULL-time INSERT downstream. Drop those
+        # messages here — they don't carry the typed columns we ingest.
+        root = this.catch(deleted())
+    - mapping: |
         let evt = this
         # Subject is "ems-esp.<topic>"; pull the topic suffix.
         let topic = meta("nats_subject").split(".").index(1)


### PR DESCRIPTION
Some ems-esp.<topic> sub-topics publish bare strings ("off", "on", numeric scalars) instead of JSON objects. The structured-this access failed with "parse as json: invalid character 'o' looking for beginning of value" — same shape of bug as the warp_meter partial-array case: root assignment aborts, downstream INSERT lands with NULL-time and contributes to the load that previously OOM-killed the TimescaleDB primary. Add a guard processor that drops messages whose body isn't parseable as structured JSON.