### PR TITLE
fix(authentik): bump WAL storage 1Gi → 2Gi

### DIFF
--- a/kubernetes/applications/authentik/overlays/prod/kustomization.yaml
+++ b/kubernetes/applications/authentik/overlays/prod/kustomization.yaml
@@ -129,7 +129,7 @@ replacements:
           - spec.storage.size
 
   # Inject database WAL storage size
-  - sourceValue: 1Gi
+  - sourceValue: 2Gi
     targets:
       - select:
           kind: Cluster


### PR DESCRIPTION
Storage outage took rustfs offline overnight, breaking barman-cloud WAL archiving. WALs accumulated locally on the 1Gi PVC, filled it, and the primary refused to start ("Not enough WAL disk space"), taking authentik down. Doubling the WAL PVC gives headroom for future archive interruptions; longhorn online-resize handles the expansion without recreating the volume.