### PR TITLE
fix(redpanda-connect): warp_charge_tracker — timestamp() → now().ts_format()

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/streams/warp_charge_tracker.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_charge_tracker.yaml
@@ -65,7 +65,8 @@ output:
           credentials:
             id: ${RUSTFS_ACCESS_KEY}
             secret: ${RUSTFS_SECRET_KEY}
-          path: warp_charge_tracker/${!timestamp("2006/01/02/15")}/${!uuid_v4()}.parquet
+          # `timestamp(...)` does not exist in Connect interpolations; `now().ts_format(...)` is the right form.
+          path: warp_charge_tracker/${!now().ts_format("2006/01/02/15")}/${!uuid_v4()}.parquet
           batching:
             count: 10000
             period: 1h


### PR DESCRIPTION
Fixes the CrashLoopBackOff that started right after #761 was merged.

`timestamp("2006/01/02/15")` is not a valid Connect interpolation function — Connect logs:
\`\`\`
lint=\"/streams/warp_charge_tracker.yaml(68,67) unrecognised function 'timestamp': }/${!\"
shutting down due to stream linter errors
\`\`\`

`now().ts_format("...")` is the correct form (already used elsewhere in the same file). One-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)