### PR TITLE
fix(redpanda-connect): chunk solaredge_inverter backfill by day + nul…

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/streams/migrate_solaredge_inverter.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/migrate_solaredge_inverter.yaml
@@ -1,6 +1,12 @@
 # One-shot historical backfill: InfluxDB iox."solaredge.inverter" → migration.solaredge_inverter
 # Cutover: MIN(time) public.solaredge_inverter = 2026-04-23 20:32:50.480246+00
 # Influx data: ~385k rows across both inverters (topic = solaredge-{1,2}/modbus/inverter)
+#
+# Chunked by day to keep the HTTP response + Bloblang queue under the
+# 2Gi pod limit. A single full-range fetch (~385k rows in one JSON
+# array) OOMs the Connect pod even at 2Gi. Per-row INSERT (no batching)
+# stays gentle on the TS primary.
+#
 # Influx-only fields (ac_current_l2/l3, ac_voltage_l2/l3, ac_power_apparent/reactive, power_factor) preserved in raw.
 # Timescale-only field `status` not in Influx → stays NULL.
 input:
@@ -12,9 +18,21 @@ input:
 
 pipeline:
   processors:
+    # 5 day-buckets covering 2026-04-18 → 2026-04-23 20:32:50 cutover
+    - mapping: |
+        root = [
+          {"start":"2026-04-18T00:00:00Z","end":"2026-04-19T00:00:00Z"},
+          {"start":"2026-04-19T00:00:00Z","end":"2026-04-20T00:00:00Z"},
+          {"start":"2026-04-20T00:00:00Z","end":"2026-04-21T00:00:00Z"},
+          {"start":"2026-04-21T00:00:00Z","end":"2026-04-22T00:00:00Z"},
+          {"start":"2026-04-22T00:00:00Z","end":"2026-04-23T00:00:00Z"},
+          {"start":"2026-04-23T00:00:00Z","end":"2026-04-23T20:32:50.480246Z"},
+        ]
+    - unarchive:
+        format: json_array
     - mapping: |
         root.db = "homelab"
-        root.q = "SELECT * FROM \"solaredge.inverter\" WHERE time < '2026-04-23 20:32:50.480246' ORDER BY time"
+        root.q = "SELECT * FROM \"solaredge.inverter\" WHERE time >= '" + this.start + "' AND time < '" + this.end + "' ORDER BY time"
         root.format = "json"
     - http:
         url: http://influxdb3.influxdb.svc:8181/api/v3/query_sql
@@ -26,22 +44,24 @@ pipeline:
         format: json_array
     - mapping: |
         let evt = this
-        # topic = solaredge-N/modbus/inverter → inverter_id = N
-        let inv_id = $evt.topic.split("/").index(0).split("-").index(1).number()
-        root = {
-          "time":              $evt.time,
-          "inverter_id":       $inv_id,
-          "ac_power_actual":   $evt.ac_power_actual,
-          "ac_current_actual": $evt.ac_current_actual,
-          "ac_voltage_l1":     $evt.ac_voltage_l1,
-          "ac_frequency":      $evt.ac_frequency,
-          "dc_power":          $evt.dc_power,
-          "dc_current":        $evt.dc_current,
-          "dc_voltage":        $evt.dc_voltage,
-          "energytotal":       $evt.energytotal,
-          "temperature":       $evt.temperature,
-          "status":            null,
-          "raw":               $evt,
+        # Drop rows with no topic tag (rare edge case in Influx).
+        root = if $evt.topic == null { deleted() } else {
+          let inv_id = $evt.topic.split("/").index(0).split("-").index(1).number()
+          {
+            "time":              $evt.time,
+            "inverter_id":       $inv_id,
+            "ac_power_actual":   $evt.ac_power_actual,
+            "ac_current_actual": $evt.ac_current_actual,
+            "ac_voltage_l1":     $evt.ac_voltage_l1,
+            "ac_frequency":      $evt.ac_frequency,
+            "dc_power":          $evt.dc_power,
+            "dc_current":        $evt.dc_current,
+            "dc_voltage":        $evt.dc_voltage,
+            "energytotal":       $evt.energytotal,
+            "temperature":       $evt.temperature,
+            "status":            null,
+            "raw":               $evt,
+          }
         }
 
 output:


### PR DESCRIPTION
…l-topic guard

A single HTTP fetch of all 385k rows OOMed the Connect pod (still at 2Gi) — too large a JSON array to hold + Bloblang process at once. Split the SELECT into 6 day-buckets via a generate→json_array → unarchive→http chain so the in-flight HTTP response is at most ~77k rows. Per-row INSERT downstream is unchanged.

Also: a few Influx rows arrive with topic=null (rare edge case); without a guard, $evt.topic.split() blew up the entire mapping. Drop those rows explicitly.

Same chunking shape will go on migrate_solaredge_powerflow, migrate_ems_esp and migrate_knx in their own commits.