### PR TITLE
feat(redpanda-connect): Phase C — drop raw from SQL INSERTs

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/streams/ems_esp.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/ems_esp.yaml
@@ -102,8 +102,7 @@ output:
               burngas, burngas2, ignwork, fanwork,
               oilpreheat, threewayvalve, circ,
               disinfecting, activated, tapwateractive, storagetemp1,
-              servicecodenumber,
-              raw
+              servicecodenumber
             )
             VALUES (
               $1, $2,
@@ -117,8 +116,7 @@ output:
               ($36::numeric)::smallint, ($37::numeric)::smallint, $38, $39,
               ($40::numeric)::smallint, ($41::numeric)::smallint, ($42::numeric)::smallint,
               ($43::numeric)::smallint, ($44::numeric)::smallint, ($45::numeric)::smallint, $46,
-              $47,
-              $48
+              $47
             )
           args_mapping: |
             root = [
@@ -169,7 +167,6 @@ output:
               this.tapwateractive,
               this.storagetemp1,
               this.servicecodenumber,
-              this.raw.string(),
             ]
       - aws_s3:
           bucket: nats-archive

--- a/kubernetes/applications/redpanda-connect/base/streams/knx.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/knx.yaml
@@ -53,8 +53,8 @@ output:
           init_statement: |
             SET timezone = 'UTC';
           query: |
-            INSERT INTO knx (time, ga, knx_main, knx_middle, knx_sub, knx_name, dpt, value, raw)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+            INSERT INTO knx (time, ga, knx_main, knx_middle, knx_sub, knx_name, dpt, value)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
             ON CONFLICT (time, ga) DO NOTHING
           args_mapping: |
             root = [
@@ -66,7 +66,6 @@ output:
               this.knx_name,
               this.dpt,
               this.value,
-              this.raw.string(),
             ]
       - aws_s3:
           bucket: nats-archive

--- a/kubernetes/applications/redpanda-connect/base/streams/solaredge_inverter.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/solaredge_inverter.yaml
@@ -60,8 +60,7 @@ output:
               energytotal, temperature, status,
               ac_current_l1, ac_current_l2, ac_current_l3,
               ac_voltage_l2, ac_voltage_l3,
-              ac_power_apparent, ac_power_factor, ac_power_reactive,
-              raw
+              ac_power_apparent, ac_power_factor, ac_power_reactive
             )
             VALUES (
               $1, $2,
@@ -70,8 +69,7 @@ output:
               $10, $11, $12,
               $13, $14, $15,
               $16, $17,
-              $18, $19, $20,
-              $21
+              $18, $19, $20
             )
             ON CONFLICT (time, inverter_id) DO NOTHING
           args_mapping: |
@@ -96,7 +94,6 @@ output:
               this.ac_power_apparent,
               this.ac_power_factor,
               this.ac_power_reactive,
-              this.raw.string(),
             ]
       - aws_s3:
           bucket: nats-archive

--- a/kubernetes/applications/redpanda-connect/base/streams/solaredge_powerflow.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/solaredge_powerflow.yaml
@@ -66,8 +66,7 @@ output:
               consumer_inverter,
               consumer_used_battery_production, consumer_used_pv_production, consumer_used_production,
               inverter_battery_production, inverter_pv_production,
-              inverter_consumption, inverter_production,
-              raw
+              inverter_consumption, inverter_production
             )
             VALUES (
               $1, $2,
@@ -80,8 +79,7 @@ output:
               $15,
               $16, $17, $18,
               $19, $20,
-              $21, $22,
-              $23
+              $21, $22
             )
             ON CONFLICT (time, inverter_id) DO NOTHING
           args_mapping: |
@@ -108,7 +106,6 @@ output:
               this.inverter_pv_production,
               this.inverter_consumption,
               this.inverter_production,
-              this.raw.string(),
             ]
       - aws_s3:
           bucket: nats-archive

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_charge_manager.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_charge_manager.yaml
@@ -33,13 +33,12 @@ output:
           init_statement: |
             SET timezone = 'UTC';
           query: |
-            INSERT INTO warp_charge_manager (time, sub_topic, raw)
-            VALUES ($1, $2, $3)
+            INSERT INTO warp_charge_manager (time, sub_topic)
+            VALUES ($1, $2)
           args_mapping: |
             root = [
               this.time,
               this.sub_topic,
-              this.raw.string(),
             ]
       - aws_s3:
           bucket: nats-archive

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_charge_tracker.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_charge_tracker.yaml
@@ -52,16 +52,14 @@ output:
               user_id, charge_duration, energy_charged, tracked_charges,
               authorization_type, meter_start, timestamp_minutes,
               evse_uptime_start, first_charge_timestamp,
