### PR TITLE
fix(redpanda-connect): tighten parquet batching to count 2000 / period 15m

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/streams/ems_esp.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/ems_esp.yaml
@@ -104,8 +104,8 @@ output:
             secret: ${RUSTFS_SECRET_KEY}
           path: ems_esp/${!now().ts_format("2006/01/02/15")}/${!uuid_v4()}.parquet
           batching:
-            count: 5000
-            period: 1h
+            count: 2000
+            period: 15m
             processors:
               - mapping: |
                   root = {

--- a/kubernetes/applications/redpanda-connect/base/streams/knx.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/knx.yaml
@@ -78,8 +78,8 @@ output:
             secret: ${RUSTFS_SECRET_KEY}
           path: knx/${!now().ts_format("2006/01/02/15")}/${!uuid_v4()}.parquet
           batching:
-            count: 5000
-            period: 1h
+            count: 2000
+            period: 15m
             processors:
               - mapping: |
                   root = {

--- a/kubernetes/applications/redpanda-connect/base/streams/solaredge_inverter.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/solaredge_inverter.yaml
@@ -79,8 +79,8 @@ output:
             secret: ${RUSTFS_SECRET_KEY}
           path: solaredge_inverter/${!now().ts_format("2006/01/02/15")}/${!uuid_v4()}.parquet
           batching:
-            count: 5000
-            period: 1h
+            count: 2000
+            period: 15m
             processors:
               - mapping: |
                   root = {

--- a/kubernetes/applications/redpanda-connect/base/streams/solaredge_powerflow.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/solaredge_powerflow.yaml
@@ -83,8 +83,8 @@ output:
             secret: ${RUSTFS_SECRET_KEY}
           path: solaredge_powerflow/${!now().ts_format("2006/01/02/15")}/${!uuid_v4()}.parquet
           batching:
-            count: 5000
-            period: 1h
+            count: 2000
+            period: 15m
             processors:
               - mapping: |
                   root = {

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_charge_manager.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_charge_manager.yaml
@@ -51,8 +51,8 @@ output:
             secret: ${RUSTFS_SECRET_KEY}
           path: warp_charge_manager/${!now().ts_format("2006/01/02/15")}/${!uuid_v4()}.parquet
           batching:
-            count: 5000
-            period: 1h
+            count: 2000
+            period: 15m
             processors:
               - mapping: |
                   root = {

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_charge_tracker.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_charge_tracker.yaml
@@ -69,8 +69,8 @@ output:
           # `timestamp(...)` does not exist in Connect interpolations; `now().ts_format(...)` is the right form.
           path: warp_charge_tracker/${!now().ts_format("2006/01/02/15")}/${!uuid_v4()}.parquet
           batching:
-            count: 5000
-            period: 1h
+            count: 2000
+            period: 15m
             processors:
               - mapping: |
                   root = {

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_evse.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_evse.yaml
@@ -63,8 +63,8 @@ output:
             secret: ${RUSTFS_SECRET_KEY}
           path: warp_evse/${!now().ts_format("2006/01/02/15")}/${!uuid_v4()}.parquet
           batching:
-            count: 5000
-            period: 1h
+            count: 2000
+            period: 15m
             processors:
               - mapping: |
                   root = {

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_meter.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_meter.yaml
@@ -89,8 +89,8 @@ output:
             secret: ${RUSTFS_SECRET_KEY}
           path: warp_meter/${!now().ts_format("2006/01/02/15")}/${!uuid_v4()}.parquet
           batching:
-            count: 5000
-            period: 1h
+            count: 2000
+            period: 15m
             processors:
               - mapping: |
                   root = {

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_system.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_system.yaml
@@ -75,8 +75,8 @@ output:
             secret: ${RUSTFS_SECRET_KEY}
           path: warp_system/${!now().ts_format("2006/01/02/15")}/${!uuid_v4()}.parquet
           batching:
-            count: 5000
-            period: 1h
+            count: 2000
+            period: 15m
             processors:
               - mapping: |
                   root = {


### PR DESCRIPTION
## Summary
- Pod kept OOMing at 1Gi (PR #774) because 9 streams × 5000-msg buffers held until 1h period elapsed
- Reduce to count 2000 / period 15m → ~250-400Mi steady-state instead
- 864 files/day total (was 216) — daily compaction job will collapse them later

## Test plan
- [ ] Pod stays running after merge, no further OOMKills
- [ ] Memory stabilizes well below 1Gi limit
- [ ] First batches flush within 15min on every stream

🤖 Generated with [Claude Code](https://claude.com/claude-code)