### PR TITLE
feat(iot-mcp-bridge): deploy Phase 0a manifests (homelab#749)

### DIFF
--- a/kubernetes/applications/iot-mcp-bridge/base/certificate.yaml
+++ b/kubernetes/applications/iot-mcp-bridge/base/certificate.yaml
@@ -1,0 +1,14 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+
+metadata:
+  name: iot-mcp-bridge-tls-cert
+  namespace: iot-mcp-bridge
+
+spec:
+  secretName: iot-mcp-bridge-tls-cert
+  issuerRef:
+    name: letsencrypt-dns01-issuer
+    kind: ClusterIssuer
+  dnsNames:
+    - PLACEHOLDER

--- a/kubernetes/applications/iot-mcp-bridge/base/ingress-route.yaml
+++ b/kubernetes/applications/iot-mcp-bridge/base/ingress-route.yaml
@@ -1,0 +1,30 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+
+metadata:
+  name: iot-mcp-bridge
+  namespace: iot-mcp-bridge
+  annotations:
+    # ExternalDNS configuration for Cloudflare
+    external-dns.alpha.kubernetes.io/target: udm-pro.zimmermann.sh
+    external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
+    kubernetes.io/ingress.class: traefik
+
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - kind: Rule
+      match: Host(`PLACEHOLDER`)
+      priority: 10
+      # No forward-auth — claude.ai cannot do interactive login; Bearer-token
+      # validation lives in the pod (Phase 0b, homelab#750).
+      middlewares:
+        - name: chain-standard
+          namespace: ingress-controller
+      services:
+        - kind: Service
+          name: iot-mcp-bridge
+          port: 8080
+  tls:
+    secretName: iot-mcp-bridge-tls-cert

--- a/kubernetes/applications/iot-mcp-bridge/base/kustomization.yaml
+++ b/kubernetes/applications/iot-mcp-bridge/base/kustomization.yaml
@@ -1,0 +1,27 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: iot-mcp-bridge
+resources:
+  - ./namespace.yaml
+  - ./certificate.yaml
+  - ./ingress-route.yaml
+
+helmCharts:
+  - name: application
+    repo: https://stakater.github.io/stakater-charts
+    releaseName: iot-mcp-bridge
+    version: 6.16.1
+    valuesFile: values.yaml
+    namespace: iot-mcp-bridge
+    apiVersions:
+      - monitoring.coreos.com/v1
+
+labels:
+  - includeSelectors: false
+    pairs:
+      homelab.app: iot-mcp-bridge
+
+# Wave 30 = after timescaledb (wave 3) and Kyverno-cloned secret is in place.
+commonAnnotations:
+  argocd.argoproj.io/sync-wave: "30"

--- a/kubernetes/applications/iot-mcp-bridge/base/namespace.yaml
+++ b/kubernetes/applications/iot-mcp-bridge/base/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+
+metadata:
+  name: iot-mcp-bridge

--- a/kubernetes/applications/iot-mcp-bridge/base/values.yaml
+++ b/kubernetes/applications/iot-mcp-bridge/base/values.yaml
@@ -1,0 +1,86 @@
+# Override chart's default resource naming (`application`)
+applicationName: iot-mcp-bridge
+
+deployment:
+  enabled: true
+  image:
+    repository: ghcr.io/alexander-zimmermann/iot-mcp-bridge
+    tag: 0.1.0
+    pullPolicy: IfNotPresent
+
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+
+  env:
+    MCP_DB_HOST:
+      value: timescaledb-db-rw.timescaledb.svc.cluster.local
+    MCP_DB_PORT:
+      value: "5432"
+    MCP_DB_NAME:
+      value: homelab
+    MCP_DB_USER:
+      valueFrom:
+        secretKeyRef:
+          name: timescaledb-db-iot-mcp-bridge-ro-secret
+          key: username
+    MCP_DB_PASSWORD:
+      valueFrom:
+        secretKeyRef:
+          name: timescaledb-db-iot-mcp-bridge-ro-secret
+          key: password
+    MCP_AUTH_ENABLED:
+      value: "false"
+    MCP_LOG_FORMAT:
+      value: json
+    TZ:
+      value: Europe/Berlin
+
+  ports:
+    - containerPort: 8080
+      name: mcp
+      protocol: TCP
+
+  livenessProbe:
+    enabled: true
+    httpGet:
+      path: /healthz
+      port: mcp
+    initialDelaySeconds: 10
+    periodSeconds: 30
+
+  readinessProbe:
+    enabled: true
+    httpGet:
+      path: /healthz
+      port: mcp
+    initialDelaySeconds: 5
+    periodSeconds: 10
+
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+  containerSecurityContext:
+    runAsUser: 1000
+    runAsGroup: 1000
+    runAsNonRoot: true
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop: [ALL]
+
+  securityContext:
+    fsGroup: 1000
+
+service:
+  enabled: true
+  type: ClusterIP
+  ports:
+    - port: 8080
+      name: mcp
+      protocol: TCP
+      targetPort: mcp

--- a/kubernetes/applications/iot-mcp-bridge/overlays/dev/kustomization.yaml
+++ b/kubernetes/applications/iot-mcp-bridge/overlays/dev/kustomization.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+replacements:
+  # Inject dev hostname into Certificate dnsNames and IngressRoute Host(...) match.
+  - sourceValue: mcp.zimmermann.phd
+    targets:
+      - select:
+          kind: Certificate
+          name: iot-mcp-bridge-tls-cert
+        fieldPaths:
+          - spec.dnsNames.0
+      - select:
+          kind: IngressRoute
+          name: iot-mcp-bridge
+        fieldPaths:
+          - spec.routes.0.match
+        options:
+          delimiter: "`"
+          index: 1

--- a/kubernetes/applications/iot-mcp-bridge/overlays/prod/kustomization.yaml
+++ b/kubernetes/applications/iot-mcp-bridge/overlays/prod/kustomization.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+replacements:
+  # Inject prod hostname into Certificate dnsNames and IngressRoute Host(...) match.
+  - sourceValue: mcp.zimmermann.sh
+    targets:
+      - select:
+          kind: Certificate
+          name: iot-mcp-bridge-tls-cert
+        fieldPaths:
+          - spec.dnsNames.0
+      - select:
+          kind: IngressRoute
+          name: iot-mcp-bridge
+        fieldPaths:
+          - spec.routes.0.match
+        options:
+          delimiter: "`"
+          index: 1

--- a/kubernetes/components/admission-controller/base/clusterpolicy-secrets.yaml
+++ b/kubernetes/components/admission-controller/base/clusterpolicy-secrets.yaml
@@ -360,3 +360,23 @@ spec:
         clone:
           namespace: timescaledb
           name: timescaledb-db-connect-secret
+
+    # Syncs CNPG-managed iot-mcp-bridge read-only DB-user secret from
+    # timescaledb into iot-mcp-bridge
+    - name: sync-timescaledb-db-iot-mcp-bridge-ro-secret
+      match:
+        any:
+          - resources:
+              kinds:
+                - Namespace
+              names:
+                - iot-mcp-bridge
+      generate:
+        apiVersion: v1
+        kind: Secret
+        name: timescaledb-db-iot-mcp-bridge-ro-secret
+        namespace: iot-mcp-bridge
+        synchronize: true
+        clone:
+          namespace: timescaledb
+          name: timescaledb-db-iot-mcp-bridge-ro-secret


### PR DESCRIPTION
Kustomize app under kubernetes/applications/iot-mcp-bridge with the Stakater application chart 6.16.1. Picked up automatically by the ApplicationSet generator. Overlays inject prod (mcp.zimmermann.sh) / dev (mcp.zimmermann.phd) hostnames into Certificate + IngressRoute.

The IngressRoute uses chain-standard (no forward-auth) because claude.ai is a backend caller; Bearer-token validation moves into the pod itself in Phase 0b.

Adds a Kyverno clone rule that syncs the read-only DB credentials secret (timescaledb-db-iot-mcp-bridge-ro-secret) from the timescaledb namespace into the new iot-mcp-bridge namespace at namespace-creation time, mirroring the existing redpanda-connect pattern.