### PR TITLE
chore(redpanda-connect): enable solaredge_powerflow backfill

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/kustomization.yaml
+++ b/kubernetes/applications/redpanda-connect/base/kustomization.yaml
@@ -26,14 +26,16 @@ configMapGenerator:
       - streams/warp_charge_tracker.yaml
       - streams/warp_meter.yaml
       # One-shot historical backfills (InfluxDB → migration.<table>).
-      # Per-row INSERT, max_in_flight: 4 to avoid pgbouncer saturation.
-      # Streams are removed from this list as soon as their staging table
-      # is fully populated, so they don't re-fire on pod restart.
+      # Counter-based emit (count: N, interval: 90s) to keep each chunk
+      # in its own batch and avoid the array-fan-out single-batch stall.
+      # Streams are removed from this list as soon as their staging
+      # table is fully populated, so they don't re-fire on pod restart.
       # Already-completed (data sits in migration.*; pending bulk merge):
       #   migrate_warp_charge_tracker (38 rows)
       #   migrate_warp_evse (3653 rows)
       #   migrate_warp_meter (188791 rows)
-      - streams/migrate_solaredge_inverter.yaml
+      #   migrate_solaredge_inverter (178322 rows)
+      - streams/migrate_solaredge_powerflow.yaml
 
 labels:
   - includeSelectors: false

--- a/kubernetes/applications/redpanda-connect/base/streams/migrate_solaredge_powerflow.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/migrate_solaredge_powerflow.yaml
@@ -1,22 +1,45 @@
 # One-shot historical backfill: InfluxDB iox."solaredge.powerflow" → migration.solaredge_powerflow
 # Cutover: MIN(time) public.solaredge_powerflow = 2026-04-23 20:32:50.480471+00
-# Influx data: ~385k rows across both inverters (topic = solaredge-{1,2}/powerflow)
+# Influx data: ~178k rows in the 5-day pre-cutover window (~178k from solaredge_inverter
+# parity check; total Influx ~385k across the full retained range).
+#
+# Same chunked-emit shape as migrate_solaredge_inverter: 6 separate
+# generate emissions over time, counter() picks the day-bucket. Avoids
+# the array-fan-out single-batch stall we saw before.
+#
 # Influx has battery_power (signed) and battery_discharge but NO battery_charge.
 # Reconstruction: solaredge2mqtt convention is battery_power = charge - discharge,
-# so charge = max(battery_power + battery_discharge, 0). Use Influx columns where present, fall through to raw.
+# so charge = max(battery_power + battery_discharge, 0).
 # Influx-only fields (consumer_inverter, consumer_used_*_production, inverter_*_production) preserved in raw.
 input:
   generate:
-    count: 1
-    interval: 0s
+    count: 6
+    interval: 90s
     mapping: |
-      root = {}
+      let n = counter() - 1
+      let starts = [
+        "2026-04-18T00:00:00Z",
+        "2026-04-19T00:00:00Z",
+        "2026-04-20T00:00:00Z",
+        "2026-04-21T00:00:00Z",
+        "2026-04-22T00:00:00Z",
+        "2026-04-23T00:00:00Z",
+      ]
+      let ends = [
+        "2026-04-19T00:00:00Z",
+        "2026-04-20T00:00:00Z",
+        "2026-04-21T00:00:00Z",
+        "2026-04-22T00:00:00Z",
+        "2026-04-23T00:00:00Z",
+        "2026-04-23T20:32:50.480471Z",
+      ]
+      root = {"start": $starts.index($n), "end": $ends.index($n)}
 
 pipeline:
   processors:
     - mapping: |
         root.db = "homelab"
-        root.q = "SELECT * FROM \"solaredge.powerflow\" WHERE time < '2026-04-23 20:32:50.480471' ORDER BY time"
+        root.q = "SELECT * FROM \"solaredge.powerflow\" WHERE time >= '" + this.start + "' AND time < '" + this.end + "' ORDER BY time"
         root.format = "json"
     - http:
         url: http://influxdb3.influxdb.svc:8181/api/v3/query_sql
@@ -28,29 +51,26 @@ pipeline:
         format: json_array
     - mapping: |
         let evt = this
