### PR TITLE
feat(timescaledb): drop raw + GIN(raw) from bootstrap.sql

### DIFF
--- a/kubernetes/applications/timescaledb/base/scripts/bootstrap.sql
+++ b/kubernetes/applications/timescaledb/base/scripts/bootstrap.sql
@@ -18,7 +18,6 @@ CREATE TABLE knx (
     knx_name    TEXT             NOT NULL,
     dpt         TEXT             NOT NULL,
     value       DOUBLE PRECISION NOT NULL,
-    raw         JSONB,
     PRIMARY KEY (time, ga)
 );
 SELECT create_hypertable('knx', 'time', chunk_time_interval => INTERVAL '1 day');
@@ -35,7 +34,7 @@ FROM knx GROUP BY bucket, ga, knx_name WITH NO DATA;
 
 -- =========================================================
 -- SolarEdge Inverter (solaredge-{1,2}.modbus.inverter)
--- Hot-path columns from energy-inverter dashboard, full payload in raw.
+-- Hot-path columns from energy-inverter dashboard.
 -- =========================================================
 CREATE TABLE solaredge_inverter (
     time               TIMESTAMPTZ      NOT NULL,
@@ -58,12 +57,10 @@ CREATE TABLE solaredge_inverter (
     ac_power_apparent  DOUBLE PRECISION,
     ac_power_factor    DOUBLE PRECISION,
     ac_power_reactive  DOUBLE PRECISION,
-    raw                JSONB,
     PRIMARY KEY (time, inverter_id)
 );
 SELECT create_hypertable('solaredge_inverter', 'time', chunk_time_interval => INTERVAL '1 day');
 CREATE INDEX ON solaredge_inverter (inverter_id, time DESC);
-CREATE INDEX ON solaredge_inverter USING GIN (raw jsonb_path_ops);
 
 CREATE MATERIALIZED VIEW solaredge_inverter_1h
 WITH (timescaledb.continuous, timescaledb.materialized_only = true) AS
@@ -102,12 +99,10 @@ CREATE TABLE solaredge_powerflow (
     inverter_pv_production           DOUBLE PRECISION,
     inverter_consumption             DOUBLE PRECISION,
     inverter_production              DOUBLE PRECISION,
-    raw                              JSONB,
     PRIMARY KEY (time, inverter_id)
 );
 SELECT create_hypertable('solaredge_powerflow', 'time', chunk_time_interval => INTERVAL '1 day');
 CREATE INDEX ON solaredge_powerflow (inverter_id, time DESC);
-CREATE INDEX ON solaredge_powerflow USING GIN (raw jsonb_path_ops);
 
 CREATE MATERIALIZED VIEW solaredge_powerflow_1h
 WITH (timescaledb.continuous, timescaledb.materialized_only = true) AS
@@ -183,12 +178,10 @@ CREATE TABLE ems_esp (
     tapwateractive    SMALLINT,
     storagetemp1      DOUBLE PRECISION,
     -- Service
-    servicecodenumber DOUBLE PRECISION,
-    raw               JSONB
+    servicecodenumber DOUBLE PRECISION
 );
 SELECT create_hypertable('ems_esp', 'time', chunk_time_interval => INTERVAL '1 day');
 CREATE INDEX ON ems_esp (topic, time DESC);
-CREATE INDEX ON ems_esp USING GIN (raw jsonb_path_ops);
 
 CREATE MATERIALIZED VIEW ems_esp_boiler_1h
 WITH (timescaledb.continuous, timescaledb.materialized_only = true) AS
@@ -216,18 +209,15 @@ GROUP BY bucket WITH NO DATA;
 
 -- =========================================================
 -- WARP — split along the WARP-API topic hierarchy.
--- All tables: (time, sub_topic, raw JSONB) + GIN.
 -- =========================================================
 
 -- warp.rtc.time, warp.esp32.temperature, warp.ntp.state
 CREATE TABLE warp_system (
     time       TIMESTAMPTZ NOT NULL,
-    sub_topic  TEXT        NOT NULL,
-    raw        JSONB
+    sub_topic  TEXT        NOT NULL
 );
 SELECT create_hypertable('warp_system', 'time', chunk_time_interval => INTERVAL '1 day');
 CREATE INDEX ON warp_system (sub_topic, time DESC);
-CREATE INDEX ON warp_system USING GIN (raw jsonb_path_ops);
 
 -- warp.evse.state, warp.evse.low_level_state
 -- Typed: 4 state/error fields used in energy-wallbox dashboard.
@@ -241,22 +231,18 @@ CREATE TABLE warp_evse (
     allowed_charging_current DOUBLE PRECISION,
     iec61851_state           SMALLINT,
     lock_state               SMALLINT,
-    contactor_state          SMALLINT,
-    raw                      JSONB
+    contactor_state          SMALLINT
 );
 SELECT create_hypertable('warp_evse', 'time', chunk_time_interval => INTERVAL '1 day');
 CREATE INDEX ON warp_evse (sub_topic, time DESC);
-CREATE INDEX ON warp_evse USING GIN (raw jsonb_path_ops);
 
 -- warp.charge_manager.{state, low_level_state, config, available_current, ...}
 CREATE TABLE warp_charge_manager (
     time       TIMESTAMPTZ NOT NULL,
-    sub_topic  TEXT        NOT NULL,
-    raw        JSONB
+    sub_topic  TEXT        NOT NULL
 );
 SELECT create_hypertable('warp_charge_manager', 'time', chunk_time_interval => INTERVAL '1 day');
 CREATE INDEX ON warp_charge_manager (sub_topic, time DESC);
-CREATE INDEX ON warp_charge_manager USING GIN (raw jsonb_path_ops);
 
 -- warp.charge_tracker.{state, current_charge, last_charges}
 -- Typed: 4 fields from energy-wallbox dashboard.
@@ -272,16 +258,14 @@ CREATE TABLE warp_charge_tracker (
     timestamp_minutes      DOUBLE PRECISION,
     evse_uptime_start      DOUBLE PRECISION,
     first_charge_timestamp DOUBLE PRECISION,
-    generator_state        SMALLINT,
-    raw                    JSONB
+    generator_state        SMALLINT
 );
 SELECT create_hypertable('warp_charge_tracker', 'time', chunk_time_interval => INTERVAL '1 day');
 CREATE INDEX ON warp_charge_tracker (sub_topic, time DESC);
 CREATE INDEX ON warp_charge_tracker (user_id, time DESC) WHERE user_id IS NOT NULL;
-CREATE INDEX ON warp_charge_tracker USING GIN (raw jsonb_path_ops);
 
 -- warp.meter.all_values (86 floats), warp.meters.<N>.values (39 floats), warp.meters.<N>.update
--- Typed: phase V/A/W (positions 0-8 confirmed via Telegraf XPath). Rest in raw.
+-- Typed: phase V/A/W (positions 0-8 confirmed via Telegraf XPath).
 CREATE TABLE warp_meter (
     time        TIMESTAMPTZ      NOT NULL,
     sub_topic   TEXT             NOT NULL,
@@ -294,8 +278,7 @@ CREATE TABLE warp_meter (
     current_l3  DOUBLE PRECISION,
     power_l1    DOUBLE PRECISION,
     power_l2    DOUBLE PRECISION,
-    power_l3    DOUBLE PRECISION,
-    raw         JSONB
+    power_l3    DOUBLE PRECISION
 );
 SELECT create_hypertable('warp_meter', 'time', chunk_time_interval => INTERVAL '1 day');
 CREATE INDEX ON warp_meter (sub_topic, time DESC);


### PR DESCRIPTION
## Summary

Final step of Phase C (#758): mirror the post-DROP-COLUMN live state into `bootstrap.sql` so a fresh init reproduces the lean schema.

- Remove `raw JSONB` from all 9 hot tables (`knx`, `ems_esp`, `solaredge_inverter`, `solaredge_powerflow`, `warp_evse`, `warp_charge_manager`, `warp_charge_tracker`, `warp_meter`, `warp_system`).
- Remove the 6 `CREATE INDEX ... USING GIN (raw jsonb_path_ops)` declarations (knx and warp_meter never had a GIN on raw).
- Drop the now-misleading "All tables: (time, sub_topic, raw JSONB) + GIN" header comment in the WARP section, and the "full payload in raw" hint above solaredge_inverter.

## Lambda-architecture coverage after this lands

| Window | Where raw lives |
|---|---|
| pre-Phase-A (≤ 2026-04-29) | rustfs `nats-archive/<table>/__rescue__/<YYYY-MM-DD>.parquet` (one-shot Job, this branch) |
| Phase-A live (since 2026-04-29 / 2026-05-01) | rustfs `nats-archive/<table>/<YYYY/MM/DD/HH>/<uuid>.parquet` (continuous Connect output) |
| TSDB | typed cols only |

## What earlier in Phase C already happened (ad-hoc)

1. ✅ Rescue Job: `__rescue__/` parquet for all 9 tables (~318 MB total)
2. ✅ #818 (Bloblang stops writing raw)
3. ✅ `ALTER TABLE ... DROP COLUMN raw` on the 9 tables
4. ✅ VACUUM FULL per table

PVC: 8.3 GiB → 2.2 GiB used (-6.1 GiB freed, 23% utilization).

## Test plan

- [ ] No live cluster impact — file only runs on a fresh CNPG init
- [ ] On a fresh init: 9 hot tables exist, no raw column, GIN(raw) indexes absent
- [ ] Live cluster `\d+ <table>` already matches this file post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)