### PR TITLE
docs(readme): refresh catalog after recent additions; drop InfluxDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,13 +172,14 @@ A quick taste of what's running — full catalog in [`kubernetes/README.md`](kub
 - **GitOps everywhere** — [Argo CD](https://argo-cd.readthedocs.io/) reconciles the cluster, [Renovate](https://docs.renovatebot.com/) opens PRs for every dependency bump.
 - **Immutable OS** — [Talos Linux](https://www.talos.dev/) with disk encryption, managed by [Omni](https://omni.siderolabs.com/).
 - **Identity & edge** — [Authentik](https://goauthentik.io/) SSO/forward-auth, [Traefik](https://traefik.io/) with pre/post-auth middleware chains, [CrowdSec](https://www.crowdsec.net/) behavior-based IPS, [Cloudflare](https://www.cloudflare.com/) WAF.
-- **Data plane** — [CloudNativePG](https://cloudnative-pg.io/) with Barman S3 PITR backups, [Redis](https://redis.io/), [NATS](https://nats.io/), [InfluxDB](https://www.influxdata.com/), [RustFS](https://github.com/rustfs/rustfs) for S3-compatible object storage.
+- **Data plane** — [CloudNativePG](https://cloudnative-pg.io/) with Barman S3 PITR backups, [TimescaleDB](https://www.timescale.com/) for sensor time-series, [Redis](https://redis.io/), [RustFS](https://github.com/rustfs/rustfs) for S3-compatible object storage.
+- **Streaming & agents** — [NATS](https://nats.io/) JetStream as the message bus, [Redpanda Connect](https://docs.redpanda.com/redpanda-connect/about/) fanning streams into TimescaleDB and Parquet on S3, plus protocol bridges (KNX, solar) and an MCP bridge that exposes the data to AI agents.
 - **Observability** — [Prometheus](https://prometheus.io/), [Grafana](https://grafana.com/), [Loki](https://grafana.com/oss/loki/), [Alloy](https://grafana.com/docs/alloy/), [Gatus](https://gatus.io/), plus [kromgo](https://github.com/kashalls/kromgo) powering the badges above.
 
 ## Repository structure
 
 ```
-homelab/
+lares/
 ├── infrastructure/   # Layer 1 — Proxmox IaC (OpenTofu + bpg/proxmox)
 ├── cluster/          # Layer 2 — Omni cluster templates + machine classes
 ├── kubernetes/       # Layer 3 — Argo CD-reconciled manifests

--- a/cluster/README.md
+++ b/cluster/README.md
@@ -1,7 +1,7 @@
 # Cluster — Omni + Talos
 
-[![Talos](https://img.shields.io/badge/Talos-v1.12.6-blue?style=flat-square&logo=talos&logoColor=white)](https://www.talos.dev/)
-[![Kubernetes](https://img.shields.io/badge/Kubernetes-v1.34.6-blue?style=flat-square&logo=kubernetes&logoColor=white)](https://kubernetes.io/)
+[![Talos](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.zimmermann.sh%2Ftalos_version&style=flat-square&logo=talos&logoColor=white&color=blue&label=Talos)](https://www.talos.dev/)
+[![Kubernetes](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.zimmermann.sh%2Fkubernetes_version&style=flat-square&logo=kubernetes&logoColor=white&color=blue&label=Kubernetes)](https://kubernetes.io/)
 [![Omni](https://img.shields.io/badge/Managed%20by-Omni-ff7300?style=flat-square&logo=sidero&logoColor=white)](https://omni.siderolabs.com/)
 
 > **Layer 2 of [the homelab stack](../README.md).** This is just cluster definition — machine shapes and Talos/Kubernetes versions. It has no opinion on what runs underneath (any infra provider works) or on top (standard Kubernetes manifests).

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -129,14 +129,15 @@ All components grouped by what they do. Icons via [homarr-labs/dashboard-icons](
 
 ### Storage & Data
 
-|                                                                                                      | Component                                                                     | Purpose                                |
-| ---------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- | -------------------------------------- |
-| <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/kubernetes.png" height="18" /> | CSI Block + NFS                                                               | Persistent volumes for workloads       |
-| <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/rustfs.png" height="18" />     | [RustFS](https://github.com/rustfs/rustfs)                                    | S3-compatible object storage           |
-| <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/postgresql.png" height="18" /> | [CloudNativePG](https://cloudnative-pg.io/) + [Barman](https://pgbarman.org/) | Postgres operator with S3 PITR backups |
-| <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/redis.png" height="18" />      | [Redis](https://redis.io/)                                                    | In-memory cache                        |
-|                                                                                                      | [NATS](https://nats.io/)                                                      | Lightweight messaging                  |
-| <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/influxdb.png" height="18" />   | [InfluxDB](https://www.influxdata.com/)                                       | Time-series DB for IoT telemetry       |
+|                                                                                                        | Component                                                                          | Purpose                                                       |
+| ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/kubernetes.png" height="18" />   | CSI Block + NFS                                                                    | Persistent volumes for workloads                              |
+| <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/rustfs.png" height="18" />       | [RustFS](https://github.com/rustfs/rustfs)                                         | S3-compatible object storage                                  |
+| <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/postgresql.png" height="18" />   | [CloudNativePG](https://cloudnative-pg.io/) + [Barman](https://pgbarman.org/)      | Postgres operator with S3 PITR backups                        |
+| <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/timescale.png" height="18" />    | [TimescaleDB](https://www.timescale.com/)                                          | Time-series Postgres for sensor & telemetry data              |
+| <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/redis.png" height="18" />        | [Redis](https://redis.io/)                                                         | In-memory cache                                               |
+| <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/nats.png" height="18" />         | [NATS](https://nats.io/) JetStream + [NACK](https://github.com/nats-io/nack)       | Message bus + KV/object stores; operator-managed              |
+| <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/redpanda.png" height="18" />     | [Redpanda Connect](https://docs.redpanda.com/redpanda-connect/about/)              | Stream pipelines (NATS → TimescaleDB / Parquet on RustFS)     |
 
 ### Observability
 
@@ -151,13 +152,17 @@ All components grouped by what they do. Icons via [homarr-labs/dashboard-icons](
 
 ### Applications
 
-|                                                                                                    | Component                            | Purpose                                   |
-| -------------------------------------------------------------------------------------------------- | ------------------------------------ | ----------------------------------------- |
-|                                                                                                    | [Homepage](https://gethomepage.dev/) | Service start page                        |
-| <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/wikijs.png" height="18" />   | [Wiki.js](https://js.wiki/)          | Knowledge base                            |
-| <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/node-red.png" height="18" /> | [Node-RED](https://nodered.org/)     | Flow-based automation                     |
-|                                                                                                    | SolarEdge2MQTT                       | PV inverter → MQTT / InfluxDB             |
-|                                                                                                    | SMTPRelay                            | Outbound mail relay for cluster workloads |
+|                                                                                                    | Component                                                                  | Purpose                                                            |
+| -------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+|                                                                                                    | [Homepage](https://gethomepage.dev/)                                       | Service start page                                                 |
+| <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/wikijs.png" height="18" />   | [Wiki.js](https://js.wiki/)                                                | Knowledge base                                                     |
+| <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/node-red.png" height="18" /> | [Node-RED](https://nodered.org/)                                           | Flow-based automation                                              |
+|                                                                                                    | knx-nats-bridge                                                            | KNX bus ↔ NATS subjects (home automation gateway)                  |
+|                                                                                                    | iot-mcp-bridge                                                             | MCP server exposing TimescaleDB / NATS to AI agents                |
+|                                                                                                    | SolarEdge2MQTT                                                             | PV inverter → MQTT (consumed by Redpanda Connect)                  |
+|                                                                                                    | [Fritz!Box Exporter](https://github.com/pdreker/fritz_exporter)            | Prometheus metrics from the Fritz!Box                              |
+|                                                                                                    | [UniFi Poller](https://github.com/unpoller/unpoller)                       | Prometheus metrics from the UniFi controller                       |
+|                                                                                                    | SMTPRelay                                                                  | Outbound mail relay for cluster workloads                          |
 
 ## Portability note
 


### PR DESCRIPTION
Top-level README:
- Drop InfluxDB from the data-plane bullet (no longer in use), add TimescaleDB instead.
- Add a new "Streaming & agents" highlight covering NATS JetStream, Redpanda Connect, the protocol bridges (KNX, solar) and the MCP bridge — the part of the stack that grew most over the last weeks.
- Repository-structure tree: rename root from `homelab/` to `lares/`.

kubernetes/README.md:
- Storage & Data: drop InfluxDB row, add TimescaleDB, mark NATS as JetStream + NACK (operator-managed), add Redpanda Connect.
- Applications: add knx-nats-bridge, iot-mcp-bridge, fritz-exporter, unifi-poller. Update SolarEdge2MQTT description to reflect the current MQTT → Redpanda Connect → TimescaleDB path (no longer writing InfluxDB directly).

cluster/README.md:
- Replace hardcoded `Talos-v1.12.6` and `Kubernetes-v1.34.6` SVG badges with kromgo endpoint badges (same pattern as the top-level README), so the badges track the live cluster instead of drifting silently when versions get bumped. Renovate's customManagers don't cover Markdown badges, so this avoids the trap.

Note (out of scope): live Grafana datasources (datasources.yaml) and KNX dashboards still reference InfluxDB. They need a separate cleanup PR — this commit only updates the docs catalog.