-        let inv_id = $evt.topic.split("/").index(0).split("-").index(1).number()
-        # battery_charge reconstruction: solaredge2mqtt publishes battery_power as net flow
-        # (negative = discharge to house, positive = charge from PV/grid). When power > 0,
-        # the charge component equals power + discharge (discharge is reported separately).
-        let bp = $evt.battery_power.or(0)
-        let bd = $evt.battery_discharge.or(0)
-        let computed_charge = $bp + $bd
-        let charge = if $computed_charge > 0 { $computed_charge } else { 0 }
-        root = {
-          "time":               $evt.time,
-          "inverter_id":        $inv_id,
-          "pv_production":      $evt.pv_production,
-          "grid_power":         $evt.grid_power,
-          "grid_consumption":   $evt.grid_consumption,
-          "grid_delivery":      $evt.grid_delivery,
-          "battery_charge":     $charge,
-          "battery_discharge":  $evt.battery_discharge,
-          "consumer_total":     $evt.consumer_total,
-          "consumer_house":     $evt.consumer_house,
-          "consumer_evcharger": $evt.consumer_evcharger,
-          "inverter_power":     $evt.inverter_power,
-          "inverter_dc_power":  $evt.inverter_dc_power,
-          "raw":                $evt,
+        # Drop rows with no topic tag (rare edge case in Influx).
+        root = if $evt.topic == null { deleted() } else {
+          {
+            "time":               $evt.time,
+            "inverter_id":        $evt.topic.split("/").index(0).split("-").index(1).number(),
+            "pv_production":      $evt.pv_production,
+            "grid_power":         $evt.grid_power,
+            "grid_consumption":   $evt.grid_consumption,
+            "grid_delivery":      $evt.grid_delivery,
+            "battery_charge":     if ($evt.battery_power.or(0) + $evt.battery_discharge.or(0)) > 0 {
+                                    $evt.battery_power.or(0) + $evt.battery_discharge.or(0)
+                                  } else { 0 },
+            "battery_discharge":  $evt.battery_discharge,
+            "consumer_total":     $evt.consumer_total,
+            "consumer_house":     $evt.consumer_house,
+            "consumer_evcharger": $evt.consumer_evcharger,
+            "inverter_power":     $evt.inverter_power,
+            "inverter_dc_power":  $evt.inverter_dc_power,
+            "raw":                $evt,
+          }
         }
 
 output:

--- a/kubernetes/applications/timescaledb/base/scripts/migration_schema.sql
+++ b/kubernetes/applications/timescaledb/base/scripts/migration_schema.sql
@@ -13,21 +13,26 @@ CREATE SCHEMA IF NOT EXISTS migration AUTHORIZATION homelab;
 GRANT USAGE ON SCHEMA migration TO connect;
 
 -- ---------- knx (raw nullable already, dpt NOT NULL → backfill uses 'unknown') ----------
+-- LIKE INCLUDING CONSTRAINTS only copies CHECK / NOT NULL, not the PK.
+-- Backfill streams use ON CONFLICT (time, ga) so PK must exist explicitly.
 CREATE TABLE migration.knx (LIKE public.knx INCLUDING DEFAULTS INCLUDING CONSTRAINTS);
 ALTER TABLE migration.knx OWNER TO homelab;
 SELECT create_hypertable('migration.knx', 'time', chunk_time_interval => INTERVAL '1 day');
+ALTER TABLE migration.knx ADD PRIMARY KEY (time, ga);
 GRANT INSERT, SELECT ON migration.knx TO connect;
 
 -- ---------- solaredge_inverter (PK time,inverter_id; raw NOT NULL) ----------
 CREATE TABLE migration.solaredge_inverter (LIKE public.solaredge_inverter INCLUDING DEFAULTS INCLUDING CONSTRAINTS);
 ALTER TABLE migration.solaredge_inverter OWNER TO homelab;
 SELECT create_hypertable('migration.solaredge_inverter', 'time', chunk_time_interval => INTERVAL '1 day');
+ALTER TABLE migration.solaredge_inverter ADD PRIMARY KEY (time, inverter_id);
 GRANT INSERT, SELECT ON migration.solaredge_inverter TO connect;
 
 -- ---------- solaredge_powerflow (PK time,inverter_id; raw NOT NULL) ----------
 CREATE TABLE migration.solaredge_powerflow (LIKE public.solaredge_powerflow INCLUDING DEFAULTS INCLUDING CONSTRAINTS);
 ALTER TABLE migration.solaredge_powerflow OWNER TO homelab;
 SELECT create_hypertable('migration.solaredge_powerflow', 'time', chunk_time_interval => INTERVAL '1 day');
+ALTER TABLE migration.solaredge_powerflow ADD PRIMARY KEY (time, inverter_id);
 GRANT INSERT, SELECT ON migration.solaredge_powerflow TO connect;
 
 -- ---------- ems_esp (no PK; raw NOT NULL) ----------


### PR DESCRIPTION
- migrate_solaredge_powerflow: counter-based 6-emit pattern matching the now-stable migrate_solaredge_inverter shape. Each emission fires 90s apart, fetches one day-bucket from Influx, drops null-topic rows, computes battery_charge from battery_power + battery_discharge.
- kustomization: drop migrate_solaredge_inverter (done, 178322 rows in staging), add migrate_solaredge_powerflow.
- migration_schema.sql: add the missing PRIMARY KEY ALTERs for knx, solaredge_inverter, solaredge_powerflow that were applied manually in-cluster after the ON CONFLICT clauses started failing — keeps the one-shot DDL artefact reproducible from scratch.