### PR TITLE
chore(timescaledb): tighten compress_after 7d → 2d

### DIFF
--- a/kubernetes/applications/timescaledb/base/scripts/bootstrap.sql
+++ b/kubernetes/applications/timescaledb/base/scripts/bootstrap.sql
@@ -324,9 +324,10 @@ SELECT add_continuous_aggregate_policy('warp_meter_1h',
 -- =========================================================
 -- Native compression — segment_by chosen for the column the queries
 -- usually filter on; order_by time DESC matches "most recent first".
--- compress_after = 7 days keeps the live-write window uncompressed
--- (compressed chunks support inserts + upserts in TS 2.16+, but the
--- recent window stays cheaper for ad-hoc analytics).
+-- compress_after = 2 days aligns with the CAGG refresh window
+-- (start_offset => 2 days) so the materialization always reads from
+-- heap, while still leaving today + yesterday in the live-write window
+-- for cheap point lookups and late-arriving rows.
 -- =========================================================
 ALTER TABLE knx SET (timescaledb.compress,
     timescaledb.compress_segmentby = 'ga',
@@ -356,15 +357,15 @@ ALTER TABLE warp_meter SET (timescaledb.compress,
     timescaledb.compress_segmentby = 'meter_id',
     timescaledb.compress_orderby = 'time DESC');
 
-SELECT add_compression_policy('knx',                 INTERVAL '7 days');
-SELECT add_compression_policy('solaredge_inverter',  INTERVAL '7 days');
-SELECT add_compression_policy('solaredge_powerflow', INTERVAL '7 days');
-SELECT add_compression_policy('ems_esp',             INTERVAL '7 days');
-SELECT add_compression_policy('warp_system',         INTERVAL '7 days');
-SELECT add_compression_policy('warp_evse',           INTERVAL '7 days');
-SELECT add_compression_policy('warp_charge_manager', INTERVAL '7 days');
-SELECT add_compression_policy('warp_charge_tracker', INTERVAL '7 days');
-SELECT add_compression_policy('warp_meter',          INTERVAL '7 days');
+SELECT add_compression_policy('knx',                 INTERVAL '2 days');
+SELECT add_compression_policy('solaredge_inverter',  INTERVAL '2 days');
+SELECT add_compression_policy('solaredge_powerflow', INTERVAL '2 days');
+SELECT add_compression_policy('ems_esp',             INTERVAL '2 days');
+SELECT add_compression_policy('warp_system',         INTERVAL '2 days');
+SELECT add_compression_policy('warp_evse',           INTERVAL '2 days');
+SELECT add_compression_policy('warp_charge_manager', INTERVAL '2 days');
+SELECT add_compression_policy('warp_charge_tracker', INTERVAL '2 days');
+SELECT add_compression_policy('warp_meter',          INTERVAL '2 days');
 
 -- =========================================================
 -- Retention policies — 365d on every hot hypertable. Raw chunks past


### PR DESCRIPTION
## Summary
- Closes #820. Compression-Policy auf allen 9 Hypertables von `7 days` auf `2 days` umgestellt.
- Live-Cluster bereits umgestellt + Compression-Jobs getriggert; bootstrap.sql gespiegelt damit frische Cluster mit dem neuen Wert hochkommen.

## Why
Messung am Live-Cluster zeigte 99,4–100 % der Hot-Table-Bytes in unkomprimierten Chunks. Ad-hoc-Test-Kompression auf 5 schweren Live-Traffic-Chunks (knx, warp_meter/evse/system/charge_manager) ergab 95,6–97,5 % Reduktion — `segmentby` ist über alle Tabellen sauber gewählt, kein Audit nötig.

`compress_after: 2 days` passt zum CAGG-Refresh (`start_offset => 2 days`): Materialization liest immer aus Heap, heute + gestern bleiben unkomprimiert für Point-Lookups und Late-Arrivals.

## Impact
- Live-Footprint sofort: **~1,85 GiB → ~1,06 GiB (−42 %)**
- Steady-State 365d-Projektion: **~5,7 GiB** (≪ 10-GiB-PVC, ≪ InfluxDB-2-Baseline)
- Test-Kompressions-Ratios: knx 95,6 %, warp_meter 95,6 %, warp_evse 96,9 %, warp_charge_manager 96,9 %, warp_system 97,5 %

## Out of scope (Follow-ups aus #820)
- `chunk_time_interval`-Audit (optional, Issue Punkt 4)
- Unused-Index-Audit via `pg_stat_user_indexes` (Issue Punkt 3)

## Test plan
- [x] Bootstrap.sql diff inspected (nur Policy- + Kommentar-Änderung)
- [x] Live-Cluster: alle 9 Policies auf `2 days` (`timescaledb_information.jobs`)
- [x] Compression-Jobs gelaufen, kein Error
- [ ] 24h-Observation: CAGG-Refresh-Latenz, Pooler-Insert-Latenz, Disk-Druck

🤖 Generated with [Claude Code](https://claude.com/claude-code)