### PR TITLE
feat(redpanda-connect): cold-archive fan_out for the 4 remaining warp streams

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/streams/warp_charge_manager.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_charge_manager.yaml
@@ -23,17 +23,44 @@ pipeline:
         }
 
 output:
-  sql_raw:
-    driver: pgx
-    dsn: postgres://${PGUSER}:${PGPASSWORD}@timescaledb-db-pooler.timescaledb.svc.cluster.local:5432/homelab?sslmode=disable
-    init_statement: |
-      SET timezone = 'UTC';
-    query: |
-      INSERT INTO warp_charge_manager (time, sub_topic, raw)
-      VALUES ($1, $2, $3)
-    args_mapping: |
-      root = [
-        this.time,
-        this.sub_topic,
-        this.raw.string(),
-      ]
+  broker:
+    pattern: fan_out
+    outputs:
+      - sql_raw:
+          driver: pgx
+          dsn: postgres://${PGUSER}:${PGPASSWORD}@timescaledb-db-pooler.timescaledb.svc.cluster.local:5432/homelab?sslmode=disable
+          init_statement: |
+            SET timezone = 'UTC';
+          query: |
+            INSERT INTO warp_charge_manager (time, sub_topic, raw)
+            VALUES ($1, $2, $3)
+          args_mapping: |
+            root = [
+              this.time,
+              this.sub_topic,
+              this.raw.string(),
+            ]
+      - aws_s3:
+          bucket: nats-archive
+          region: us-east-1
+          endpoint: http://rustfs-svc.rustfs.svc.cluster.local:9000
+          force_path_style_urls: true
+          credentials:
+            id: ${RUSTFS_ACCESS_KEY}
+            secret: ${RUSTFS_SECRET_KEY}
+          path: warp_charge_manager/${!now().ts_format("2006/01/02/15")}/${!uuid_v4()}.parquet
+          batching:
+            count: 10000
+            period: 1h
+            processors:
+              - mapping: |
+                  root = {
+                    "time":    this.time,
+                    "subject": meta("nats_subject"),
+                    "payload": this.raw.format_json(),
+                  }
+              - parquet_encode:
+                  schema:
+                    - { name: time,    type: UTF8 }
+                    - { name: subject, type: UTF8 }
+                    - { name: payload, type: UTF8 }

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_evse.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_evse.yaml
@@ -27,25 +27,52 @@ pipeline:
         }
 
 output:
-  sql_raw:
-    driver: pgx
-    dsn: postgres://${PGUSER}:${PGPASSWORD}@timescaledb-db-pooler.timescaledb.svc.cluster.local:5432/homelab?sslmode=disable
-    init_statement: |
-      SET timezone = 'UTC';
-    query: |
-      INSERT INTO warp_evse (
-        time, sub_topic,
-        charger_state, error_state, contactor_error, dc_fault_current_state,
-        raw
-      )
-      VALUES ($1, $2, $3, $4, $5, $6, $7)
-    args_mapping: |
-      root = [
-        this.time,
-        this.sub_topic,
-        this.charger_state,
-        this.error_state,
-        this.contactor_error,
-        this.dc_fault_current_state,
-        this.raw.string(),
-      ]
+  broker:
+    pattern: fan_out
+    outputs:
+      - sql_raw:
+          driver: pgx
+          dsn: postgres://${PGUSER}:${PGPASSWORD}@timescaledb-db-pooler.timescaledb.svc.cluster.local:5432/homelab?sslmode=disable
+          init_statement: |
+            SET timezone = 'UTC';
+          query: |
+            INSERT INTO warp_evse (
+              time, sub_topic,
+              charger_state, error_state, contactor_error, dc_fault_current_state,
+              raw
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7)
+          args_mapping: |
+            root = [
+              this.time,
+              this.sub_topic,
+              this.charger_state,
+              this.error_state,
+              this.contactor_error,
+              this.dc_fault_current_state,
+              this.raw.string(),
+            ]
+      - aws_s3:
+          bucket: nats-archive
+          region: us-east-1
+          endpoint: http://rustfs-svc.rustfs.svc.cluster.local:9000
+          force_path_style_urls: true
+          credentials:
+            id: ${RUSTFS_ACCESS_KEY}
+            secret: ${RUSTFS_SECRET_KEY}
+          path: warp_evse/${!now().ts_format("2006/01/02/15")}/${!uuid_v4()}.parquet
+          batching:
+            count: 10000
+            period: 1h
+            processors:
+              - mapping: |
+                  root = {
+                    "time":    this.time,
+                    "subject": meta("nats_subject"),
+                    "payload": this.raw.format_json(),
+                  }
+              - parquet_encode:
+                  schema:
+                    - { name: time,    type: UTF8 }
+                    - { name: subject, type: UTF8 }
+                    - { name: payload, type: UTF8 }

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_meter.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_meter.yaml
@@ -45,33 +45,60 @@ pipeline:
         }
 
 output:
