### PR TITLE
chore(rustfs): replace minio/mc with rclone for bucket initialization

### DIFF
--- a/kubernetes/applications/rustfs/base/initialize-buckets-job.yaml
+++ b/kubernetes/applications/rustfs/base/initialize-buckets-job.yaml
@@ -34,8 +34,8 @@ spec:
             - --retry-max-time=300
             - http://rustfs-svc.rustfs.svc.cluster.local:9000/health
       containers:
-        - name: mc
-          image: minio/mc:latest
+        - name: rclone
+          image: rclone/rclone:1.74.0
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -45,16 +45,22 @@ spec:
             readOnlyRootFilesystem: true
           command: ["/bin/sh", "/scripts/initialize-rustfs-buckets.sh"]
           env:
-            - name: RUSTFS_URL
-              value: "http://rustfs-svc.rustfs.svc.cluster.local:9000"
             - name: BUCKETS
               value: "authentik-backups longhorn-backups timescaledb-backups nats-archive"
-            - name: ACCESS_KEY
+            - name: RCLONE_CONFIG_RUSTFS_TYPE
+              value: s3
+            - name: RCLONE_CONFIG_RUSTFS_PROVIDER
+              value: Other
+            - name: RCLONE_CONFIG_RUSTFS_ENDPOINT
+              value: "http://rustfs-svc.rustfs.svc.cluster.local:9000"
+            - name: RCLONE_CONFIG_RUSTFS_FORCE_PATH_STYLE
+              value: "true"
+            - name: RCLONE_CONFIG_RUSTFS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
                   name: rustfs-admin-credentials
                   key: RUSTFS_ACCESS_KEY
-            - name: SECRET_KEY
+            - name: RCLONE_CONFIG_RUSTFS_SECRET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
                   name: rustfs-admin-credentials

--- a/kubernetes/applications/rustfs/base/scripts/initialize-rustfs-buckets.sh
+++ b/kubernetes/applications/rustfs/base/scripts/initialize-rustfs-buckets.sh
@@ -1,19 +1,12 @@
 #!/bin/sh
-set -euo pipefail
+set -eu
 
 # Required environment variables:
-#   RUSTFS_URL   - e.g. http://rustfs-svc.rustfs.svc.cluster.local:9000
-#   BUCKETS      - space-separated list of bucket names to create
-#   ACCESS_KEY   - RustFS admin access key
-#   SECRET_KEY   - RustFS admin secret key
-
-export MC_CONFIG_DIR=$(mktemp -d)
-mc alias set rustfs "$RUSTFS_URL" "$ACCESS_KEY" "$SECRET_KEY"
+#   BUCKETS                              - space-separated list of bucket names to create
+#   RCLONE_CONFIG_RUSTFS_*               - rclone S3 remote config (endpoint, keys, etc.)
 
 for BUCKET in $BUCKETS; do
-  if ! mc ls "rustfs/$BUCKET" >/dev/null 2>&1; then
-    mc mb "rustfs/$BUCKET"
-  fi
+  rclone mkdir "rustfs:$BUCKET"
 done
 
 echo "Done"


### PR DESCRIPTION
Switch from minio/mc (no longer maintained, was on :latest) to rclone (pinned 1.74.0). `rclone mkdir` is idempotent so the if-not-exists check disappears; config flows via RCLONE_CONFIG_RUSTFS_* env vars, no alias step or on-disk file. Verified live against rustfs: existing 4 buckets stayed, a test bucket was created and removed cleanly. Script shrinks from 14 to 5 lines.