### PR TITLE
chore(crowdsec): extend ban duration and prune stale log processors

### DIFF
--- a/kubernetes/applications/crowdsec/base/kustomization.yaml
+++ b/kubernetes/applications/crowdsec/base/kustomization.yaml
@@ -6,6 +6,15 @@ resources:
   - ./namespace.yaml
   - ./sealed-secret.yaml
   - ./database.yaml
+  - ./rbac.yaml
+  - ./machines-prune-cronjob.yaml
+
+configMapGenerator:
+  - name: crowdsec-machines-prune-script
+    options:
+      disableNameSuffixHash: true
+    files:
+      - scripts/prune-machines.sh
 
 helmCharts:
   - name: crowdsec

--- a/kubernetes/applications/crowdsec/base/machines-prune-cronjob.yaml
+++ b/kubernetes/applications/crowdsec/base/machines-prune-cronjob.yaml
@@ -1,0 +1,64 @@
+# Daily prune of stale log processors. LAPI pods do not unregister on shutdown,
+# so old replicas accumulate after rollouts and surface in the console as
+# inactive log processors. The chart's agents_autodelete flush does not clear
+# them reliably; cscli machines prune does.
+apiVersion: batch/v1
+kind: CronJob
+
+metadata:
+  name: crowdsec-machines-prune
+  namespace: crowdsec
+
+spec:
+  schedule: "30 3 * * *"
+  timeZone: "Etc/UTC"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
+  startingDeadlineSeconds: 600
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 86400
+      template:
+        spec:
+          serviceAccountName: crowdsec-machines-prune
+          restartPolicy: OnFailure
+          imagePullSecrets:
+            - name: dhi-registry-secret
+          containers:
+            - name: prune
+              image: dhi.io/kubectl:1
+              securityContext:
+                allowPrivilegeEscalation: false
+                runAsNonRoot: true
+                runAsUser: 1000
+                runAsGroup: 1000
+                readOnlyRootFilesystem: true
+              command: ["/bin/sh", "/scripts/prune-machines.sh"]
+              env:
+                - name: NAMESPACE
+                  value: "crowdsec"
+                - name: SELECTOR
+                  value: "type=lapi,k8s-app=crowdsec" # gitleaks:allow
+                - name: DURATION
+                  value: "48h"
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+                limits:
+                  cpu: 100m
+                  memory: 128Mi
+              volumeMounts:
+                - name: scripts
+                  mountPath: /scripts
+                - name: tmp
+                  mountPath: /tmp
+          volumes:
+            - name: scripts
+              configMap:
+                name: crowdsec-machines-prune-script
+                defaultMode: 0555
+            - name: tmp
+              emptyDir: {}

--- a/kubernetes/applications/crowdsec/base/rbac.yaml
+++ b/kubernetes/applications/crowdsec/base/rbac.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: ServiceAccount
+
+metadata:
+  name: crowdsec-machines-prune
+  namespace: crowdsec
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+
+metadata:
+  name: crowdsec-machines-prune
+  namespace: crowdsec
+
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+
+metadata:
+  name: crowdsec-machines-prune
+  namespace: crowdsec
+
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: crowdsec-machines-prune
+
+subjects:
+  - kind: ServiceAccount
+    name: crowdsec-machines-prune
+    namespace: crowdsec

--- a/kubernetes/applications/crowdsec/base/scripts/prune-machines.sh
+++ b/kubernetes/applications/crowdsec/base/scripts/prune-machines.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -eu
+
+# Required environment variables:
+#   NAMESPACE   - crowdsec namespace
+#   SELECTOR    - label selector for the LAPI pod
+#   DURATION    - inactivity threshold passed to cscli machines prune
+
+POD=$(kubectl -n "$NAMESPACE" get pod -l "$SELECTOR" \
+  -o jsonpath='{.items[?(@.status.phase=="Running")].metadata.name}' \
+  | awk '{print $1}')
+
+if [ -z "$POD" ]; then
+  echo "no running lapi pod found"
+  exit 1
+fi
+
+echo "pruning stale machines via $POD"
+kubectl -n "$NAMESPACE" exec "$POD" -- cscli machines prune --duration "$DURATION" --force

--- a/kubernetes/applications/crowdsec/base/values.yaml
+++ b/kubernetes/applications/crowdsec/base/values.yaml
@@ -117,6 +117,25 @@ appsec:
         release: prometheus
 
 config:
+  # Override default profiles.yaml: extend ban duration from 4h to 24h to keep
+  # scanners blocked longer and reduce repeat alerts hitting the console quota.
+  profiles.yaml: |
+    name: default_ip_remediation
+    filters:
+      - Alert.Remediation == true && Alert.GetScope() == "Ip"
+    decisions:
+      - type: ban
+        duration: 24h
+    on_success: break
+    ---
+    name: default_range_remediation
+    filters:
+      - Alert.Remediation == true && Alert.GetScope() == "Range"
+    decisions:
+      - type: ban
+        duration: 24h
+    on_success: break
+
   # Custom configuration to be loaded in crowdsec agent or lapi
   config.yaml.local: |
     api:


### PR DESCRIPTION
Override default profiles.yaml to extend ban duration from 4h to 24h to keep scanners blocked longer and reduce repeat alerts hitting the console quota.

Add a daily CronJob that runs `cscli machines prune --duration 48h --force` against the LAPI pod. LAPI replicas do not unregister on shutdown, so old entries accumulate after rollouts and surface as inactive log processors in the CrowdSec console; the chart's agents_autodelete flush does not clear them reliably. The prune script runs from a dhi.io/kubectl image with a dedicated ServiceAccount that only has pods/exec on the LAPI pod.

Refs #677