### PR TITLE
fix(redpanda-connect): tighten S3 batching for backlog drain

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/streams/knx.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/knx.yaml
@@ -78,8 +78,8 @@ output:
             secret: ${RUSTFS_SECRET_KEY}
           path: knx/${!now().ts_format("2006/01/02/15")}/${!uuid_v4()}.parquet
           batching:
-            count: 2000
-            period: 15m
+            count: 200
+            period: 30s
             processors:
               - mapping: |
                   root = {

--- a/kubernetes/applications/redpanda-connect/base/streams/solaredge_inverter.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/solaredge_inverter.yaml
@@ -79,8 +79,8 @@ output:
             secret: ${RUSTFS_SECRET_KEY}
           path: solaredge_inverter/${!now().ts_format("2006/01/02/15")}/${!uuid_v4()}.parquet
           batching:
-            count: 2000
-            period: 15m
+            count: 200
+            period: 30s
             processors:
               - mapping: |
                   root = {

--- a/kubernetes/applications/redpanda-connect/base/streams/solaredge_powerflow.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/solaredge_powerflow.yaml
@@ -83,8 +83,8 @@ output:
             secret: ${RUSTFS_SECRET_KEY}
           path: solaredge_powerflow/${!now().ts_format("2006/01/02/15")}/${!uuid_v4()}.parquet
           batching:
-            count: 2000
-            period: 15m
+            count: 200
+            period: 30s
             processors:
               - mapping: |
                   root = {

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_charge_tracker.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_charge_tracker.yaml
@@ -69,8 +69,8 @@ output:
           # `timestamp(...)` does not exist in Connect interpolations; `now().ts_format(...)` is the right form.
           path: warp_charge_tracker/${!now().ts_format("2006/01/02/15")}/${!uuid_v4()}.parquet
           batching:
-            count: 2000
-            period: 15m
+            count: 200
+            period: 30s
             processors:
               - mapping: |
                   root = {


### PR DESCRIPTION
## Summary

- Reduce S3/parquet batching on the four stuck streams (`knx`, `solaredge_inverter`, `solaredge_powerflow`, `warp_charge_tracker`) from `count=2000/period=15m` to `count=200/period=30s`.
- Goal: let the broker `fan_out` ack ~30× faster so consumers can drain their ~365k-message backlog from the rustfs NFS outage on 2026-05-02.
- Without this, S3 acks every 15 min while live ingress is 4.5 msg/s on KNX → backlog grows instead of shrinks.
- Remaining streams (`ems_esp`, `warp_*`) are already keeping up and untouched.

**Revert to `count=2000/period=15m` in a follow-up PR once consumers have caught up to live** (verify via `nats consumer info` `num_pending → 0`). The high-frequency setting produces many small parquet files in `nats-archive/`.

## Test plan
- [ ] Argo syncs and rolls a new redpanda-connect pod
- [ ] `nats stream` shows `num_pending` decreasing for the four consumers
- [ ] DB inserts resume on `knx`, `solaredge_inverter`, `solaredge_powerflow`, `warp_charge_tracker` (check `max(time)` per table)
- [ ] No new OOMs on redpanda-connect (1 Gi limit)
- [ ] Once `num_pending=0`, follow-up PR reverts batching to 2000/15m

🤖 Generated with [Claude Code](https://claude.com/claude-code)