### PR TITLE
fix(rustfs): make compactor's duckdb binary executable

### DIFF
--- a/kubernetes/applications/rustfs/base/scripts/compact-nats-archive.sh
+++ b/kubernetes/applications/rustfs/base/scripts/compact-nats-archive.sh
@@ -19,9 +19,12 @@ STREAMS="knx ems_esp solaredge_inverter solaredge_powerflow warp_system warp_evs
 # (busybox date does not understand "yesterday").
 apk add --no-cache curl unzip ca-certificates coreutils >/dev/null
 curl -fsSL -o /tmp/duckdb.zip "https://github.com/duckdb/duckdb/releases/download/${DUCKDB_VERSION}/duckdb_cli-linux-amd64.zip"
-unzip -q /tmp/duckdb.zip -d /usr/local/bin
+unzip -o /tmp/duckdb.zip -d /usr/local/bin
+chmod +x /usr/local/bin/duckdb
 curl -fsSL -o /usr/local/bin/mc https://dl.min.io/client/mc/release/linux-amd64/mc
 chmod +x /usr/local/bin/mc
+ls -la /usr/local/bin/duckdb /usr/local/bin/mc
+/usr/local/bin/duckdb --version
 
 DAY="${COMPACT_DAY:-$(date -u -d 'yesterday' '+%Y/%m/%d')}"
 echo "Compacting day=$DAY"


### PR DESCRIPTION
## Summary
- Manual compaction run failed with `duckdb: not found` even though the unzip succeeded (mc, also at /usr/local/bin, worked fine in the same shell)
- Add explicit `chmod +x /usr/local/bin/duckdb` after unzip
- Add `ls -la` + `duckdb --version` lines so future install regressions fail visibly instead of silently getting "command not found" later in the script

## Test plan
- [ ] After merge: trigger via `kubectl -n rustfs create job --from=cronjob/nats-archive-compaction <name>`
- [ ] Logs show duckdb version + working merge
- [ ] daily.parquet appears for each stream

🤖 Generated with [Claude Code](https://claude.com/claude-code)