### PR TITLE
revert(rustfs): drop temporary 2Gi memory limit back to 512Mi

### DIFF
--- a/kubernetes/applications/rustfs/overlays/prod/kustomization.yaml
+++ b/kubernetes/applications/rustfs/overlays/prod/kustomization.yaml
@@ -63,7 +63,7 @@ patches:
             memory: 128Mi
           limits:
             cpu: 200m
-            memory: 2Gi
+            memory: 512Mi
 
   # RustFS API service with static IP and BGP advertisement
   - target:


### PR DESCRIPTION
## Summary
- Revert of PR #827: rustfs prod memory limit `2Gi → 512Mi`
- The 2Gi bump was meant to help an overnight compaction job, but root cause turned out to be S3 `ListObjectsV2` latency on the `knx/` prefix, not memory. Pod peak usage stayed at ~470 MiB during the run.

## Test plan
- [ ] ArgoCD sync of `rustfs-prod` succeeds
- [ ] Rendered `Deployment/rustfs` shows `limits.memory: 512Mi`
- [ ] Pod restarts cleanly and stays Healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)