### PR TITLE
fix(redpanda-connect): KNX backfill — 4h chunks, dynamic Bloblang tim…

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/streams/migrate_knx.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/migrate_knx.yaml
@@ -1,59 +1,41 @@
 # One-shot historical backfill: InfluxDB iox.knx → migration.knx
 # Cutover: MIN(time) public.knx = 2026-04-26 15:26:14.273504+00
-# Influx data: ~2.19M rows.
+# Influx data: ~1.55M rows (after compaction; original inventory was ~2.19M).
 #
-# Counter-based 9-emit pattern covering 2026-04-18 → 2026-04-26 15:26.
-# Per-chunk row count is ~255k → JSON ~38MB → fits 2Gi pod limit.
-# ~9 emissions × 90s = ~13 min emission window; total run including
-# per-row INSERTs probably ~25–30 min.
+# 4-hour chunks: ~31k rows/chunk → JSON ~5MB → comfortably under 2Gi
+# pod limit even with one chunk's worth of unarchived messages plus the
+# next chunk's HTTP fetch in flight. Day-chunks (~255k rows) OOM-cycled
+# the Connect pod because two chunks in queue exceeded the limit.
+# 54 emissions × 60s interval = ~54 min emission window; SQL filter
+# clips chunks past the cutover.
 #
 # Schema gaps:
 #   - Influx column `groupaddress` (Timescale: ga). 1:1 rename.
-#   - knx_main/middle/sub are Utf8 strings in Influx, SMALLINT in
-#     Timescale → SQL-side cast via numeric to avoid driver "X.0"
-#     stringification artefacts.
-#   - Influx has NO dpt field; backfill rows use 'unknown' as
-#     placeholder. Optional cleanup AFTER staging insert, BEFORE merge:
+#   - knx_main/middle/sub Utf8→SMALLINT via SQL ($N::numeric)::smallint.
+#   - Influx has NO dpt; backfill uses 'unknown'. Optional pre-merge:
 #       UPDATE migration.knx m SET dpt = src.dpt
 #         FROM (SELECT DISTINCT ga, dpt FROM public.knx) src
 #         WHERE m.ga = src.ga AND m.dpt = 'unknown';
-#   - value column is already Float64 in Influx (DPT-1 booleans were
-#     0/1 at write time).
+#   - value column already Float64 in Influx (DPT-1 booleans 0/1).
 input:
   generate:
-    count: 9
-    interval: 90s
+    count: 54
+    interval: 60s
     mapping: |
       let n = counter() - 1
-      let starts = [
-        "2026-04-18T00:00:00Z",
-        "2026-04-19T00:00:00Z",
-        "2026-04-20T00:00:00Z",
-        "2026-04-21T00:00:00Z",
-        "2026-04-22T00:00:00Z",
-        "2026-04-23T00:00:00Z",
-        "2026-04-24T00:00:00Z",
-        "2026-04-25T00:00:00Z",
-        "2026-04-26T00:00:00Z",
-      ]
-      let ends = [
-        "2026-04-19T00:00:00Z",
-        "2026-04-20T00:00:00Z",
-        "2026-04-21T00:00:00Z",
-        "2026-04-22T00:00:00Z",
-        "2026-04-23T00:00:00Z",
-        "2026-04-24T00:00:00Z",
-        "2026-04-25T00:00:00Z",
-        "2026-04-26T00:00:00Z",
-        "2026-04-26T15:26:14.273504Z",
-      ]
-      root = {"start": $starts.index($n), "end": $ends.index($n)}
+      let start_h = $n * 4
+      let end_h = $start_h + 4
+      let base_ts = "2026-04-18T00:00:00Z".ts_parse("2006-01-02T15:04:05Z")
+      let start = ($base_ts.ts_unix() + ($start_h * 3600)).ts_format("2006-01-02T15:04:05Z").string()
+      let end = ($base_ts.ts_unix() + ($end_h * 3600)).ts_format("2006-01-02T15:04:05Z").string()
+      root = {"start": $start, "end": $end}
 
 pipeline:
   processors:
     - mapping: |
+        # SQL-side cutover clip: chunks past the cutover return zero rows.
         root.db = "homelab"
-        root.q = "SELECT * FROM knx WHERE time >= '" + this.start + "' AND time < '" + this.end + "' ORDER BY time"
+        root.q = "SELECT * FROM knx WHERE time >= '" + this.start + "' AND time < '" + this.end + "' AND time < '2026-04-26 15:26:14.273504' ORDER BY time"
         root.format = "json"
     - http:
         url: http://influxdb3.influxdb.svc:8181/api/v3/query_sql
@@ -84,7 +66,6 @@ output:
     init_statement: |
       SET timezone = 'UTC';
     query: |
-      -- Cast Bloblang-numeric → SMALLINT via numeric for knx_main/middle/sub.
       INSERT INTO migration.knx (time, ga, knx_main, knx_middle, knx_sub, knx_name, dpt, value, raw)
       VALUES ($1, $2, ($3::numeric)::smallint, ($4::numeric)::smallint, ($5::numeric)::smallint, $6, $7, $8, $9)
       ON CONFLICT (time, ga) DO NOTHING


### PR DESCRIPTION
…e math

Day-chunks (~255k rows / chunk) OOM-killed the Connect pod once two chunks queued up at the 90s emission interval. The pod cycled 5x in 30 minutes and only got 25% through the 1.55M-row backfill.

Switch to 4-hour chunks (~31k rows / chunk) emitted every 60s, generated dynamically with Bloblang ts_unix arithmetic instead of a hardcoded timestamp list. SQL-side WHERE clause clips any chunk past the 2026-04-26 15:26 cutover, so we can over-emit safely (54 chunks vs the 53 needed). Per-chunk JSON is ~5MB → easily fits the 2Gi limit even with the next chunk's HTTP fetch in flight.