### PR TITLE
feat(rustfs): wire OTLP metrics push to Alloy and add alerts (#675)

### DIFF
--- a/kubernetes/applications/alloy/base/values.yaml
+++ b/kubernetes/applications/alloy/base/values.yaml
@@ -74,11 +74,12 @@ collectors:
       - filesystem-log-reader
       - daemonset
 
-  # Alloy Receiver: Opens receivers for external data sources (syslog)
+  # Alloy Receiver: Opens receivers for external data sources (syslog, OTLP)
   alloy-receiver:
-    # Include the loki destination so the syslog extraConfig can reference loki.write.loki.receiver
+    # Include loki for syslog forwarding and prometheus for OTLP metric forwarding
     includeDestinations:
       - loki
+      - prometheus
     # Expose Alloy Receiver via Cilium/BGP-announced LoadBalancer
     alloy:
       service:
@@ -86,7 +87,7 @@ collectors:
         labels:
           bgp.cilium.io/ip-pool: default
           bgp.cilium.io/advertise-service: default
-      # Syslog receiver: TCP 601 (RFC5424) and UDP 514 (RFC5424) for external infrastructure devices
+      # Syslog: TCP 601 / UDP 514 (RFC5424). OTLP HTTP: 4318 (rustfs metrics push).
       extraPorts:
         - name: syslog-tcp
           port: 601
@@ -96,6 +97,10 @@ collectors:
           port: 514
           targetPort: 514
           protocol: UDP
+        - name: otlp-http
+          port: 4318
+          targetPort: 4318
+          protocol: TCP
     extraConfig: |
       discovery.relabel "syslog" {
           targets = []
@@ -158,4 +163,22 @@ collectors:
 
           forward_to    = [loki.write.loki.receiver]
           relabel_rules = discovery.relabel.syslog.rules
+      }
+
+      // OTLP/HTTP receiver: rustfs (and future apps) push metrics here, which
+      // are then converted to Prometheus exposition by the chart-rendered
+      // otelcol.receiver.prometheus.prometheus component and remote-written.
+      otelcol.receiver.otlp "rustfs" {
+          http {
+              endpoint = "0.0.0.0:4318"
+          }
+          output {
+              metrics = [otelcol.processor.batch.rustfs.input]
+          }
+      }
+
+      otelcol.processor.batch "rustfs" {
+          output {
+              metrics = [otelcol.receiver.prometheus.prometheus.receiver]
+          }
       }

--- a/kubernetes/applications/prometheus/base/prometheus-rule.yaml
+++ b/kubernetes/applications/prometheus/base/prometheus-rule.yaml
@@ -49,3 +49,32 @@ spec:
           annotations:
             summary: "Gatus is not being scraped"
             description: "Gatus has not been scraped by Prometheus for more than 5 minutes — external reachability monitoring is offline."
+
+    - name: rustfs-alerts
+      rules:
+        - alert: RustfsDriveOffline
+          expr: max by (endpoint) (rustfs_drive_runtime_state{state="offline"}) > 0
+          for: 2m
+          labels:
+            severity: critical
+          annotations:
+            summary: "RustFS drive {{ $labels.endpoint }} marked offline"
+            description: "Health-state machine flipped {{ $labels.endpoint }} to offline — every S3 op will fail (rustfs#2601 class regression)."
+
+        - alert: RustfsDriveStateFlapping
+          expr: sum(increase(rustfs_drive_state_transition_total[15m])) by (endpoint) > 4
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "RustFS drive {{ $labels.endpoint }} flapping"
+            description: "More than 4 health-state transitions in 15m — likely too-aggressive timeouts or NFS-side latency."
+
+        - alert: RustfsDriveOpTimeout
+          expr: sum(increase(rustfs_drive_op_timeout_total[10m])) by (op) > 0
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "RustFS drive op {{ $labels.op }} timing out"
+            description: "Drive operation {{ $labels.op }} hit the per-op timeout — consider raising the matching RUSTFS_DRIVE_*_TIMEOUT_SECS env var."

--- a/kubernetes/applications/rustfs/base/values.yaml
+++ b/kubernetes/applications/rustfs/base/values.yaml
@@ -17,6 +17,14 @@ config:
     server_domains: rustfs-svc.rustfs.svc.cluster.local
     # Set log level to error to suppress verbose tracing warnings
     log_level: "error"
+    # OTLP push to Alloy. metrics.endpoint must be set explicitly — the chart
+    # does not derive it from base_endpoint.
+    obs_endpoint:
+      enabled: true
+      base_endpoint: "http://alloy-alloy-receiver.alloy.svc.cluster.local:4318"
+      metrics:
+        enabled: true
+        endpoint: "http://alloy-alloy-receiver.alloy.svc.cluster.local:4318/v1/metrics"
 
 # Skip recursive chown on PVC when root perms already match (avoids ~3 min
 # fsGroup walk over 100k+ files on NFS-backed PVC at every pod start)
@@ -33,10 +41,8 @@ storageclass:
   dataStorageSize: PLACEHOLDER
   logStorageSize: PLACEHOLDER
 
-# Per-op drive timeouts and health-state thresholds added in chart 0.0.95.
-# Chart defaults are 5s per metadata op (rustfs#2564) which trips FaultyDisk
-# on NFS-CSI under scanner load (rustfs#2601). Loosen them to give NFS-backed
-# metadata operations enough headroom.
+# Raise drive timeouts above the 5s defaults — too tight for NFS-CSI and
+# trips FaultyDisk under scanner load (rustfs#2601).
 extraEnv:
   - name: RUSTFS_DRIVE_METADATA_TIMEOUT_SECS
     value: "30"
@@ -50,3 +56,5 @@ extraEnv:
     value: "30"
   - name: RUSTFS_DRIVE_SUSPECT_FAILURE_THRESHOLD
     value: "10"
+  - name: RUSTFS_DRIVE_ACTIVE_CHECK_TIMEOUT_SECS
+    value: "30"


### PR DESCRIPTION
Push rustfs S3/bucket/disk/API metrics over OTLP HTTP to alloy-receiver, which converts them to Prometheus exposition via the chart-rendered otelcol.receiver.prometheus and remote-writes to Prometheus. Also raise RUSTFS_DRIVE_ACTIVE_CHECK_TIMEOUT_SECS to 30s for parity with the other NFS-friendly drive timeouts (the 15s active probe writes a test object which 5s is too tight for on NFS-CSI). Add three PrometheusRules: RustfsDriveOffline (critical), RustfsDriveStateFlapping and RustfsDriveOpTimeout (warning).