### PR TITLE
fix(redpanda-connect): un-chunk solaredge_inverter, bump pod mem to 4Gi

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/streams/migrate_solaredge_inverter.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/migrate_solaredge_inverter.yaml
@@ -2,10 +2,10 @@
 # Cutover: MIN(time) public.solaredge_inverter = 2026-04-23 20:32:50.480246+00
 # Influx data: ~385k rows across both inverters (topic = solaredge-{1,2}/modbus/inverter)
 #
-# Chunked by day to keep the HTTP response + Bloblang queue under the
-# 2Gi pod limit. A single full-range fetch (~385k rows in one JSON
-# array) OOMs the Connect pod even at 2Gi. Per-row INSERT (no batching)
-# stays gentle on the TS primary.
+# Same shape as the proven migrate_warp_meter run (no chunking, default
+# parallelism). Day-chunked variant got the entire 6-chunk fan-out
+# stuck as one giant batch in sql_raw with 0 messages reaching the DB.
+# Connect pod memory must be ≥4Gi to hold the full ~385k-row response.
 #
 # Influx-only fields (ac_current_l2/l3, ac_voltage_l2/l3, ac_power_apparent/reactive, power_factor) preserved in raw.
 # Timescale-only field `status` not in Influx → stays NULL.
@@ -18,21 +18,9 @@ input:
 
 pipeline:
   processors:
-    # 5 day-buckets covering 2026-04-18 → 2026-04-23 20:32:50 cutover
-    - mapping: |
-        root = [
-          {"start":"2026-04-18T00:00:00Z","end":"2026-04-19T00:00:00Z"},
-          {"start":"2026-04-19T00:00:00Z","end":"2026-04-20T00:00:00Z"},
-          {"start":"2026-04-20T00:00:00Z","end":"2026-04-21T00:00:00Z"},
-          {"start":"2026-04-21T00:00:00Z","end":"2026-04-22T00:00:00Z"},
-          {"start":"2026-04-22T00:00:00Z","end":"2026-04-23T00:00:00Z"},
-          {"start":"2026-04-23T00:00:00Z","end":"2026-04-23T20:32:50.480246Z"},
-        ]
-    - unarchive:
-        format: json_array
     - mapping: |
         root.db = "homelab"
-        root.q = "SELECT * FROM \"solaredge.inverter\" WHERE time >= '" + this.start + "' AND time < '" + this.end + "' ORDER BY time"
+        root.q = "SELECT * FROM \"solaredge.inverter\" WHERE time < '2026-04-23 20:32:50.480246' ORDER BY time"
         root.format = "json"
     - http:
         url: http://influxdb3.influxdb.svc:8181/api/v3/query_sql

--- a/kubernetes/applications/redpanda-connect/overlays/prod/kustomization.yaml
+++ b/kubernetes/applications/redpanda-connect/overlays/prod/kustomization.yaml
@@ -20,8 +20,10 @@ patches:
             memory: 256Mi
           limits:
             cpu: 500m
-            # Temporarily bumped from 512Mi for one-shot historical
-            # backfill streams (migrate_*.yaml) that pull large InfluxDB
-            # responses into memory before unarchiving. Revert to 512Mi
-            # after the migrate_* streams are removed from kustomization.
-            memory: 2Gi
+            # 4Gi during the InfluxDB → Timescale historical backfill.
+            # 2Gi was enough for warp_meter (~189k rows) but solaredge,
+            # ems_esp and especially knx need more headroom because the
+            # full HTTP response sits in memory before unarchive expands
+            # it. Revert to 512Mi after all migrate_* streams have been
+            # removed from kustomization.
+            memory: 4Gi


### PR DESCRIPTION
The day-chunked variant (one mapping → unarchive json_array → mapping → http → unarchive json_array → mapping fan-out) reproducibly stalled at output_sent=0. All 6 HTTP fetches succeeded, the pipeline processors showed 1 batch flowing through, but the giant batch of ~180k expanded messages never made it into sql_raw — looks like Connect treating the whole fan-out as a single atomic batch.

Revert to the same shape that drove the warp_meter backfill at ~750 rows/s without trouble: a single HTTP fetch, one unarchive, per-row INSERT. The trade-off is memory: the full ~385k-row response sits in the pod before unarchive walks it. 2Gi OOMed; bump the prod overlay limit to 4Gi until the migrate_*.yaml streams are removed from kustomization, then revert to 512Mi.