### PR TITLE
chore: harmonize "Prometheus Operator label (Opt-In)" comment across apps

### DIFF
--- a/kubernetes/applications/knx-nats-bridge/base/values.yaml
+++ b/kubernetes/applications/knx-nats-bridge/base/values.yaml
@@ -106,6 +106,7 @@ service:
 serviceMonitor:
   enabled: true
   additionalLabels:
+    # Prometheus Operator label (Opt-In)
     release: prometheus
   endpoints:
     - port: metrics

--- a/kubernetes/applications/redpanda-connect/base/values.yaml
+++ b/kubernetes/applications/redpanda-connect/base/values.yaml
@@ -41,4 +41,5 @@ serviceMonitor:
   enabled: true
   interval: 30s
   labels:
+    # Prometheus Operator label (Opt-In)
     release: prometheus

--- a/kubernetes/applications/unifi-poller/base/values.yaml
+++ b/kubernetes/applications/unifi-poller/base/values.yaml
@@ -2,6 +2,7 @@
 serviceMonitor:
   enabled: true
   labels:
+    # Prometheus Operator label (Opt-In)
     release: prometheus
 
 # Keep PodMonitor explicitly off (we rely on ServiceMonitor)


### PR DESCRIPTION
## Summary
- Adds the inline `# Prometheus Operator label (Opt-In)` comment above the `release: prometheus` ServiceMonitor label in the three apps that were missing it (knx-nats-bridge, redpanda-connect, unifi-poller).
- Brings them in line with the convention already used in authentik, cloudnative-pg, crowdsec, gatus, kromgo, loki, and nats.

No behavioral change — comment-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)