### PR TITLE
fix(argocd): route OIDC through bundled Dex with Authentik upstream

### DIFF
--- a/kubernetes/applications/authentik/overlays/dev/kustomization.yaml
+++ b/kubernetes/applications/authentik/overlays/dev/kustomization.yaml
@@ -41,7 +41,7 @@ replacements:
           index: 2
 
   # Blueprint env var injections — resolved at runtime via !Env tags in blueprints
-  - sourceValue: https://argocd.zimmermann.phd/auth/callback
+  - sourceValue: https://argocd.zimmermann.phd/api/dex/callback
     targets:
       - select:
           kind: Deployment

--- a/kubernetes/applications/authentik/overlays/prod/kustomization.yaml
+++ b/kubernetes/applications/authentik/overlays/prod/kustomization.yaml
@@ -41,7 +41,7 @@ replacements:
           index: 2
 
   # Blueprint env var injections — resolved at runtime via !Env tags in blueprints
-  - sourceValue: https://argocd.zimmermann.sh/auth/callback
+  - sourceValue: https://argocd.zimmermann.sh/api/dex/callback
     targets:
       - select:
           kind: Deployment

--- a/kubernetes/bootstrap/gitops-controller/base/values.yaml
+++ b/kubernetes/bootstrap/gitops-controller/base/values.yaml
@@ -18,18 +18,24 @@ configs:
     accounts.homepage: apiKey
     # ArgoCD server URL – PLACEHOLDER is replaced per environment via overlay replacements
     url: https://argocd.PLACEHOLDER
-    # OIDC via Authentik – PLACEHOLDER is replaced per environment via overlay replacements
-    oidc.config: |
-      name: Authentik
-      issuer: https://PLACEHOLDER/application/o/argocd/
-      clientID: argocd
-      clientSecret: $argocd-oidc-secret:oidc.authentik.clientSecret
-      requestedScopes:
-        - openid
-        - profile
-        - email
-        - groups
-      groupsClaim: groups
+    # OIDC via bundled Dex with Authentik upstream — PLACEHOLDER replaced per env
+    dex.config: |
+      connectors:
+        - type: oidc
+          id: authentik
+          name: Authentik
+          config:
+            issuer: https://PLACEHOLDER/application/o/argocd/
+            clientID: argocd
+            clientSecret: $argocd-oidc-secret:oidc.authentik.clientSecret
+            insecureEnableGroups: true
+            scopes:
+              - openid
+              - profile
+              - email
+              - groups
+            userIDKey: sub
+            userNameKey: name
 
   rbac:
     # Default role for authenticated users without a matching group
@@ -169,6 +175,6 @@ redis:
       cpu: 200m
       memory: 128Mi
 
-# Disable DEX server, as we are using Authentik as OIDC provider directly
+# Dex fronts Authentik as OIDC upstream — see configs.cm.[dex.config]
 dex:
-  enabled: false
+  enabled: true

--- a/kubernetes/bootstrap/gitops-controller/overlays/dev/kustomization.yaml
+++ b/kubernetes/bootstrap/gitops-controller/overlays/dev/kustomization.yaml
@@ -18,14 +18,14 @@ replacements:
           delimiter: "/"
           index: 2
 
-  # Replace the Authentik domain in the OIDC issuer URL for dev
+  # Replace the Authentik domain in the Dex upstream issuer URL for dev
   - sourceValue: "auth.zimmermann.phd"
     targets:
       - select:
           kind: ConfigMap
           name: argocd-cm
         fieldPaths:
-          - data.[oidc.config]
+          - data.[dex.config]
         options:
           delimiter: "/"
           index: 2

--- a/kubernetes/bootstrap/gitops-controller/overlays/prod/kustomization.yaml
+++ b/kubernetes/bootstrap/gitops-controller/overlays/prod/kustomization.yaml
@@ -18,14 +18,14 @@ replacements:
           delimiter: "/"
           index: 2
 
-  # Replace the Authentik domain in the OIDC issuer URL for prod
+  # Replace the Authentik domain in the Dex upstream issuer URL for prod
   - sourceValue: "auth.zimmermann.sh"
     targets:
       - select:
           kind: ConfigMap
           name: argocd-cm
         fieldPaths:
-          - data.[oidc.config]
+          - data.[dex.config]
         options:
           delimiter: "/"
           index: 2


### PR DESCRIPTION
## Summary
- Replaces direct `oidc.config` (argocd-server → Authentik) with `dex.config` (argocd-server → bundled Dex → Authentik upstream connector).
- Dex connects to the upstream IdP **on-demand at login**, not at pod start. A transient Authentik outage during bootstrap (chicken-and-egg: Argo installs Authentik) no longer poisons argocd-server's OIDC discovery cache, so the manual `kubectl rollout restart deploy/argocd-server` workaround is gone — and the system also self-heals on later Authentik restarts.
- Authentik OAuth2 provider redirect URI moves from `/auth/callback` (direct) to `/api/dex/callback` (Dex). RBAC unchanged: groups claim flows through Dex untouched (`insecureEnableGroups: true` is safe with a trusted upstream IdP).

Fixes #687

## Migration note
Authentik provider now accepts only `…/api/dex/callback`. During the ArgoCD-server rollout (~30s) new logins will fail; existing sessions survive. Atomic by design — both sides flip in the same commit.

## Test plan
- [ ] Sync `gitops-controller-prod` (or `-dev` first); `kubectl -n argocd get pods` shows new `argocd-dex-server-*` Running
- [ ] `kubectl -n argocd logs deploy/argocd-dex-server` — no `failed to query provider` loop
- [ ] In Authentik UI, ArgoCD provider shows redirect URI `https://argocd.<env>/api/dex/callback`
- [ ] Browser login via Authentik works end-to-end
- [ ] User in `platform-admins` group sees admin RBAC; non-member is `role:readonly`
- [ ] **Bootstrap-race regression test (dev only)**: `kubectl -n authentik scale deploy/authentik-server --replicas=0`, then `kubectl -n argocd rollout restart deploy/argocd-server`. Once Authentik comes back, login works *without* a second Argo restart. This is the actual fix proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)