### PR TITLE
fix(authentik): bump prod authentik-db memory to 256Mi/512Mi

### DIFF
--- a/kubernetes/applications/authentik/overlays/prod/kustomization.yaml
+++ b/kubernetes/applications/authentik/overlays/prod/kustomization.yaml
@@ -205,10 +205,10 @@ patches:
         value:
           requests:
             cpu: 50m
-            memory: 128Mi
+            memory: 256Mi
           limits:
             cpu: 200m
-            memory: 256Mi
+            memory: 512Mi
 
   # Authentik service with static IP and BGP advertisement
   - target:


### PR DESCRIPTION
Postgres pods (authentik-db-4/-5) were repeatedly OOMKilled at the prior 128Mi/256Mi cap, taking the worker down with them. Doubling requests/limits gives shared_buffers + work_mem + autovacuum headroom.