### PR TITLE
chore(argocd): align wait-for-argocd init container with rustfs/grafana

### DIFF
--- a/kubernetes/components/gitops-controller/base/provision-sa-job.yaml
+++ b/kubernetes/components/gitops-controller/base/provision-sa-job.yaml
@@ -18,20 +18,22 @@ spec:
     spec:
       serviceAccountName: argocd-sa-provisioner
       restartPolicy: OnFailure
+      imagePullSecrets:
+        - name: dhi-registry-secret
       initContainers:
-        # Wait until ArgoCD is ready before provisioning
+        # Wait until ArgoCD is ready
         - name: wait-for-argocd
-          image: curlimages/curl:8.20.0
-          command: ["/bin/sh", "-c"]
+          image: dhi.io/curl:8-alpine3.23
+          command: ["curl"]
           args:
-            - |
-              until curl -sf "$ARGOCD_URL/healthz" >/dev/null; do
-                echo "Waiting for ArgoCD..."
-                sleep 3
-              done
-          env:
-            - name: ARGOCD_URL
-              value: "http://argocd-server.gitops-controller.svc.cluster.local"
+            - --silent
+            - --fail
+            - --retry-connrefused
+            - --retry-all-errors
+            - --retry=60
+            - --retry-delay=3
+            - --retry-max-time=300
+            - http://argocd-server.gitops-controller.svc.cluster.local/healthz
       containers:
         - name: provision
           image: alpine/k8s:1.36.0


### PR DESCRIPTION
## Summary

\`provision-argocd-sa\` was the only remaining \`wait-for-*\` init container still using \`curlimages/curl\` + \`/bin/sh\` shell loop. PR #832 already migrated rustfs and grafana to \`dhi.io/curl\` + \`curl --retry\`. This brings argocd in line so all three jobs share the same distroless DHI pattern.

Verified the pull secret \`dhi-registry-secret\` is already replicated into the \`gitops-controller\` namespace via the Kyverno \`sync-cluster-secrets\` policy.

## Test plan

- [ ] ArgoCD sync of \`gitops-controller-prod\` succeeds and \`provision-argocd-sa\` Job completes 1/1
- [ ] (No regression) all three \`wait-for-*\` init containers across rustfs / grafana / argocd succeed using the same image and arg pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)