-              generator_state,
-              raw
+              generator_state
             )
             VALUES (
               $1, $2,
               $3, $4, $5, $6,
               $7, $8, $9,
               $10, $11,
-              ($12::numeric)::smallint,
-              $13
+              ($12::numeric)::smallint
             )
           args_mapping: |
             root = [
@@ -77,7 +75,6 @@ output:
               this.evse_uptime_start,
               this.first_charge_timestamp,
               this.generator_state,
-              this.raw.string(),
             ]
       # Cold archive: original NATS payload as Parquet on RustFS
       - aws_s3:

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_evse.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_evse.yaml
@@ -45,15 +45,13 @@ output:
               time, sub_topic,
               charger_state, error_state, contactor_error, dc_fault_current_state,
               allowed_charging_current,
-              iec61851_state, lock_state, contactor_state,
-              raw
+              iec61851_state, lock_state, contactor_state
             )
             VALUES (
               $1, $2,
               $3, $4, $5, $6,
               $7,
-              ($8::numeric)::smallint, ($9::numeric)::smallint, ($10::numeric)::smallint,
-              $11
+              ($8::numeric)::smallint, ($9::numeric)::smallint, ($10::numeric)::smallint
             )
           args_mapping: |
             root = [
@@ -67,7 +65,6 @@ output:
               this.iec61851_state,
               this.lock_state,
               this.contactor_state,
-              this.raw.string(),
             ]
       - aws_s3:
           bucket: nats-archive

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_meter.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_meter.yaml
@@ -59,10 +59,9 @@ output:
               time, sub_topic, meter_id,
               voltage_l1, voltage_l2, voltage_l3,
               current_l1, current_l2, current_l3,
-              power_l1, power_l2, power_l3,
-              raw
+              power_l1, power_l2, power_l3
             )
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
           args_mapping: |
             root = [
               this.time,
@@ -77,7 +76,6 @@ output:
               this.power_l1,
               this.power_l2,
               this.power_l3,
-              this.raw.string(),
             ]
       - aws_s3:
           bucket: nats-archive

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_system.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_system.yaml
@@ -57,13 +57,12 @@ output:
           init_statement: |
             SET timezone = 'UTC';
           query: |
-            INSERT INTO warp_system (time, sub_topic, raw)
-            VALUES ($1, $2, $3)
+            INSERT INTO warp_system (time, sub_topic)
+            VALUES ($1, $2)
           args_mapping: |
             root = [
               this.time,
               this.sub_topic,
-              this.raw.string(),
             ]
       - aws_s3:
           bucket: nats-archive


### PR DESCRIPTION
## Summary

Phase C step from #758: live streams stop populating the `raw JSONB` column in TimescaleDB. Cold-archive output to rustfs Parquet keeps writing the full raw payload, so the Lambda-architecture promise is intact.

Changed across 9 stream configs:
- `knx`, `ems_esp`, `solaredge_inverter`, `solaredge_powerflow`, `warp_evse`, `warp_charge_manager`, `warp_charge_tracker`, `warp_meter`, `warp_system`

For each:
- `INSERT INTO ... raw)` → without the raw column
- `VALUES (..., \$N)` → without the corresponding placeholder
- `args_mapping ... this.raw.string()` → removed

The mapping still produces `raw: \$evt` in-memory so the S3 batch processor (`this.raw.format_json()`) continues to write the original payload to the rustfs cold-archive.

## Ordering

This PR **must merge BEFORE** the `DROP COLUMN raw` SQL on the 9 tables (Phase C step 6, applied ad-hoc, not in a PR). Otherwise live INSERTs would fail with `column raw does not exist`.

## Risks

- 9 streams roll. After Argo sync I'll verify per stream:
  - `output_error` stays 0
  - `num_pending` on each consumer stays at 0 (no ack stall from broken inserts)
  - Live cold-archive (rustfs `nats-archive/<table>/<YYYY/MM/DD/HH>/...parquet`) keeps growing
  - Old typed-col writes (`seltemp`, `burngas`, `consumer_used_production`, etc.) continue

## What's next (after this PR)

1. `DROP COLUMN raw` on the 9 hot tables (live cluster, ad-hoc psql)
2. VACUUM FULL per table to reclaim disk
3. `bootstrap.sql` sync — remove `raw` and `GIN(raw)` indexes from CREATE TABLE statements (separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)