### PR TITLE
feat(redpanda-connect): write live cold-archive parquet with zstd

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/streams/ems_esp.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/ems_esp.yaml
@@ -188,6 +188,7 @@ output:
                     "payload": this.raw.format_json(),
                   }
               - parquet_encode:
+                  default_compression: zstd
                   schema:
                     - { name: time,    type: UTF8 }
                     - { name: subject, type: UTF8 }

--- a/kubernetes/applications/redpanda-connect/base/streams/knx.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/knx.yaml
@@ -87,6 +87,7 @@ output:
                     "payload": this.raw.format_json(),
                   }
               - parquet_encode:
+                  default_compression: zstd
                   schema:
                     - { name: time,    type: UTF8 }
                     - { name: subject, type: UTF8 }

--- a/kubernetes/applications/redpanda-connect/base/streams/solaredge_inverter.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/solaredge_inverter.yaml
@@ -115,6 +115,7 @@ output:
                     "payload": this.raw.format_json(),
                   }
               - parquet_encode:
+                  default_compression: zstd
                   schema:
                     - { name: time,    type: UTF8 }
                     - { name: subject, type: UTF8 }

--- a/kubernetes/applications/redpanda-connect/base/streams/solaredge_powerflow.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/solaredge_powerflow.yaml
@@ -127,6 +127,7 @@ output:
                     "payload": this.raw.format_json(),
                   }
               - parquet_encode:
+                  default_compression: zstd
                   schema:
                     - { name: time,    type: UTF8 }
                     - { name: subject, type: UTF8 }

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_charge_manager.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_charge_manager.yaml
@@ -60,6 +60,7 @@ output:
                     "payload": this.raw.format_json(),
                   }
               - parquet_encode:
+                  default_compression: zstd
                   schema:
                     - { name: time,    type: UTF8 }
                     - { name: subject, type: UTF8 }

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_charge_tracker.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_charge_tracker.yaml
@@ -98,6 +98,7 @@ output:
                     "payload": this.raw.format_json(),
                   }
               - parquet_encode:
+                  default_compression: zstd
                   schema:
                     - { name: time,    type: UTF8 }
                     - { name: subject, type: UTF8 }

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_evse.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_evse.yaml
@@ -86,6 +86,7 @@ output:
                     "payload": this.raw.format_json(),
                   }
               - parquet_encode:
+                  default_compression: zstd
                   schema:
                     - { name: time,    type: UTF8 }
                     - { name: subject, type: UTF8 }

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_meter.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_meter.yaml
@@ -97,6 +97,7 @@ output:
                     "payload": this.raw.format_json(),
                   }
               - parquet_encode:
+                  default_compression: zstd
                   schema:
                     - { name: time,    type: UTF8 }
                     - { name: subject, type: UTF8 }

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_system.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_system.yaml
@@ -84,6 +84,7 @@ output:
                     "payload": this.raw.format_json(),
                   }
               - parquet_encode:
+                  default_compression: zstd
                   schema:
                     - { name: time,    type: UTF8 }
                     - { name: subject, type: UTF8 }


### PR DESCRIPTION
## Summary

Set `default_compression: zstd` on the `parquet_encode` step of all 9 stream configs.

Without it, benthos writes **uncompressed** parquet for the live cold-archive output. Verified today against a live hour-file:

```
knx/2026/05/03/07/02e2475a-...parquet  rows=2000  compression={'UNCOMPRESSED'}
```

Meanwhile, the compactor's nightly daily.parquet output (and the rebalanced rescue files in `<table>/YYYY/MM/DD/daily.parquet`) all use ZSTD with ~5× win over the uncompressed bytes.

## Why this matters

- **rustfs disk pressure**: today's drain produced 2095 small uncompressed parquets just for knx — those would've been ~5× smaller as ZSTD.
- **Compactor stress**: the compactor needs to read all small files; uncompressed means 5× more network/disk I/O. rustfs OOMed three times during today's manual compaction run for 2026-05-02; tighter live files reduce that load.
- **Format alignment**: live files now match the daily.parquet format (ZSTD), so post-compaction reads are uniform.

## Cost

ZSTD-1 (benthos default) on small parquet writes is a few % CPU per message. Pod is at 1 CPU limit, currently using ~150m at peak — plenty of headroom.

## Test plan

- [ ] Argo syncs, redpanda-connect rolls
- [ ] After Argo sync: a fresh hour-file shows `compression={'ZSTD'}` (not UNCOMPRESSED)
- [ ] `output_error` stays 0, `num_pending` stays 0 (no ack stall)
- [ ] rustfs disk usage of new hour files is ~3-5× smaller than equivalent old hour files

🤖 Generated with [Claude Code](https://claude.com/claude-code)