### PR TITLE
feat(iot-mcp-bridge): expose Prometheus /metrics on :9090 + ServiceMo…

### DIFF
--- a/kubernetes/applications/iot-mcp-bridge/base/values.yaml
+++ b/kubernetes/applications/iot-mcp-bridge/base/values.yaml
@@ -5,7 +5,7 @@ deployment:
   enabled: true
   image:
     repository: ghcr.io/alexander-zimmermann/iot-mcp-bridge
-    tag: 0.2.0
+    tag: 0.3.0
     pullPolicy: IfNotPresent
 
   replicas: 1
@@ -67,6 +67,9 @@ deployment:
     - containerPort: 8080
       name: mcp
       protocol: TCP
+    - containerPort: 9090
+      name: metrics
+      protocol: TCP
 
   livenessProbe:
     enabled: true
@@ -111,3 +114,17 @@ service:
       name: mcp
       protocol: TCP
       targetPort: mcp
+    - port: 9090
+      name: metrics
+      protocol: TCP
+      targetPort: metrics
+
+serviceMonitor:
+  enabled: true
+  additionalLabels:
+    # Prometheus Operator label (Opt-In)
+    release: prometheus
+  endpoints:
+    - port: metrics
+      interval: 30s
+      path: /metrics


### PR DESCRIPTION
…nitor

Bumps the deployed image to v0.3.0 (carrying the Prometheus instrumentation introduced in alexander-zimmermann/iot-mcp-bridge#6) and wires the cluster side of the metrics exposure: a second container/service port on 9090 (named `metrics`) and a Prometheus ServiceMonitor that targets it with the `release: prometheus` opt-in label and 30s scrape interval.