### PR TITLE
fix(jobs): drop /bin/sh from wait-for-* init containers, use curl --retry

### DIFF
--- a/kubernetes/applications/grafana/base/provision-sa-job.yaml
+++ b/kubernetes/applications/grafana/base/provision-sa-job.yaml
@@ -21,19 +21,19 @@ spec:
       imagePullSecrets:
         - name: dhi-registry-secret
       initContainers:
-        # Wait until Grafana is ready before provisioning
+        # Wait until Grafana is ready
         - name: wait-for-grafana
           image: dhi.io/curl:8-alpine3.23
-          command: ["/bin/sh", "-c"]
+          command: ["curl"]
           args:
-            - |
-              until curl -sf "$GRAFANA_URL/api/health" >/dev/null; do
-                echo "Waiting for Grafana..."
-                sleep 3
-              done
-          env:
-            - name: GRAFANA_URL
-              value: "http://grafana.grafana.svc.cluster.local"
+            - --silent
+            - --fail
+            - --retry-connrefused
+            - --retry-all-errors
+            - --retry=60
+            - --retry-delay=3
+            - --retry-max-time=300
+            - http://grafana.grafana.svc.cluster.local/api/health
       containers:
         - name: provision
           image: alpine/k8s:1.36.0

--- a/kubernetes/applications/rustfs/base/initialize-buckets-job.yaml
+++ b/kubernetes/applications/rustfs/base/initialize-buckets-job.yaml
@@ -22,16 +22,17 @@ spec:
       initContainers:
         - name: wait-for-rustfs
           image: dhi.io/curl:8-alpine3.23
-          command: ["/bin/sh", "-c"]
+          command: ["curl"]
           args:
-            - |
-              until curl -sSf "$RUSTFS_URL/health" >/dev/null; do
-                echo "Waiting for RustFS..."
-                sleep 3
-              done
-          env:
-            - name: RUSTFS_URL
-              value: "http://rustfs-svc.rustfs.svc.cluster.local:9000"
+            - --silent
+            - --show-error
+            - --fail
+            - --retry-connrefused
+            - --retry-all-errors
+            - --retry=60
+            - --retry-delay=3
+            - --retry-max-time=300
+            - http://rustfs-svc.rustfs.svc.cluster.local:9000/health
       containers:
         - name: mc
           image: minio/mc:latest


### PR DESCRIPTION
## Summary

The DHI hardened curl image (\`dhi.io/curl:8-alpine3.23\`, introduced in ec79d48) is distroless and has **no \`/bin/sh\`**, so the existing \`until curl …; sleep 3; done\` shell loop in \`wait-for-rustfs\` and \`wait-for-grafana\` fails immediately with \`exec /bin/sh: no such file or directory\` and the Job hits its backoff limit.

Observed today on \`initialize-rustfs-buckets\` after the rustfs PostSync hook fired (rustfs-prod app stuck Degraded).

## Approach

\`curl\` can poll itself — no shell needed:

\`\`\`yaml
command: ["curl"]
args:
  - --silent
  - --show-error
  - --fail
  - --retry-connrefused      # treat ECONNREFUSED as retriable
  - --retry-all-errors       # treat HTTP 5xx etc. as retriable
  - --retry=60               # up to 60 attempts
  - --retry-delay=3          # 3s between attempts
  - --retry-max-time=300     # absolute cap of 5 min
  - http://…/health
\`\`\`

Replicates the loop semantics, works in distroless images, and the \`env: RUSTFS_URL/GRAFANA_URL\` block on the init container becomes redundant (URL was constant) and is removed.

Affected:
- \`kubernetes/applications/rustfs/base/initialize-buckets-job.yaml\`
- \`kubernetes/applications/grafana/base/provision-sa-job.yaml\`

## Test plan

- [ ] ArgoCD sync of \`rustfs-prod\` succeeds and \`initialize-rustfs-buckets\` completes 1/1
- [ ] \`rustfs-prod\` returns to Healthy (CronJob health was the only outstanding gap there)
- [ ] On next \`grafana-prod\` sync, \`provision-grafana-sa\` completes 1/1

🤖 Generated with [Claude Code](https://claude.com/claude-code)