### PR TITLE
feat(timescaledb): Phase B DDL — typed cols, raw nullable, 365d retention

### DIFF
--- a/kubernetes/applications/timescaledb/base/scripts/migration_extend_schema.sql
+++ b/kubernetes/applications/timescaledb/base/scripts/migration_extend_schema.sql
@@ -1,0 +1,106 @@
+-- Phase B (#757) — extend hot tables with Influx-only typed cols, make raw
+-- nullable, and add 365d retention. Idempotent where possible: ADD COLUMN
+-- IF NOT EXISTS, ALTER COLUMN DROP NOT NULL is no-op if already nullable,
+-- add_retention_policy is wrapped to skip if already configured.
+--
+-- CAGGs are already materialized_only = true (verified live), so the flip
+-- step from the issue is intentionally omitted.
+--
+-- Apply with:
+--   kubectl -n timescaledb exec -i timescaledb-db-1 -- psql -U postgres -d homelab < migration_extend_schema.sql
+--
+-- After apply: live streams keep writing the existing typed cols only; new
+-- columns stay NULL until the Bloblang update lands (separate PR) and the
+-- 13d backfill runs.
+
+-- ---------- ems_esp: 28 new typed cols ----------
+ALTER TABLE public.ems_esp
+  ADD COLUMN IF NOT EXISTS seltemp           DOUBLE PRECISION,
+  ADD COLUMN IF NOT EXISTS comforttemp       DOUBLE PRECISION,
+  ADD COLUMN IF NOT EXISTS ecotemp           DOUBLE PRECISION,
+  ADD COLUMN IF NOT EXISTS manualtemp        DOUBLE PRECISION,
+  ADD COLUMN IF NOT EXISTS reducetemp        DOUBLE PRECISION,
+  ADD COLUMN IF NOT EXISTS noreducetemp      DOUBLE PRECISION,
+  ADD COLUMN IF NOT EXISTS tempautotemp      DOUBLE PRECISION,
+  ADD COLUMN IF NOT EXISTS targetflowtemp    DOUBLE PRECISION,
+  ADD COLUMN IF NOT EXISTS selflowtemp       DOUBLE PRECISION,
+  ADD COLUMN IF NOT EXISTS selburnpow        DOUBLE PRECISION,
+  ADD COLUMN IF NOT EXISTS flowtempoffset    DOUBLE PRECISION,
+  ADD COLUMN IF NOT EXISTS nompower          DOUBLE PRECISION,
+  ADD COLUMN IF NOT EXISTS nrg               DOUBLE PRECISION,
+  ADD COLUMN IF NOT EXISTS nrgheat           DOUBLE PRECISION,
+  ADD COLUMN IF NOT EXISTS nrgtotal          DOUBLE PRECISION,
+  ADD COLUMN IF NOT EXISTS ubauptime         DOUBLE PRECISION,
+  ADD COLUMN IF NOT EXISTS burngas           SMALLINT,
+  ADD COLUMN IF NOT EXISTS burngas2          SMALLINT,
+  ADD COLUMN IF NOT EXISTS ignwork           DOUBLE PRECISION,
+  ADD COLUMN IF NOT EXISTS fanwork           DOUBLE PRECISION,
+  ADD COLUMN IF NOT EXISTS oilpreheat        SMALLINT,
+  ADD COLUMN IF NOT EXISTS threewayvalve     SMALLINT,
+  ADD COLUMN IF NOT EXISTS circ              SMALLINT,
+  ADD COLUMN IF NOT EXISTS disinfecting      SMALLINT,
+  ADD COLUMN IF NOT EXISTS activated         SMALLINT,
+  ADD COLUMN IF NOT EXISTS tapwateractive    SMALLINT,
+  ADD COLUMN IF NOT EXISTS storagetemp1      DOUBLE PRECISION,
+  ADD COLUMN IF NOT EXISTS servicecodenumber DOUBLE PRECISION;
+
+-- ---------- solaredge_inverter: 8 new typed cols ----------
+ALTER TABLE public.solaredge_inverter
+  ADD COLUMN IF NOT EXISTS ac_current_l1     DOUBLE PRECISION,
+  ADD COLUMN IF NOT EXISTS ac_current_l2     DOUBLE PRECISION,
+  ADD COLUMN IF NOT EXISTS ac_current_l3     DOUBLE PRECISION,
+  ADD COLUMN IF NOT EXISTS ac_voltage_l2     DOUBLE PRECISION,
+  ADD COLUMN IF NOT EXISTS ac_voltage_l3     DOUBLE PRECISION,
+  ADD COLUMN IF NOT EXISTS ac_power_apparent DOUBLE PRECISION,
+  ADD COLUMN IF NOT EXISTS ac_power_factor   DOUBLE PRECISION,
+  ADD COLUMN IF NOT EXISTS ac_power_reactive DOUBLE PRECISION;
+
+-- ---------- solaredge_powerflow: 9 new typed cols ----------
+ALTER TABLE public.solaredge_powerflow
+  ADD COLUMN IF NOT EXISTS battery_power                    DOUBLE PRECISION,
+  ADD COLUMN IF NOT EXISTS consumer_inverter                DOUBLE PRECISION,
+  ADD COLUMN IF NOT EXISTS consumer_used_battery_production DOUBLE PRECISION,
+  ADD COLUMN IF NOT EXISTS consumer_used_pv_production      DOUBLE PRECISION,
+  ADD COLUMN IF NOT EXISTS consumer_used_production         DOUBLE PRECISION,
+  ADD COLUMN IF NOT EXISTS inverter_battery_production      DOUBLE PRECISION,
+  ADD COLUMN IF NOT EXISTS inverter_pv_production           DOUBLE PRECISION,
+  ADD COLUMN IF NOT EXISTS inverter_consumption             DOUBLE PRECISION,
+  ADD COLUMN IF NOT EXISTS inverter_production              DOUBLE PRECISION;
+
+-- ---------- warp_evse: 4 new typed cols ----------
+ALTER TABLE public.warp_evse
+  ADD COLUMN IF NOT EXISTS allowed_charging_current DOUBLE PRECISION,
+  ADD COLUMN IF NOT EXISTS iec61851_state           SMALLINT,
+  ADD COLUMN IF NOT EXISTS lock_state               SMALLINT,
+  ADD COLUMN IF NOT EXISTS contactor_state          SMALLINT;
+
+-- ---------- warp_charge_tracker: 6 new typed cols ----------
+ALTER TABLE public.warp_charge_tracker
+  ADD COLUMN IF NOT EXISTS authorization_type     DOUBLE PRECISION,
+  ADD COLUMN IF NOT EXISTS meter_start            DOUBLE PRECISION,
+  ADD COLUMN IF NOT EXISTS timestamp_minutes      DOUBLE PRECISION,
+  ADD COLUMN IF NOT EXISTS evse_uptime_start      DOUBLE PRECISION,
+  ADD COLUMN IF NOT EXISTS first_charge_timestamp DOUBLE PRECISION,
+  ADD COLUMN IF NOT EXISTS generator_state        SMALLINT;
+
+-- ---------- raw nullable on 8 tables (knx already nullable) ----------
+ALTER TABLE public.ems_esp             ALTER COLUMN raw DROP NOT NULL;
+ALTER TABLE public.solaredge_inverter  ALTER COLUMN raw DROP NOT NULL;
+ALTER TABLE public.solaredge_powerflow ALTER COLUMN raw DROP NOT NULL;
+ALTER TABLE public.warp_evse           ALTER COLUMN raw DROP NOT NULL;
+ALTER TABLE public.warp_charge_tracker ALTER COLUMN raw DROP NOT NULL;
+ALTER TABLE public.warp_meter          ALTER COLUMN raw DROP NOT NULL;
+ALTER TABLE public.warp_system         ALTER COLUMN raw DROP NOT NULL;
+ALTER TABLE public.warp_charge_manager ALTER COLUMN raw DROP NOT NULL;
+
+-- ---------- 365d retention on all 9 hypertables ----------
+-- if_not_exists=>true makes re-running this script safe.
+SELECT add_retention_policy('public.knx',                 INTERVAL '365 days', if_not_exists => true);
+SELECT add_retention_policy('public.solaredge_inverter',  INTERVAL '365 days', if_not_exists => true);
+SELECT add_retention_policy('public.solaredge_powerflow', INTERVAL '365 days', if_not_exists => true);
+SELECT add_retention_policy('public.ems_esp',             INTERVAL '365 days', if_not_exists => true);
+SELECT add_retention_policy('public.warp_system',         INTERVAL '365 days', if_not_exists => true);
+SELECT add_retention_policy('public.warp_evse',           INTERVAL '365 days', if_not_exists => true);
+SELECT add_retention_policy('public.warp_charge_manager', INTERVAL '365 days', if_not_exists => true);
+SELECT add_retention_policy('public.warp_charge_tracker', INTERVAL '365 days', if_not_exists => true);
+SELECT add_retention_policy('public.warp_meter',          INTERVAL '365 days', if_not_exists => true);


### PR DESCRIPTION
## Summary

Phase B step 1 from #757: a one-shot DDL script that brings the 9 hot hypertables to their final shape:

- **55 new typed cols** for Influx-only fields across 5 tables
  - `ems_esp`: 28
  - `solaredge_inverter`: 8
  - `solaredge_powerflow`: 9
  - `warp_evse`: 4
  - `warp_charge_tracker`: 6
- **`raw` NULLABLE** on the 8 tables that had it `NOT NULL` (knx was already nullable)
- **365-day retention** on all 9 hot hypertables

CAGGs (`knx_1h`, `solaredge_inverter_1h`, `solaredge_powerflow_1h`, `ems_esp_boiler_1h`, `ems_esp_dhw_1h`, `warp_meter_1h`) are already `materialized_only = true` on the live cluster, so that step from the issue is omitted as no-op.

The script uses `IF NOT EXISTS` on `ADD COLUMN` and `if_not_exists => true` on `add_retention_policy` so re-runs are safe.

## Apply

After merge, run manually:

```bash
kubectl -n timescaledb exec -i timescaledb-db-1 -- psql -U postgres -d homelab \
  < kubernetes/applications/timescaledb/base/scripts/migration_extend_schema.sql
```

This is **not auto-applied by Argo** — the script lives in the GitOps repo as the source of truth, but execution stays manual (matches the existing `migration_schema.sql` pattern).

## Risks

- **PVC at 85%**: TSDB data PVC has 1.6 GiB free of 10 GiB. `ADD COLUMN` on hypertables with compressed chunks rewrites those chunks; per the issue, delta <100 MiB per table → ~500 MiB worst case. If `df` drops below 500 MiB after apply, abort and resize the PVC before continuing.
- **Live INSERTs**: between this DDL apply and the Bloblang update PR, live inserts leave the new columns NULL. That's intentional — the day-chunked UPDATE backfill (later PR) populates them.
- **Compression**: existing compressed chunks pick up the new col definition lazily on read; no immediate decompression-recompression storm.

## What's NOT in this PR

- Bloblang updates for the 5 affected streams (separate PR after this lands and live-verifies).
- The 13-day backfill of typed cols from `raw` JSONB (manual day-chunked UPDATE, no GitOps tracking).
- `bootstrap.sql` mirroring (final PR after backfill, when schema is settled).

## Test plan
- [ ] Apply the script via `kubectl exec`, all statements succeed
- [ ] `\d+ public.ems_esp` shows 28 new columns, all NULL
- [ ] `SELECT count(*) FROM timescaledb_information.jobs WHERE proc_name='policy_retention'` returns 9
- [ ] `df -h /var/lib/postgresql/data` shows >500 MiB free after apply
- [ ] `SELECT view_name, materialized_only FROM timescaledb_information.continuous_aggregates` still all `t`
- [ ] Live ingest unchanged: `output_sent` on Connect grows at the previous rate

🤖 Generated with [Claude Code](https://claude.com/claude-code)