### PR TITLE
feat(redpanda-connect): cold-archive bootstrap + warp_charge_tracker fan_out

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/streams/warp_charge_tracker.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_charge_tracker.yaml
@@ -27,25 +27,57 @@ pipeline:
         }
 
 output:
-  sql_raw:
-    driver: pgx
-    dsn: postgres://${PGUSER}:${PGPASSWORD}@timescaledb-db-pooler.timescaledb.svc.cluster.local:5432/homelab?sslmode=disable
-    init_statement: |
-      SET timezone = 'UTC';
-    query: |
-      INSERT INTO warp_charge_tracker (
-        time, sub_topic,
-        user_id, charge_duration, energy_charged, tracked_charges,
-        raw
-      )
-      VALUES ($1, $2, $3, $4, $5, $6, $7)
-    args_mapping: |
-      root = [
-        this.time,
-        this.sub_topic,
-        this.user_id,
-        this.charge_duration,
-        this.energy_charged,
-        this.tracked_charges,
-        this.raw.string(),
-      ]
+  broker:
+    # Both outputs must succeed before the NATS message is acked.
+    # If RustFS is down, NATS will retry → TS-Insert is also delayed.
+    # That is the desired behavior: cold archive must keep up with TS.
+    pattern: fan_out
+    outputs:
+      # Hot tier: typed columns into TimescaleDB
+      - sql_raw:
+          driver: pgx
+          dsn: postgres://${PGUSER}:${PGPASSWORD}@timescaledb-db-pooler.timescaledb.svc.cluster.local:5432/homelab?sslmode=disable
+          init_statement: |
+            SET timezone = 'UTC';
+          query: |
+            INSERT INTO warp_charge_tracker (
+              time, sub_topic,
+              user_id, charge_duration, energy_charged, tracked_charges,
+              raw
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7)
+          args_mapping: |
+            root = [
+              this.time,
+              this.sub_topic,
+              this.user_id,
+              this.charge_duration,
+              this.energy_charged,
+              this.tracked_charges,
+              this.raw.string(),
+            ]
+      # Cold archive: original NATS payload as Parquet on RustFS
+      - aws_s3:
+          bucket: nats-archive
+          region: us-east-1
+          endpoint: http://rustfs-svc.rustfs.svc.cluster.local:9000
+          force_path_style_urls: true
+          credentials:
+            id: ${RUSTFS_ACCESS_KEY}
+            secret: ${RUSTFS_SECRET_KEY}
+          path: warp_charge_tracker/${!timestamp("2006/01/02/15")}/${!uuid_v4()}.parquet
+          batching:
+            count: 10000
+            period: 1h
+            processors:
+              - mapping: |
+                  root = {
+                    "time":    this.time,
+                    "subject": meta("nats_subject"),
+                    "payload": this.raw.format_json(),
+                  }
+              - parquet_encode:
+                  schema:
+                    - { name: time,    type: UTF8 }
+                    - { name: subject, type: UTF8 }
+                    - { name: payload, type: UTF8 }

--- a/kubernetes/applications/redpanda-connect/base/values.yaml
+++ b/kubernetes/applications/redpanda-connect/base/values.yaml
@@ -25,6 +25,17 @@ env:
       secretKeyRef:
         name: timescaledb-db-connect-secret
         key: password
+  # RustFS admin credentials for the cold-archive parquet output (cloned from rustfs namespace by Kyverno)
+  - name: RUSTFS_ACCESS_KEY
+    valueFrom:
+      secretKeyRef:
+        name: rustfs-admin-credentials
+        key: RUSTFS_ACCESS_KEY
+  - name: RUSTFS_SECRET_KEY
+    valueFrom:
+      secretKeyRef:
+        name: rustfs-admin-credentials
+        key: RUSTFS_SECRET_KEY
 
 serviceMonitor:
   enabled: true

--- a/kubernetes/applications/rustfs/base/initialize-buckets-job.yaml
+++ b/kubernetes/applications/rustfs/base/initialize-buckets-job.yaml
@@ -45,7 +45,7 @@ spec:
             - name: RUSTFS_URL
               value: "http://rustfs-svc.rustfs.svc.cluster.local:9000"
             - name: BUCKETS
-              value: "authentik-backups longhorn-backups timescaledb-backups"
+              value: "authentik-backups longhorn-backups timescaledb-backups nats-archive"
             - name: ACCESS_KEY
               valueFrom:
                 secretKeyRef:

--- a/kubernetes/components/admission-controller/base/clusterpolicy-secrets.yaml
+++ b/kubernetes/components/admission-controller/base/clusterpolicy-secrets.yaml
@@ -285,6 +285,25 @@ spec:
           namespace: rustfs
           name: rustfs-admin-credentials
 
+    # Syncs RustFS admin credentials from rustfs into redpanda-connect for the cold-archive parquet output
+    - name: sync-rustfs-admin-credentials-redpanda-connect
+      match:
+        any:
+          - resources:
+              kinds:
+                - Namespace
+              names:
+                - redpanda-connect
+      generate:
+        apiVersion: v1
+        kind: Secret
+        name: rustfs-admin-credentials
+        namespace: redpanda-connect
+        synchronize: true
+        clone:
+          namespace: rustfs
+          name: rustfs-admin-credentials
+
     # Syncs KNX NATS Bridge credentials from nats into knx-nats-bridge for NATS authentication
     - name: sync-knx-nats-bridge-credentials
       match:


### PR DESCRIPTION
Implements step 1 of #756 (Phase A — Live cold-archive).

## Summary
- New RustFS bucket `nats-archive` (added to `rustfs/base/initialize-buckets-job.yaml`).
- Kyverno: clone `rustfs-admin-credentials` from `rustfs` namespace into `redpanda-connect`.
- `redpanda-connect` Helm values: RUSTFS_ACCESS_KEY / RUSTFS_SECRET_KEY env vars from the cloned secret.
- `streams/warp_charge_tracker.yaml`: `output: sql_raw` → `output: broker.fan_out` with both `sql_raw` (existing TS path) and `aws_s3` (new RustFS Parquet path).

## Why only one stream
warp_charge_tracker has the lowest traffic (~38 historical rows). Used as canary to verify:
- Connect's `aws_s3` + `parquet_encode` works against RustFS (untested combo here).
- `pattern: fan_out` requires both outputs to ack before NATS releases the message — observe whether RustFS-write latency creates backpressure on the TS-Insert path.
- Path layout `<stream>/YYYY/MM/DD/HH/<uuid>.parquet` reads cleanly with DuckDB.

If clean: PR 2 follows with the remaining 8 streams.

## Test plan (run after merge + ArgoCD sync)
- [ ] `kubectl -n rustfs logs job/initialize-rustfs-buckets` confirms `nats-archive` created.
- [ ] `kubectl -n redpanda-connect get secret rustfs-admin-credentials` exists.
- [ ] redpanda-connect pod restart clean, logs show no aws_s3 errors.
- [ ] After ~1h (or 10k messages, whichever first), Parquet files visible: `mc ls rfs/nats-archive/warp_charge_tracker/$(date -u +%Y/%m/%d/%H)/`.
- [ ] DuckDB read: `SELECT * FROM read_parquet('s3://nats-archive/warp_charge_tracker/.../*.parquet') LIMIT 5;` returns sane rows (subject = `warp.charge_tracker.…`, payload = original JSON).
- [ ] Connect metrics: `output_sent{path="root.output.broker.outputs.0",…}` and `output_sent{path="…outputs.1",…}` for stream `warp_charge_tracker` grow at the same rate.
- [ ] No backpressure on TS — `public.warp_charge_tracker` row count grows at the previous rate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)