### PR TITLE
revert(redpanda-connect): restore S3 batching to count=2000/period=15m

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/streams/knx.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/knx.yaml
@@ -78,8 +78,8 @@ output:
             secret: ${RUSTFS_SECRET_KEY}
           path: knx/${!now().ts_format("2006/01/02/15")}/${!uuid_v4()}.parquet
           batching:
-            count: 200
-            period: 30s
+            count: 2000
+            period: 15m
             processors:
               - mapping: |
                   root = {

--- a/kubernetes/applications/redpanda-connect/base/streams/solaredge_inverter.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/solaredge_inverter.yaml
@@ -79,8 +79,8 @@ output:
             secret: ${RUSTFS_SECRET_KEY}
           path: solaredge_inverter/${!now().ts_format("2006/01/02/15")}/${!uuid_v4()}.parquet
           batching:
-            count: 200
-            period: 30s
+            count: 2000
+            period: 15m
             processors:
               - mapping: |
                   root = {

--- a/kubernetes/applications/redpanda-connect/base/streams/solaredge_powerflow.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/solaredge_powerflow.yaml
@@ -83,8 +83,8 @@ output:
             secret: ${RUSTFS_SECRET_KEY}
           path: solaredge_powerflow/${!now().ts_format("2006/01/02/15")}/${!uuid_v4()}.parquet
           batching:
-            count: 200
-            period: 30s
+            count: 2000
+            period: 15m
             processors:
               - mapping: |
                   root = {

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_charge_tracker.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_charge_tracker.yaml
@@ -69,8 +69,8 @@ output:
           # `timestamp(...)` does not exist in Connect interpolations; `now().ts_format(...)` is the right form.
           path: warp_charge_tracker/${!now().ts_format("2006/01/02/15")}/${!uuid_v4()}.parquet
           batching:
-            count: 200
-            period: 30s
+            count: 2000
+            period: 15m
             processors:
               - mapping: |
                   root = {


### PR DESCRIPTION
## Summary

Reverts the temporary aggressive batching from #805 now that all four affected streams (`knx`, `solaredge_inverter`, `solaredge_powerflow`, `warp_charge_tracker`) have drained to `num_pending=0` and DB lag is <1s.

With `count=200/period=30s` we were writing ~120 small parquet files per stream per hour into rustfs. Back to `count=2000/period=15m` for normal cold-archive file sizes.

The underlying root cause (`max_ack_pending=256` makes the `count=2000` batch trigger unreachable for high-volume streams, leaving period as the only flush trigger and starving the ack rate) is addressed separately in a follow-up PR.

## Test plan
- [ ] Argo syncs and rolls a new redpanda-connect pod
- [ ] `num_pending` stays at 0 on all four consumers (steady state)
- [ ] DB inserts on `knx`, `solaredge_inverter`, `solaredge_powerflow` continue with <60s lag
- [ ] No new OOMs

🤖 Generated with [Claude Code](https://claude.com/claude-code)