### PR TITLE
fix(alloy): forward rustfs OTLP metrics to exporter input, not receiver

### DIFF
--- a/kubernetes/applications/alloy/base/values.yaml
+++ b/kubernetes/applications/alloy/base/values.yaml
@@ -165,9 +165,8 @@ collectors:
           relabel_rules = discovery.relabel.syslog.rules
       }
 
-      // OTLP/HTTP receiver: rustfs (and future apps) push metrics here, which
-      // are then converted to Prometheus exposition by the chart-rendered
-      // otelcol.receiver.prometheus.prometheus component and remote-written.
+      // OTLP/HTTP receiver for rustfs metrics; forwarded to the chart-rendered
+      // otelcol.exporter.prometheus.prometheus exporter for remote-write.
       otelcol.receiver.otlp "rustfs" {
           http {
               endpoint = "0.0.0.0:4318"
@@ -179,6 +178,6 @@ collectors:
 
       otelcol.processor.batch "rustfs" {
           output {
-              metrics = [otelcol.receiver.prometheus.prometheus.receiver]
+              metrics = [otelcol.exporter.prometheus.prometheus.input]
           }
       }


### PR DESCRIPTION
## Summary
- Fix wrong forward target in the OTLP→Prometheus pipeline added in #799
- Chart renders `otelcol.exporter.prometheus "prometheus"` (exporter, not receiver) — exporters take `.input` not `.receiver`
- Without this, alloy-receiver fails to reload its config and no rustfs metrics reach Prometheus

## Symptom in alloy-receiver logs
```
error during the initial load: /etc/alloy/config.alloy:78:20:
component "otelcol.receiver.prometheus.prometheus.receiver" does not exist or is out of scope
```

## Test plan
- [ ] After ArgoCD sync, alloy-receiver pods stop logging the reload error
- [ ] In Prometheus: `count by (__name__)({__name__=~"rustfs.*"})` returns non-empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)