### PR TITLE
chore(rustfs): bump prod memory limit to 2Gi for overnight job

### DIFF
--- a/kubernetes/applications/rustfs/overlays/prod/kustomization.yaml
+++ b/kubernetes/applications/rustfs/overlays/prod/kustomization.yaml
@@ -63,7 +63,7 @@ patches:
             memory: 128Mi
           limits:
             cpu: 200m
-            memory: 512Mi
+            memory: 2Gi
 
   # RustFS API service with static IP and BGP advertisement
   - target:


### PR DESCRIPTION
## Summary
- Temporary bump of rustfs prod memory limit from `512Mi` to `2Gi` to accommodate a larger overnight processing job
- Request stays at `128Mi`; only the limit changes
- Revert after the job completes

## Test plan
- [ ] ArgoCD sync succeeds for `rustfs` app
- [ ] rustfs pod restarts cleanly with new limit
- [ ] Overnight job completes without OOMKill
- [ ] Open follow-up revert PR back to `512Mi`

🤖 Generated with [Claude Code](https://claude.com/claude-code)