### PR TITLE
refactor(authentik): tighten iot-mcp-bridge OAuth redirect_uri to strict

### DIFF
--- a/kubernetes/applications/authentik/base/blueprints/iot-mcp-bridge.yaml
+++ b/kubernetes/applications/authentik/base/blueprints/iot-mcp-bridge.yaml
@@ -18,13 +18,8 @@ entries:
       client_id: iot-mcp-bridge
       client_secret: !Env IOT_MCP_BRIDGE_OIDC_CLIENT_SECRET
       signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
-      # Anthropic does not document the exact callback URL claude.ai uses for
-      # custom connectors. Start permissive (regex) so the first OAuth round-
-      # trip succeeds; once the real URL appears in Authentik → Events,
-      # tighten this back to matching_mode: strict with the literal URL stored
-      # in ANTHROPIC_OAUTH_REDIRECT_URI.
       redirect_uris:
-        - matching_mode: regex
+        - matching_mode: strict
           url: !Env ANTHROPIC_OAUTH_REDIRECT_URI
       property_mappings:
         - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-openid]]


### PR DESCRIPTION
## Summary
- Switch `iot-mcp-bridge` OAuth provider `redirect_uris[0].matching_mode` from `regex` (open-redirect surface) to `strict`.
- Verified during the Phase 0b rollout: claude.ai's real OAuth callback is `https://claude.ai/api/mcp/auth_callback` (captured from Authentik → Events → `authorize_application`), which matches the placeholder already set in `ANTHROPIC_OAUTH_REDIRECT_URI`. No env-var change needed.

Closes #750.

## Test plan
- [ ] After Argo sync:
  - claude.ai connector `iot-mcp-bridge` reconnect still succeeds (consent screen → token exchange → tool calls)
  - Authentik admin UI → Providers → iot-mcp-bridge → Redirect URIs shows `strict` mode
  - `kubectl -n iot-mcp-bridge logs deploy/iot-mcp-bridge | grep auth_accepted` continues to show valid `sub` per request

🤖 Generated with [Claude Code](https://claude.com/claude-code)