### PR TITLE
feat(redpanda-connect): cold-archive fan_out for knx + ems_esp + solaredge_* (Phase A done)

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/streams/ems_esp.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/ems_esp.yaml
@@ -52,42 +52,69 @@ pipeline:
         }
 
 output:
-  sql_raw:
-    driver: pgx
-    max_in_flight: 16
-    dsn: postgres://${PGUSER}:${PGPASSWORD}@timescaledb-db-pooler.timescaledb.svc.cluster.local:5432/homelab?sslmode=disable
-    init_statement: |
-      SET timezone = 'UTC';
-    query: |
-      INSERT INTO ems_esp (
-        time, topic,
-        curflowtemp, rettemp, outdoortemp, switchtemp, syspress,
-        curtemp, curflow, setflowtemp, flowsettemp, flowtemphc, settemp,
-        curburnpow,
-        charging, heatingactive, heatingpump, valvestatus, pumpstatus,
-        raw
-      )
-      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)
-    args_mapping: |
-      root = [
-        this.time,
-        this.topic,
-        this.curflowtemp,
-        this.rettemp,
-        this.outdoortemp,
-        this.switchtemp,
-        this.syspress,
-        this.curtemp,
-        this.curflow,
-        this.setflowtemp,
-        this.flowsettemp,
-        this.flowtemphc,
-        this.settemp,
-        this.curburnpow,
-        this.charging,
-        this.heatingactive,
-        this.heatingpump,
-        this.valvestatus,
-        this.pumpstatus,
-        this.raw.string(),
-      ]
+  broker:
+    pattern: fan_out
+    outputs:
+      - sql_raw:
+          driver: pgx
+          max_in_flight: 16
+          dsn: postgres://${PGUSER}:${PGPASSWORD}@timescaledb-db-pooler.timescaledb.svc.cluster.local:5432/homelab?sslmode=disable
+          init_statement: |
+            SET timezone = 'UTC';
+          query: |
+            INSERT INTO ems_esp (
+              time, topic,
+              curflowtemp, rettemp, outdoortemp, switchtemp, syspress,
+              curtemp, curflow, setflowtemp, flowsettemp, flowtemphc, settemp,
+              curburnpow,
+              charging, heatingactive, heatingpump, valvestatus, pumpstatus,
+              raw
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)
+          args_mapping: |
+            root = [
+              this.time,
+              this.topic,
+              this.curflowtemp,
+              this.rettemp,
+              this.outdoortemp,
+              this.switchtemp,
+              this.syspress,
+              this.curtemp,
+              this.curflow,
+              this.setflowtemp,
+              this.flowsettemp,
+              this.flowtemphc,
+              this.settemp,
+              this.curburnpow,
+              this.charging,
+              this.heatingactive,
+              this.heatingpump,
+              this.valvestatus,
+              this.pumpstatus,
+              this.raw.string(),
+            ]
+      - aws_s3:
+          bucket: nats-archive
+          region: us-east-1
+          endpoint: http://rustfs-svc.rustfs.svc.cluster.local:9000
+          force_path_style_urls: true
+          credentials:
+            id: ${RUSTFS_ACCESS_KEY}
+            secret: ${RUSTFS_SECRET_KEY}
+          path: ems_esp/${!now().ts_format("2006/01/02/15")}/${!uuid_v4()}.parquet
+          batching:
+            count: 5000
+            period: 1h
+            processors:
+              - mapping: |
+                  root = {
+                    "time":    this.time,
+                    "subject": meta("nats_subject"),
+                    "payload": this.raw.format_json(),
+                  }
+              - parquet_encode:
+                  schema:
+                    - { name: time,    type: UTF8 }
+                    - { name: subject, type: UTF8 }
+                    - { name: payload, type: UTF8 }

--- a/kubernetes/applications/redpanda-connect/base/streams/knx.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/knx.yaml
@@ -43,25 +43,52 @@ pipeline:
         }
 
 output:
