### PR TITLE
fix(rustfs): add gcompat so duckdb runs on alpine musl

### DIFF
--- a/kubernetes/applications/rustfs/base/scripts/compact-nats-archive.sh
+++ b/kubernetes/applications/rustfs/base/scripts/compact-nats-archive.sh
@@ -17,7 +17,9 @@ STREAMS="knx ems_esp solaredge_inverter solaredge_powerflow warp_system warp_evs
 
 # Install tooling first; coreutils gives us GNU date for relative-time parsing
 # (busybox date does not understand "yesterday").
-apk add --no-cache curl unzip ca-certificates coreutils >/dev/null
+# gcompat is a glibc shim — DuckDB's linux-amd64 build is glibc-linked and
+# refuses to run on alpine's musl without it.
+apk add --no-cache curl unzip ca-certificates coreutils gcompat >/dev/null
 curl -fsSL -o /tmp/duckdb.zip "https://github.com/duckdb/duckdb/releases/download/${DUCKDB_VERSION}/duckdb_cli-linux-amd64.zip"
 unzip -o /tmp/duckdb.zip -d /usr/local/bin
 chmod +x /usr/local/bin/duckdb


### PR DESCRIPTION
## Summary
- After #782 duckdb was extracted and executable, but invocation still failed: `/usr/local/bin/duckdb: not found` even with absolute path
- Root cause: DuckDB's official linux-amd64 build is glibc-linked; alpine ships musl libc. Kernel returns ENOENT for the ELF interpreter → shell prints "not found"
- Install `gcompat` (~2 MB glibc shim)

## Test plan
- [ ] After merge, trigger via `kubectl -n rustfs create job --from=cronjob/nats-archive-compaction <name>`
- [ ] Logs show `duckdb --version` succeeding
- [ ] daily.parquet appears for each stream

🤖 Generated with [Claude Code](https://claude.com/claude-code)