### PR TITLE
chore(fleet): drop unused ubuntu_01 fleet VM and clarify template com…

### DIFF
--- a/infrastructure/manifest/40-template/template-vm.yaml
+++ b/infrastructure/manifest/40-template/template-vm.yaml
@@ -1,5 +1,5 @@
 template_vm:
-  ## Linux VM templates
+  ## Standard Linux VM templates
   vm_debian_trixie:
     vm_id: 10000
     image_id: vm_debian_trixie
@@ -30,6 +30,7 @@ template_vm:
     ci_network_config: std_linux
     ci_meta_config: std_linux
 
+  ## Cluster management VM (Omni)
   vm_ubuntu_noble_cluster_mgmt:
     vm_id: 10005
     image_id: vm_ubuntu_noble

--- a/infrastructure/manifest/50-fleet/fleet-vm.yaml
+++ b/infrastructure/manifest/50-fleet/fleet-vm.yaml
@@ -1,9 +1,4 @@
 fleet_vm:
-  ## Linux VM fleets
-  ubuntu_01:
-    template_id: vm_ubuntu_noble
-    vm_id: 1001
-
   ## Cluster management VM (Omni)
   cluster_mgmt_01:
     template_id: vm_ubuntu_noble_cluster_mgmt


### PR DESCRIPTION
…ments

Why: ubuntu_01 was never deployed; cluster_mgmt_01 is the only fleet VM. Group template-vm.yaml entries by purpose (standard vs cluster mgmt).