### PR TITLE
fix(redpanda-connect): cap sql_raw max_in_flight at 16

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/streams/ems_esp.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/ems_esp.yaml
@@ -54,6 +54,7 @@ pipeline:
 output:
   sql_raw:
     driver: pgx
+    max_in_flight: 16
     dsn: postgres://${PGUSER}:${PGPASSWORD}@timescaledb-db-pooler.timescaledb.svc.cluster.local:5432/homelab?sslmode=disable
     init_statement: |
       SET timezone = 'UTC';

--- a/kubernetes/applications/redpanda-connect/base/streams/knx.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/knx.yaml
@@ -45,6 +45,7 @@ pipeline:
 output:
   sql_raw:
     driver: pgx
+    max_in_flight: 16
     dsn: postgres://${PGUSER}:${PGPASSWORD}@timescaledb-db-pooler.timescaledb.svc.cluster.local:5432/homelab?sslmode=disable
     init_statement: |
       SET timezone = 'UTC';

--- a/kubernetes/applications/redpanda-connect/base/streams/solaredge_inverter.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/solaredge_inverter.yaml
@@ -37,6 +37,7 @@ pipeline:
 output:
   sql_raw:
     driver: pgx
+    max_in_flight: 16
     dsn: postgres://${PGUSER}:${PGPASSWORD}@timescaledb-db-pooler.timescaledb.svc.cluster.local:5432/homelab?sslmode=disable
     init_statement: |
       SET timezone = 'UTC';

--- a/kubernetes/applications/redpanda-connect/base/streams/solaredge_powerflow.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/solaredge_powerflow.yaml
@@ -38,6 +38,7 @@ pipeline:
 output:
   sql_raw:
     driver: pgx
+    max_in_flight: 16
     dsn: postgres://${PGUSER}:${PGPASSWORD}@timescaledb-db-pooler.timescaledb.svc.cluster.local:5432/homelab?sslmode=disable
     init_statement: |
       SET timezone = 'UTC';

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_charge_manager.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_charge_manager.yaml
@@ -28,6 +28,7 @@ output:
     outputs:
       - sql_raw:
           driver: pgx
+          max_in_flight: 16
           dsn: postgres://${PGUSER}:${PGPASSWORD}@timescaledb-db-pooler.timescaledb.svc.cluster.local:5432/homelab?sslmode=disable
           init_statement: |
             SET timezone = 'UTC';

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_charge_tracker.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_charge_tracker.yaml
@@ -36,6 +36,7 @@ output:
       # Hot tier: typed columns into TimescaleDB
       - sql_raw:
           driver: pgx
+          max_in_flight: 16
           dsn: postgres://${PGUSER}:${PGPASSWORD}@timescaledb-db-pooler.timescaledb.svc.cluster.local:5432/homelab?sslmode=disable
           init_statement: |
             SET timezone = 'UTC';

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_evse.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_evse.yaml
@@ -32,6 +32,7 @@ output:
     outputs:
       - sql_raw:
           driver: pgx
+          max_in_flight: 16
           dsn: postgres://${PGUSER}:${PGPASSWORD}@timescaledb-db-pooler.timescaledb.svc.cluster.local:5432/homelab?sslmode=disable
           init_statement: |
             SET timezone = 'UTC';

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_meter.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_meter.yaml
@@ -50,6 +50,7 @@ output:
     outputs:
       - sql_raw:
           driver: pgx
+          max_in_flight: 16
           dsn: postgres://${PGUSER}:${PGPASSWORD}@timescaledb-db-pooler.timescaledb.svc.cluster.local:5432/homelab?sslmode=disable
           init_statement: |
             SET timezone = 'UTC';

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_system.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_system.yaml
@@ -52,6 +52,7 @@ output:
     outputs:
       - sql_raw:
           driver: pgx
+          max_in_flight: 16
           dsn: postgres://${PGUSER}:${PGPASSWORD}@timescaledb-db-pooler.timescaledb.svc.cluster.local:5432/homelab?sslmode=disable
           init_statement: |
             SET timezone = 'UTC';


### PR DESCRIPTION
PgBouncer max_client_conn=200 was overrun by 9 streams × default max_in_flight=64. Cap each stream's sql_raw at 16 → 144 max in-flight, comfortably under the 200 limit. Knocks out the BackoffLimitExceeded on timescaledb-apply-grants and the FATAL: no more connections allowed errors on Connect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)