### PR TITLE
chore(longhorn): add daily snapshot-cleanup recurring job

### DIFF
--- a/kubernetes/components/csi-block-storage-controller/base/recurring-jobs.yaml
+++ b/kubernetes/components/csi-block-storage-controller/base/recurring-jobs.yaml
@@ -27,3 +27,18 @@ spec:
     - default
   retain: 0
   concurrency: 2
+
+---
+apiVersion: longhorn.io/v1beta2
+kind: RecurringJob
+metadata:
+  name: snapshot-cleanup
+  namespace: csi-block-storage-controller
+
+spec:
+  cron: "0 5 * * *" # Every day at 5am, after backup-daily (02:00)
+  task: snapshot-cleanup
+  groups:
+    - default
+  retain: 0
+  concurrency: 2


### PR DESCRIPTION
Three orphan snapshots from 2026-04-29 (~10 GiB combined) were discovered during the authentik WAL-disk recovery. They were not created by backup-daily (no `backup-d-` prefix) and no retention policy ever cleaned them up, contributing to the dp-03 disk pressure.

Schedule a daily snapshot-cleanup task at 05:00 (three hours after backup-daily) to coalesce markRemoved snapshots automatically and prevent similar buildup from manual or test snapshots.