### PR TITLE
chore(longhorn): add snapshot-cleanup to StorageClass recurringJobSel…

### DIFF
--- a/kubernetes/components/csi-block-storage-controller/base/storage-classes.yaml
+++ b/kubernetes/components/csi-block-storage-controller/base/storage-classes.yaml
@@ -15,7 +15,7 @@ parameters:
   staleReplicaTimeout: "1440" # 1 day
   fsType: "ext4"
   dataLocality: "strict-local"
-  recurringJobSelector: '[{"name":"trim-weekly", "isGroup":false}]'
+  recurringJobSelector: '[{"name":"trim-weekly", "isGroup":false},{"name":"snapshot-cleanup", "isGroup":false}]'
 
 ---
 # Backup-Enabled Storage Class
@@ -34,4 +34,4 @@ parameters:
   numberOfReplicas: "2"
   staleReplicaTimeout: "1440" # 1 day
   fsType: "ext4"
-  recurringJobSelector: '[{"name":"backup-daily", "isGroup":false},{"name":"trim-weekly", "isGroup":false}]'
+  recurringJobSelector: '[{"name":"backup-daily", "isGroup":false},{"name":"trim-weekly", "isGroup":false},{"name":"snapshot-cleanup", "isGroup":false}]'

--- a/kubernetes/components/csi-block-storage-controller/base/values.yaml
+++ b/kubernetes/components/csi-block-storage-controller/base/values.yaml
@@ -72,7 +72,7 @@ persistence:
   # Recurring job selector for a default Longhorn StorageClass
   recurringJobSelector:
     enable: true
-    jobList: '[{"name":"trim-weekly", "isGroup":false}]'
+    jobList: '[{"name":"trim-weekly", "isGroup":false},{"name":"snapshot-cleanup", "isGroup":false}]'
 
 defaultBackupStore:
   # Setup RusstFS as local backupstore


### PR DESCRIPTION
…ectors

The snapshot-cleanup RecurringJob added in the previous PR ran but matched zero volumes — Longhorn associates jobs with volumes via the per-volume label `recurring-job.longhorn.io/<name>=enabled`, which is applied at provisioning time from the StorageClass parameter `recurringJobSelector`. None of the three StorageClasses had snapshot-cleanup listed, so no volume opted in.

Add snapshot-cleanup to the selectors of all three Longhorn StorageClasses (default via Helm values, plus longhorn-postgres and longhorn-backup) so newly provisioned volumes are tagged automatically. Existing volumes will be relabeled in a one-time manual step after sync.