### PR TITLE
fix(redpanda-connect): cold-archive batch count 10000→5000

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/streams/warp_charge_manager.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_charge_manager.yaml
@@ -50,7 +50,7 @@ output:
             secret: ${RUSTFS_SECRET_KEY}
           path: warp_charge_manager/${!now().ts_format("2006/01/02/15")}/${!uuid_v4()}.parquet
           batching:
-            count: 10000
+            count: 5000
             period: 1h
             processors:
               - mapping: |

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_charge_tracker.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_charge_tracker.yaml
@@ -68,7 +68,7 @@ output:
           # `timestamp(...)` does not exist in Connect interpolations; `now().ts_format(...)` is the right form.
           path: warp_charge_tracker/${!now().ts_format("2006/01/02/15")}/${!uuid_v4()}.parquet
           batching:
-            count: 10000
+            count: 5000
             period: 1h
             processors:
               - mapping: |

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_evse.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_evse.yaml
@@ -62,7 +62,7 @@ output:
             secret: ${RUSTFS_SECRET_KEY}
           path: warp_evse/${!now().ts_format("2006/01/02/15")}/${!uuid_v4()}.parquet
           batching:
-            count: 10000
+            count: 5000
             period: 1h
             processors:
               - mapping: |

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_meter.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_meter.yaml
@@ -88,7 +88,7 @@ output:
             secret: ${RUSTFS_SECRET_KEY}
           path: warp_meter/${!now().ts_format("2006/01/02/15")}/${!uuid_v4()}.parquet
           batching:
-            count: 10000
+            count: 5000
             period: 1h
             processors:
               - mapping: |

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_system.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_system.yaml
@@ -74,7 +74,7 @@ output:
             secret: ${RUSTFS_SECRET_KEY}
           path: warp_system/${!now().ts_format("2006/01/02/15")}/${!uuid_v4()}.parquet
           batching:
-            count: 10000
+            count: 5000
             period: 1h
             processors:
               - mapping: |


### PR DESCRIPTION
Pod OOMKilled at +11min after #764. With count: 10000 / period: 1h on 5 streams, period triggered first — ~50k messages buffered. Drop count to 5000 (peak buffer ~60 MB) so count triggers within the period window for hot streams.

🤖 Generated with [Claude Code](https://claude.com/claude-code)