### PR TITLE
fix(rustfs): install coreutils so compactor can parse 'yesterday'

### DIFF
--- a/kubernetes/applications/rustfs/base/scripts/compact-nats-archive.sh
+++ b/kubernetes/applications/rustfs/base/scripts/compact-nats-archive.sh
@@ -15,15 +15,16 @@ set -euo pipefail
 
 STREAMS="knx ems_esp solaredge_inverter solaredge_powerflow warp_system warp_evse warp_charge_manager warp_charge_tracker warp_meter"
 
-DAY="${COMPACT_DAY:-$(date -u -d 'yesterday' '+%Y/%m/%d')}"
-echo "Compacting day=$DAY"
-
-# Install duckdb + mc into ephemeral /tmp (image is alpine, no local cache).
-apk add --no-cache curl unzip ca-certificates >/dev/null
+# Install tooling first; coreutils gives us GNU date for relative-time parsing
+# (busybox date does not understand "yesterday").
+apk add --no-cache curl unzip ca-certificates coreutils >/dev/null
 curl -fsSL -o /tmp/duckdb.zip "https://github.com/duckdb/duckdb/releases/download/${DUCKDB_VERSION}/duckdb_cli-linux-amd64.zip"
 unzip -q /tmp/duckdb.zip -d /usr/local/bin
 curl -fsSL -o /usr/local/bin/mc https://dl.min.io/client/mc/release/linux-amd64/mc
 chmod +x /usr/local/bin/mc
+
+DAY="${COMPACT_DAY:-$(date -u -d 'yesterday' '+%Y/%m/%d')}"
+echo "Compacting day=$DAY"
 
 export MC_CONFIG_DIR=$(mktemp -d)
 mc alias set rustfs "$RUSTFS_URL" "$ACCESS_KEY" "$SECRET_KEY"


### PR DESCRIPTION
## Summary
- Last night's 01:00 UTC run failed in 27s (BackoffLimitExceeded). Pods were cleaned up before logs could be grabbed, but root cause is `date -d 'yesterday'` — a GNU date feature that busybox does not parse
- Install `coreutils` (~3MB) for GNU date, and reorder so apk add runs before the date computation
- `set -euo pipefail` stays — busybox 1.30+ supports pipefail and we use the same pattern in `initialize-rustfs-buckets.sh`, `provision-grafana-sa.sh` etc.

## Test plan
- [ ] After merge: trigger a run (manual job from the cronjob, or wait for 01:00 UTC tomorrow)
- [ ] Verify daily.parquet lands for each stream prefix
- [ ] Verify hour-folders deleted only after success

🤖 Generated with [Claude Code](https://claude.com/claude-code)