### PR TITLE
chore(timescaledb): shrink max_wal_size 1600MB → 1200MB on prod

### DIFF
--- a/kubernetes/applications/timescaledb/overlays/prod/kustomization.yaml
+++ b/kubernetes/applications/timescaledb/overlays/prod/kustomization.yaml
@@ -23,8 +23,12 @@ replacements:
         fieldPaths:
           - spec.walStorage.size
 
-  # max_wal_size — 80% of WAL PVC
-  - sourceValue: "1600MB"
+  # max_wal_size — 40% of WAL PVC. Sized down from 1600MB after the
+  # InfluxDB → Timescale historical backfill filled the WAL volume to
+  # 82%; lower max_wal_size = more frequent checkpoints + smaller
+  # steady-state WAL footprint, leaving room for future bursts before
+  # they hit the 2Gi PVC ceiling.
+  - sourceValue: "800MB"
     targets:
       - select:
           kind: Cluster

--- a/kubernetes/applications/timescaledb/overlays/prod/kustomization.yaml
+++ b/kubernetes/applications/timescaledb/overlays/prod/kustomization.yaml
@@ -23,12 +23,13 @@ replacements:
         fieldPaths:
           - spec.walStorage.size
 
-  # max_wal_size — 40% of WAL PVC. Sized down from 1600MB after the
-  # InfluxDB → Timescale historical backfill filled the WAL volume to
-  # 82%; lower max_wal_size = more frequent checkpoints + smaller
-  # steady-state WAL footprint, leaving room for future bursts before
-  # they hit the 2Gi PVC ceiling.
-  - sourceValue: "800MB"
+  # max_wal_size — 60% of WAL PVC. Sized down from 1600MB (80%) after
+  # the InfluxDB → Timescale backfill pushed the WAL volume to 82%;
+  # PG holds WAL up to roughly max_wal_size as a recycle buffer, so a
+  # one-time burst permanently bumps the steady-state footprint. 60%
+  # leaves ~800MB burst headroom on the 2Gi PVC without forcing
+  # checkpoints as aggressively as 50% would.
+  - sourceValue: "1200MB"
     targets:
       - select:
           kind: Cluster


### PR DESCRIPTION
## Summary
- Drop `max_wal_size` on the prod TimescaleDB cluster from 1600MB (80% of WAL PVC) to 1200MB (60%). After the InfluxDB → Timescale backfill burst the WAL volume sat at 82% and won't shrink on its own (PG keeps WAL files up to ~max_wal_size as a recycle buffer).
- 60% steady-state usage leaves ~40% (~800MB) burst headroom on the 2Gi PVC without forcing checkpoints as aggressively as 50% would.

## Test plan
- [ ] After ArgoCD sync, CNPG reloads config (no restart).
- [ ] `kubectl -n timescaledb exec timescaledb-db-1 -c postgres -- psql -U postgres -c "SHOW max_wal_size;"` returns `1200MB`.
- [ ] Within ~10 min, `df -h /var/lib/postgresql/wal` drops from 82% toward ~60% as old WAL files recycle out.
- [ ] No spike in checkpoint or `pg_stat_bgwriter` issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)