### PR TITLE
feat(timescaledb): enable native compression on all hypertables

### DIFF
--- a/kubernetes/applications/timescaledb/base/scripts/bootstrap.sql
+++ b/kubernetes/applications/timescaledb/base/scripts/bootstrap.sql
@@ -279,6 +279,51 @@ SELECT add_continuous_aggregate_policy('warp_meter_1h',
     schedule_interval => INTERVAL '1 hour');
 
 -- =========================================================
+-- Native compression — segment_by chosen for the column the queries
+-- usually filter on; order_by time DESC matches "most recent first".
+-- compress_after = 7 days keeps the live-write window uncompressed
+-- (compressed chunks support inserts + upserts in TS 2.16+, but the
+-- recent window stays cheaper for ad-hoc analytics).
+-- =========================================================
+ALTER TABLE knx SET (timescaledb.compress,
+    timescaledb.compress_segmentby = 'ga',
+    timescaledb.compress_orderby = 'time DESC');
+ALTER TABLE solaredge_inverter SET (timescaledb.compress,
+    timescaledb.compress_segmentby = 'inverter_id',
+    timescaledb.compress_orderby = 'time DESC');
+ALTER TABLE solaredge_powerflow SET (timescaledb.compress,
+    timescaledb.compress_segmentby = 'inverter_id',
+    timescaledb.compress_orderby = 'time DESC');
+ALTER TABLE ems_esp SET (timescaledb.compress,
+    timescaledb.compress_segmentby = 'topic',
+    timescaledb.compress_orderby = 'time DESC');
+ALTER TABLE warp_system SET (timescaledb.compress,
+    timescaledb.compress_segmentby = 'sub_topic',
+    timescaledb.compress_orderby = 'time DESC');
+ALTER TABLE warp_evse SET (timescaledb.compress,
+    timescaledb.compress_segmentby = 'sub_topic',
+    timescaledb.compress_orderby = 'time DESC');
+ALTER TABLE warp_charge_manager SET (timescaledb.compress,
+    timescaledb.compress_segmentby = 'sub_topic',
+    timescaledb.compress_orderby = 'time DESC');
+ALTER TABLE warp_charge_tracker SET (timescaledb.compress,
+    timescaledb.compress_segmentby = 'sub_topic',
+    timescaledb.compress_orderby = 'time DESC');
+ALTER TABLE warp_meter SET (timescaledb.compress,
+    timescaledb.compress_segmentby = 'meter_id',
+    timescaledb.compress_orderby = 'time DESC');
+
+SELECT add_compression_policy('knx',                 INTERVAL '7 days');
+SELECT add_compression_policy('solaredge_inverter',  INTERVAL '7 days');
+SELECT add_compression_policy('solaredge_powerflow', INTERVAL '7 days');
+SELECT add_compression_policy('ems_esp',             INTERVAL '7 days');
+SELECT add_compression_policy('warp_system',         INTERVAL '7 days');
+SELECT add_compression_policy('warp_evse',           INTERVAL '7 days');
+SELECT add_compression_policy('warp_charge_manager', INTERVAL '7 days');
+SELECT add_compression_policy('warp_charge_tracker', INTERVAL '7 days');
+SELECT add_compression_policy('warp_meter',          INTERVAL '7 days');
+
+-- =========================================================
 -- Transfer ownership from `postgres` (CNPG runs initdb as superuser)
 -- to the application user `homelab`, so it can issue table-level GRANTs.
 -- =========================================================


### PR DESCRIPTION
## Summary
Native TimescaleDB compression turned on for all 9 hypertables, with `compress_after = 7 days` so the live-write window stays uncompressed.

| table | segment_by |
|---|---|
| knx | ga |
| solaredge_inverter | inverter_id |
| solaredge_powerflow | inverter_id |
| ems_esp | topic |
| warp_system | sub_topic |
| warp_evse | sub_topic |
| warp_charge_manager | sub_topic |
| warp_charge_tracker | sub_topic |
| warp_meter | meter_id |

`compress_orderby = time DESC` everywhere.

## Effect (already applied to live cluster)
First compression pass on chunks older than 7 days:

| table | before | after | Δ |
|---|---|---|---|
| knx | 1711 MB | 1059 MB | -38% |
| ems_esp | 864 MB | 608 MB | -30% |
| solaredge_inverter | 694 MB | 465 MB | -33% |
| solaredge_powerflow | 589 MB | 350 MB | -41% |
| warp_meter | 311 MB | 296 MB | -5% |

Data PVC: 6.0G/10G → **4.6G/10G** (61% → 48%). More chunks compress automatically as they age past 7d. Steady-state expected ~1-2 GB.

## Live cluster state
The ALTER TABLE statements and `add_compression_policy` calls have already been issued by hand on the live cluster (the bootstrap.sql here is initdb-only and runs only on fresh init); this PR just keeps the source-of-truth in sync.

## Test plan
- [ ] After ArgoCD sync, no errors in CNPG operator logs.
- [ ] `SELECT * FROM timescaledb_information.jobs WHERE proc_name='policy_compression';` shows 9 jobs (already there).
- [ ] Data PVC continues trending toward 1-2 GB as more chunks age past 7 days.
- [ ] Live ingestion stays healthy (Connect streams continue to insert into uncompressed recent chunks).
- [ ] CAGG queries still return data across compressed + uncompressed chunk boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)