### PR TITLE
fix(prometheus): use /spec/replicas as Alertmanager guard anchor

### DIFF
--- a/kubernetes/applications/prometheus/overlays/dev/kustomization.yaml
+++ b/kubernetes/applications/prometheus/overlays/dev/kustomization.yaml
@@ -115,8 +115,8 @@ patches:
       name: prometheus
     patch: |-
       - op: test
-        path: /spec/image
-        value: quay.io/prometheus/alertmanager:v0.32.0
+        path: /spec/replicas
+        value: 1
       - op: add
         path: /spec/resources
         value:

--- a/kubernetes/applications/prometheus/overlays/prod/kustomization.yaml
+++ b/kubernetes/applications/prometheus/overlays/prod/kustomization.yaml
@@ -115,8 +115,8 @@ patches:
       name: prometheus
     patch: |-
       - op: test
-        path: /spec/image
-        value: quay.io/prometheus/alertmanager:v0.32.0
+        path: /spec/replicas
+        value: 1
       - op: add
         path: /spec/resources
         value:


### PR DESCRIPTION
## Summary
- Switch the `Alertmanager` patch's `op: test` anchor from `/spec/image` to `/spec/replicas` (consistent with the sibling `Prometheus` patch).
- The original `/spec/image` anchor in `ba78f4a1` was an unintentional choice — the commit's intent was structural identity guards, not image-version pins. As a side effect it blocked every Renovate automerge that bumped the chart's transitive Alertmanager image (e.g. #767: chart 84.5.0 → alertmanager v0.32.1).

## Test plan
- [ ] CI: `Check: K8s Workload Integrity (kubernetes/applications/prometheus/overlays/{dev,prod})` passes against current main
- [ ] After merge, rebase #767 (kube-prometheus-stack 84.5.0) — workload-integrity should now pass and automerge can complete
- [ ] ArgoCD diff preview on this PR shows no spec change to the rendered Alertmanager CR

🤖 Generated with [Claude Code](https://claude.com/claude-code)