-  sql_raw:
-    driver: pgx
-    max_in_flight: 16
-    dsn: postgres://${PGUSER}:${PGPASSWORD}@timescaledb-db-pooler.timescaledb.svc.cluster.local:5432/homelab?sslmode=disable
-    init_statement: |
-      SET timezone = 'UTC';
-    query: |
-      INSERT INTO knx (time, ga, knx_main, knx_middle, knx_sub, knx_name, dpt, value, raw)
-      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-      ON CONFLICT (time, ga) DO NOTHING
-    args_mapping: |
-      root = [
-        this.time,
-        this.ga,
-        this.knx_main,
-        this.knx_middle,
-        this.knx_sub,
-        this.knx_name,
-        this.dpt,
-        this.value,
-        this.raw.string(),
-      ]
+  broker:
+    pattern: fan_out
+    outputs:
+      - sql_raw:
+          driver: pgx
+          max_in_flight: 16
+          dsn: postgres://${PGUSER}:${PGPASSWORD}@timescaledb-db-pooler.timescaledb.svc.cluster.local:5432/homelab?sslmode=disable
+          init_statement: |
+            SET timezone = 'UTC';
+          query: |
+            INSERT INTO knx (time, ga, knx_main, knx_middle, knx_sub, knx_name, dpt, value, raw)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+            ON CONFLICT (time, ga) DO NOTHING
+          args_mapping: |
+            root = [
+              this.time,
+              this.ga,
+              this.knx_main,
+              this.knx_middle,
+              this.knx_sub,
+              this.knx_name,
+              this.dpt,
+              this.value,
+              this.raw.string(),
+            ]
+      - aws_s3:
+          bucket: nats-archive
+          region: us-east-1
+          endpoint: http://rustfs-svc.rustfs.svc.cluster.local:9000
+          force_path_style_urls: true
+          credentials:
+            id: ${RUSTFS_ACCESS_KEY}
+            secret: ${RUSTFS_SECRET_KEY}
+          path: knx/${!now().ts_format("2006/01/02/15")}/${!uuid_v4()}.parquet
+          batching:
+            count: 5000
+            period: 1h
+            processors:
+              - mapping: |
+                  root = {
+                    "time":    this.time,
+                    "subject": meta("nats_subject"),
+                    "payload": this.raw.format_json(),
+                  }
+              - parquet_encode:
+                  schema:
+                    - { name: time,    type: UTF8 }
+                    - { name: subject, type: UTF8 }
+                    - { name: payload, type: UTF8 }

--- a/kubernetes/applications/redpanda-connect/base/streams/solaredge_inverter.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/solaredge_inverter.yaml
@@ -35,34 +35,61 @@ pipeline:
         }
 
 output:
-  sql_raw:
-    driver: pgx
-    max_in_flight: 16
-    dsn: postgres://${PGUSER}:${PGPASSWORD}@timescaledb-db-pooler.timescaledb.svc.cluster.local:5432/homelab?sslmode=disable
-    init_statement: |
-      SET timezone = 'UTC';
-    query: |
-      INSERT INTO solaredge_inverter (
-        time, inverter_id,
-        ac_power_actual, ac_current_actual, ac_voltage_l1, ac_frequency,
-        dc_power, dc_current, dc_voltage,
-        energytotal, temperature, status, raw
-      )
-      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
-      ON CONFLICT (time, inverter_id) DO NOTHING
-    args_mapping: |
-      root = [
-        this.time,
-        this.inverter_id,
-        this.ac_power_actual,
-        this.ac_current_actual,
-        this.ac_voltage_l1,
-        this.ac_frequency,
-        this.dc_power,
-        this.dc_current,
-        this.dc_voltage,
-        this.energytotal,
-        this.temperature,
-        this.status,
-        this.raw.string(),
-      ]
+  broker:
+    pattern: fan_out
+    outputs:
+      - sql_raw:
+          driver: pgx
+          max_in_flight: 16
+          dsn: postgres://${PGUSER}:${PGPASSWORD}@timescaledb-db-pooler.timescaledb.svc.cluster.local:5432/homelab?sslmode=disable
+          init_statement: |
+            SET timezone = 'UTC';
+          query: |
+            INSERT INTO solaredge_inverter (
+              time, inverter_id,
+              ac_power_actual, ac_current_actual, ac_voltage_l1, ac_frequency,
+              dc_power, dc_current, dc_voltage,
+              energytotal, temperature, status, raw
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+            ON CONFLICT (time, inverter_id) DO NOTHING
+          args_mapping: |
+            root = [
+              this.time,
+              this.inverter_id,
+              this.ac_power_actual,
+              this.ac_current_actual,
+              this.ac_voltage_l1,
+              this.ac_frequency,
+              this.dc_power,
+              this.dc_current,
+              this.dc_voltage,
+              this.energytotal,
+              this.temperature,
+              this.status,
+              this.raw.string(),
+            ]
+      - aws_s3:
+          bucket: nats-archive
+          region: us-east-1
+          endpoint: http://rustfs-svc.rustfs.svc.cluster.local:9000
+          force_path_style_urls: true
+          credentials:
+            id: ${RUSTFS_ACCESS_KEY}
+            secret: ${RUSTFS_SECRET_KEY}
+          path: solaredge_inverter/${!now().ts_format("2006/01/02/15")}/${!uuid_v4()}.parquet
+          batching:
+            count: 5000
+            period: 1h
+            processors:
+              - mapping: |
+                  root = {
+                    "time":    this.time,
+                    "subject": meta("nats_subject"),
+                    "payload": this.raw.format_json(),
+                  }
+              - parquet_encode:
+                  schema:
+                    - { name: time,    type: UTF8 }
+                    - { name: subject, type: UTF8 }
+                    - { name: payload, type: UTF8 }

--- a/kubernetes/applications/redpanda-connect/base/streams/solaredge_powerflow.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/solaredge_powerflow.yaml
@@ -36,37 +36,64 @@ pipeline:
         }
 
 output:
