### PR TITLE
chore(jobs): use dhi.io/curl for wait-for-* init containers

### DIFF
--- a/kubernetes/applications/grafana/base/provision-sa-job.yaml
+++ b/kubernetes/applications/grafana/base/provision-sa-job.yaml
@@ -18,10 +18,12 @@ spec:
     spec:
       serviceAccountName: grafana-sa-provisioner
       restartPolicy: OnFailure
+      imagePullSecrets:
+        - name: dhi-registry-secret
       initContainers:
         # Wait until Grafana is ready before provisioning
         - name: wait-for-grafana
-          image: curlimages/curl:8.20.0
+          image: dhi.io/curl:8-alpine3.23
           command: ["/bin/sh", "-c"]
           args:
             - |

--- a/kubernetes/applications/rustfs/base/initialize-buckets-job.yaml
+++ b/kubernetes/applications/rustfs/base/initialize-buckets-job.yaml
@@ -16,10 +16,12 @@ spec:
     spec:
       serviceAccountName: default
       restartPolicy: OnFailure
+      imagePullSecrets:
+        - name: dhi-registry-secret
       # Wait until RustFS is reachable
       initContainers:
         - name: wait-for-rustfs
-          image: curlimages/curl:8.20.0
+          image: dhi.io/curl:8-alpine3.23
           command: ["/bin/sh", "-c"]
           args:
             - |


### PR DESCRIPTION
Switch the wait-for-grafana and wait-for-rustfs init containers from curlimages/curl to dhi.io/curl:8-alpine3.23 (Docker Hardened Image) and add the dhi-registry-secret pull secret at pod level (already replicated into both namespaces by the Kyverno sync-cluster-secrets policy).

Main containers (alpine/k8s for Grafana, minio/mc for RustFS) stay as is since DHI does not ship equivalent multi-tool images.