### PR TITLE
fix(redpanda-connect): cap migrate parallelism, drop done migrate str…

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/kustomization.yaml
+++ b/kubernetes/applications/redpanda-connect/base/kustomization.yaml
@@ -26,12 +26,13 @@ configMapGenerator:
       - streams/warp_charge_tracker.yaml
       - streams/warp_meter.yaml
       # One-shot historical backfills (InfluxDB → migration.<table>).
-      # Per-row INSERT only — multi-row jsonb_array_elements OOM-killed
-      # the TS primary. Removed entry-by-entry after each table is
-      # merged into public.<table>.
-      - streams/migrate_warp_charge_tracker.yaml
-      - streams/migrate_warp_evse.yaml
-      - streams/migrate_warp_meter.yaml
+      # Per-row INSERT, max_in_flight: 4 to avoid pgbouncer saturation.
+      # Streams are removed from this list as soon as their staging table
+      # is fully populated, so they don't re-fire on pod restart.
+      # Already-completed (data sits in migration.*; pending bulk merge):
+      #   migrate_warp_charge_tracker (38 rows)
+      #   migrate_warp_evse (3653 rows)
+      #   migrate_warp_meter (188791 rows)
       - streams/migrate_solaredge_inverter.yaml
 
 labels:

--- a/kubernetes/applications/redpanda-connect/base/streams/migrate_solaredge_inverter.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/migrate_solaredge_inverter.yaml
@@ -67,6 +67,10 @@ output:
   sql_raw:
     driver: pgx
     dsn: postgres://${PGUSER}:${PGPASSWORD}@timescaledb-db-pooler.timescaledb.svc.cluster.local:5432/homelab?sslmode=disable
+    # Cap parallel inserts so we don't saturate pgbouncer max_client_conn.
+    # Default 64 × 6 day-chunks × N migrate streams was enough to lock
+    # the pooler out for live streams.
+    max_in_flight: 4
     init_statement: |
       SET timezone = 'UTC';
     query: |


### PR DESCRIPTION
…eams

Two related changes to keep pgbouncer max_client_conn under control:

1. migrate_solaredge_inverter: set sql_raw max_in_flight: 4. Default was 64 messages parallel; with 6 day-chunks expanded to ~77k rows each, in-flight inserts saturated the pooler and locked out the live streams (knx, warp_evse, warp_charge_manager, ems_esp...) with "FATAL: no more connections allowed (max_client_conn)".

2. Remove the three completed migrate streams (warp_charge_tracker, warp_evse, warp_meter) from the streams ConfigMap. Their staging tables are already populated; on each pod restart they would re-fetch from Influx and re-INSERT (ON CONFLICT skips), pointlessly consuming pooler slots while the new stream tries to make progress. The data in migration.* persists regardless and will be bulk-merged into public.* once all 7 staging tables are filled.