### PR TITLE
test(rustfs): bump chart to 0.0.95 with NFS-friendly drive timeouts

### DIFF
--- a/kubernetes/applications/rustfs/base/kustomization.yaml
+++ b/kubernetes/applications/rustfs/base/kustomization.yaml
@@ -14,7 +14,7 @@ helmCharts:
   - name: rustfs
     repo: https://rustfs.github.io/helm
     releaseName: rustfs
-    version: 0.0.94
+    version: 0.0.95
     valuesFile: values.yaml
     namespace: rustfs
 

--- a/kubernetes/applications/rustfs/base/values.yaml
+++ b/kubernetes/applications/rustfs/base/values.yaml
@@ -32,3 +32,21 @@ storageclass:
   name: nfs-csi
   dataStorageSize: PLACEHOLDER
   logStorageSize: PLACEHOLDER
+
+# Per-op drive timeouts and health-state thresholds added in chart 0.0.95.
+# Chart defaults are 5s per metadata op (rustfs#2564) which trips FaultyDisk
+# on NFS-CSI under scanner load (rustfs#2601). Loosen them to give NFS-backed
+# metadata operations enough headroom.
+extraEnv:
+  - name: RUSTFS_DRIVE_METADATA_TIMEOUT_SECS
+    value: "30"
+  - name: RUSTFS_DRIVE_DISK_INFO_TIMEOUT_SECS
+    value: "30"
+  - name: RUSTFS_DRIVE_LIST_DIR_TIMEOUT_SECS
+    value: "60"
+  - name: RUSTFS_DRIVE_WALKDIR_TIMEOUT_SECS
+    value: "120"
+  - name: RUSTFS_DRIVE_WALKDIR_STALL_TIMEOUT_SECS
+    value: "30"
+  - name: RUSTFS_DRIVE_SUSPECT_FAILURE_THRESHOLD
+    value: "10"


### PR DESCRIPTION
Chart 0.0.95 introduces per-op drive timeouts (rustfs#2564) defaulting to 5s for read_metadata/disk_info/list_dir/walk_dir. On NFS-CSI under scanner load, these trip the new health state machine into FaultyDisk after 2 consecutive timeouts, breaking SNSD with InsufficientWriteQuorum (rustfs#2601). Override the new RUSTFS_DRIVE_*_TIMEOUT_SECS env vars and raise the suspect-failure threshold to give NFS metadata ops headroom.