### PR TITLE
Revert "feat(container): bump knx-nats-bridge 0.1.4 → 0.3.0 (#838)"

### DIFF
--- a/kubernetes/applications/knx-nats-bridge/base/values.yaml
+++ b/kubernetes/applications/knx-nats-bridge/base/values.yaml
@@ -5,7 +5,7 @@ deployment:
   enabled: true
   image:
     repository: ghcr.io/alexander-zimmermann/knx-nats-bridge
-    tag: 0.3.0
+    tag: 0.1.4
     pullPolicy: IfNotPresent
 
   # KNX tunnel allows only one connection per credential; never run two replicas.


### PR DESCRIPTION
## Summary
- Reverts #838. Image `0.3.0` requires the new catalog ConfigMap (`knx-catalog.yaml`) which is not yet on `main` — it lives on `feat/phase-1-knx-catalog`.
- Production pod is in `CrashLoopBackOff` (`FileNotFoundError: /etc/knx-nats-bridge/knx-catalog.yaml`).
- Pinning back to `0.1.4` lets the existing `knx-nats-bridge-mapping` ConfigMap continue to work until the catalog migration lands.

## Test plan
- [ ] Merge → ArgoCD syncs `knx-nats-bridge-prod`
- [ ] `kubectl -n knx-nats-bridge get pods` shows `Running 1/1`
- [ ] Bridge logs show successful KNX tunnel + NATS connect

🤖 Generated with [Claude Code](https://claude.com/claude-code)