-  sql_raw:
-    driver: pgx
-    dsn: postgres://${PGUSER}:${PGPASSWORD}@timescaledb-db-pooler.timescaledb.svc.cluster.local:5432/homelab?sslmode=disable
-    init_statement: |
-      SET timezone = 'UTC';
-    query: |
-      INSERT INTO warp_meter (
-        time, sub_topic, meter_id,
-        voltage_l1, voltage_l2, voltage_l3,
-        current_l1, current_l2, current_l3,
-        power_l1, power_l2, power_l3,
-        raw
-      )
-      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
-    args_mapping: |
-      root = [
-        this.time,
-        this.sub_topic,
-        this.meter_id,
-        this.voltage_l1,
-        this.voltage_l2,
-        this.voltage_l3,
-        this.current_l1,
-        this.current_l2,
-        this.current_l3,
-        this.power_l1,
-        this.power_l2,
-        this.power_l3,
-        this.raw.string(),
-      ]
+  broker:
+    pattern: fan_out
+    outputs:
+      - sql_raw:
+          driver: pgx
+          dsn: postgres://${PGUSER}:${PGPASSWORD}@timescaledb-db-pooler.timescaledb.svc.cluster.local:5432/homelab?sslmode=disable
+          init_statement: |
+            SET timezone = 'UTC';
+          query: |
+            INSERT INTO warp_meter (
+              time, sub_topic, meter_id,
+              voltage_l1, voltage_l2, voltage_l3,
+              current_l1, current_l2, current_l3,
+              power_l1, power_l2, power_l3,
+              raw
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+          args_mapping: |
+            root = [
+              this.time,
+              this.sub_topic,
+              this.meter_id,
+              this.voltage_l1,
+              this.voltage_l2,
+              this.voltage_l3,
+              this.current_l1,
+              this.current_l2,
+              this.current_l3,
+              this.power_l1,
+              this.power_l2,
+              this.power_l3,
+              this.raw.string(),
+            ]
+      - aws_s3:
+          bucket: nats-archive
+          region: us-east-1
+          endpoint: http://rustfs-svc.rustfs.svc.cluster.local:9000
+          force_path_style_urls: true
+          credentials:
+            id: ${RUSTFS_ACCESS_KEY}
+            secret: ${RUSTFS_SECRET_KEY}
+          path: warp_meter/${!now().ts_format("2006/01/02/15")}/${!uuid_v4()}.parquet
+          batching:
+            count: 10000
+            period: 1h
+            processors:
+              - mapping: |
+                  root = {
+                    "time":    this.time,
+                    "subject": meta("nats_subject"),
+                    "payload": this.raw.format_json(),
+                  }
+              - parquet_encode:
+                  schema:
+                    - { name: time,    type: UTF8 }
+                    - { name: subject, type: UTF8 }
+                    - { name: payload, type: UTF8 }

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_system.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_system.yaml
@@ -47,17 +47,44 @@ pipeline:
         }
 
 output:
-  sql_raw:
-    driver: pgx
-    dsn: postgres://${PGUSER}:${PGPASSWORD}@timescaledb-db-pooler.timescaledb.svc.cluster.local:5432/homelab?sslmode=disable
-    init_statement: |
-      SET timezone = 'UTC';
-    query: |
-      INSERT INTO warp_system (time, sub_topic, raw)
-      VALUES ($1, $2, $3)
-    args_mapping: |
-      root = [
-        this.time,
-        this.sub_topic,
-        this.raw.string(),
-      ]
+  broker:
+    pattern: fan_out
+    outputs:
+      - sql_raw:
+          driver: pgx
+          dsn: postgres://${PGUSER}:${PGPASSWORD}@timescaledb-db-pooler.timescaledb.svc.cluster.local:5432/homelab?sslmode=disable
+          init_statement: |
+            SET timezone = 'UTC';
+          query: |
+            INSERT INTO warp_system (time, sub_topic, raw)
+            VALUES ($1, $2, $3)
+          args_mapping: |
+            root = [
+              this.time,
+              this.sub_topic,
+              this.raw.string(),
+            ]
+      - aws_s3:
+          bucket: nats-archive
+          region: us-east-1
+          endpoint: http://rustfs-svc.rustfs.svc.cluster.local:9000
+          force_path_style_urls: true
+          credentials:
+            id: ${RUSTFS_ACCESS_KEY}
+            secret: ${RUSTFS_SECRET_KEY}
+          path: warp_system/${!now().ts_format("2006/01/02/15")}/${!uuid_v4()}.parquet
+          batching:
+            count: 10000
+            period: 1h
+            processors:
+              - mapping: |
+                  root = {
+                    "time":    this.time,
+                    "subject": meta("nats_subject"),
+                    "payload": this.raw.format_json(),
+                  }
+              - parquet_encode:
+                  schema:
+                    - { name: time,    type: UTF8 }
+                    - { name: subject, type: UTF8 }
+                    - { name: payload, type: UTF8 }


### PR DESCRIPTION
Phase A continuation of #756. Converts the 4 remaining warp streams to broker fan_out (TS + RustFS Parquet). knx / ems_esp / solaredge_* stay single-output for now — separate PR after these are observed stable.

## Changed
- streams/warp_evse.yaml
- streams/warp_charge_manager.yaml
- streams/warp_meter.yaml
- streams/warp_system.yaml

Same shape as the canary in #761:
- both outputs must ack before NATS releases the message
- aws_s3 output writes Parquet (UTF8 schema: time/subject/payload) into `s3://nats-archive/<stream>/YYYY/MM/DD/HH/<uuid>.parquet`
- 1h batching (count: 10000 OR period: 1h)

## Test plan
- [ ] Pod restart clean, no lint errors
- [ ] All 4 streams: `output_connection_up=1` on both broker outputs
- [ ] After ~1h: `mc ls rfs/nats-archive/` shows files in `warp_evse/`, `warp_charge_manager/`, `warp_meter/`, `warp_system/`
- [ ] DuckDB read of one parquet file from each stream returns sane rows
- [ ] TS-Live-Inserts continue at the previous rate (no backpressure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)