### PR TITLE
fix(redpanda-connect): drop max_in_flight from migrate_solaredge_inve…

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/streams/migrate_solaredge_inverter.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/migrate_solaredge_inverter.yaml
@@ -67,10 +67,6 @@ output:
   sql_raw:
     driver: pgx
     dsn: postgres://${PGUSER}:${PGPASSWORD}@timescaledb-db-pooler.timescaledb.svc.cluster.local:5432/homelab?sslmode=disable
-    # Cap parallel inserts so we don't saturate pgbouncer max_client_conn.
-    # Default 64 × 6 day-chunks × N migrate streams was enough to lock
-    # the pooler out for live streams.
-    max_in_flight: 4
     init_statement: |
       SET timezone = 'UTC';
     query: |


### PR DESCRIPTION
…rter

With max_in_flight: 4 the output stalled at output_sent=0 even though all 6 day-chunks fetched cleanly (http_request_code_2xx=6) and the pipeline reported 1 batch flowing through. Default max_in_flight (64 batches) is fine because only one migrate_* stream is active at a time now — the previous max_client_conn cascade happened because four migrate streams were active simultaneously.