### PR TITLE
fix(timescaledb): grant CAGG selects per-table for iot_mcp_bridge_ro

### DIFF
--- a/kubernetes/applications/timescaledb/base/scripts/grants.sql
+++ b/kubernetes/applications/timescaledb/base/scripts/grants.sql
@@ -17,11 +17,22 @@ BEGIN
         GRANT SELECT ON ALL TABLES IN SCHEMA public TO iot_mcp_bridge_ro;
         ALTER DEFAULT PRIVILEGES IN SCHEMA public
             GRANT SELECT ON TABLES TO iot_mcp_bridge_ro;
-        -- Continuous aggregates store materialised data under _timescaledb_internal;
-        -- iot_mcp_bridge_ro needs SELECT there to read CAGGs.
+
+        -- Grant SELECT only on CAGG materialisation tables; a blanket grant
+        -- on _timescaledb_internal would hit TS bookkeeping tables owned by
+        -- the postgres superuser.
         GRANT USAGE ON SCHEMA _timescaledb_internal TO iot_mcp_bridge_ro;
-        GRANT SELECT ON ALL TABLES IN SCHEMA _timescaledb_internal TO iot_mcp_bridge_ro;
-        ALTER DEFAULT PRIVILEGES IN SCHEMA _timescaledb_internal
-            GRANT SELECT ON TABLES TO iot_mcp_bridge_ro;
+        DECLARE
+            cagg RECORD;
+        BEGIN
+            FOR cagg IN
+                SELECT format('%I.%I',
+                              materialization_hypertable_schema,
+                              materialization_hypertable_name) AS qname
+                FROM timescaledb_information.continuous_aggregates
+            LOOP
+                EXECUTE format('GRANT SELECT ON %s TO iot_mcp_bridge_ro', cagg.qname);
+            END LOOP;
+        END;
     END IF;
 END$$;


### PR DESCRIPTION
A blanket "GRANT SELECT ON ALL TABLES IN SCHEMA _timescaledb_internal" fails because that schema also holds TimescaleDB bookkeeping tables (bgw_job_stat_history etc.) owned by the postgres superuser, which the homelab role cannot grant. Iterate over
timescaledb_information.continuous_aggregates instead and grant SELECT on each CAGG's materialisation hypertable individually — those are owned by the hypertable owner (homelab) and can be granted, and the loop scales automatically when new CAGGs are added later.

Unblocks the apply-grants Job that has been failing since #763 merged.