### PR TITLE
chore(redpanda-connect): enable knx backfill (last + largest table)

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/kustomization.yaml
+++ b/kubernetes/applications/redpanda-connect/base/kustomization.yaml
@@ -36,7 +36,8 @@ configMapGenerator:
       #   migrate_warp_meter (188791 rows)
       #   migrate_solaredge_inverter (178322 rows)
       #   migrate_solaredge_powerflow (178326 rows)
-      - streams/migrate_ems_esp.yaml
+      #   migrate_ems_esp (570017 rows)
+      - streams/migrate_knx.yaml
 
 labels:
   - includeSelectors: false


### PR DESCRIPTION
Swap migrate_ems_esp (done, 570017 rows in staging) for migrate_knx in the streams ConfigMap. KNX is the largest dataset at ~2.19M rows over 9 day-chunks; per-chunk ~255k rows still fits the 2Gi pod budget. Counter-based 9-emit pattern × 90s interval = ~13 min emission window; total run ~25–30 min including the per-row INSERT throughput.

After this completes, all 7 staging tables are populated and we can move to the bulk merge into public.* + CAGG refresh + InfluxDB decommission.