### PR TITLE
chore(redpanda-connect): enable ems_esp backfill (12 day-chunks)

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/kustomization.yaml
+++ b/kubernetes/applications/redpanda-connect/base/kustomization.yaml
@@ -35,7 +35,8 @@ configMapGenerator:
       #   migrate_warp_evse (3653 rows)
       #   migrate_warp_meter (188791 rows)
       #   migrate_solaredge_inverter (178322 rows)
-      - streams/migrate_solaredge_powerflow.yaml
+      #   migrate_solaredge_powerflow (178326 rows)
+      - streams/migrate_ems_esp.yaml
 
 labels:
   - includeSelectors: false

--- a/kubernetes/applications/redpanda-connect/base/streams/migrate_ems_esp.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/migrate_ems_esp.yaml
@@ -1,21 +1,54 @@
 # One-shot historical backfill: InfluxDB iox."ems-esp" → migration.ems_esp
 # Cutover: MIN(time) public.ems_esp = 2026-04-29 16:32:24.121308+00
-# Influx data: ~578k rows across 6 topics (boiler_data, boiler_data_dhw, mixer_data_hc1,
-#   thermostat_data, thermostat_data_hc1, thermostat_data_dhw).
-# Topic prefix `ems-esp/` is stripped to match live convention.
-# All ~88 Influx-only fields (burner stats, energy counters, service codes) preserved in raw.
+# Influx data: ~578k rows across 6 topics (boiler_data, boiler_data_dhw,
+# mixer_data_hc1, thermostat_data, thermostat_data_hc1, thermostat_data_dhw).
+#
+# Counter-based 12-emit pattern (11 full days + a partial day for the
+# cutover tail). Each chunk holds ~52k rows — comfortably under the
+# 2Gi pod limit. Topic prefix `ems-esp/` is stripped to match the live
+# stream's typed `topic` column. All ~88 Influx-only fields (burner
+# stats, energy counters, service codes) preserved in raw.
 input:
   generate:
-    count: 1
-    interval: 0s
+    count: 12
+    interval: 90s
     mapping: |
-      root = {}
+      let n = counter() - 1
+      let starts = [
+        "2026-04-18T00:00:00Z",
+        "2026-04-19T00:00:00Z",
+        "2026-04-20T00:00:00Z",
+        "2026-04-21T00:00:00Z",
+        "2026-04-22T00:00:00Z",
+        "2026-04-23T00:00:00Z",
+        "2026-04-24T00:00:00Z",
+        "2026-04-25T00:00:00Z",
+        "2026-04-26T00:00:00Z",
+        "2026-04-27T00:00:00Z",
+        "2026-04-28T00:00:00Z",
+        "2026-04-29T00:00:00Z",
+      ]
+      let ends = [
+        "2026-04-19T00:00:00Z",
+        "2026-04-20T00:00:00Z",
+        "2026-04-21T00:00:00Z",
+        "2026-04-22T00:00:00Z",
+        "2026-04-23T00:00:00Z",
+        "2026-04-24T00:00:00Z",
+        "2026-04-25T00:00:00Z",
+        "2026-04-26T00:00:00Z",
+        "2026-04-27T00:00:00Z",
+        "2026-04-28T00:00:00Z",
+        "2026-04-29T00:00:00Z",
+        "2026-04-29T16:32:24.121308Z",
+      ]
+      root = {"start": $starts.index($n), "end": $ends.index($n)}
 
 pipeline:
   processors:
     - mapping: |
         root.db = "homelab"
-        root.q = "SELECT * FROM \"ems-esp\" WHERE time < '2026-04-29 16:32:24.121308' ORDER BY time"
+        root.q = "SELECT * FROM \"ems-esp\" WHERE time >= '" + this.start + "' AND time < '" + this.end + "' ORDER BY time"
         root.format = "json"
     - http:
         url: http://influxdb3.influxdb.svc:8181/api/v3/query_sql
@@ -27,29 +60,30 @@ pipeline:
         format: json_array
     - mapping: |
         let evt = this
-        # Influx topic = "ems-esp/<topic>"; strip prefix to match live stream's `topic` value.
-        let topic_parts = $evt.topic.split("/")
-        root = {
-          "time":          $evt.time,
-          "topic":         $topic_parts.index(1),
-          "curflowtemp":   $evt.curflowtemp,
-          "rettemp":       $evt.rettemp,
-          "outdoortemp":   $evt.outdoortemp,
-          "switchtemp":    $evt.switchtemp,
-          "syspress":      $evt.syspress,
-          "curtemp":       $evt.curtemp,
-          "curflow":       $evt.curflow,
-          "setflowtemp":   $evt.setflowtemp,
-          "flowsettemp":   $evt.flowsettemp,
-          "flowtemphc":    $evt.flowtemphc,
-          "settemp":       $evt.settemp,
-          "curburnpow":    $evt.curburnpow,
-          "charging":      $evt.charging,
-          "heatingactive": $evt.heatingactive,
-          "heatingpump":   $evt.heatingpump,
-          "valvestatus":   $evt.valvestatus,
-          "pumpstatus":    $evt.pumpstatus,
-          "raw":           $evt,
+        # Drop rows with no topic tag (rare edge case in Influx).
+        root = if $evt.topic == null { deleted() } else {
+          {
+            "time":          $evt.time,
+            "topic":         $evt.topic.split("/").index(1),
+            "curflowtemp":   $evt.curflowtemp,
+            "rettemp":       $evt.rettemp,
+            "outdoortemp":   $evt.outdoortemp,
+            "switchtemp":    $evt.switchtemp,
+            "syspress":      $evt.syspress,
+            "curtemp":       $evt.curtemp,
+            "curflow":       $evt.curflow,
+            "setflowtemp":   $evt.setflowtemp,
+            "flowsettemp":   $evt.flowsettemp,
+            "flowtemphc":    $evt.flowtemphc,
+            "settemp":       $evt.settemp,
+            "curburnpow":    $evt.curburnpow,
+            "charging":      $evt.charging,
+            "heatingactive": $evt.heatingactive,
+            "heatingpump":   $evt.heatingpump,
+            "valvestatus":   $evt.valvestatus,
+            "pumpstatus":    $evt.pumpstatus,
+            "raw":           $evt,
+          }
         }
 
 output:


### PR DESCRIPTION
- migrate_ems_esp: counter-based 12-emit pattern covering 2026-04-18 → 2026-04-29 16:32 cutover. Same shape as the now-stable solaredge_inverter / solaredge_powerflow runs. ems-esp/ topic prefix stripped. Boolean flag columns cast Float64→SMALLINT via numeric.
- kustomization: drop migrate_solaredge_powerflow (done, 178326 rows staged), add migrate_ems_esp.

Expected duration: ~18 minutes (12 chunks × 90s emission interval). Per-chunk row count ~52k, fits comfortably in the 2Gi pod limit.