### PR TITLE
fix(redpanda-connect): bump memory limit to 1Gi (OOM)

### DIFF
--- a/kubernetes/applications/redpanda-connect/overlays/prod/kustomization.yaml
+++ b/kubernetes/applications/redpanda-connect/overlays/prod/kustomization.yaml
@@ -17,7 +17,7 @@ patches:
         value:
           requests:
             cpu: 50m
-            memory: 128Mi
+            memory: 256Mi
           limits:
             cpu: 200m
-            memory: 512Mi
+            memory: 1Gi


### PR DESCRIPTION
## Summary
- Pod was OOMKilled at 512Mi after Phase A converted all 9 streams to broker.fan_out
- Baseline already ~414Mi at idle; concurrent parquet flushes spike further
- Bump request 128Mi→256Mi, limit 512Mi→1Gi (~2x headroom)

## Test plan
- [ ] After merge, Argo syncs Deployment, pod restarts cleanly
- [ ] No further OOMKills
- [ ] Memory stays well below new 1Gi cap once first 1h batches flush

🤖 Generated with [Claude Code](https://claude.com/claude-code)