### PR TITLE
fix(authentik): bump iot-mcp-bridge access_token_validity to 24h

### DIFF
--- a/kubernetes/applications/authentik/base/blueprints/iot-mcp-bridge.yaml
+++ b/kubernetes/applications/authentik/base/blueprints/iot-mcp-bridge.yaml
@@ -18,6 +18,9 @@ entries:
       client_id: iot-mcp-bridge
       client_secret: !Env IOT_MCP_BRIDGE_OIDC_CLIENT_SECRET
       signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
+      # Long access-token TTL: claude.ai-MCP-Proxy ignoriert refresh_token (anthropics/claude-code#46328)
+      access_token_validity: hours=24
+      refresh_token_validity: days=30
       redirect_uris:
         - matching_mode: strict
           url: !Env ANTHROPIC_OAUTH_REDIRECT_URI


### PR DESCRIPTION
## Summary
- Set `access_token_validity: hours=24` (default 1h) and pin `refresh_token_validity: days=30` (Authentik default, made explicit) on the iot-mcp-bridge OAuth2 provider.
- claude.ai's MCP proxy currently does **not** perform `refresh_token` grants for custom connectors (open bug [anthropics/claude-code#46328](https://github.com/anthropics/claude-code/issues/46328) since 2026-04-10), so a 1h access-token TTL forces a manual reconnect every hour. 24h matches the `expires_in` reported in adjacent issues and keeps the rotation window meaningful while we wait for Anthropic's fix.

Closes the last open Phase 0b usability gap; tracks #750.

## Test plan
- [ ] After Argo sync:
  - Authentik admin UI → Providers → iot-mcp-bridge shows `Access token validity: hours=24`
  - claude.ai connector reconnect, then idle >1h → `tool_invoked` logs continue without "Verbindung abgelaufen"

🤖 Generated with [Claude Code](https://claude.com/claude-code)