### PR TITLE
chore(argocd): bump repo-server liveness probe timeout to 3s

### DIFF
--- a/kubernetes/bootstrap/gitops-controller/base/values.yaml
+++ b/kubernetes/bootstrap/gitops-controller/base/values.yaml
@@ -62,6 +62,12 @@ controller:
       labels:
         release: prometheus
 
+# Repo server renders manifests; livenessProbe default 1s is too tight for /healthz?full=true
+# (does git ls-remote on every registered repo) and caused restart storms on transient network blips.
+repoServer:
+  livenessProbe:
+    timeoutSeconds: 3
+
 # ApplicationSet controller generates Applications from generators (e.g. Git, List, Cluster, etc.)
 applicationSet:
   resources:


### PR DESCRIPTION
## Summary
- Override `repoServer.livenessProbe.timeoutSeconds` from chart default `1` to `3`
- The probe hits `/healthz?full=true`, which performs `git ls-remote` against every registered repo — a sub-second network blip trips it
- Last night the repo-server was killed 8× in 9 minutes (00:44–00:53 UTC) while answering normal gRPC calls in 10–20 ms; root cause was probe timeout, not server load

## Test plan
- [ ] ArgoCD sync of `gitops-controller-prod` succeeds
- [ ] Rendered `Deployment/argocd-repo-server` shows `livenessProbe.timeoutSeconds: 3`
- [ ] Repo-server pod stays up across the next overnight maintenance window without restart-storms

🤖 Generated with [Claude Code](https://claude.com/claude-code)