### PR TITLE
docs(readme): expand H1 to "Lares — A Declarative, Agentic Homelab"

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 &nbsp;
 <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/opentofu.png" height="40" alt="OpenTofu" />
 
-# Lares
+# Lares — A Declarative, Agentic Homelab
 
 _Roman household guardians — a homelab stack across three independent layers: infrastructure, cluster, apps._
 


### PR DESCRIPTION
The bare `# Lares` headline was too terse on its own — adds a short qualifier that names the two load-bearing properties of the stack: declarative (GitOps end-to-end) and agentic (the iot-mcp-bridge roadmap toward AI-driven observation and control).