### PR TITLE
chore(redpanda-connect): enable solaredge_inverter backfill (per-row)

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/kustomization.yaml
+++ b/kubernetes/applications/redpanda-connect/base/kustomization.yaml
@@ -32,6 +32,7 @@ configMapGenerator:
       - streams/migrate_warp_charge_tracker.yaml
       - streams/migrate_warp_evse.yaml
       - streams/migrate_warp_meter.yaml
+      - streams/migrate_solaredge_inverter.yaml
 
 labels:
   - includeSelectors: false


### PR DESCRIPTION
Wire migrate_solaredge_inverter.yaml (~385k rows across both inverters) into the streams ConfigMap. Per-row INSERT pattern, same shape as the already-stable migrate_warp_meter run that completed without DB pressure. Expected duration ~10–15 min at the rate observed for warp_meter (~750 rows/s once pgbouncer recovery settled).