### PR TITLE
fix(redpanda-connect): raise max_ack_pending to match batch count

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/streams/ems_esp.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/ems_esp.yaml
@@ -9,7 +9,7 @@ input:
     durable: redpanda-connect-ems-esp
     deliver: all
     ack_wait: 30s
-    max_ack_pending: 256
+    max_ack_pending: 2000
 
 pipeline:
   processors:

--- a/kubernetes/applications/redpanda-connect/base/streams/knx.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/knx.yaml
@@ -9,7 +9,7 @@ input:
     durable: redpanda-connect-knx
     deliver: all
     ack_wait: 30s
-    max_ack_pending: 256
+    max_ack_pending: 2000
 
 pipeline:
   processors:

--- a/kubernetes/applications/redpanda-connect/base/streams/solaredge_inverter.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/solaredge_inverter.yaml
@@ -9,7 +9,7 @@ input:
     durable: redpanda-connect-solaredge-inverter
     deliver: all
     ack_wait: 30s
-    max_ack_pending: 256
+    max_ack_pending: 2000
 
 pipeline:
   processors:

--- a/kubernetes/applications/redpanda-connect/base/streams/solaredge_powerflow.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/solaredge_powerflow.yaml
@@ -9,7 +9,7 @@ input:
     durable: redpanda-connect-solaredge-powerflow
     deliver: all
     ack_wait: 30s
-    max_ack_pending: 256
+    max_ack_pending: 2000
 
 pipeline:
   processors:

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_charge_manager.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_charge_manager.yaml
@@ -9,7 +9,7 @@ input:
     durable: redpanda-connect-warp-charge-manager
     deliver: all
     ack_wait: 30s
-    max_ack_pending: 256
+    max_ack_pending: 2000
 
 pipeline:
   processors:

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_charge_tracker.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_charge_tracker.yaml
@@ -9,7 +9,7 @@ input:
     durable: redpanda-connect-warp-charge-tracker
     deliver: all
     ack_wait: 30s
-    max_ack_pending: 256
+    max_ack_pending: 2000
 
 pipeline:
   processors:

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_evse.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_evse.yaml
@@ -9,7 +9,7 @@ input:
     durable: redpanda-connect-warp-evse
     deliver: all
     ack_wait: 30s
-    max_ack_pending: 256
+    max_ack_pending: 2000
 
 pipeline:
   processors:

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_meter.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_meter.yaml
@@ -9,7 +9,7 @@ input:
     durable: redpanda-connect-warp-meter
     deliver: all
     ack_wait: 30s
-    max_ack_pending: 256
+    max_ack_pending: 2000
 
 pipeline:
   processors:

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_system.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_system.yaml
@@ -11,7 +11,7 @@ input:
           durable: redpanda-connect-warp-system-rtc
           deliver: all
           ack_wait: 30s
-          max_ack_pending: 256
+          max_ack_pending: 2000
       - nats_jetstream:
           urls: ["nats://nats.nats.svc:4222"]
           auth:
@@ -22,7 +22,7 @@ input:
           durable: redpanda-connect-warp-system-esp32
           deliver: all
           ack_wait: 30s
-          max_ack_pending: 256
+          max_ack_pending: 2000
       - nats_jetstream:
           urls: ["nats://nats.nats.svc:4222"]
           auth:
@@ -33,7 +33,7 @@ input:
           durable: redpanda-connect-warp-system-ntp
           deliver: all
           ack_wait: 30s
-          max_ack_pending: 256
+          max_ack_pending: 2000
 
 pipeline:
   processors:


### PR DESCRIPTION
## Summary

Root-cause fix for the KNX/Solaredge backlog stall that triggered #805 / #810.

NATS consumers had `max_ack_pending=256` while the S3 cold-archive output batches with `count=2000/period=15m`. With only 256 messages allowed in-flight at once, the `count=2000` trigger could **never** fire — flushes happened only via the 15-min period fallback. Effective ack rate: 256 msgs / 15 min ≈ **0.3 msg/s**. KNX ingress is ~4.5 msg/s → consumer fell behind live by ~12k msgs/hour and never caught up. The rustfs outage on 2026-05-02 simply made it terminal.

This bumps `max_ack_pending` to **2000** across all 9 stream configs (warp_system has 3 sub-inputs) so the count-based batch trigger becomes reachable.

Memory: at 9 streams × 2000 msgs × ~1 KB = ~18 MB additional in-flight buffering, well within the 1 GiB pod limit.

## Stacked on
[#810](https://github.com/alexander-zimmermann/lares/pull/810). Merge that one first.

## Test plan
- [ ] After merge: redpanda-connect rolls a new pod, all consumers stay at `num_pending=0`
- [ ] DB lag for `knx`, `solaredge_inverter`, `solaredge_powerflow` stays sub-second under steady-state load
- [ ] If a future S3 outage causes a backlog, consumers should recover on their own once S3 is back (since count=2000 trigger is now reachable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)