-  sql_raw:
-    driver: pgx
-    max_in_flight: 16
-    dsn: postgres://${PGUSER}:${PGPASSWORD}@timescaledb-db-pooler.timescaledb.svc.cluster.local:5432/homelab?sslmode=disable
-    init_statement: |
-      SET timezone = 'UTC';
-    query: |
-      INSERT INTO solaredge_powerflow (
-        time, inverter_id,
-        pv_production,
-        grid_power, grid_consumption, grid_delivery,
-        battery_charge, battery_discharge,
-        consumer_total, consumer_house, consumer_evcharger,
-        inverter_power, inverter_dc_power, raw
-      )
-      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
-      ON CONFLICT (time, inverter_id) DO NOTHING
-    args_mapping: |
-      root = [
-        this.time,
-        this.inverter_id,
-        this.pv_production,
-        this.grid_power,
-        this.grid_consumption,
-        this.grid_delivery,
-        this.battery_charge,
-        this.battery_discharge,
-        this.consumer_total,
-        this.consumer_house,
-        this.consumer_evcharger,
-        this.inverter_power,
-        this.inverter_dc_power,
-        this.raw.string(),
-      ]
+  broker:
+    pattern: fan_out
+    outputs:
+      - sql_raw:
+          driver: pgx
+          max_in_flight: 16
+          dsn: postgres://${PGUSER}:${PGPASSWORD}@timescaledb-db-pooler.timescaledb.svc.cluster.local:5432/homelab?sslmode=disable
+          init_statement: |
+            SET timezone = 'UTC';
+          query: |
+            INSERT INTO solaredge_powerflow (
+              time, inverter_id,
+              pv_production,
+              grid_power, grid_consumption, grid_delivery,
+              battery_charge, battery_discharge,
+              consumer_total, consumer_house, consumer_evcharger,
+              inverter_power, inverter_dc_power, raw
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+            ON CONFLICT (time, inverter_id) DO NOTHING
+          args_mapping: |
+            root = [
+              this.time,
+              this.inverter_id,
+              this.pv_production,
+              this.grid_power,
+              this.grid_consumption,
+              this.grid_delivery,
+              this.battery_charge,
+              this.battery_discharge,
+              this.consumer_total,
+              this.consumer_house,
+              this.consumer_evcharger,
+              this.inverter_power,
+              this.inverter_dc_power,
+              this.raw.string(),
+            ]
+      - aws_s3:
+          bucket: nats-archive
+          region: us-east-1
+          endpoint: http://rustfs-svc.rustfs.svc.cluster.local:9000
+          force_path_style_urls: true
+          credentials:
+            id: ${RUSTFS_ACCESS_KEY}
+            secret: ${RUSTFS_SECRET_KEY}
+          path: solaredge_powerflow/${!now().ts_format("2006/01/02/15")}/${!uuid_v4()}.parquet
+          batching:
+            count: 5000
+            period: 1h
+            processors:
+              - mapping: |
+                  root = {
+                    "time":    this.time,
+                    "subject": meta("nats_subject"),
+                    "payload": this.raw.format_json(),
+                  }
+              - parquet_encode:
+                  schema:
+                    - { name: time,    type: UTF8 }
+                    - { name: subject, type: UTF8 }
+                    - { name: payload, type: UTF8 }


### PR DESCRIPTION
Completes Phase A from #756. Same fan_out pattern as the warp family (#761/#762/#764/#768/#769) for the remaining 4 streams: knx, ems_esp, solaredge_inverter, solaredge_powerflow.

After this all 9 live streams write to TS hot tier AND RustFS cold-archive Parquet under uniform path layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)