### PR TITLE
fix(redpanda-connect): inline inverter_id, drop unsupported let-in-else

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/streams/migrate_solaredge_inverter.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/migrate_solaredge_inverter.yaml
@@ -46,10 +46,9 @@ pipeline:
         let evt = this
         # Drop rows with no topic tag (rare edge case in Influx).
         root = if $evt.topic == null { deleted() } else {
-          let inv_id = $evt.topic.split("/").index(0).split("-").index(1).number()
           {
             "time":              $evt.time,
-            "inverter_id":       $inv_id,
+            "inverter_id":       $evt.topic.split("/").index(0).split("-").index(1).number(),
             "ac_power_actual":   $evt.ac_power_actual,
             "ac_current_actual": $evt.ac_current_actual,
             "ac_voltage_l1":     $evt.ac_voltage_l1,


### PR DESCRIPTION
Bloblang lint rejected the previous shape — `let` bindings are top-level only, not allowed inside an `else` block. Inline the inverter_id derivation directly into the object literal so the mapping parses cleanly. The Connect pod was crash-looping on stream lint errors, never reaching the actual http processors.