### PR TITLE
feat(iot-mcp-bridge): wire up KNX catalog (Phase 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ build/
 
 # --- KI ---
 .claude/
+
+# --- KNX ---
+*.knxproj

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -2,6 +2,8 @@ version: "3"
 
 vars:
   SCRIPTS_DIR: "{{.ROOT_DIR}}/scripts"
+  KNX_BRIDGE_DIR: "{{.ROOT_DIR}}/../knx-nats-bridge"
+  KNX_CATALOG_PATH: "{{.ROOT_DIR}}/kubernetes/applications/knx-nats-bridge/base/config/knx-catalog.yaml"
 
 includes:
   infra:
@@ -11,6 +13,8 @@ includes:
     taskfile: ./tasks/kubernetes.yaml
   cluster:
     taskfile: ./tasks/cluster.yaml
+  knx:
+    taskfile: ./tasks/knx.yaml
 
 tasks:
   default:

--- a/kubernetes/applications/iot-mcp-bridge/base/import-knx-catalog-job.yaml
+++ b/kubernetes/applications/iot-mcp-bridge/base/import-knx-catalog-job.yaml
@@ -1,0 +1,65 @@
+# PostSync Job that imports the KNX catalog (group address → name/room/
+# function/description) from the cloned knx-nats-bridge-catalog ConfigMap
+# into the `knx_catalog` Postgres table. Uses admin credentials (homelab
+# role) — the read-only role the MCP server runs with cannot write.
+# Idempotent: re-runs only update changed rows and purge stale ones.
+apiVersion: batch/v1
+kind: Job
+
+metadata:
+  name: iot-mcp-bridge-import-knx-catalog
+  namespace: iot-mcp-bridge
+  annotations:
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+
+spec:
+  backoffLimit: 3
+  ttlSecondsAfterFinished: 3600
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: importer
+          image: ghcr.io/alexander-zimmermann/iot-mcp-bridge:0.5.1
+          command: ["python", "-m", "iot_mcp_bridge.cli.import_knx_catalog"]
+          args:
+            - --catalog-path=/etc/iot-mcp-bridge/knx-catalog.yaml
+          env:
+            - name: MCP_DB_HOST
+              value: timescaledb-db-rw.timescaledb.svc.cluster.local
+            - name: MCP_DB_PORT
+              value: "5432"
+            - name: MCP_DB_NAME
+              value: homelab
+            - name: MCP_DB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: timescaledb-db-app
+                  key: username
+            - name: MCP_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: timescaledb-db-app
+                  key: password
+            - name: MCP_AUTH_ENABLED
+              value: "false"
+            - name: TZ
+              value: Europe/Berlin
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+          volumeMounts:
+            - name: catalog
+              mountPath: /etc/iot-mcp-bridge/knx-catalog.yaml
+              subPath: knx-catalog.yaml
+              readOnly: true
+      volumes:
+        - name: catalog
+          configMap:
+            name: knx-nats-bridge-catalog
+            defaultMode: 0444

--- a/kubernetes/applications/iot-mcp-bridge/base/kustomization.yaml
+++ b/kubernetes/applications/iot-mcp-bridge/base/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ./namespace.yaml
   - ./certificate.yaml
   - ./ingress-route.yaml
+  - ./import-knx-catalog-job.yaml
 
 helmCharts:
   - name: application

--- a/kubernetes/applications/iot-mcp-bridge/base/values.yaml
+++ b/kubernetes/applications/iot-mcp-bridge/base/values.yaml
@@ -5,7 +5,7 @@ deployment:
   enabled: true
   image:
     repository: ghcr.io/alexander-zimmermann/iot-mcp-bridge
-    tag: 0.3.0
+    tag: 0.5.1
     pullPolicy: IfNotPresent
 
   replicas: 1

--- a/kubernetes/applications/knx-nats-bridge/base/config/knx-catalog.yaml
+++ b/kubernetes/applications/knx-nats-bridge/base/config/knx-catalog.yaml
@@ -1,6762 +1,10915 @@
 0/0/100:
   dpt: '17.001'
+  function: Allgemein
   name: Allgemein.Zentral.KG.Szenen
 0/0/101:
   dpt: '1.003'
+  function: Allgemein
   name: Allgemein.Zentral.KG.Alles-Aus
 0/0/120:
   dpt: '17.001'
+  function: Allgemein
   name: Allgemein.Zentral.EG.Szenen
 0/0/121:
   dpt: '1.001'
+  function: Allgemein
   name: Allgemein.Zentral.EG.Alles-Aus
 0/0/140:
   dpt: '17.001'
+  function: Allgemein
   name: Allgemein.Zentral.OG.Szenen
 0/0/141:
   dpt: '1.001'
+  function: Allgemein
   name: Allgemein.Zentral.OG.Alles-Aus
 0/0/160:
   dpt: '17.001'
+  function: Allgemein
   name: Allgemein.Zentral.DG.Szenen
 0/0/161:
   dpt: '1.001'
+  function: Allgemein
   name: Allgemein.Zentral.DG.Alles-Aus
 0/0/180:
   dpt: '17.001'
+  function: Allgemein
   name: Allgemein.Zentral.A.Szenen
 0/0/181:
   dpt: '1.001'
+  function: Allgemein
   name: Allgemein.Zentral.A.Alles-Aus
 0/0/200:
   dpt: '17.001'
+  function: Allgemein
   name: Allgemein.Zentral.Szenen
 0/0/201:
   dpt: '1.001'
+  function: Allgemein
   name: Allgemein.Zentral.Alles-Aus
 0/0/211:
   dpt: '1.011'
+  function: Allgemein
   name: Allgemein.Zentral.Anwesend.Alexander
 0/0/212:
   dpt: '1.011'
+  function: Allgemein
   name: Allgemein.Zentral.Anwesend.Vanessa
 0/0/213:
   dpt: '1.011'
+  function: Allgemein
   name: Allgemein.Zentral.Anwesend.Luis
 0/0/214:
   dpt: '1.011'
+  function: Allgemein
   name: Allgemein.Zentral.Anwesend.Gregory
 0/0/220:
   dpt: '10.001'
+  function: Allgemein
   name: Allgemein.Zentral.Uhrzeit
 0/0/221:
   dpt: '11.001'
+  function: Allgemein
   name: Allgemein.Zentral.Datum
 0/0/222:
   dpt: '19.001'
+  function: Allgemein
   name: Allgemein.Zentral.Datum-Uhrzeit
 0/0/230:
   dpt: '1.001'
+  function: Allgemein
   name: Allgemein.Zentral.Tag/Nacht
 0/0/231:
   dpt: '1.024'
+  function: Allgemein
   name: Allgemein.Zentral.Nacht/Tag
 0/0/232:
   dpt: '1.002'
+  function: Allgemein
   name: Allgemein.Zentral.Sommer/Winter
 0/1/0:
   dpt: '17.001'
+  function: Allgemein
   name: Allgemein.KG.Flur.Szenen
+  room: Flur
 0/1/1:
   dpt: '1.001'
+  function: Allgemein
   name: Allgemein.KG.Flur.Alles-Aus
+  room: Flur
 0/1/20:
   dpt: '17.001'
+  function: Allgemein
   name: Allgemein.KG.Garage.Szenen
+  room: Garage
 0/1/21:
   dpt: '1.001'
+  function: Allgemein
   name: Allgemein.KG.Garage.Alles-Aus
+  room: Garage
 0/1/40:
   dpt: '17.001'
+  function: Allgemein
   name: Allgemein.KG.Technikraum.Szenen
+  room: Technikraum
 0/1/41:
   dpt: '1.001'
+  function: Allgemein
   name: Allgemein.KG.Technikraum.Alles-Aus
+  room: Technikraum
 0/1/60:
   dpt: '17.001'
+  function: Allgemein
   name: Allgemein.KG.Vorratsraum.Szenen
+  room: Vorratsraum
 0/1/61:
   dpt: '1.001'
+  function: Allgemein
   name: Allgemein.KG.Vorratsraum.Alles-Aus
+  room: Vorratsraum
 0/1/80:
   dpt: '17.001'
+  function: Allgemein
   name: Allgemein.KG.Hauswirtschaftsraum.Szenen
+  room: Hauswirtschaftsraum
 0/1/81:
   dpt: '1.001'
+  function: Allgemein
   name: Allgemein.KG.Hauswirtschaftsraum.Alles-Aus
+  room: Hauswirtschaftsraum
 0/2/0:
   dpt: '17.001'
+  function: Allgemein
   name: Allgemein.EG.Flur.Szenen
+  room: Flur
 0/2/1:
   dpt: '1.001'
+  function: Allgemein
   name: Allgemein.EG.Flur.Alles-Aus
+  room: Flur
 0/2/100:
   dpt: '17.001'
+  function: Allgemein
   name: Allgemein.EG.Küche.Szenen
+  room: Küche
 0/2/101:
   dpt: '1.001'
+  function: Allgemein
   name: Allgemein.EG.Küche.Alles-Aus
+  room: Küche
 0/2/20:
   dpt: '17.001'
+  function: Allgemein
   name: Allgemein.EG.Gäste-WC.Szenen
+  room: Gäste-WC
 0/2/21:
   dpt: '1.001'
+  function: Allgemein
   name: Allgemein.EG.Gäste-WC.Alles-Aus
+  room: Gäste-WC
 0/2/40:
   dpt: '17.001'
+  function: Allgemein
   name: Allgemein.EG.Büro.Szenen
+  room: Büro
 0/2/41:
   dpt: '1.001'
+  function: Allgemein
   name: Allgemein.EG.Büro.Alles-Aus
+  room: Büro
 0/2/42:
   dpt: '1.001'
+  function: Allgemein
   name: Allgemein.EG.Büro.Alles-Aus-Trigger
+  room: Büro
 0/2/60:
   dpt: '17.001'
+  function: Allgemein
   name: Allgemein.EG.Wohnzimmer.Szenen
+  room: Wohnzimmer
 0/2/61:
   dpt: '1.001'
+  function: Allgemein
   name: Allgemein.EG.Wohnzimmer.Alles-Aus
+  room: Wohnzimmer
 0/2/62:
   dpt: '1.001'
+  function: Allgemein
   name: Allgemein.EG.Wohnzimmer.Alles-Aus-Trigger
+  room: Wohnzimmer
 0/2/80:
   dpt: '17.001'
+  function: Allgemein
   name: Allgemein.EG.Esszimmer.Szenen
+  room: Esszimmer
 0/2/81:
   dpt: '1.001'
+  function: Allgemein
   name: Allgemein.EG.Esszimmer.Alles-Aus
+  room: Esszimmer
 0/3/0:
   dpt: '17.001'
+  function: Allgemein
   name: Allgemein.OG.Flur.Szenen
+  room: Flur
 0/3/1:
   dpt: '1.001'
+  function: Allgemein
   name: Allgemein.OG.Flur.Alles-Aus
+  room: Flur
 0/3/100:
   dpt: '17.001'
+  function: Allgemein
   name: Allgemein.OG.Schlafzimmer-Eltern.Szenen
+  room: Schlafzimmer-Eltern
 0/3/101:
   dpt: '1.001'
+  function: Allgemein
   name: Allgemein.OG.Schlafzimmer-Eltern.Alles-Aus
+  room: Schlafzimmer-Eltern
 0/3/102:
   dpt: '1.001'
+  function: Allgemein
   name: Allgemein.OG.Schlafzimmer-Eltern.Alles-Aus-Trigger
+  room: Schlafzimmer-Eltern
 0/3/120:
   dpt: '17.001'
+  function: Allgemein
   name: Allgemein.OG.Begehbarer-Schrank.Szenen
+  room: Begehbarer-Schrank
 0/3/121:
   dpt: '1.001'
+  function: Allgemein
   name: Allgemein.OG.Begehbarer-Schrank.Alles-Aus
+  room: Begehbarer-Schrank
 0/3/140:
   dpt: '17.001'
+  function: Allgemein
   name: Allgemein.OG.Badezimmer-Eltern.Szenen
+  room: Badezimmer-Eltern
 0/3/141:
   dpt: '1.001'
+  function: Allgemein
   name: Allgemein.OG.Badezimmer-Eltern.Alles-Aus
+  room: Badezimmer-Eltern
 0/3/142:
   dpt: '1.001'
+  function: Allgemein
   name: Allgemein.OG.Badezimmer-Eltern.Alles-Aus-Trigger
+  room: Badezimmer-Eltern
 0/3/20:
   dpt: '17.001'
+  function: Allgemein
   name: Allgemein.OG.Abstellraum.Szenen
+  room: Abstellraum
 0/3/21:
   dpt: '1.001'
+  function: Allgemein
   name: Allgemein.OG.Abstellraum.Alles-Aus
+  room: Abstellraum
 0/3/22:
   dpt: '1.001'
+  function: Allgemein
   name: Allgemein.OG.Abstellraum.Alles-Aus-Trigger
+  room: Abstellraum
 0/3/40:
   dpt: '17.001'
+  function: Allgemein
   name: Allgemein.OG.Badezimmer-Kinder.Szenen
+  room: Badezimmer-Kinder
 0/3/41:
   dpt: '1.001'
+  function: Allgemein
   name: Allgemein.OG.Badezimmer-Kinder.Alles-Aus
+  room: Badezimmer-Kinder
 0/3/42:
   dpt: '1.001'
+  function: Allgemein
   name: Allgemein.OG.Badezimmer-Kinder.Alles-Aus-Trigger
+  room: Badezimmer-Kinder
 0/3/60:
   dpt: '17.001'
+  function: Allgemein
   name: Allgemein.OG.Schlafzimmer-Gregory.Szenen
+  room: Schlafzimmer-Gregory
 0/3/61:
   dpt: '1.001'
+  function: Allgemein
   name: Allgemein.OG.Schlafzimmer-Gregory.Alles-Aus
+  room: Schlafzimmer-Gregory
 0/3/62:
   dpt: '1.001'
+  function: Allgemein
   name: Allgemein.OG.Schlafzimmer-Gregory.Alles-Aus-Trigger
+  room: Schlafzimmer-Gregory
 0/3/80:
   dpt: '17.001'
+  function: Allgemein
   name: Allgemein.OG.Schlafzimmer-Luis.Szenen
+  room: Schlafzimmer-Luis
 0/3/81:
   dpt: '1.001'
+  function: Allgemein
   name: Allgemein.OG.Schlafzimmer-Luis.Alles-Aus
+  room: Schlafzimmer-Luis
 0/3/82:
   dpt: '1.001'
+  function: Allgemein
   name: Allgemein.OG.Schlafzimmer-Luis.Alles-Aus-Trigger
+  room: Schlafzimmer-Luis
 0/4/0:
   dpt: '17.001'
+  function: Allgemein
   name: Allgemein.DG.Speicher.Szenen
+  room: Speicher
 0/4/1:
   dpt: '1.001'
+  function: Allgemein
   name: Allgemein.DG.Speicher.Alles-Aus
+  room: Speicher
 0/5/0:
   dpt: '17.001'
+  function: Allgemein
   name: Allgemein.A.Fassade.Szenen
+  room: Fassade
 0/5/1:
   dpt: '1.001'
+  function: Allgemein
   name: Allgemein.A.Fassade.Alles-Aus
+  room: Fassade
 0/5/100:
   dpt: '17.001'
+  function: Allgemein
   name: Allgemein.A.Dach.Szenen
+  room: Dach
 0/5/101:
   dpt: '1.001'
+  function: Allgemein
   name: Allgemein.A.Dach.Alles-Aus
+  room: Dach
 0/5/20:
   dpt: '17.001'
+  function: Allgemein
   name: Allgemein.A.Eingang.Szenen
+  room: Eingang
 0/5/21:
   dpt: '1.001'
+  function: Allgemein
   name: Allgemein.A.Eingang.Alles-Aus
+  room: Eingang
 0/5/40:
   dpt: '17.001'
+  function: Allgemein
   name: Allgemein.A.Terrasse.Szenen
+  room: Terrasse
 0/5/41:
   dpt: '1.001'
+  function: Allgemein
   name: Allgemein.A.Terrasse.Alles-Aus
+  room: Terrasse
 0/5/60:
   dpt: '17.001'
+  function: Allgemein
   name: Allgemein.A.Balkon.Szenen
+  room: Balkon
 0/5/61:
   dpt: '1.001'
+  function: Allgemein
   name: Allgemein.A.Balkon.Alles-Aus
+  room: Balkon
 0/5/80:
   dpt: '17.001'
+  function: Allgemein
   name: Allgemein.A.Garten.Szenen
+  room: Garten
 0/5/81:
   dpt: '1.001'
+  function: Allgemein
   name: Allgemein.A.Garten.Alles-Aus
+  room: Garten
 10/1/0:
   dpt: '1.003'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Flur.KNX.Decke.Sperren
+  room: Flur
 10/1/1:
   dpt: '1.011'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Flur.KNX.Decke.Sperren-Status
+  room: Flur
 10/1/10:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Flur.KNX.Decke.Slave
+  room: Flur
 10/1/100:
   dpt: '1.003'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Garage.EMA.Sperren
+  room: Garage
 10/1/101:
   dpt: '1.011'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Garage.EMA.Sperren-Staus
+  room: Garage
 10/1/102:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Garage.EMA.Ein/Aus
+  room: Garage
 10/1/106:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Garage.EMA.HLK
+  room: Garage
 10/1/107:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Garage.EMA.Präsenz
+  room: Garage
 10/1/109:
   dpt: '1.024'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Garage.EMA.Tag/Nacht
+  room: Garage
 10/1/120:
   dpt: '1.003'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Technikraum.KNX.Sperren
+  room: Technikraum
 10/1/121:
   dpt: '1.011'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Technikraum.KNX.Sperren-Status
+  room: Technikraum
 10/1/122:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Technikraum.KNX.Ein/Aus
+  room: Technikraum
 10/1/123:
   dpt: '5.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Technikraum.KNX.Dimmen
+  room: Technikraum
 10/1/124:
   dpt: '9.004'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Technikraum.KNX.Schaltschwelle
+  room: Technikraum
 10/1/126:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Technikraum.KNX.HLK
+  room: Technikraum
 10/1/127:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Technikraum.KNX.Präsenz
+  room: Technikraum
 10/1/128:
   dpt: '9.004'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Technikraum.KNX.Helligkeit
+  room: Technikraum
 10/1/129:
   dpt: '1.024'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Technikraum.KNX.Tag/Nacht
+  room: Technikraum
 10/1/130:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Technikraum.KNX.Slave
+  room: Technikraum
 10/1/140:
   dpt: '1.003'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Vorratsraum.KNX.Sperren
+  room: Vorratsraum
 10/1/141:
   dpt: '1.011'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Vorratsraum.KNX.Sperren-Status
+  room: Vorratsraum
 10/1/142:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Vorratsraum.KNX.Ein/Aus
+  room: Vorratsraum
 10/1/143:
   dpt: '5.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Vorratsraum.KNX.Dimmen
+  room: Vorratsraum
 10/1/144:
   dpt: '9.004'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Vorratsraum.KNX.Schaltschwelle
+  room: Vorratsraum
 10/1/146:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Vorratsraum.KNX.HLK
+  room: Vorratsraum
 10/1/147:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Vorratsraum.KNX.Präsenz
+  room: Vorratsraum
 10/1/148:
   dpt: '9.004'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Vorratsraum.KNX.Helligkeit
+  room: Vorratsraum
 10/1/149:
   dpt: '1.024'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Vorratsraum.KNX.Tag/Nacht
+  room: Vorratsraum
 10/1/150:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Vorratsraum.KNX.Slave
+  room: Vorratsraum
 10/1/160:
   dpt: '1.003'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Hauswirtschaftsraum.KNX.Sperren
+  room: Hauswirtschaftsraum
 10/1/161:
   dpt: '1.011'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Hauswirtschaftsraum.KNX.Sperren-Status
+  room: Hauswirtschaftsraum
 10/1/162:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Hauswirtschaftsraum.KNX.Ein/Aus
+  room: Hauswirtschaftsraum
 10/1/163:
   dpt: '5.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Hauswirtschaftsraum.KNX.Dimmen
+  room: Hauswirtschaftsraum
 10/1/164:
   dpt: '9.004'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Hauswirtschaftsraum.KNX.Schaltschwelle
+  room: Hauswirtschaftsraum
 10/1/166:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Hauswirtschaftsraum.KNX.HLK
+  room: Hauswirtschaftsraum
 10/1/167:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Hauswirtschaftsraum.KNX.Präsenz
+  room: Hauswirtschaftsraum
 10/1/168:
   dpt: '9.004'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Hauswirtschaftsraum.KNX.Helligkeit
+  room: Hauswirtschaftsraum
 10/1/169:
   dpt: '1.024'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Hauswirtschaftsraum.KNX.Tag/Nacht
+  room: Hauswirtschaftsraum
 10/1/170:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Hauswirtschaftsraum.KNX.Slave
+  room: Hauswirtschaftsraum
 10/1/2:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Flur.KNX.Decke.Ein/Aus
+  room: Flur
 10/1/20:
   dpt: '1.003'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Flur.KNX.Wand.Sperren
+  room: Flur
 10/1/21:
   dpt: '1.011'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Flur.KNX.Wand.Sperren-Status
+  room: Flur
 10/1/22:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Flur.KNX.Wand.Ein/Aus
+  room: Flur
 10/1/23:
   dpt: '5.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Flur.KNX.Wand.Dimmen
+  room: Flur
 10/1/25:
   dpt: '1.011'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Flur.KNX.Wand.Schaltschwelle-Status
+  room: Flur
 10/1/26:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Flur.KNX.Wand.HLK
+  room: Flur
 10/1/27:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Flur.KNX.Wand.Präsenz
+  room: Flur
 10/1/28:
   dpt: '9.004'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Flur.KNX.Wand.Helligkeit
+  room: Flur
 10/1/29:
   dpt: '1.024'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Flur.KNX.Wand.Tag/Nacht
+  room: Flur
 10/1/3:
   dpt: '5.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Flur.KNX.Decke.Dimmen
+  room: Flur
 10/1/30:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Flur.KNX.Wand.Slave
+  room: Flur
 10/1/40:
   dpt: '1.003'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Flur.EMA.Sperren
+  room: Flur
 10/1/41:
   dpt: '1.011'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Flur.EMA.Sperren-Status
+  room: Flur
 10/1/42:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Flur.EMA.Ein/Aus
+  room: Flur
 10/1/46:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Flur.EMA.HLK
+  room: Flur
 10/1/47:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Flur.EMA.Präsenz
+  room: Flur
 10/1/49:
   dpt: '1.024'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Flur.EMA.Tag/Nacht
+  room: Flur
 10/1/5:
   dpt: '1.011'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Flur.KNX.Decke.Schaltschwelle-Status
+  room: Flur
 10/1/6:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Flur.KNX.Decke.HLK
+  room: Flur
 10/1/60:
   dpt: '1.003'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Garage.KNX.Decke.Sperren
+  room: Garage
 10/1/61:
   dpt: '1.011'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Garage.KNX.Decke.Sperren-Status
+  room: Garage
 10/1/62:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Garage.KNX.Decke.Ein/Aus
+  room: Garage
 10/1/63:
   dpt: '5.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Garage.KNX.Decke.Dimmen
+  room: Garage
 10/1/64:
   dpt: '9.004'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Garage.KNX.Decke.Schaltschwelle
+  room: Garage
 10/1/66:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Garage.KNX.Decke.HLK
+  room: Garage
 10/1/67:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Garage.KNX.Decke.Präsenz
+  room: Garage
 10/1/68:
   dpt: '9.004'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Garage.KNX.Decke.Helligkeit
+  room: Garage
 10/1/69:
   dpt: '1.024'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Garage.KNX.Decke.Tag/Nacht
+  room: Garage
 10/1/7:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Flur.KNX.Decke.Präsenz
+  room: Flur
 10/1/70:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Garage.KNX.Decke.Slave
+  room: Garage
 10/1/8:
   dpt: '9.004'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Flur.KNX.Decke.Helligkeit
+  room: Flur
 10/1/82:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Garage.KNX.Wand.Ein/Aus
+  room: Garage
 10/1/83:
   dpt: '5.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Garage.KNX.Wand.Dimmen
+  room: Garage
 10/1/86:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Garage.KNX.Wand.HLK
+  room: Garage
 10/1/87:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Garage.KNX.Wand.Präsenz
+  room: Garage
 10/1/88:
   dpt: '9.004'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Garage.KNX.Wand.Helligkeit
+  room: Garage
 10/1/89:
   dpt: '1.024'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Garage.KNX.Wand.Tag/Nacht
+  room: Garage
 10/1/9:
   dpt: '1.024'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Flur.KNX.Decke.Tag/Nacht
+  room: Flur
 10/1/90:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.KG.Garage.KNX.Wand.Slave
+  room: Garage
 10/2/0:
   dpt: '1.003'
+  function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.KNX.Eingang.Sperren
+  room: Flur
 10/2/1:
   dpt: '1.011'
+  function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.KNX.Eingang.Sperren-Status
+  room: Flur
 10/2/10:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.KNX.Eingang.Slave
+  room: Flur
 10/2/100:
   dpt: '1.003'
+  function: Bewegungsmelder
   name: Bewegungsmelder.EG.Büro.EMA.Sperren
+  room: Büro
 10/2/101:
   dpt: '1.011'
+  function: Bewegungsmelder
   name: Bewegungsmelder.EG.Büro.EMA.Sperren-Status
+  room: Büro
 10/2/102:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.EG.Büro.EMA.Ein/Aus
+  room: Büro
 10/2/106:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.EG.Büro.EMA.HLK
+  room: Büro
 10/2/107:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.EG.Büro.EMA.Präsenz
+  room: Büro
 10/2/109:
   dpt: '1.024'
+  function: Bewegungsmelder
   name: Bewegungsmelder.EG.Büro.EMA.Tag/Nacht
+  room: Büro
 10/2/120:
   dpt: '1.003'
+  function: Bewegungsmelder
   name: Bewegungsmelder.EG.Wohnzimmer.EMA.Sperren
+  room: Wohnzimmer
 10/2/121:
   dpt: '1.011'
+  function: Bewegungsmelder
   name: Bewegungsmelder.EG.Wohnzimmer.EMA.Sperren-Status
+  room: Wohnzimmer
 10/2/122:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.EG.Wohnzimmer.EMA.Ein/Aus
+  room: Wohnzimmer
 10/2/126:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.EG.Wohnzimmer.EMA.HLK
+  room: Wohnzimmer
 10/2/127:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.EG.Wohnzimmer.EMA.Präsenz
+  room: Wohnzimmer
 10/2/129:
   dpt: '1.024'
+  function: Bewegungsmelder
   name: Bewegungsmelder.EG.Wohnzimmer.EMA.Tag/Nacht
+  room: Wohnzimmer
 10/2/140:
   dpt: '1.003'
+  function: Bewegungsmelder
   name: Bewegungsmelder.EG.Esszimmer.EMA.Sperren
+  room: Esszimmer
 10/2/141:
   dpt: '1.011'
+  function: Bewegungsmelder
   name: Bewegungsmelder.EG.Esszimmer.EMA.Sperren-Status
+  room: Esszimmer
 10/2/142:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.EG.Esszimmer.EMA.Ein/Aus
+  room: Esszimmer
 10/2/146:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.EG.Esszimmer.EMA.HLK
+  room: Esszimmer
 10/2/147:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.EG.Esszimmer.EMA.Präsenz
+  room: Esszimmer
 10/2/149:
   dpt: '1.024'
+  function: Bewegungsmelder
   name: Bewegungsmelder.EG.Esszimmer.EMA.Tag/Nacht
+  room: Esszimmer
 10/2/2:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.KNX.Eingang.Ein/Aus
+  room: Flur
 10/2/20:
   dpt: '1.003'
+  function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.KNX.Diele.Sperren
+  room: Flur
 10/2/21:
   dpt: '1.011'
+  function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.KNX.Diele.Sperren-Status
+  room: Flur
 10/2/22:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.KNX.Diele.Ein/Aus
+  room: Flur
 10/2/23:
   dpt: '5.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.KNX.Diele.Dimmen
+  room: Flur
 10/2/25:
   dpt: '1.011'
+  function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.KNX.Diele.Schaltschwelle-Status
+  room: Flur
 10/2/26:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.KNX.Diele.HLK
+  room: Flur
 10/2/27:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.KNX.Diele.Präsenz
+  room: Flur
 10/2/28:
   dpt: '9.004'
+  function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.KNX.Diele.Helligkeit
+  room: Flur
 10/2/29:
   dpt: '1.024'
+  function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.KNX.Diele.Tag/Nacht
+  room: Flur
 10/2/3:
   dpt: '5.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.KNX.Eingang.Dimmen
+  room: Flur
 10/2/30:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.KNX.Diele.Slave
+  room: Flur
 10/2/42:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.KNX.Garderobe.Ein/Aus
+  room: Flur
 10/2/46:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.KNX.Garderobe.HLK
+  room: Flur
 10/2/47:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.KNX.Garderobe.Präsenz
+  room: Flur
 10/2/48:
   dpt: '9.004'
+  function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.KNX.Garderobe.Helligkeit
+  room: Flur
 10/2/49:
   dpt: '1.024'
+  function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.KNX.Garderobe.Tag/Nacht
+  room: Flur
 10/2/5:
   dpt: '1.011'
+  function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.KNX.Eingang.Schaltschwelle-Status
+  room: Flur
 10/2/50:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.KNX.Garderobe.Slave
+  room: Flur
 10/2/6:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.KNX.Eingang.HLK
+  room: Flur
 10/2/60:
   dpt: '1.003'
+  function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.EMA.Sperren
+  room: Flur
 10/2/61:
   dpt: '1.011'
+  function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.EMA.Sperren-Status
+  room: Flur
 10/2/62:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.EMA.Ein/Aus
+  room: Flur
 10/2/66:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.EMA.HLK
+  room: Flur
 10/2/67:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.EMA.Präsenz
+  room: Flur
 10/2/69:
   dpt: '1.024'
+  function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.EMA.Tag/Nacht
+  room: Flur
 10/2/7:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.KNX.Eingang.Präsenz
+  room: Flur
 10/2/8:
   dpt: '9.004'
+  function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.KNX.Eingang.Helligkeit
+  room: Flur
 10/2/80:
   dpt: '1.003'
+  function: Bewegungsmelder
   name: Bewegungsmelder.EG.Gäste-WC.KNX.Sperren
+  room: Gäste-WC
 10/2/81:
   dpt: '1.011'
+  function: Bewegungsmelder
   name: Bewegungsmelder.EG.Gäste-WC.KNX.Sperren-Status
+  room: Gäste-WC
 10/2/82:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.EG.Gäste-WC.KNX.Ein/Aus
+  room: Gäste-WC
 10/2/83:
   dpt: '5.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.EG.Gäste-WC.KNX.Dimmen
+  room: Gäste-WC
 10/2/85:
   dpt: '1.011'
+  function: Bewegungsmelder
   name: Bewegungsmelder.EG.Gäste-WC.KNX.Schaltschwelle-Status
+  room: Gäste-WC
 10/2/86:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.EG.Gäste-WC.KNX.HLK
+  room: Gäste-WC
 10/2/87:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.EG.Gäste-WC.KNX.Präsenz
+  room: Gäste-WC
 10/2/88:
   dpt: '9.004'
+  function: Bewegungsmelder
   name: Bewegungsmelder.EG.Gäste-WC.KNX.Helligkeit
+  room: Gäste-WC
 10/2/89:
   dpt: '1.024'
+  function: Bewegungsmelder
   name: Bewegungsmelder.EG.Gäste-WC.KNX.Tag/Nacht
+  room: Gäste-WC
 10/2/9:
   dpt: '1.024'
+  function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.KNX.Eingang.Tag/Nacht
+  room: Flur
 10/2/90:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.EG.Gäste-WC.KNX.Slave
+  room: Gäste-WC
 10/3/10:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Flur.KNX.Treppe.Slave
+  room: Flur
 10/3/100:
   dpt: '1.003'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Badezimmer-Kinder.KNX.Sperren
+  room: Badezimmer-Kinder
 10/3/101:
   dpt: '1.011'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Badezimmer-Kinder.KNX.Sperren-Status
+  room: Badezimmer-Kinder
 10/3/102:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Badezimmer-Kinder.KNX.Ein/Aus
+  room: Badezimmer-Kinder
 10/3/103:
   dpt: '5.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Badezimmer-Kinder.KNX.Dimmen
+  room: Badezimmer-Kinder
 10/3/105:
   dpt: '1.011'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Badezimmer-Kinder.KNX.Schaltschwelle-Status
+  room: Badezimmer-Kinder
 10/3/106:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Badezimmer-Kinder.KNX.HLK
+  room: Badezimmer-Kinder
 10/3/107:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Badezimmer-Kinder.KNX.Präsenz
+  room: Badezimmer-Kinder
 10/3/108:
   dpt: '9.004'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Badezimmer-Kinder.KNX.Helligkeit
+  room: Badezimmer-Kinder
 10/3/109:
   dpt: '1.024'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Badezimmer-Kinder.KNX.Tag/Nacht
+  room: Badezimmer-Kinder
 10/3/110:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Badezimmer-Kinder.KNX.Slave
+  room: Badezimmer-Kinder
 10/3/160:
   dpt: '1.003'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Schlafzimmer-Eltern.KNX.Sperren
+  room: Schlafzimmer-Eltern
 10/3/161:
   dpt: '1.011'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Schlafzimmer-Eltern.KNX..Sperren-Status
+  room: Schlafzimmer-Eltern
 10/3/162:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Schlafzimmer-Eltern.KNX.Ein/Aus
+  room: Schlafzimmer-Eltern
 10/3/163:
   dpt: '5.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Schlafzimmer-Eltern.KNX.Dimmen
+  room: Schlafzimmer-Eltern
 10/3/165:
   dpt: '1.011'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Schlafzimmer-Eltern.KNX.Schaltschwelle-Status
+  room: Schlafzimmer-Eltern
 10/3/166:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Schlafzimmer-Eltern.KNX.HLK
+  room: Schlafzimmer-Eltern
 10/3/167:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Schlafzimmer-Eltern.KNX.Präsenz
+  room: Schlafzimmer-Eltern
 10/3/168:
   dpt: '9.004'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Schlafzimmer-Eltern.KNX.Helligkeit
+  room: Schlafzimmer-Eltern
 10/3/169:
   dpt: '1.024'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Schlafzimmer-Eltern.KNX.Tag/Nacht
+  room: Schlafzimmer-Eltern
 10/3/170:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Schlafzimmer-Eltern.KNX.Slave
+  room: Schlafzimmer-Eltern
 10/3/180:
   dpt: '1.003'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Begehbarer-Schrank.KNX.Sperren
+  room: Begehbarer-Schrank
 10/3/181:
   dpt: '1.011'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Begehbarer-Schrank.KNX.Sperren-Status
+  room: Begehbarer-Schrank
 10/3/182:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Begehbarer-Schrank.KNX.Ein/Aus
+  room: Begehbarer-Schrank
 10/3/183:
   dpt: '5.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Begehbarer-Schrank.KNX.Dimmen
+  room: Begehbarer-Schrank
 10/3/185:
   dpt: '1.011'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Begehbarer-Schrank.KNX.Schaltschwelle-Status
+  room: Begehbarer-Schrank
 10/3/186:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Begehbarer-Schrank.KNX.HLK
+  room: Begehbarer-Schrank
 10/3/187:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Begehbarer-Schrank.KNX.Präsenz
+  room: Begehbarer-Schrank
 10/3/188:
   dpt: '9.004'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Begehbarer-Schrank.KNX.Helligkeit
+  room: Begehbarer-Schrank
 10/3/189:
   dpt: '1.024'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Begehbarer-Schrank.KNX.Tag/Nacht
+  room: Begehbarer-Schrank
 10/3/190:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Begehbarer-Schrank.KNX.Slave
+  room: Begehbarer-Schrank
 10/3/2:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Flur.KNX.Treppe.Ein/Aus
+  room: Flur
 10/3/20:
   dpt: '1.003'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Flur.KNX.Gang.Sperren
+  room: Flur
 10/3/200:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Badezimmer-Eltern.KNX.Sperren
+  room: Badezimmer-Eltern
 10/3/201:
   dpt: '1.011'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Badezimmer-Eltern.KNX.Sperren-Status
+  room: Badezimmer-Eltern
 10/3/202:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Badezimmer-Eltern.KNX.Ein/Aus
+  room: Badezimmer-Eltern
 10/3/203:
   dpt: '5.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Badezimmer-Eltern.KNX.Dimmen
+  room: Badezimmer-Eltern
 10/3/205:
   dpt: '1.011'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Badezimmer-Eltern.KNX.Schaltschwelle-Status
+  room: Badezimmer-Eltern
 10/3/206:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Badezimmer-Eltern.KNX.HLK
+  room: Badezimmer-Eltern
 10/3/207:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Badezimmer-Eltern.KNX.Präsenz
+  room: Badezimmer-Eltern
 10/3/208:
   dpt: '9.004'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Badezimmer-Eltern.KNX.Helligkeit
+  room: Badezimmer-Eltern
 10/3/209:
   dpt: '1.024'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Badezimmer-Eltern.KNX.Tag/Nacht
+  room: Badezimmer-Eltern
 10/3/21:
   dpt: '1.011'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Flur.KNX.Gang.Sperren-Status
+  room: Flur
 10/3/210:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Badezimmer-Eltern.KNX.Slave
+  room: Badezimmer-Eltern
 10/3/22:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Flur.KNX.Gang.Ein/Aus
+  room: Flur
 10/3/23:
   dpt: '5.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Flur.KNX.Gang.Dimmen
+  room: Flur
 10/3/25:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Flur.KNX.Gang.Schaltschwelle-Status
+  room: Flur
 10/3/26:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Flur.KNX.Gang.HLK
+  room: Flur
 10/3/27:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Flur.KNX.Gang.Präsenz
+  room: Flur
 10/3/28:
   dpt: '9.004'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Flur.KNX.Gang.Helligkeit
+  room: Flur
 10/3/29:
   dpt: '1.024'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Flur.KNX.Gang.Tag/Nacht
+  room: Flur
 10/3/30:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Flur.KNX.Gang.Slave
+  room: Flur
 10/3/40:
   dpt: '1.003'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Flur.EMA.Treppe.Sperren
+  room: Flur
 10/3/41:
   dpt: '1.011'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Flur.EMA.Treppe.Sperren-Status
+  room: Flur
 10/3/42:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Flur.EMA.Treppe.Ein/Aus
+  room: Flur
 10/3/46:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Flur.EMA.Treppe.HLK
+  room: Flur
 10/3/47:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Flur.EMA.Treppe.Präsenz
+  room: Flur
 10/3/49:
   dpt: '1.024'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Flur.EMA.Treppe.Tag/Nacht
+  room: Flur
 10/3/6:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Flur.KNX.Treppe.HLK
+  room: Flur
 10/3/60:
   dpt: '1.003'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Flur.EMA.Gang.Sperren
+  room: Flur
 10/3/61:
   dpt: '1.011'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Flur.EMA.Gang.Sperren-Status
+  room: Flur
 10/3/62:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Flur.EMA.Gang.Ein/Aus
+  room: Flur
 10/3/66:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Flur.EMA.Gang.HLK
+  room: Flur
 10/3/67:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Flur.EMA.Gang.Präsenz
+  room: Flur
 10/3/69:
   dpt: '1.024'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Flur.EMA.Gang.Tag/Nacht
+  room: Flur
 10/3/7:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Flur.KNX.Treppe.Präsenz
+  room: Flur
 10/3/8:
   dpt: '9.004'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Flur.KNX.Treppe.Helligkeit
+  room: Flur
 10/3/9:
   dpt: '1.024'
+  function: Bewegungsmelder
   name: Bewegungsmelder.OG.Flur.KNX.Treppe.Tag/Nacht
+  room: Flur
 10/4/0:
   dpt: '1.003'
+  function: Bewegungsmelder
   name: Bewegungsmelder.DG.KNX.Sperren
+  room: KNX
 10/4/1:
   dpt: '1.011'
+  function: Bewegungsmelder
   name: Bewegungsmelder.DG.KNX.Sperren-Status
+  room: KNX
 10/4/10:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.DG.KNX.Slave
+  room: KNX
 10/4/2:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.DG.KNX.Ein/Aus
+  room: KNX
 10/4/3:
   dpt: '5.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.DG.KNX.Dimmen
+  room: KNX
 10/4/4:
   dpt: '9.004'
+  function: Bewegungsmelder
   name: Bewegungsmelder.DG.KNX.Schaltschwelle
+  room: KNX
 10/4/6:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.DG.KNX.HLK
+  room: KNX
 10/4/7:
   dpt: '1.001'
+  function: Bewegungsmelder
   name: Bewegungsmelder.DG.KNX.Präsenz
+  room: KNX
 10/4/8:
   dpt: '9.004'
+  function: Bewegungsmelder
   name: Bewegungsmelder.DG.KNX.Helligkeit
+  room: KNX
 10/4/9:
   dpt: '1.024'
+  function: Bewegungsmelder
   name: Bewegungsmelder.DG.KNX.Tag/Nacht
+  room: KNX
 11/0/100:
   dpt: '1.011'
+  function: Sicherheit
   name: Sicherheit.Zentral.KG.Fenster/Tür.Offen-Status
 11/0/120:
   dpt: '1.011'
+  function: Sicherheit
   name: Sicherheit.Zentral.EG.Fenster/Tür.Offen-Status
 11/0/140:
   dpt: '1.011'
+  function: Sicherheit
   name: Sicherheit.Zentral.OG.Fenster/Tür.Offen-Status
 11/1/1:
   dpt: '1.019'
+  function: Sicherheit
   name: Sicherheit.KG.Garage.Fenster.Geöffnet-Status
+  room: Garage
 11/1/11:
   dpt: '1.019'
+  function: Sicherheit
   name: Sicherheit.KG.Garage.Garagentor.Geöffnet-Status
+  room: Garage
 11/1/21:
   dpt: '1.019'
+  function: Sicherheit
   name: Sicherheit.KG.Technikraum.Fenster.Geöffnet-Status
+  room: Technikraum
 11/1/31:
   dpt: '1.005'
+  function: Sicherheit
   name: Sicherheit.KG.Technikraum.Gasmelder.Alarm
+  room: Technikraum
 11/1/41:
   dpt: '1.005'
+  function: Sicherheit
   name: Sicherheit.KG.Technikraum.CO-Melder.Alarm
+  room: Technikraum
 11/1/51:
   dpt: '1.005'
+  function: Sicherheit
   name: Sicherheit.KG.Technikraum.Wassermelder.Alarm
+  room: Technikraum
 11/1/61:
   dpt: '1.019'
+  function: Sicherheit
   name: Sicherheit.KG.Vorratsraum.Fenster.Geöffnet-Status
+  room: Vorratsraum
 11/1/71:
   dpt: '1.005'
+  function: Sicherheit
   name: Sicherheit.KG.Vorratsraum.Gasmelder.Alarm
+  room: Vorratsraum
 11/1/81:
   dpt: '1.019'
+  function: Sicherheit
   name: Sicherheit.KG.Hauswirtschaftsraum.Fenster.Geöffnet-Status
+  room: Hauswirtschaftsraum
 11/1/91:
   dpt: '1.005'
+  function: Sicherheit
   name: Sicherheit.KG.Hauswirtschaftsraum.Wassermelder.Alarm
+  room: Hauswirtschaftsraum
 11/2/1:
   dpt: '1.019'
+  function: Sicherheit
   name: Sicherheit.EG.Flur.Fenster.Geöffnet-Status
+  room: Flur
 11/2/101:
   dpt: '1.019'
+  function: Sicherheit
   name: Sicherheit.EG.Küche.Fenster.Links.Geöffnet-Status
+  room: Küche
 11/2/102:
   dpt: '1.019'
+  function: Sicherheit
   name: Sicherheit.EG.Küche.Fenster.Links.Stellung-Kipp-Status
+  room: Küche
 11/2/103:
   dpt: '1.019'
+  function: Sicherheit
   name: Sicherheit.EG.Küche.Fenster.Links.Stellung-Geöffnet-Status
+  room: Küche
 11/2/11:
   dpt: '1.019'
+  function: Sicherheit
   name: Sicherheit.EG.Flur.Tür.Geöffnet-Status
+  room: Flur
 11/2/111:
   dpt: '1.019'
+  function: Sicherheit
   name: Sicherheit.EG.Küche.Fenster.Mitte-Links.Geöffnet-Status
+  room: Küche
 11/2/112:
   dpt: '1.019'
+  function: Sicherheit
   name: Sicherheit.EG.Küche.Fenster.Mitte-Links.Stellung-Kipp-Status
+  room: Küche
 11/2/113:
   dpt: '1.019'
+  function: Sicherheit
   name: Sicherheit.EG.Küche.Fenster.Mitte-Links.Stellung-Geöffnet-Status
+  room: Küche
 11/2/121:
   dpt: '1.019'
+  function: Sicherheit
   name: Sicherheit.EG.Küche.Fenster.Mitte-Rechts.Geöffnet-Status
+  room: Küche
 11/2/122:
   dpt: '1.019'
+  function: Sicherheit
   name: Sicherheit.EG.Küche.Fenster.Mitte-Rechts.Stellung-Kipp-Status
+  room: Küche
 11/2/123:
   dpt: '1.019'
+  function: Sicherheit
   name: Sicherheit.EG.Küche.Fenster.Mitte-Rechts.Stellung-Geöffnet-Status
+  room: Küche
 11/2/131:
   dpt: '1.019'
+  function: Sicherheit
   name: Sicherheit.EG.Küche.Fenster.Rechts.Geöffnet-Status
+  room: Küche
 11/2/132:
   dpt: '1.019'
+  function: Sicherheit
   name: Sicherheit.EG.Küche.Fenster.Rechts.Stellung-Kipp-Status
+  room: Küche
 11/2/133:
   dpt: '1.019'
+  function: Sicherheit
   name: Sicherheit.EG.Küche.Fenster.Rechts.Stellung-Geöffnet-Status
+  room: Küche
 11/2/141:
   dpt: '1.005'
+  function: Sicherheit
   name: Sicherheit.EG.Küche.Wassermelder.Küchenzeile.Links.Alarm
+  room: Küche
 11/2/151:
   dpt: '1.005'
+  function: Sicherheit
   name: Sicherheit.EG.Küche.Wassermelder.Küchenzeile.Rechts.Alarm
+  room: Küche
 11/2/161:
   dpt: '1.005'
+  function: Sicherheit
   name: Sicherheit.EG.Küche.Wassermelder.Kücheninsel.Alarm
+  room: Küche
 11/2/2:
   dpt: '1.019'
+  function: Sicherheit
   name: Sicherheit.EG.Flur.Fenster.Stellung-Kipp-Status
+  room: Flur
 11/2/21:
   dpt: '1.005'
+  function: Sicherheit
   name: Sicherheit.EG.Flur.Wassermelder-Alarm
+  room: Flur
 11/2/3:
   dpt: '1.019'
+  function: Sicherheit
   name: Sicherheit.EG.Flur.Fenster.Stellung-Geöffnet-Status
+  room: Flur
 11/2/31:
   dpt: '1.019'
+  function: Sicherheit
   name: Sicherheit.EG.Gäste-WC.Fenster.Geöffnet-Status
+  room: Gäste-WC
 11/2/32:
   dpt: '1.019'
+  function: Sicherheit
   name: Sicherheit.EG.Gäste-WC.Fenster.Stellung-Kipp-Status
+  room: Gäste-WC
 11/2/33:
   dpt: '1.019'
+  function: Sicherheit
   name: Sicherheit.EG.Gäste-WC.Fenster.Stellung-Geöffnet-Status
+  room: Gäste-WC
 11/2/41:
   dpt: '1.019'
+  function: Sicherheit
   name: Sicherheit.EG.Büro.Fenster.Links.Geöffnet-Status
+  room: Büro
 11/2/42:
   dpt: '1.019'
+  function: Sicherheit
   name: Sicherheit.EG.Büro.Fenster.Links.Stellung-Kipp-Status
+  room: Büro
 11/2/43:
   dpt: '1.019'
+  function: Sicherheit
   name: Sicherheit.EG.Büro.Fenster.Links.Stellung-Geöffnet-Status
+  room: Büro
 11/2/51:
   dpt: '1.019'
+  function: Sicherheit
   name: Sicherheit.EG.Büro.Fenster.Mitte.Geöffnet-Status
+  room: Büro
 11/2/52:
   dpt: '1.019'
+  function: Sicherheit
   name: Sicherheit.EG.Büro.Fenster.Mitte.Stellung-Kipp-Status
+  room: Büro
 11/2/53:
   dpt: '1.019'
+  function: Sicherheit
   name: Sicherheit.EG.Büro.Fenster.Mitte.Stellung-Geöffnet-Status
+  room: Büro
 11/2/61:
   dpt: '1.019'
+  function: Sicherheit
   name: Sicherheit.EG.Büro.Fenster.Rechts.Geöffnet-Status
+  room: Büro
 11/2/62:
   dpt: '1.019'
+  function: Sicherheit
   name: Sicherheit.EG.Büro.Fenster.Rechts.Stellung-Kipp-Status
+  room: Büro
 11/2/63:
   dpt: '1.019'
+  function: Sicherheit
   name: Sicherheit.EG.Büro.Fenster.Rechts.Stellung-Geöffnet-Status
+  room: Büro
 11/2/71:
   dpt: '1.019'
+  function: Sicherheit
   name: Sicherheit.EG.Büro.Fenster.Seite.Geöffnet-Status
+  room: Büro
 11/2/72:
   dpt: '1.019'
+  function: Sicherheit
   name: Sicherheit.EG.Büro.Fenster.Seite.Stellung-Kipp-Status
+  room: Büro
 11/2/73:
   dpt: '1.019'
+  function: Sicherheit
   name: Sicherheit.EG.Büro.Fenster.Seite.Stellung-Geöffnet-Status
+  room: Büro
 11/2/81:
   dpt: '1.019'
+  function: Sicherheit
   name: Sicherheit.EG.Wohnzimmer.Fenster.Geöffnet-Status
+  room: Wohnzimmer
 11/2/91:
   dpt: '1.019'
+  function: Sicherheit
   name: Sicherheit.EG.Esszimmer.Fenster.Geöffnet-Status
+  room: Esszimmer
 11/3/1:
   dpt: '1.019'
+  function: Sicherheit
   name: Sicherheit.OG.Flur.Fenster.Treppe.Geöffnet-Status
+  room: Flur
 11/3/11:
   dpt: '1.019'
+  function: Sicherheit
   name: Sicherheit.OG.Flur.Fenster.Galerie.Geöffnet-Status
+  room: Flur
 11/3/12:
   dpt: '1.019'
+  function: Sicherheit
   name: Sicherheit.OG.Flur.Fenster.Galerie.Stellung-Kipp-Status
+  room: Flur
 11/3/13:
   dpt: '1.019'
+  function: Sicherheit
   name: Sicherheit.OG.Flur.Fenster.Galerie.Stellung-Geöffnet-Status
+  room: Flur
 11/3/2:
   dpt: '1.019'
+  function: Sicherheit
   name: Sicherheit.OG.Flur.Fenster.Treppe.Stellung-Kipp-Status
+  room: Flur
 11/3/21:
   dpt: '1.019'
+  function: Sicherheit
   name: Sicherheit.OG.Abstellraum.Fenster.Geöffnet-Status
+  room: Abstellraum
 11/3/22:
   dpt: '1.019'
+  function: Sicherheit
   name: Sicherheit.OG.Abstellraum.Fenster.Stellung-Kipp-Status
+  room: Abstellraum
 11/3/23:
   dpt: '1.019'
+  function: Sicherheit
   name: Sicherheit.OG.Abstellraum.Fenster.Stellung-Geöffnet-Status
+  room: Abstellraum
 11/3/3:
   dpt: '1.019'
+  function: Sicherheit
   name: Sicherheit.OG.Flur.Fenster.Treppe.Stellung-Geöffnet-Status
+  room: Flur
 11/3/31:
   dpt: '1.019'
+  function: Sicherheit
   name: Sicherheit.OG.Badezimmer-Kinder.Fenster.Geöffnet-Status
+  room: Badezimmer-Kinder
 11/3/32:
   dpt: '1.019'
+  function: Sicherheit
   name: Sicherheit.OG.Badezimmer-Kinder.Fenster.Stellung-Kipp-Status
+  room: Badezimmer-Kinder
 11/3/33:
   dpt: '1.019'
+  function: Sicherheit
   name: Sicherheit.OG.Badezimmer-Kinder.Fenster.Stellung-Geöffnet-Status
+  room: Badezimmer-Kinder
 11/3/41:
   dpt: '1.019'
+  function: Sicherheit
   name: Sicherheit.OG.Schlafzimmer-Gregory.Fenster.Geöffnet-Status
+  room: Schlafzimmer-Gregory
 11/3/51:
   dpt: '1.019'
+  function: Sicherheit
   name: Sicherheit.OG.Schlafzimmer-Luis.Fenster.Geöffnet-Status
+  room: Schlafzimmer-Luis
 11/3/61:
   dpt: '1.019'
+  function: Sicherheit
   name: Sicherheit.OG.Schlafzimmer-Eltern.Fenster.Geöffnet-Status
+  room: Schlafzimmer-Eltern
 11/3/71:
   dpt: '1.005'
+  function: Sicherheit
   name: Sicherheit.OG.Schlafzimmer-Eltern.Wassermelder.Alarm
+  room: Schlafzimmer-Eltern
 11/3/81:
   dpt: '1.019'
+  function: Sicherheit
   name: Sicherheit.OG.Badezimmer-Eltern.Fenster.Geöffnet-Status
+  room: Badezimmer-Eltern
 11/3/82:
   dpt: '1.019'
+  function: Sicherheit
   name: Sicherheit.OG.Badezimmer-Eltern.Fenster.Stellung-Kipp-Status
+  room: Badezimmer-Eltern
 11/3/83:
   dpt: '1.019'
+  function: Sicherheit
   name: Sicherheit.OG.Badezimmer-Eltern.Fenster.Stellung-Geöffnet-Status
+  room: Badezimmer-Eltern
 13/0/200:
   dpt: '5.010'
+  function: Multimedia
   name: Multimedia.Zentral.Stream.Alexander.Voreinstellung
 13/0/201:
   dpt: '5.010'
+  function: Multimedia
   name: Multimedia.Zentral.Stream.Alexander.Aktion
 13/0/202:
   dpt: '1.001'
+  function: Multimedia
   name: Multimedia.Zentral.Stream.Alexander.Wiederholung
 13/0/203:
   dpt: '1.011'
+  function: Multimedia
   name: Multimedia.Zentral.Stream.Alexander.Wiederholung-Status
 13/0/204:
   dpt: '1.001'
+  function: Multimedia
   name: Multimedia.Zentral.Stream.Alexander.Shuffle
 13/0/205:
   dpt: '1.011'
+  function: Multimedia
   name: Multimedia.Zentral.Stream.Alexander.Shuffle-Status
 13/0/210:
   dpt: '5.010'
+  function: Multimedia
   name: Multimedia.Zentral.Stream.Vanessa.Voreinstellung
 13/0/211:
   dpt: '5.010'
+  function: Multimedia
   name: Multimedia.Zentral.Stream.Vanessa.Aktion
 13/0/212:
   dpt: '1.001'
+  function: Multimedia
   name: Multimedia.Zentral.Stream.Vanessa.Wiederholung
 13/0/213:
   dpt: '1.011'
+  function: Multimedia
   name: Multimedia.Zentral.Stream.Vanessa.Wiederholung-Status
 13/0/214:
   dpt: '1.001'
+  function: Multimedia
   name: Multimedia.Zentral.Stream.Vanessa.Shuffle
 13/0/215:
   dpt: '1.011'
+  function: Multimedia
   name: Multimedia.Zentral.Stream.Vanessa.Shuffle-Status
 13/0/220:
   dpt: '5.010'
+  function: Multimedia
   name: Multimedia.Zentral.Stream.Luis.Voreinstellung
 13/0/221:
   dpt: '5.010'
+  function: Multimedia
   name: Multimedia.Zentral.Stream.Luis.Aktion
 13/0/222:
   dpt: '1.001'
+  function: Multimedia
   name: Multimedia.Zentral.Stream.Luis.Wiederholung
 13/0/223:
   dpt: '1.011'
+  function: Multimedia
   name: Multimedia.Zentral.Stream.Luis.Wiederholung-Status
 13/0/224:
   dpt: '1.001'
+  function: Multimedia
   name: Multimedia.Zentral.Stream.Luis.Shuffle
 13/0/225:
   dpt: '1.011'
+  function: Multimedia
   name: Multimedia.Zentral.Stream.Luis.Shuffle-Status
 13/0/230:
   dpt: '5.010'
+  function: Multimedia
   name: Multimedia.Zentral.Stream.Gregory.Voreinstellung
 13/0/231:
   dpt: '5.010'
+  function: Multimedia
   name: Multimedia.Zentral.Stream.Gregory.Aktion
 13/0/232:
   dpt: '1.001'
+  function: Multimedia
   name: Multimedia.Zentral.Stream.Gregory.Wiederholung
 13/0/233:
   dpt: '1.011'
+  function: Multimedia
   name: Multimedia.Zentral.Stream.Gregory.Wiederholung-Status
 13/0/234:
   dpt: '1.001'
+  function: Multimedia
   name: Multimedia.Zentral.Stream.Gregory.Shuffle
 13/0/235:
   dpt: '1.011'
+  function: Multimedia
   name: Multimedia.Zentral.Stream.Gregory.Shuffle-Status
 13/2/101:
   dpt: '1.001'
+  function: Multimedia
   name: Multimedia.EG.Wohnzimmer.Sony-TV.Ein/Aus
+  room: Wohnzimmer
 13/2/102:
   dpt: '1.011'
+  function: Multimedia
   name: Multimedia.EG.Wohnzimmer.Sony-TV.Ein/Aus-Status
+  room: Wohnzimmer
 13/2/103:
   dpt: '1.001'
+  function: Multimedia
   name: Multimedia.EG.Wohnzimmer.Sony-TV.Stummschalten
+  room: Wohnzimmer
 13/2/104:
   dpt: '1.011'
+  function: Multimedia
   name: Multimedia.EG.Wohnzimmer.Sony-TV.Stummschalten-Status
+  room: Wohnzimmer
 13/2/105:
   dpt: '5.001'
+  function: Multimedia
   name: Multimedia.EG.Wohnzimmer.Sony-TV.Lautstärke
+  room: Wohnzimmer
 13/2/106:
   dpt: '5.001'
+  function: Multimedia
   name: Multimedia.EG.Wohnzimmer.Sony-TV.Lautstärke-Status
+  room: Wohnzimmer
 13/2/121:
   dpt: '1.001'
+  function: Multimedia
   name: Multimedia.EG.Esszimmer.Shape.Ein/Aus
+  room: Esszimmer
 13/2/122:
   dpt: '1.011'
+  function: Multimedia
   name: Multimedia.EG.Esszimmer.Shape.Ein/Aus-Status
+  room: Esszimmer
 13/2/123:
   dpt: '1.001'
+  function: Multimedia
   name: Multimedia.EG.Esszimmer.Shape.Stummschalten
+  room: Esszimmer
 13/2/124:
   dpt: '1.011'
+  function: Multimedia
   name: Multimedia.EG.Esszimmer.Shape.Stummschalten-Status
+  room: Esszimmer
 13/2/125:
   dpt: '5.001'
+  function: Multimedia
   name: Multimedia.EG.Esszimmer.Shape.Lautstärke
+  room: Esszimmer
 13/2/126:
   dpt: '5.001'
+  function: Multimedia
   name: Multimedia.EG.Esszimmer.Shape.Lautstärke-Status
+  room: Esszimmer
 13/2/127:
   dpt: '5.010'
+  function: Multimedia
   name: Multimedia.EG.Esszimmer.Shape.Quelle
+  room: Esszimmer
 13/2/128:
   dpt: '5.010'
+  function: Multimedia
   name: Multimedia.EG.Esszimmer.Shape.Quelle-Status
+  room: Esszimmer
 13/2/141:
   dpt: '1.001'
+  function: Multimedia
   name: Multimedia.EG.Küche.Sonos.Ein/Aus
+  room: Küche
 13/2/142:
   dpt: '1.011'
+  function: Multimedia
   name: Multimedia.EG.Küche.Sonos.Ein/Aus-Status
+  room: Küche
 13/2/143:
   dpt: '1.001'
+  function: Multimedia
   name: Multimedia.EG.Küche.Sonos.Stummschalten
+  room: Küche
 13/2/144:
   dpt: '1.011'
+  function: Multimedia
   name: Multimedia.EG.Küche.Sonos.Stummschalten-Status
+  room: Küche
 13/2/145:
   dpt: '5.001'
+  function: Multimedia
   name: Multimedia.EG.Küche.Sonos.Lautstärke
+  room: Küche
 13/2/146:
   dpt: '5.001'
+  function: Multimedia
   name: Multimedia.EG.Küche.Sonos.Lautstärke-Status
+  room: Küche
 13/2/41:
   dpt: '1.001'
+  function: Multimedia
   name: Multimedia.EG.Büro.Sonos.Ein/Aus
+  room: Büro
 13/2/42:
   dpt: '1.011'
+  function: Multimedia
   name: Multimedia.EG.Büro.Sonos.Ein/Aus-Status
+  room: Büro
 13/2/43:
   dpt: '1.001'
+  function: Multimedia
   name: Multimedia.EG.Büro.Sonos.Stummschalten
+  room: Büro
 13/2/44:
   dpt: '1.011'
+  function: Multimedia
   name: Multimedia.EG.Büro.Sonos.Stummschalten-Status
+  room: Büro
 13/2/45:
   dpt: '5.001'
+  function: Multimedia
   name: Multimedia.EG.Büro.Sonos.Lautstärke
+  room: Büro
 13/2/46:
   dpt: '5.001'
+  function: Multimedia
   name: Multimedia.EG.Büro.Sonos.Lautstärke-Status
+  room: Büro
 13/2/61:
   dpt: '1.001'
+  function: Multimedia
   name: Multimedia.EG.Wohnzimmer.Aalto.Ein/Aus
+  room: Wohnzimmer
 13/2/62:
   dpt: '1.011'
+  function: Multimedia
   name: Multimedia.EG.Wohnzimmer.Aalto.Ein/Aus-Status
+  room: Wohnzimmer
 13/2/63:
   dpt: '1.001'
+  function: Multimedia
   name: Multimedia.EG.Wohnzimmer.Aalto.Stummschalten
+  room: Wohnzimmer
 13/2/64:
   dpt: '1.011'
+  function: Multimedia
   name: Multimedia.EG.Wohnzimmer.Aalto.Stummschalten-Status
+  room: Wohnzimmer
 13/2/65:
   dpt: '5.001'
+  function: Multimedia
   name: Multimedia.EG.Wohnzimmer.Aalto.Lautstärke
+  room: Wohnzimmer
 13/2/66:
   dpt: '5.001'
+  function: Multimedia
   name: Multimedia.EG.Wohnzimmer.Aalto.Lautstärke-Status
+  room: Wohnzimmer
 13/2/67:
   dpt: '5.010'
+  function: Multimedia
   name: Multimedia.EG.Wohnzimmer.Aalto.Quelle
+  room: Wohnzimmer
 13/2/68:
   dpt: '5.010'
+  function: Multimedia
   name: Multimedia.EG.Wohnzimmer.Aalto.Quelle-Status
+  room: Wohnzimmer
 13/2/81:
   dpt: '1.001'
+  function: Multimedia
   name: Multimedia.EG.Wohnzimmer.Asano.Ein/Aus
+  room: Wohnzimmer
 13/2/82:
   dpt: '1.011'
+  function: Multimedia
   name: Multimedia.EG.Wohnzimmer.Asano.Ein/Aus-Status
+  room: Wohnzimmer
 13/2/83:
   dpt: '1.001'
+  function: Multimedia
   name: Multimedia.EG.Wohnzimmer.Asano.Stummschalten
+  room: Wohnzimmer
 13/2/84:
   dpt: '1.011'
+  function: Multimedia
   name: Multimedia.EG.Wohnzimmer.Asano.Stummschalten-Status
+  room: Wohnzimmer
 13/2/85:
   dpt: '5.001'
+  function: Multimedia
   name: Multimedia.EG.Wohnzimmer.Asano.Lautstärke
+  room: Wohnzimmer
 13/2/86:
   dpt: '5.001'
+  function: Multimedia
   name: Multimedia.EG.Wohnzimmer.Asano.Lautstärke-Status
+  room: Wohnzimmer
 13/2/87:
   dpt: '5.010'
+  function: Multimedia
   name: Multimedia.EG.Wohnzimmer.Asano.Quelle
+  room: Wohnzimmer
 13/2/88:
   dpt: '5.010'
+  function: Multimedia
   name: Multimedia.EG.Wohnzimmer.Asano.Quelle-Status
+  room: Wohnzimmer
 13/3/101:
   dpt: '1.001'
+  function: Multimedia
   name: Multimedia.OG.Schlafzimmer-Eltern.Asano.Ein/Aus
+  room: Schlafzimmer-Eltern
 13/3/102:
   dpt: '1.011'
+  function: Multimedia
   name: Multimedia.OG.Schlafzimmer-Eltern.Asano.Ein/Aus-Status
+  room: Schlafzimmer-Eltern
 13/3/103:
   dpt: '1.001'
+  function: Multimedia
   name: Multimedia.OG.Schlafzimmer-Eltern.Asano.Stummschalten
+  room: Schlafzimmer-Eltern
 13/3/104:
   dpt: '1.011'
+  function: Multimedia
   name: Multimedia.OG.Schlafzimmer-Eltern.Asano.Stummschalten-Status
+  room: Schlafzimmer-Eltern
 13/3/105:
   dpt: '5.001'
+  function: Multimedia
   name: Multimedia.OG.Schlafzimmer-Eltern.Asano.Lautstärke
+  room: Schlafzimmer-Eltern
 13/3/106:
   dpt: '5.001'
+  function: Multimedia
   name: Multimedia.OG.Schlafzimmer-Eltern.Asano.Lautstärke-Status
+  room: Schlafzimmer-Eltern
 13/3/107:
   dpt: '5.010'
+  function: Multimedia
   name: Multimedia.OG.Schlafzimmer-Eltern.Asano.Quelle
+  room: Schlafzimmer-Eltern
 13/3/108:
   dpt: '5.010'
+  function: Multimedia
   name: Multimedia.OG.Schlafzimmer-Eltern.Asano.Quelle-Status
+  room: Schlafzimmer-Eltern
 13/3/121:
   dpt: '1.001'
+  function: Multimedia
   name: Multimedia.OG.Schlafzimmer-Eltern.Sony-TV.Ein/Aus
+  room: Schlafzimmer-Eltern
 13/3/122:
   dpt: '1.011'
+  function: Multimedia
   name: Multimedia.OG.Schlafzimmer-Eltern.Sony-TV.Ein/Aus-Status
+  room: Schlafzimmer-Eltern
 13/3/123:
   dpt: '1.001'
+  function: Multimedia
   name: Multimedia.OG.Schlafzimmer-Eltern.Sony-TV.Stummschalten
+  room: Schlafzimmer-Eltern
 13/3/124:
   dpt: '1.011'
+  function: Multimedia
   name: Multimedia.OG.Schlafzimmer-Eltern.Sony-TV.Stummschalten-Status
+  room: Schlafzimmer-Eltern
 13/3/125:
   dpt: '5.001'
+  function: Multimedia
   name: Multimedia.OG.Schlafzimmer-Eltern.Sony-TV.Lautstärke
+  room: Schlafzimmer-Eltern
 13/3/126:
   dpt: '5.001'
+  function: Multimedia
   name: Multimedia.OG.Schlafzimmer-Eltern.Sony-TV.Lautstärke-Status
+  room: Schlafzimmer-Eltern
 13/3/141:
   dpt: '1.001'
+  function: Multimedia
   name: Multimedia.OG.Badezimmer-Eltern.Asano.Ein/Aus
+  room: Badezimmer-Eltern
 13/3/142:
   dpt: '1.011'
+  function: Multimedia
   name: Multimedia.OG.Badezimmer-Eltern.Asano.Ein/Aus-Status
+  room: Badezimmer-Eltern
 13/3/143:
   dpt: '1.001'
+  function: Multimedia
   name: Multimedia.OG.Badezimmer-Eltern.Asano.Stummschalten
+  room: Badezimmer-Eltern
 13/3/144:
   dpt: '1.011'
+  function: Multimedia
   name: Multimedia.OG.Badezimmer-Eltern.Asano.Stummschalten-Status
+  room: Badezimmer-Eltern
 13/3/145:
   dpt: '5.001'
+  function: Multimedia
   name: Multimedia.OG.Badezimmer-Eltern.Asano.Lautstärke
+  room: Badezimmer-Eltern
 13/3/146:
   dpt: '5.001'
+  function: Multimedia
   name: Multimedia.OG.Badezimmer-Eltern.Asano.Lautstärke-Status
+  room: Badezimmer-Eltern
 13/3/147:
   dpt: '5.010'
+  function: Multimedia
   name: Multimedia.OG.Badezimmer-Eltern.Asano.Quelle
+  room: Badezimmer-Eltern
 13/3/148:
   dpt: '5.010'
+  function: Multimedia
   name: Multimedia.OG.Badezimmer-Eltern.Asano.Quelle-Status
+  room: Badezimmer-Eltern
 13/3/61:
   dpt: '1.001'
+  function: Multimedia
   name: Multimedia.OG.Schlafzimmer-Gregory.Sonos.Ein/Aus
+  room: Schlafzimmer-Gregory
 13/3/62:
   dpt: '1.011'
+  function: Multimedia
   name: Multimedia.OG.Schlafzimmer-Gregory.Sonos.Ein/Aus-Status
+  room: Schlafzimmer-Gregory
 13/3/63:
   dpt: '1.001'
+  function: Multimedia
   name: Multimedia.OG.Schlafzimmer-Gregory.Sonos.Stummschalten
+  room: Schlafzimmer-Gregory
 13/3/81:
   dpt: '1.001'
+  function: Multimedia
   name: Multimedia.OG.Schlafzimmer-Luis.Sonos.Ein/Aus
+  room: Schlafzimmer-Luis
 13/3/82:
   dpt: '1.011'
+  function: Multimedia
   name: Multimedia.OG.Schlafzimmer-Luis.Sonos.Ein/Aus-Status
+  room: Schlafzimmer-Luis
 13/5/1:
   dpt: '1.001'
+  function: Multimedia
   name: Multimedia.A.Terrasse.Asano.Ein/Aus
+  room: Terrasse
 13/5/2:
   dpt: '1.011'
+  function: Multimedia
   name: Multimedia.A.Terrasse.Asano.Ein/Aus-Status
+  room: Terrasse
 13/5/3:
   dpt: '1.001'
+  function: Multimedia
   name: Multimedia.A.Terrasse.Asano.Stummschalten
+  room: Terrasse
 13/5/4:
   dpt: '1.011'
+  function: Multimedia
   name: Multimedia.A.Terrasse.Asano.Stummschalten-Status
+  room: Terrasse
 13/5/5:
   dpt: '5.001'
+  function: Multimedia
   name: Multimedia.A.Terrasse.Asano.Lautstärke
+  room: Terrasse
 13/5/6:
   dpt: '5.001'
+  function: Multimedia
   name: Multimedia.A.Terrasse.Asano.Lautstärke-Status
+  room: Terrasse
 13/5/7:
   dpt: '5.010'
+  function: Multimedia
   name: Multimedia.A.Terrasse.Asano.Quelle
+  room: Terrasse
 13/5/8:
   dpt: '5.010'
+  function: Multimedia
   name: Multimedia.A.Terrasse.Asano.Quelle-Status
+  room: Terrasse
 15/1/1:
   dpt: '1.011'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Status
 15/1/10:
   dpt: '1.011'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Störung.Akku
 15/1/11:
   dpt: '1.011'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Störung.Übertragungseinrichtung
 15/1/2:
   dpt: '1.015'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Neustart
 15/1/20:
   dpt: '1.001'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Sicherungsbereich.Haus.Unscharf
 15/1/21:
   dpt: '1.011'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Sicherungsbereich.Haus.Unscharf-Status
 15/1/22:
   dpt: '1.001'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Sicherungsbereich.Haus.Intern-Scharf
 15/1/23:
   dpt: '1.011'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Sicherungsbereich.Haus.Intern-Scharf-Status
 15/1/24:
   dpt: '1.011'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Sicherungsbereich.Haus.Intern-Scharf-Bereit
 15/1/25:
   dpt: '1.001'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Sicherungsbereich.Haus.Extern-Scharf
 15/1/26:
   dpt: '1.011'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Sicherungsbereich.Haus.Extern-Scharf-Status
 15/1/27:
   dpt: '1.011'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Sicherungsbereich.Haus.Extern-Scharf-Bereit
 15/1/28:
   dpt: '1.005'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Sicherungsbereich.Haus.Alarm
 15/1/29:
   dpt: '1.015'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Sicherungsbereich.Haus.Alarm-Zurücksetzen
 15/1/3:
   dpt: '1.007'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Zustände-Lesen
 15/1/30:
   dpt: '1.011'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Sicherungsbereich.Haus.Störung
 15/1/4:
   dpt: '1.007'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Zustände-Aktualisieren
 15/1/40:
   dpt: '1.003'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Meldebereich.Sabotage.Sperren
 15/1/41:
   dpt: '1.011'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Meldebereich.Sabotage.Sperren-Status
 15/1/42:
   dpt: '1.011'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Meldebereich.Sabotage.Status
 15/1/43:
   dpt: '1.003'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Meldebereich.IR-Melder.Sperren
 15/1/44:
   dpt: '1.011'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Meldebereich.IR-Melder.Sperren-Status
 15/1/45:
   dpt: '1.011'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Meldebereich.IR-Melder.Status
 15/1/46:
   dpt: '1.003'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Meldebereich.Fensterkontakt.Sperren
 15/1/47:
   dpt: '1.011'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Meldebereich.Fensterkontakt.Sperren-Status
 15/1/48:
   dpt: '1.011'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Meldebereich.Fensterkontakt.Status
 15/1/49:
   dpt: '1.003'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Meldebereich.Türkontakt.Sperren
 15/1/5:
   dpt: '1.011'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Sabotage.Deckelkontakt
 15/1/50:
   dpt: '1.011'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Meldebereich.Türkontakt.Sperren-Status
 15/1/51:
   dpt: '1.011'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Meldebereich.Türkontakt.Status
 15/1/6:
   dpt: '1.011'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Sabotage.Signalgeber.Leitungsüberwachung.ASG
 15/1/7:
   dpt: '1.011'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Sabotage.Signalgeber.Leitungsüberwachung.OSG
 15/1/8:
   dpt: '1.011'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Sabotage.Signalgeber.Wandabreißkontakt
 15/1/9:
   dpt: '1.011'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Störung.Strom
 15/3/1:
   dpt: '1.005'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Fassade.Objekterkennung.Person
 15/3/10:
   dpt: '1.005'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Fassade.Aktivität.Linienüberschreitung
 15/3/11:
   dpt: '1.005'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Fassade.Geräusch.Gespräch
 15/3/12:
   dpt: '1.005'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Fassade.Geräusch.Sirene
 15/3/121:
   dpt: '1.005'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Esszimmer.Objekterkennung.Person
 15/3/122:
   dpt: '1.005'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Esszimmer.Objekterkennung.Fahrzeug
 15/3/123:
   dpt: '5.010'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Esszimmer.Gesichtserkennung.Gesicht-Bekannt
 15/3/124:
   dpt: '1.005'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Esszimmer.Gesichtserkennung.Gesicht-Unbekannt
 15/3/125:
   dpt: '5.010'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Esszimmer.Gesichtserkennung.Gesicht-Markiert
 15/3/126:
   dpt: '5.010'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Esszimmer.Nummerschilderkennnung.Fahrzeug-Bekannt
 15/3/127:
   dpt: '1.005'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Esszimmer.Nummerschilderkennnung.Fahrzeug-Unbekannt
 15/3/128:
   dpt: '5.010'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Esszimmer.Nummerschilderkennnung.Fahrzeug-Markiert
 15/3/129:
   dpt: '1.005'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Esszimmer.Aktivität.Bewegung
 15/3/13:
   dpt: '1.005'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Fassade.Geräusch.Glasbruch
 15/3/130:
   dpt: '1.005'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Esszimmer.Aktivität.Linienüberschreitung
 15/3/131:
   dpt: '1.005'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Esszimmer.Geräusch.Gespräch
 15/3/132:
   dpt: '1.005'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Esszimmer.Geräusch.Sirene
 15/3/133:
   dpt: '1.005'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Esszimmer.Geräusch.Glasbruch
 15/3/134:
   dpt: '1.005'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Esszimmer.Geräusch.Einbruch
 15/3/14:
   dpt: '1.005'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Fassade.Geräusch.Einbruch
 15/3/2:
   dpt: '1.005'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Fassade.Objekterkennung.Fahrzeug
 15/3/3:
   dpt: '5.010'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Fassade.Gesichtserkennung.Gesicht-Bekannt
 15/3/4:
   dpt: '1.005'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Fassade.Gesichtserkennung.Gesicht-Unbekannt
 15/3/41:
   dpt: '1.005'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Eingang.Objekterkennung.Person
 15/3/42:
   dpt: '1.005'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Eingang.Objekterkennung.Fahrzeug
 15/3/43:
   dpt: '5.010'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Eingang.Gesichtserkennung.Gesicht-Bekannt
 15/3/44:
   dpt: '1.005'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Eingang.Gesichtserkennung.Gesicht-Unbekannt
 15/3/45:
   dpt: '5.010'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Eingang.Gesichtserkennung.Gesicht-Markiert
 15/3/46:
   dpt: '5.010'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Eingang.Nummerschilderkennnung.Fahrzeug-Bekannt
 15/3/47:
   dpt: '1.005'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Eingang.Nummerschilderkennnung.Fahrzeug-Unbekannt
 15/3/48:
   dpt: '5.010'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Eingang.Nummerschilderkennnung.Fahrzeug-Markiert
 15/3/49:
   dpt: '1.005'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Eingang.Aktivität.Bewegung
 15/3/5:
   dpt: '5.010'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Fassade.Gesichtserkennung.Gesicht-Markiert
 15/3/50:
   dpt: '1.005'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Eingang.Aktivität.Linienüberschreitung
 15/3/51:
   dpt: '1.005'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Eingang.Geräusch.Gespräch
 15/3/52:
   dpt: '1.005'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Eingang.Geräusch.Sirene
 15/3/53:
   dpt: '1.005'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Eingang.Geräusch.Glasbruch
 15/3/54:
   dpt: '1.005'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Eingang.Geräusch.Einbruch
 15/3/6:
   dpt: '5.010'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Fassade.Nummerschilderkennnung.Fahrzeug-Bekannt
 15/3/7:
   dpt: '1.005'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Fassade.Nummerschilderkennnung.Fahrzeug-Unbekannt
 15/3/8:
   dpt: '5.010'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Fassade.Nummerschilderkennnung.Fahrzeug-Markiert
 15/3/81:
   dpt: '1.005'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Wohnzimmer.Objekterkennung.Person
 15/3/82:
   dpt: '1.005'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Wohnzimmer.Objekterkennung.Fahrzeug
 15/3/83:
   dpt: '5.010'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Wohnzimmer.Gesichtserkennung.Gesicht-Bekannt
 15/3/84:
   dpt: '1.005'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Wohnzimmer.Gesichtserkennung.Gesicht-Unbekannt
 15/3/85:
   dpt: '5.010'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Wohnzimmer.Gesichtserkennung.Gesicht-Markiert
 15/3/86:
   dpt: '5.010'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Wohnzimmer.Nummerschilderkennnung.Fahrzeug-Bekannt
 15/3/87:
   dpt: '1.005'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Wohnzimmer.Nummerschilderkennnung.Fahrzeug-Unbekannt
 15/3/88:
   dpt: '5.010'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Wohnzimmer.Nummerschilderkennnung.Fahrzeug-Markiert
 15/3/89:
   dpt: '1.005'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Wohnzimmer.Aktivität.Bewegung
 15/3/9:
   dpt: '1.005'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Fassade.Aktivität.Bewegung
 15/3/90:
   dpt: '1.005'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Wohnzimmer.Aktivität.Linienüberschreitung
 15/3/91:
   dpt: '1.005'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Wohnzimmer.Geräusch.Gespräch
 15/3/92:
   dpt: '1.005'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Wohnzimmer.Geräusch.Sirene
 15/3/93:
   dpt: '1.005'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Wohnzimmer.Geräusch.Glasbruch
 15/3/94:
   dpt: '1.005'
+  function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Wohnzimmer.Geräusch.Einbruch
 16/1/0:
   dpt: '13.013'
+  function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Netzbezug.Zählerstand-Gesamt
 16/1/1:
   dpt: '13.013'
+  function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Netzbezug.Zählerstand-Tagtarif
 16/1/10:
   dpt: '13.013'
+  function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Einspeisung.Zählerstand-Tagtarif-2
 16/1/11:
   dpt: '13.013'
+  function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Einspeisung.Zählerstand-Nachttarif-1
 16/1/12:
   dpt: '13.013'
+  function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Einspeisung.Zählerstand-Nachttarif-2
 16/1/13:
   dpt: '14.056'
+  function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Einspeisung.Wirkleistung-Gesamt-1
 16/1/14:
   dpt: '14.056'
+  function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Einspeisung.Wirkleistung-Gesamt-2
 16/1/15:
   dpt: '14.056'
+  function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Einspeisung.Wirkleistung-L1
 16/1/16:
   dpt: '14.056'
+  function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Einspeisung.Wirkleistung-L2
 16/1/17:
   dpt: '14.056'
+  function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Einspeisung.Wirkleistung-L3
 16/1/18:
   dpt: '14.019'
+  function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Stromstärke-L1
 16/1/19:
   dpt: '14.019'
+  function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Stromstärke-L2
 16/1/2:
   dpt: '13.013'
+  function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Netzbezug.Zählerstand-Nachttarif
 16/1/20:
   dpt: '14.019'
+  function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Stromstärke-L3
 16/1/21:
   dpt: '14.027'
+  function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Spannung-L1
 16/1/22:
   dpt: '14.027'
+  function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Spannung-L2
 16/1/23:
   dpt: '14.027'
+  function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Spannung-L3
 16/1/24:
   dpt: '14.000'
+  function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Wirkleistung-Gesamt
 16/1/3:
   dpt: '14.056'
+  function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Netzbezug.Wirkleistung-Gesamt
 16/1/4:
   dpt: '14.056'
+  function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Netzbezug.Wirkleistung-L1
 16/1/40:
   dpt: '14.005'
+  function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Wasser.Zählerstand-Skala-1
 16/1/41:
   dpt: '14.005'
+  function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Wasser.Zählerstand-Skala-2
 16/1/42:
   dpt: '14.005'
+  function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Wasser.Stichwert-Skala-1
 16/1/43:
   dpt: '14.005'
+  function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Wasser.Stichwert-Skala-2
 16/1/44:
   dpt: '14.005'
+  function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Wasser.Verbrauchswert-Skala-1
 16/1/45:
   dpt: '14.005'
+  function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Wasser.Verbrauchswert-Skala-2
 16/1/46:
   dpt: '14.005'
+  function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Wasser.Durchfluss-Gesamt
 16/1/47:
   dpt: '14.005'
+  function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Wasser.Durchfluss-Skala-1
 16/1/48:
   dpt: '14.005'
+  function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Wasser.Durchfluss-Skala-2
 16/1/49:
   dpt: '1.005'
+  function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Wasser.Durchfluss-Skala-1-Alarm
 16/1/5:
   dpt: '14.056'
+  function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Netzbezug.Wirkleistung-L2
 16/1/50:
   dpt: '1.005'
+  function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Wasser.Durchfluss-Skala-2-Alarm
 16/1/51:
   dpt: '1.005'
+  function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Wasser.Durchfluss-Skala-1-Alarm-Erweitert
 16/1/52:
   dpt: '1.005'
+  function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Wasser.Durchfluss-Skala-2-Alarm-Erweitert
 16/1/53:
   dpt: '1.001'
+  function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Wasser.Skalenumschaltung
 16/1/54:
   dpt: '11.001'
+  function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Wasser.Letztes-Stichdatum
 16/1/55:
   dpt: '11.001'
+  function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Wasser.Nächstes-Stichdatum
 16/1/56:
   dpt: '7.001'
+  function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Wasser.Reset
 16/1/57:
   dpt: '10.001'
+  function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Wasser.Reset-Uhrzeit
 16/1/58:
   dpt: '11.001'
+  function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Wasser.Reset-Datum
 16/1/59:
   dpt: '16.000'
+  function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Wasser.Seriennummer
 16/1/6:
   dpt: '14.056'
+  function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Netzbezug.Wirkleistung-L3
 16/1/7:
   dpt: '13.013'
+  function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Einspeisung.Zählerstand-Gesamt-1
 16/1/8:
   dpt: '13.013'
+  function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Einspeisung.Zählerstand-Gesamt-2
 16/1/9:
   dpt: '13.013'
+  function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Einspeisung.Zählerstand-Tagtarif-1
 16/3/1:
   dpt: '5.010'
+  function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Lüftermodi
 16/3/10:
   dpt: '1.011'
+  function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Lüftermodus-Mittel-Status
 16/3/11:
   dpt: '1.001'
+  function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Lüftermodus-Hoch
 16/3/12:
   dpt: '1.011'
+  function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Lüftermodus-Hoch-Status
 16/3/2:
   dpt: '5.010'
+  function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Lüftermodi-Status
 16/3/20:
   dpt: '1.002'
+  function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Status
 16/3/21:
   dpt: '5.001'
+  function: Versorgungstechnik
   name: Versorgungstechnik.KWL.ComfoConnect-Status
 16/3/22:
   dpt: '1.002'
+  function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Wartungsmodus-Status
 16/3/23:
   dpt: '1.002'
+  function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Filterwechsel-Status
 16/3/24:
   dpt: '7.007'
+  function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Filter-Betriebsstunden
 16/3/25:
   dpt: '13.002'
+  function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Luftstrom
 16/3/26:
   dpt: '9.001'
+  function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Temperatur-Abluft
 16/3/27:
   dpt: '9.001'
+  function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Temperatur-Fortluft
 16/3/28:
   dpt: '9.001'
+  function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Temperatur-Außenluft
 16/3/29:
   dpt: '9.001'
+  function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Temperatur-Zuluft
 16/3/3:
   dpt: '1.001'
+  function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Lüftermodus-Auto
 16/3/30:
   dpt: '9.007'
+  function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Luftfeuchtigkeit-Abluft
 16/3/31:
   dpt: '9.007'
+  function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Luftfeuchtigkeit-Fortluft
 16/3/32:
   dpt: '9.007'
+  function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Luftfeuchtigkeit-Außenluft
 16/3/33:
   dpt: '9.007'
+  function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Luftfeuchtigkeit-Zuluft
 16/3/4:
   dpt: '1.011'
+  function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Lüftermodus-Auto-Status
 16/3/5:
   dpt: '1.001'
+  function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Lüftermodus-Away
 16/3/6:
   dpt: '1.011'
+  function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Lüftermodus-Away-Status
 16/3/7:
   dpt: '1.001'
+  function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Lüftermodus-Niedrig
 16/3/8:
   dpt: '1.011'
+  function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Lüftermodus-Niedrig-Status
 16/3/9:
   dpt: '1.001'
+  function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Lüftermodus-Mittel
 16/5/102:
   dpt: '1.011'
+  function: Versorgungstechnik
   name: Versorgungstechnik.Bewässerung.Kreislauf-10.Ein/Aus-Status
 16/5/112:
   dpt: '1.011'
+  function: Versorgungstechnik
   name: Versorgungstechnik.Bewässerung.Kreislauf-11.Ein/Aus-Status
 16/5/12:
   dpt: '1.011'
+  function: Versorgungstechnik
   name: Versorgungstechnik.Bewässerung.Kreislauf-1.Ein/Aus-Status
 16/5/122:
   dpt: '1.011'
+  function: Versorgungstechnik
   name: Versorgungstechnik.Bewässerung.Kreislauf-12.Ein/Aus-Status
 16/5/132:
   dpt: '1.011'
+  function: Versorgungstechnik
   name: Versorgungstechnik.Bewässerung.Kreislauf-13.Ein/Aus-Status
 16/5/142:
   dpt: '1.011'
+  function: Versorgungstechnik
   name: Versorgungstechnik.Bewässerung.Kreislauf-14.Ein/Aus-Status
 16/5/2:
   dpt: '1.011'
+  function: Versorgungstechnik
   name: Versorgungstechnik.Bewässerung.Kreislauf-Master.Ein/Aus-Status
 16/5/22:
   dpt: '1.011'
+  function: Versorgungstechnik
   name: Versorgungstechnik.Bewässerung.Kreislauf-2..Ein/Aus-Status
 16/5/32:
   dpt: '1.011'
+  function: Versorgungstechnik
   name: Versorgungstechnik.Bewässerung.Kreislauf-3.Ein/Aus-Status
 16/5/42:
   dpt: '1.011'
+  function: Versorgungstechnik
   name: Versorgungstechnik.Bewässerung.Kreislauf-4.Ein/Aus-Status
 16/5/52:
   dpt: '1.011'
+  function: Versorgungstechnik
   name: Versorgungstechnik.Bewässerung.Kreislauf-5.Ein/Aus-Status
 16/5/62:
   dpt: '1.011'
+  function: Versorgungstechnik
   name: Versorgungstechnik.Bewässerung.Kreislauf-6.Ein/Aus-Status
 16/5/72:
   dpt: '1.011'
+  function: Versorgungstechnik
   name: Versorgungstechnik.Bewässerung.Kreislauf-7.Ein/Aus-Staus
 16/5/82:
   dpt: '1.011'
+  function: Versorgungstechnik
   name: Versorgungstechnik.Bewässerung.Kreislauf-8.Ein/Aus-Status
 16/5/92:
   dpt: '1.011'
+  function: Versorgungstechnik
   name: Versorgungstechnik.Bewässerung.Kreislauf-9.Ein/Aus-Status
 17/0/20:
   dpt: '1.011'
+  function: Informationstechnik
   name: Informationstechnik.Container.Monitor-Status
 17/2/104:
   dpt: '1.011'
+  function: Informationstechnik
   name: Informationstechnik.Container.Postgres.Monitor-Status
 17/2/109:
   dpt: '1.011'
+  function: Informationstechnik
   name: Informationstechnik.Container.Prometheus.Monitor-Status
 17/2/114:
   dpt: '1.011'
+  function: Informationstechnik
   name: Informationstechnik.Container.Redis.Monitor-Status
 17/2/119:
   dpt: '1.011'
+  function: Informationstechnik
   name: Informationstechnik.Container.Telegraf.Monitor-Status
 17/2/124:
   dpt: '1.011'
+  function: Informationstechnik
   name: Informationstechnik.Container.Traefik.Monitor-Status
 17/2/129:
   dpt: '1.011'
+  function: Informationstechnik
   name: Informationstechnik.Container.Unifi-poller.Monitor-Status
 17/2/134:
   dpt: '1.011'
+  function: Informationstechnik
   name: Informationstechnik.Container.Watchtower.Monitor-Status
 17/2/139:
   dpt: '1.011'
+  function: Informationstechnik
   name: Informationstechnik.Container.Whoami.Monitor-Status
 17/2/14:
   dpt: '1.011'
+  function: Informationstechnik
   name: Informationstechnik.Container.Authelia.Monitor-Status
 17/2/19:
   dpt: '1.011'
+  function: Informationstechnik
   name: Informationstechnik.Container.Bivac.Monitor-Status
 17/2/24:
   dpt: '1.011'
+  function: Informationstechnik
   name: Informationstechnik.Container.Blackbox-exporter.Monitor-Status
 17/2/29:
   dpt: '1.011'
+  function: Informationstechnik
   name: Informationstechnik.Container.Cadvisor.Monitor-Status
 17/2/34:
   dpt: '1.011'
+  function: Informationstechnik
   name: Informationstechnik.Container.Crowdsec.Monitor-Status
 17/2/39:
   dpt: '1.011'
+  function: Informationstechnik
   name: Informationstechnik.Container.Fritz-exporter.Monitor-Status
 17/2/4:
   dpt: '1.011'
+  function: Informationstechnik
   name: Informationstechnik.Container.Alertmanager.Monitor-Status
 17/2/44:
   dpt: '1.011'
+  function: Informationstechnik
   name: Informationstechnik.Container.Gollum.Monitor-Status
 17/2/49:
   dpt: '1.011'
+  function: Informationstechnik
   name: Informationstechnik.Container.Grafana.Monitor-Status
 17/2/54:
   dpt: '1.011'
+  function: Informationstechnik
   name: Informationstechnik.Container.Guacamole.Monitor-Status
 17/2/59:
   dpt: '1.011'
+  function: Informationstechnik
   name: Informationstechnik.Container.Guacd.Monitor-Status
 17/2/64:
   dpt: '1.011'
+  function: Informationstechnik
   name: Informationstechnik.Container.Heimdall.Monitor-Status
 17/2/69:
   dpt: '1.011'
+  function: Informationstechnik
   name: Informationstechnik.Container.Influx.Monitor-Status
 17/2/74:
   dpt: '1.011'
+  function: Informationstechnik
   name: Informationstechnik.Container.Loki.Monitor-Status
 17/2/79:
   dpt: '1.011'
+  function: Informationstechnik
   name: Informationstechnik.Container.Minio.Monitor-Status
 17/2/84:
   dpt: '1.011'
+  function: Informationstechnik
   name: Informationstechnik.Container.Mosquitto.Monitor-Status
 17/2/89:
   dpt: '1.011'
+  function: Informationstechnik
   name: Informationstechnik.Container.Node-exporter.Monitor-Status
 17/2/9:
   dpt: '1.011'
+  function: Informationstechnik
   name: Informationstechnik.Container.Alloy.Monitor-Status
 17/2/94:
   dpt: '1.011'
+  function: Informationstechnik
   name: Informationstechnik.Container.Node-red.Monitor-Status
 17/2/99:
   dpt: '1.011'
+  function: Informationstechnik
   name: Informationstechnik.Container.Portainer.Monitor-Status
 2/0/200:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.Zentral.Kilowattstunde-Löschen
 2/1/0:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.KG.Flur.K1-L1.Steckdose.Sperren
+  room: Flur
 2/1/1:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.KG.Flur.K1-L1.Steckdose.Ein/Aus
+  room: Flur
 2/1/10:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.KG.Flur.K1-L2.Heizkörper.Sperren
+  room: Flur
 2/1/100:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.KG.Technikraum.K1-L1.Heizung.Sperren
+  room: Technikraum
 2/1/101:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.KG.Technikraum.K1-L1.Heizung.Ein/Aus
+  room: Technikraum
 2/1/102:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.KG.Technikraum.K1-L1.Heizung.Ein/Aus-Status
+  room: Technikraum
 2/1/103:
   dpt: '13.100'
+  function: Schalten
   name: Schalten.KG.Technikraum.K1-L1.Heizung.Betriebsstunden
+  room: Technikraum
 2/1/104:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.KG.Technikraum.K1-L1.Heizung.Betriebsstunden-Löschen
+  room: Technikraum
 2/1/105:
   dpt: '13.013'
+  function: Schalten
   name: Schalten.KG.Technikraum.K1-L1.Heizung.Kilowattstunde
+  room: Technikraum
 2/1/106:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.KG.Technikraum.K1-L1.Heizung.Löschen-Kilowattstunde
+  room: Technikraum
 2/1/107:
   dpt: '7.012'
+  function: Schalten
   name: Schalten.KG.Technikraum.K1-L1.Heizung.Stromwert
+  room: Technikraum
 2/1/11:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.KG.Flur.K1-L2.Heizkörper.Ein/Aus
+  room: Flur
 2/1/110:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.KG.Technikraum.K1-L2.Heizung.Sperren
+  room: Technikraum
 2/1/111:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.KG.Technikraum.K1-L2.Heizung.Ein/Aus
+  room: Technikraum
 2/1/112:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.KG.Technikraum.K1-L2.Heizung.Ein/Aus-Status
+  room: Technikraum
 2/1/113:
   dpt: '13.100'
+  function: Schalten
   name: Schalten.KG.Technikraum.K1-L2.Heizung.Betriebsstunden
+  room: Technikraum
 2/1/114:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.KG.Technikraum.K1-L2.Heizung.Betriebsstunden-Löschen
+  room: Technikraum
 2/1/115:
   dpt: '13.013'
+  function: Schalten
   name: Schalten.KG.Technikraum.K1-L2.Heizung.Kilowattstunde
+  room: Technikraum
 2/1/116:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.KG.Technikraum.K1-L2.Heizung.Kilowattstunde-Löschen
+  room: Technikraum
 2/1/117:
   dpt: '7.012'
+  function: Schalten
   name: Schalten.KG.Technikraum.K1-L2.Heizung.Stromwert
+  room: Technikraum
 2/1/12:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.KG.Flur.K1-L2.Heizkörper.Ein/Aus-Status
+  room: Flur
 2/1/120:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.KG.Technikraum.K2-L1.Netzwerkschrank.Sperren
+  room: Technikraum
 2/1/121:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.KG.Technikraum.K2-L1.Netzwerkschrank.Ein/Aus
+  room: Technikraum
 2/1/122:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.KG.Technikraum.K2-L1.Netzwerkschrank.Ein/Aus-Status
+  room: Technikraum
 2/1/123:
   dpt: '13.100'
+  function: Schalten
   name: Schalten.KG.Technikraum.K2-L1.Netzwerkschrank.Betriebsstunden
+  room: Technikraum
 2/1/124:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.KG.Technikraum.K2-L1.Netzwerkschrank.Betriebsstunden-Löschen
+  room: Technikraum
 2/1/125:
   dpt: '13.013'
+  function: Schalten
   name: Schalten.KG.Technikraum.K2-L1.Netzwerkschrank.Kilowattstunde
+  room: Technikraum
 2/1/126:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.KG.Technikraum.K2-L1.Netzwerkschrank.Kilowattstunde-Löschen
+  room: Technikraum
 2/1/127:
   dpt: '7.012'
+  function: Schalten
   name: Schalten.KG.Technikraum.K2-L1.Netzwerkschrank.Stromwert
+  room: Technikraum
 2/1/130:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.KG.Technikraum.K2-L2.Netzwerkschrank.Sperren
+  room: Technikraum
 2/1/131:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.KG.Technikraum.K2-L2.Netzwerkschrank.Ein/Aus
+  room: Technikraum
 2/1/132:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.KG.Technikraum.K2-L2.Netzwerkschrank.Ein/Aus-Status
+  room: Technikraum
 2/1/133:
   dpt: '13.100'
+  function: Schalten
   name: Schalten.KG.Technikraum.K2-L2.Netzwerkschrank.Betriebsstunden
+  room: Technikraum
 2/1/134:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.KG.Technikraum.K2-L2.Netzwerkschrank.Betriebsstunden-Löschen
+  room: Technikraum
 2/1/135:
   dpt: '13.013'
+  function: Schalten
   name: Schalten.KG.Technikraum.K2-L2.Netzwerkschrank.Kilowattstunde
+  room: Technikraum
 2/1/136:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.KG.Technikraum.K2-L2.Netzwerkschrank.Kilowattstunde-Löschen
+  room: Technikraum
 2/1/137:
   dpt: '7.012'
+  function: Schalten
   name: Schalten.KG.Technikraum.K2-L2.Netzwerkschrank.Stromwert
+  room: Technikraum
 2/1/140:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.KG.Technikraum.K3-L3.Entfeuchter.Sperren
+  room: Technikraum
 2/1/141:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.KG.Technikraum.K3-L3.Entfeuchter.Ein/Aus
+  room: Technikraum
 2/1/142:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.KG.Technikraum.K3-L3.Entfeuchter.Ein/Aus-Status
+  room: Technikraum
 2/1/143:
   dpt: '13.100'
+  function: Schalten
   name: Schalten.KG.Technikraum.K3-L3.Entfeuchter.Betriebsstunden
+  room: Technikraum
 2/1/144:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.KG.Technikraum.K3-L3.Entfeuchter.Betriebsstunden-Löschen
+  room: Technikraum
 2/1/145:
   dpt: '13.013'
+  function: Schalten
   name: Schalten.KG.Technikraum.K3-L3.Entfeuchter.Kilowattstunde
+  room: Technikraum
 2/1/146:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.KG.Technikraum.K3-L3.Entfeuchter.Kilowattstunde-Löschen
+  room: Technikraum
 2/1/147:
   dpt: '7.012'
+  function: Schalten
   name: Schalten.KG.Technikraum.K3-L3.Entfeuchter.Stromwert
+  room: Technikraum
 2/1/150:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.KG.Technikraum.Bewässerung.Regen.Sperren
+  room: Technikraum
 2/1/151:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.KG.Technikraum.Bewässerung.Regen.Ein/Aus
+  room: Technikraum
 2/1/152:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.KG.Technikraum.Bewässerung.Regen.Ein/Aus-Status
+  room: Technikraum
 2/1/2:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.KG.Flur.K1-L1.Steckdose.Ein/Aus-Status
+  room: Flur
 2/1/200:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.KG.Vorratsraum.K1-L3.Entfeuchter.Sperren
+  room: Vorratsraum
 2/1/201:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.KG.Vorratsraum.K1-L3.Entfeuchter.Ein/Aus
+  room: Vorratsraum
 2/1/202:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.KG.Vorratsraum.K1-L3.Entfeuchter.Ein/Aus-Status
+  room: Vorratsraum
 2/1/203:
   dpt: '13.100'
+  function: Schalten
   name: Schalten.KG.Vorratsraum.K1-L3.Entfeuchter.Betriebsstunden
+  room: Vorratsraum
 2/1/204:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.KG.Vorratsraum.K1-L3.Entfeuchter.Betriebsstunden-Löschen
+  room: Vorratsraum
 2/1/205:
   dpt: '13.013'
+  function: Schalten
   name: Schalten.KG.Vorratsraum.K1-L3.Entfeuchter.Kilowattstunde
+  room: Vorratsraum
 2/1/206:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.KG.Vorratsraum.K1-L3.Entfeuchter.Kilowattstunde-Löschen
+  room: Vorratsraum
 2/1/207:
   dpt: '7.012'
+  function: Schalten
   name: Schalten.KG.Vorratsraum.K1-L3.Entfeuchter.Stromwert
+  room: Vorratsraum
 2/1/210:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.KG.Vorratsraum.K1-L2.Steckdose.Sperren
+  room: Vorratsraum
 2/1/211:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.KG.Vorratsraum.K1-L2.Steckdose.Ein/Aus
+  room: Vorratsraum
 2/1/212:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.KG.Vorratsraum.K1-L2.Steckdose.Ein/Aus-Status
+  room: Vorratsraum
 2/1/220:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.KG.Vorratsraum.K2-L1.Wasserstop.Sperren
+  room: Vorratsraum
 2/1/221:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.KG.Vorratsraum.K2-L1.Wasserstop.Ein/Aus
+  room: Vorratsraum
 2/1/222:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.KG.Vorratsraum.K2-L1.Wasserstop.Ein/Aus-Status
+  room: Vorratsraum
 2/1/230:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.KG.Vorratsraum.K3-L1.Lüftung.Sperren
+  room: Vorratsraum
 2/1/231:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.KG.Vorratsraum.K3-L1.Lüftung.Ein/Aus
+  room: Vorratsraum
 2/1/232:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.KG.Vorratsraum.K3-L1.Lüftung.Ein/Aus-Status
+  room: Vorratsraum
 2/1/233:
   dpt: '13.100'
+  function: Schalten
   name: Schalten.KG.Vorratsraum.K3-L1.Lüftung.Betriebsstunden
+  room: Vorratsraum
 2/1/234:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.KG.Vorratsraum.K3-L1.Lüftung.Betriebsstunden-Löschen
+  room: Vorratsraum
 2/1/235:
   dpt: '13.013'
+  function: Schalten
   name: Schalten.KG.Vorratsraum.K3-L1.Lüftung.Kilowattstunde
+  room: Vorratsraum
 2/1/236:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.KG.Vorratsraum.K3-L1.Lüftung.Kilowattstunde-Löschen
+  room: Vorratsraum
 2/1/237:
   dpt: '7.012'
+  function: Schalten
   name: Schalten.KG.Vorratsraum.K3-L1.Lüftung.Stromwert
+  room: Vorratsraum
 2/1/50:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.KG.Garage.K1-L3.Entfeuchter.Sperren
+  room: Garage
 2/1/51:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.KG.Garage.K1-L3.Entfeuchter.Ein/Aus
+  room: Garage
 2/1/52:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.KG.Garage.K1-L3.Entfeuchter.Ein/Aus-Status
+  room: Garage
 2/1/53:
   dpt: '13.100'
+  function: Schalten
   name: Schalten.KG.Garage.K1-L3.Entfeuchter.Betriebsstunden
+  room: Garage
 2/1/54:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.KG.Garage.K1-L3.Entfeuchter.Betriebsstunden-Löschen
+  room: Garage
 2/1/55:
   dpt: '13.013'
+  function: Schalten
   name: Schalten.KG.Garage.K1-L3.Entfeuchter.Kilowattstunde
+  room: Garage
 2/1/56:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.KG.Garage.K1-L3.Entfeuchter.Kilowattstunde-Löschen
+  room: Garage
 2/1/57:
   dpt: '7.012'
+  function: Schalten
   name: Schalten.KG.Garage.K1-L3.Entfeuchter.Stromwert
+  room: Garage
 2/1/60:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.KG.Garage.K2-L2.Steckdose.Sperren
+  room: Garage
 2/1/61:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.KG.Garage.K2-L2.Steckdose.Ein/Aus
+  room: Garage
 2/1/62:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.KG.Garage.K2-L2.Steckdose.Ein/Aus-Status
+  room: Garage
 2/1/70:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.KG.Garage.K3-L1.Garagentor.Sperren
+  room: Garage
 2/1/71:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.KG.Garage.K3-L1.Garagentor.Ein/Aus
+  room: Garage
 2/1/72:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.KG.Garage.K3-L1.Garagentor.Ein/Aus-Status
+  room: Garage
 2/2/100:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.EG.Büro.K1-L2.Steckdose.Sperren
+  room: Büro
 2/2/101:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.EG.Büro.K1-L2.Steckdose.Ein/Aus
+  room: Büro
 2/2/102:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.EG.Büro.K1-L2.Steckdose.Ein/Aus-Status
+  room: Büro
 2/2/110:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.EG.Büro.K2-L2.Schreibtisch.Sperren
+  room: Büro
 2/2/111:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.EG.Büro.K2-L2.Schreibtisch.Ein/Aus
+  room: Büro
 2/2/112:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.EG.Büro.K2-L2.Schreibtisch.Ein/Aus-Status
+  room: Büro
 2/2/120:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.EG.Büro.K2-L3.Schreibtisch.Sperren
+  room: Büro
 2/2/121:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.EG.Büro.K2-L3.Schreibtisch.Ein/Aus
+  room: Büro
 2/2/122:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.EG.Büro.K2-L3.Schreibtisch.Ein/Aus-Status
+  room: Büro
 2/2/150:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.EG.Wohnzimmer.K1-L2.Steckdose.Sperren
+  room: Wohnzimmer
 2/2/151:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.EG.Wohnzimmer.K1-L2.Steckdose.Ein/Aus
+  room: Wohnzimmer
 2/2/152:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.EG.Wohnzimmer.K1-L2.Steckdose.Ein/Aus-Status
+  room: Wohnzimmer
 2/2/160:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.EG.Wohnzimmer.K2-L2.Steckdose.Sperren
+  room: Wohnzimmer
 2/2/161:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.EG.Wohnzimmer.K2-L2.Steckdose.Ein/Aus
+  room: Wohnzimmer
 2/2/162:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.EG.Wohnzimmer.K2-L2.Steckdose.Ein/Aus-Status
+  room: Wohnzimmer
 2/2/170:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.EG.Wohnzimmer.K3-L1.Fernseh.Sperren
+  room: Wohnzimmer
 2/2/171:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.EG.Wohnzimmer.K3-L1.Fernseh.Ein/Aus
+  room: Wohnzimmer
 2/2/172:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.EG.Wohnzimmer.K3-L1.Fernseh.Ein/Aus-Status
+  room: Wohnzimmer
 2/2/180:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.EG.Wohnzimmer.K3-L2.Fernseh.Sperren
+  room: Wohnzimmer
 2/2/181:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.EG.Wohnzimmer.K3-L2.Fernseh.Ein/Aus
+  room: Wohnzimmer
 2/2/182:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.EG.Wohnzimmer.K3-L2.Fernseh.Ein/Aus-Status
+  room: Wohnzimmer
 2/2/190:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.EG.Wohnzimmer.K3-L3.Fernseh.Sperren
+  room: Wohnzimmer
 2/2/191:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.EG.Wohnzimmer.K3-L3.Fernseh.Ein/Aus
+  room: Wohnzimmer
 2/2/192:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.EG.Wohnzimmer.K3-L3.Fernseh.Ein/Aus-Status
+  room: Wohnzimmer
 2/2/200:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.EG.Wohnzimmer.K4-L1.Ofen.Sperren
+  room: Wohnzimmer
 2/2/201:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.EG.Wohnzimmer.K4-L1.Ofen.Ein/Aus
+  room: Wohnzimmer
 2/2/202:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.EG.Wohnzimmer.K4-L1.Ofen.Ein/Aus-Status
+  room: Wohnzimmer
 2/2/203:
   dpt: '13.100'
+  function: Schalten
   name: Schalten.EG.Wohnzimmer.K4-L1.Ofen.Betriebsstunden
+  room: Wohnzimmer
 2/2/204:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.EG.Wohnzimmer.K4-L1.Ofen.Betriebsstunden-Löschen
+  room: Wohnzimmer
 2/2/205:
   dpt: '13.013'
+  function: Schalten
   name: Schalten.EG.Wohnzimmer.K4-L1.Ofen.Kilowattstunde
+  room: Wohnzimmer
 2/2/206:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.EG.Wohnzimmer.K4-L1.Ofen.Kilowattstunde-Löschen
+  room: Wohnzimmer
 2/2/207:
   dpt: '7.012'
+  function: Schalten
   name: Schalten.EG.Wohnzimmer.K4-L1.Ofen.Stromwert
+  room: Wohnzimmer
 2/3/100:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.OG.Badezimmer-Kinder.K1-L2.Schrank.Sperren
+  room: Badezimmer-Kinder
 2/3/101:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.OG.Badezimmer-Kinder.K1-L2.Schrank.Ein/Aus
+  room: Badezimmer-Kinder
 2/3/102:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.OG.Badezimmer-Kinder.K1-L2.Schrank.Ein/Aus-Status
+  room: Badezimmer-Kinder
 2/3/110:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.OG.Badezimmer-Kinder.K1-L3.Schrank.Sperren
+  room: Badezimmer-Kinder
 2/3/111:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.OG.Badezimmer-Kinder.K1-L3.Schrank.Ein/Aus
+  room: Badezimmer-Kinder
 2/3/112:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.OG.Badezimmer-Kinder.K1-L3.Schrank.Ein/Aus-Status
+  room: Badezimmer-Kinder
 2/3/120:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.OG.Badezimmer-Kinder.K2-L3.Heizkörper.Sperren
+  room: Badezimmer-Kinder
 2/3/121:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.OG.Badezimmer-Kinder.K2-L3.Heizkörper.Ein/Aus
+  room: Badezimmer-Kinder
 2/3/122:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.OG.Badezimmer-Kinder.K2-L3.Heizkörper.Ein/Aus-Status
+  room: Badezimmer-Kinder
 2/3/150:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.OG.Schlafzimmer-Gregory.K1-L1.Steckdose.Sperren
+  room: Schlafzimmer-Gregory
 2/3/151:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.OG.Schlafzimmer-Gregory.K1-L1.Steckdose.Ein/Aus
+  room: Schlafzimmer-Gregory
 2/3/152:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.OG.Schlafzimmer-Gregory.K1-L1.Steckdose.Ein/Aus-Status
+  room: Schlafzimmer-Gregory
 2/3/160:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.OG.Schlafzimmer-Gregory.K2-L2.Steckdose.Sperren
+  room: Schlafzimmer-Gregory
 2/3/161:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.OG.Schlafzimmer-Gregory.K2-L2.Steckdose.Ein/Aus
+  room: Schlafzimmer-Gregory
 2/3/162:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.OG.Schlafzimmer-Gregory.K2-L2.Steckdose.Ein/Aus-Status
+  room: Schlafzimmer-Gregory
 2/3/50:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.OG.Abstellraum.K1-L1.Steckdose.Sperren
+  room: Abstellraum
 2/3/51:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.OG.Abstellraum.K1-L1.Steckdose.Ein/Aus
+  room: Abstellraum
 2/3/52:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.OG.Abstellraum.K1-L1.Steckdose.Ein/Aus-Status
+  room: Abstellraum
 2/3/60:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.OG.Abstellraum.K2-L1.Steckdose.Sperren
+  room: Abstellraum
 2/3/61:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.OG.Abstellraum.K2-L1.Steckdose.Ein/Aus
+  room: Abstellraum
 2/3/62:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.OG.Abstellraum.K2-L1.Steckdose.Ein/Aus-Status
+  room: Abstellraum
 2/4/0:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.DG.Speicher.K1-L1.Steckdose.Sperren
+  room: Speicher
 2/4/1:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.DG.Speicher.K1-L1.Steckdose.Ein/Aus
+  room: Speicher
 2/4/10:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.DG.Speicher.K1-L2.Steckdose.Sperren
+  room: Speicher
 2/4/11:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.DG.Speicher.K1-L2.Steckdose.Ein/Aus
+  room: Speicher
 2/4/12:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.DG.Speicher.K1-L2.Steckdose.Ein/Aus-Status
+  room: Speicher
 2/4/2:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.DG.Speicher.K1-L1.Steckdose.Ein/Aus-Status
+  room: Speicher
 2/5/0:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.A.Fassade.K1-L1.Steckdose.Sperren
+  room: Fassade
 2/5/1:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.A.Fassade.K1-L1.Steckdose.Ein/Aus
+  room: Fassade
 2/5/100:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.A.Terrasse.K1-L1.Steckdose.Sperren
+  room: Terrasse
 2/5/101:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.A.Terrasse.K1-L1.Steckdose.Ein/Aus
+  room: Terrasse
 2/5/102:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.A.Terrasse.K1-L1.Steckdose.Ein/Aus-Status
+  room: Terrasse
 2/5/110:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.A.Terrasse.K1-L2.Steckdose.Sperren
+  room: Terrasse
 2/5/111:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.A.Terrasse.K1-L2.Steckdose.Ein/Aus
+  room: Terrasse
 2/5/112:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.A.Terrasse.K1-L2.Steckdose.Ein/Aus-Status
+  room: Terrasse
 2/5/150:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.A.Balkon.K1-L1.Steckdose.Sperren
+  room: Balkon
 2/5/151:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.A.Balkon.K1-L1.Steckdose.Ein/Aus
+  room: Balkon
 2/5/152:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.A.Balkon.K1-L1.Steckdose.Ein/Aus-Status
+  room: Balkon
 2/5/160:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.A.Balkon.K1-L2.Steckdose.Sperren
+  room: Balkon
 2/5/161:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.A.Balkon.K1-L2.Steckdose.Ein/Aus
+  room: Balkon
 2/5/162:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.A.Balkon.K1-L2.Steckdose.Ein/Aus-Status
+  room: Balkon
 2/5/2:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.A.Fassade.K1-L1.Steckdose.Ein/Aus-Status
+  room: Fassade
 3/1/0:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K1-L3.Entfeuchter.Sperren
+  room: Hauswirtschaftsraum
 3/1/1:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K1-L3.Entfeuchter.Ein/Aus
+  room: Hauswirtschaftsraum
 3/1/10:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K1-L3.Heizkörper.Sperren
+  room: Hauswirtschaftsraum
 3/1/11:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K1-L3.Heizkörper.Ein/Aus
+  room: Hauswirtschaftsraum
 3/1/12:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K1-L3.Heizkörper.Ein/Aus-Status
+  room: Hauswirtschaftsraum
 3/1/13:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K2-L2.Fehrnseh.Sperren
+  room: Hauswirtschaftsraum
 3/1/14:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K2-L2.Fehrnseh.Ein/Aus
+  room: Hauswirtschaftsraum
 3/1/15:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K2-L2.Fehrnseh.Ein/Aus-Status
+  room: Hauswirtschaftsraum
 3/1/2:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K1-L3.Entfeuchter.Ein/Aus-Status
+  room: Hauswirtschaftsraum
 3/1/20:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K3-L1.Trockner.Sperren
+  room: Hauswirtschaftsraum
 3/1/21:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K3-L1.Trockner.Ein/Aus
+  room: Hauswirtschaftsraum
 3/1/22:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K3-L1.Trockner.Ein/Aus-Status
+  room: Hauswirtschaftsraum
 3/1/23:
   dpt: '13.100'
+  function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K3-L1.Trockner.Betriebsstunden
+  room: Hauswirtschaftsraum
 3/1/24:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K3-L1.Trockner.Betriebsstunden-Löschen
+  room: Hauswirtschaftsraum
 3/1/25:
   dpt: '13.013'
+  function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K3-L1.Trockner.Kilowattstunde
+  room: Hauswirtschaftsraum
 3/1/26:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K3-L1.Trockner.Kilowattstunde-Löschen
+  room: Hauswirtschaftsraum
 3/1/27:
   dpt: '7.012'
+  function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K3-L1.Trockner.Stromwert
+  room: Hauswirtschaftsraum
 3/1/28:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K3-L1.Trockner.Status
+  room: Hauswirtschaftsraum
 3/1/3:
   dpt: '13.100'
+  function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K1-L3.Entfeuchter.Betriebsstunden
+  room: Hauswirtschaftsraum
 3/1/30:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K4-L1.Waschmaschine.Sperren
+  room: Hauswirtschaftsraum
 3/1/31:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K4-L1.Waschmaschine.Ein/Aus
+  room: Hauswirtschaftsraum
 3/1/32:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K4-L1.Waschmaschine.Ein/Aus-Status
+  room: Hauswirtschaftsraum
 3/1/33:
   dpt: '13.100'
+  function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K4-L1.Waschmaschine.Betriebsstunden
+  room: Hauswirtschaftsraum
 3/1/34:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K4-L1.Waschmaschine.Betriebsstunden-Löschen
+  room: Hauswirtschaftsraum
 3/1/35:
   dpt: '13.013'
+  function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K4-L1.Waschmaschine.Kilowattstunde
+  room: Hauswirtschaftsraum
 3/1/36:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K4-L1.Waschmaschine.Kilowattstunde-Löschen
+  room: Hauswirtschaftsraum
 3/1/37:
   dpt: '7.012'
+  function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K4-L1.Waschmaschine.Stromwert
+  room: Hauswirtschaftsraum
 3/1/38:
   dpt: '1.000'
+  function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K4-L1.Waschmaschine.Status
+  room: Hauswirtschaftsraum
 3/1/4:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K1-L3.Entfeuchter.Betriebsstunden-Löschen
+  room: Hauswirtschaftsraum
 3/1/5:
   dpt: '13.013'
+  function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K1-L3.Entfeuchter.Kilowattstunde
+  room: Hauswirtschaftsraum
 3/1/6:
   dpt: '1.010'
+  function: Schalten
   name: Schalten.KG.hauswirtschaftsraum.K1-L3.Entfeuchter.Kilowattstunde-Löschen
+  room: hauswirtschaftsraum
 3/1/7:
   dpt: '7.012'
+  function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K1-L3.Entfeuchter.Stromwert
+  room: Hauswirtschaftsraum
 3/2/0:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.EG.Esszimmer.K2-L3.Steckdose.Sperren
+  room: Esszimmer
 3/2/1:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.EG.Esszimmer.K2-L3.Steckdose.Ein/Aus
+  room: Esszimmer
 3/2/100:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.EG.Küche.K5-L1.Haubenlüfter.Sperren
+  room: Küche
 3/2/101:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.EG.Küche.K5-L1.Haubenlüfter.Ein/Aus
+  room: Küche
 3/2/102:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.EG.Küche.K5-L1.Haubenlüfter.Ein/Aus-Status
+  room: Küche
 3/2/103:
   dpt: '13.100'
+  function: Schalten
   name: Schalten.EG.Küche.K5-L1.Haubenlüfter.Betriebsstunden
+  room: Küche
 3/2/104:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.EG.Küche.K5-L1.Haubenlüfter.Betriebsstunden-Löschen
+  room: Küche
 3/2/105:
   dpt: '13.013'
+  function: Schalten
   name: Schalten.EG.Küche.K5-L1.Haubenlüfter.Kilowattstunde
+  room: Küche
 3/2/106:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.EG.Küche.K5-L1.Haubenlüfter.Kilowattstunde-Löschen
+  room: Küche
 3/2/107:
   dpt: '7.012'
+  function: Schalten
   name: Schalten.EG.Küche.K5-L1.Haubenlüfter.Stromwert
+  room: Küche
 3/2/110:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.EG.Küche.K7-L1.Kühlschrank.Sperren
+  room: Küche
 3/2/111:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.EG.Küche.K7-L1.Kühlschrank.Ein/Aus
+  room: Küche
 3/2/112:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.EG.Küche.K7-L1.Kühlschrank.Ein/Aus-Status
+  room: Küche
 3/2/113:
   dpt: '13.100'
+  function: Schalten
   name: Schalten.EG.Küche.K7-L1.Kühlschrank.Betriebsstunden
+  room: Küche
 3/2/114:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.EG.Küche.K7-L1.Kühlschrank.Betriebsstunden-Löschen
+  room: Küche
 3/2/115:
   dpt: '13.013'
+  function: Schalten
   name: Schalten.EG.Küche.K7-L1.Kühlschrank.Kilowattstunde
+  room: Küche
 3/2/116:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.EG.Küche.K7-L1.Kühlschrank.Kilowattstunde-Löschen
+  room: Küche
 3/2/117:
   dpt: '7.012'
+  function: Schalten
   name: Schalten.EG.Küche.K7-L1.Kühlschrank.Stromwert
+  room: Küche
 3/2/120:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.EG.Küche.K9-L1.Backofen.Sperren
+  room: Küche
 3/2/121:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.EG.Küche.K9-L1.Backofen.Ein/Aus
+  room: Küche
 3/2/122:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.EG.Küche.K9-L1.Backofen.Ein/Aus-Status
+  room: Küche
 3/2/123:
   dpt: '13.100'
+  function: Schalten
   name: Schalten.EG.Küche.K9-L1.Backofen.Betriebsstunden
+  room: Küche
 3/2/124:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.EG.Küche.K9-L1.Backofen.Betriebsstunden-Löschen
+  room: Küche
 3/2/125:
   dpt: '13.013'
+  function: Schalten
   name: Schalten.EG.Küche.K9-L1.Backofen.Kilowattstunde
+  room: Küche
 3/2/126:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.EG.Küche.K9-L1.Backofen.Kilowattstunde-Löschen
+  room: Küche
 3/2/127:
   dpt: '7.012'
+  function: Schalten
   name: Schalten.EG.Küche.K9-L1.Backofen.Stromwert
+  room: Küche
 3/2/130:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.EG.Küche.K10-L1.Tellerwärmer.Sperren
+  room: Küche
 3/2/131:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.EG.Küche.K10-L1.Tellerwärmer.Ein/Aus
+  room: Küche
 3/2/132:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.EG.Küche.K10-L1.Tellerwärmer.Ein/Aus-Status
+  room: Küche
 3/2/133:
   dpt: '13.100'
+  function: Schalten
   name: Schalten.EG.Küche.K10-L1.Tellerwärmer.Betriebsstunden
+  room: Küche
 3/2/134:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.EG.Küche.K10-L1.Tellerwärmer.Betriebsstunden-Löschen
+  room: Küche
 3/2/135:
   dpt: '13.013'
+  function: Schalten
   name: Schalten.EG.Küche.K10-L1.Tellerwärmer.Kilowattstunde
+  room: Küche
 3/2/136:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.EG.Küche.K10-L1.Tellerwärmer.Kilowattstunde-Löschen
+  room: Küche
 3/2/137:
   dpt: '7.012'
+  function: Schalten
   name: Schalten.EG.Küche.K10-L1.Tellerwärmer.Stromwert
+  room: Küche
 3/2/140:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.EG.Küche.K12-L1.Mikrowelle.Sperren
+  room: Küche
 3/2/141:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.EG.Küche.K12-L1.Mikrowelle.Ein/Aus
+  room: Küche
 3/2/142:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.EG.Küche.K12-L1.Mikrowelle.Ein/Aus-Status
+  room: Küche
 3/2/143:
   dpt: '13.100'
+  function: Schalten
   name: Schalten.EG.Küche.K12-L1.Mikrowelle.Betriebsstunden
+  room: Küche
 3/2/144:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.EG.Küche.K12-L1.Mikrowelle.Betriebsstunden-Löschen
+  room: Küche
 3/2/145:
   dpt: '13.013'
+  function: Schalten
   name: Schalten.EG.Küche.K12-L1.Mikrowelle.Kilowattstunde
+  room: Küche
 3/2/146:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.EG.Küche.K12-L1.Mikrowelle.Kilowattstunde-Löschen
+  room: Küche
 3/2/147:
   dpt: '7.012'
+  function: Schalten
   name: Schalten.EG.Küche.K12-L1.Mikrowelle.Stromwert
+  room: Küche
 3/2/150:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.EG.Küche.K13-L1.Kaffeemaschine.Sperren
+  room: Küche
 3/2/151:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.EG.Küche.K13-L1.Kaffeemaschine.Ein/Aus
+  room: Küche
 3/2/152:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.EG.Küche.K13-L1.Kaffeemaschine.Ein/Aus-Status
+  room: Küche
 3/2/153:
   dpt: '13.100'
+  function: Schalten
   name: Schalten.EG.Küche.K13-L1.Kaffeemaschine.Betriebsstunden
+  room: Küche
 3/2/154:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.EG.Küche.K13-L1.Kaffeemaschine.Betriebsstunden-Löschen
+  room: Küche
 3/2/155:
   dpt: '13.013'
+  function: Schalten
   name: Schalten.EG.Küche.K13-L1.Kaffeemaschine.Kilowattstunde
+  room: Küche
 3/2/156:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.EG.Küche.K13-L1.Kaffeemaschine.Kilowattstunde-Löschen
+  room: Küche
 3/2/157:
   dpt: '7.012'
+  function: Schalten
   name: Schalten.EG.Küche.K13-L1.Kaffeemaschine.Stromwert
+  room: Küche
 3/2/160:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.EG.Küche.K14-L1.Dampfgarer.Sperren
+  room: Küche
 3/2/161:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.EG.Küche.K14-L1.Dampfgarer.Ein/Aus
+  room: Küche
 3/2/162:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.EG.Küche.K14-L1.Dampfgarer.Ein/Aus-Status
+  room: Küche
 3/2/163:
   dpt: '13.100'
+  function: Schalten
   name: Schalten.EG.Küche.K14-L1.Dampfgarer.Betriebsstunden
+  room: Küche
 3/2/164:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.EG.Küche.K14-L1.Dampfgarer.Betriebsstunden-Löschen
+  room: Küche
 3/2/165:
   dpt: '13.013'
+  function: Schalten
   name: Schalten.EG.Küche.K14-L1.Dampfgarer.Kilowattstunde
+  room: Küche
 3/2/166:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.EG.Küche.K14-L1.Dampfgarer.Kilowattstunde-Löschen
+  room: Küche
 3/2/167:
   dpt: '7.012'
+  function: Schalten
   name: Schalten.EG.Küche.K14-L1.Dampfgarer.Stromwert
+  room: Küche
 3/2/170:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.EG.Küche.K15-L1.Gefrierschrank.Sperren
+  room: Küche
 3/2/171:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.EG.Küche.K15-L1.Gefrierschrank.Ein/Aus
+  room: Küche
 3/2/172:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.EG.Küche.K15-L1.Gefrierschrank.Ein/Aus-Status
+  room: Küche
 3/2/173:
   dpt: '13.100'
+  function: Schalten
   name: Schalten.EG.Küche.K15-L1.Gefrierschrank.Betriebsstunden
+  room: Küche
 3/2/174:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.EG.Küche.K15-L1.Gefrierschrank.Betriebsstunden-Löschen
+  room: Küche
 3/2/175:
   dpt: '13.013'
+  function: Schalten
   name: Schalten.EG.Küche.K15-L1.Gefrierschrank.Kilowattstunde
+  room: Küche
 3/2/176:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.EG.Küche.K15-L1.Gefrierschrank.Kilowattstunde-Löschen
+  room: Küche
 3/2/177:
   dpt: '7.012'
+  function: Schalten
   name: Schalten.EG.Küche.K15-L1.Gefrierschrank.Stromwert
+  room: Küche
 3/2/2:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.EG.Esszimmer.K2-L3.Steckdose.Ein/Aus-Status
+  room: Esszimmer
 3/2/50:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.EG.Küche.K1-L3.Steckdose.Sperren
+  room: Küche
 3/2/51:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.EG.Küche.K1-L3.Steckdose.Ein/Aus
+  room: Küche
 3/2/52:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.EG.Küche.K1-L3.Steckdose.Ein/Aus-Status
+  room: Küche
 3/2/60:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.EG.Küche.K2-L1.Steckdose.Sperren
+  room: Küche
 3/2/61:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.EG.Küche.K2-L1.Steckdose.Ein/Aus
+  room: Küche
 3/2/62:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.EG.Küche.K2-L1.Steckdose.Ein/Aus-Status
+  room: Küche
 3/2/70:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.EG.Küche.K2-L2.Steckdose.Sperren
+  room: Küche
 3/2/71:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.EG.Küche.K2-L2.Steckdose.Ein/Aus
+  room: Küche
 3/2/72:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.EG.Küche.K2-L2.Steckdose.Ein/Aus-Status
+  room: Küche
 3/2/80:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.EG.Küche.K3-L3.Kücheninsel.Sperren
+  room: Küche
 3/2/81:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.EG.Küche.K3-L3.Kücheninsel.Ein/Aus
+  room: Küche
 3/2/82:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.EG.Küche.K3-L3.Kücheninsel.Ein/Aus-Status
+  room: Küche
 3/2/90:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.EG.Küche.K4-L1.Geschirrspüler.Sperren
+  room: Küche
 3/2/91:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.EG.Küche.K4-L1.Geschirrspüler.Ein/Aus
+  room: Küche
 3/2/92:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.EG.Küche.K4-L1.Geschirrspüler.Ein/Aus-Status
+  room: Küche
 3/2/93:
   dpt: '13.100'
+  function: Schalten
   name: Schalten.EG.Küche.K4-L1.Geschirrspüler.Betriebsstunden
+  room: Küche
 3/2/94:
   dpt: '1.003'
+  function: Schalten
   name: 'Schalten.EG.Küche.K4-L1.Geschirrspüler.Betriebsstunden-Löschen '
+  room: Küche
 3/2/95:
   dpt: '13.013'
+  function: Schalten
   name: Schalten.EG.Küche.K4-L1.Geschirrspüler.Kilowattstunde
+  room: Küche
 3/2/96:
   dpt: '1.003'
+  function: Schalten
   name: Schalten.EG.Küche.K4-L1.Geschirrspüler.Kilowattstunde-Löschen
+  room: Küche
 3/2/97:
   dpt: '7.012'
+  function: Schalten
   name: Schalten.EG.Küche.K4-L1.Geschirrspüler.Stromwert
+  room: Küche
 3/3/0:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.OG.Schlafzimmer-Luis.K1-L1.Steckdose.Sperren
+  room: Schlafzimmer-Luis
 3/3/1:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.OG.Schlafzimmer-Luis.K1-L1.Steckdose.Ein/Aus
+  room: Schlafzimmer-Luis
 3/3/10:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.OG.Schlafzimmer-Luis.K2-L1.Steckdose.Sperren
+  room: Schlafzimmer-Luis
 3/3/11:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.OG.Schlafzimmer-Luis.K2-L1.Steckdose.Ein/Aus
+  room: Schlafzimmer-Luis
 3/3/12:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.OG.Schlafzimmer-Luis.K2-L1.Steckdose.Ein/Aus-Status
+  room: Schlafzimmer-Luis
 3/3/150:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.OG.Badezimmer-Eltern.K1-L2.Schrank.Sperren
+  room: Badezimmer-Eltern
 3/3/151:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.OG.Badezimmer-Eltern.K1-L2.Schrank.Ein/Aus
+  room: Badezimmer-Eltern
 3/3/152:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.OG.Badezimmer-Eltern.K1-L2.Schrank.Ein/Aus-Status
+  room: Badezimmer-Eltern
 3/3/160:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.OG.Badezimmer-Eltern.K1-L3.Schrank.Sperren
+  room: Badezimmer-Eltern
 3/3/161:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.OG.Badezimmer-Eltern.K1-L3.Schrank.Ein/Aus
+  room: Badezimmer-Eltern
 3/3/162:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.OG.Badezimmer-Eltern.K1-L3.Schrank.Ein/Aus-Status
+  room: Badezimmer-Eltern
 3/3/170:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.OG.Badezimmer-Eltern.K2-L3.Heizkörper.Sperren
+  room: Badezimmer-Eltern
 3/3/171:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.OG.Badezimmer-Eltern.K2-L3.Heizkörper.Ein/Aus
+  room: Badezimmer-Eltern
 3/3/172:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.OG.Badezimmer-Eltern.K2-L3.Heizkörper.Ein/Aus-Status
+  room: Badezimmer-Eltern
 3/3/2:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.OG.Schlafzimmer-Luis.K1-L1.Steckdose.Ein/Aus-Status
+  room: Schlafzimmer-Luis
 3/3/50:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.OG.Schlafzimmer-Eltern.K1-L1.Steckdose.Sperren
+  room: Schlafzimmer-Eltern
 3/3/51:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.OG.Schlafzimmer-Eltern.K1-L1.Steckdose.Ein/Aus
+  room: Schlafzimmer-Eltern
 3/3/52:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.OG.Schlafzimmer-Eltern.K1-L1.Steckdose.Ein/Aus-Status
+  room: Schlafzimmer-Eltern
 3/3/60:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.OG.Schlafzimmer-Eltern.K2-L1.Bett.Sperren
+  room: Schlafzimmer-Eltern
 3/3/61:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.OG.Schlafzimmer-Eltern.K2-L1.Bett.Ein/Aus
+  room: Schlafzimmer-Eltern
 3/3/62:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.OG.Schlafzimmer-Eltern.K2-L1.Bett.Ein/Aus-Status
+  room: Schlafzimmer-Eltern
 3/3/70:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.OG.Schlafzimmer-Eltern.K2-L2.Bett.Sperren
+  room: Schlafzimmer-Eltern
 3/3/71:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.OG.Schlafzimmer-Eltern.K2-L2.Bett.Ein/Aus
+  room: Schlafzimmer-Eltern
 3/3/72:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.OG.Schlafzimmer-Eltern.K2-L2.Bett.Ein/Aus-Status
+  room: Schlafzimmer-Eltern
 3/3/80:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.OG.Schlafzimmer-Eltern.K2-L3.Bett.Sperren
+  room: Schlafzimmer-Eltern
 3/3/81:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.OG.Schlafzimmer-Eltern.K2-L3.Bett.Ein/Aus
+  room: Schlafzimmer-Eltern
 3/3/82:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.OG.Schlafzimmer-Eltern.K2-L3.Bett.Ein/Aus-Status
+  room: Schlafzimmer-Eltern
 3/5/0:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.A.Garten.K1-L1.Steckdose.Sperren
+  room: Garten
 3/5/1:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.A.Garten.K1-L1.Steckdose.Ein/Aus
+  room: Garten
 3/5/10:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.A.Garten.K1-L2.Steckdose.Sperren
+  room: Garten
 3/5/100:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.A.Garten.K3-L5.Steckdose.Sperren
+  room: Garten
 3/5/101:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.A.Garten.K3-L5.Steckdose.Ein/Aus
+  room: Garten
 3/5/102:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.A.Garten.K3-L5.Steckdose.Ein/Aus-Status
+  room: Garten
 3/5/11:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.A.Garten.K1-L2.Steckdose.Ein/Aus
+  room: Garten
 3/5/12:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.A.Garten.K1-L2.Steckdose.Ein/Aus-Status
+  room: Garten
 3/5/2:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.A.Garten.K1-L1.Steckdose.Ein/Aus-Status
+  room: Garten
 3/5/20:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.A.Garten.K1-L2.Steckdose.Sperren
+  room: Garten
 3/5/21:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.A.Garten.K1-L3.Steckdose.Ein/Aus
+  room: Garten
 3/5/22:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.A.Garten.K1-L3.Steckdose.Ein/Aus-Status
+  room: Garten
 3/5/30:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.A.Garten.K2-L1.Steckdose.Sperren
+  room: Garten
 3/5/31:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.A.Garten.K2-L1.Steckdose.Ein/Aus
+  room: Garten
 3/5/32:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.A.Garten.K2-L1.Steckdose.Ein/Aus-Status
+  room: Garten
 3/5/40:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.A.Garten.K2-L2.Steckdose.Sperren
+  room: Garten
 3/5/41:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.A.Garten.K2-L2.Steckdose.Ein/Aus
+  room: Garten
 3/5/42:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.A.Garten.K2-L2.Steckdose.Ein/Aus-Status
+  room: Garten
 3/5/50:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.A.Garten.K2-L3.Steckdose.Sperren
+  room: Garten
 3/5/51:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.A.Garten.K2-L3.Steckdose.Ein/Aus
+  room: Garten
 3/5/52:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.A.Garten.K2-L3.Steckdose.Ein/Aus-Status
+  room: Garten
 3/5/60:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.A.Garten.K3-L1.Steckdose.Sperren
+  room: Garten
 3/5/61:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.A.Garten.K3-L1.Steckdose.Ein/Aus
+  room: Garten
 3/5/62:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.A.Garten.K3-L1.Steckdose.Ein/Aus-Status
+  room: Garten
 3/5/70:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.A.Garten.K3-L2.Steckdose.Sperren
+  room: Garten
 3/5/71:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.A.Garten.K3-L2.Steckdose.Ein/Aus
+  room: Garten
 3/5/72:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.A.Garten.K3-L2.Steckdose.Ein/Aus-Status
+  room: Garten
 3/5/80:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.A.Garten.K3-L3.Steckdose.Sperren
+  room: Garten
 3/5/81:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.A.Garten.K3-L3.Steckdose.Ein/Aus
+  room: Garten
 3/5/82:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.A.Garten.K3-L3.Steckdose.Ein/Aus-Status
+  room: Garten
 3/5/90:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.A.Garten.K3-L4.Steckdose.Sperren
+  room: Garten
 3/5/91:
   dpt: '1.001'
+  function: Schalten
   name: Schalten.A.Garten.K3-L4.Steckdose.Ein/Aus
+  room: Garten
 3/5/92:
   dpt: '1.011'
+  function: Schalten
   name: Schalten.A.Garten.K3-L4.Steckdose.Ein/Aus-Status
+  room: Garten
 4/0/0:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.KG.Flur.Ein/Aus
 4/0/1:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.KG.Flur.Ein/Aus-Status
 4/0/10:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.EG.Flur.Ein/Aus
 4/0/100:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.KG.Ein/Aus
 4/0/101:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.KG.Ein/Aus-Status
 4/0/11:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.EG.Flur.Ein/Aus-Status
 4/0/12:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.EG.Gäste-WC.Ein/Aus
 4/0/120:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.EG.Ein/Aus
 4/0/121:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.EG.Ein/Aus-Status
 4/0/13:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.EG.Gäste-WC.Ein/Aus-Status
 4/0/14:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.EG.Büro.Ein/Aus
 4/0/140:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.OG.Ein/Aus
 4/0/141:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.OG.Ein/Aus-Status
 4/0/15:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.EG.Büro.Ein/Aus-Status
 4/0/16:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.EG.Wohnzimmer.Ein/Aus
 4/0/160:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.DG.Ein/Aus
 4/0/161:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.DG.Ein/Aus-Status
 4/0/17:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.EG.Wohnzimmer.Ein/Aus-Status
 4/0/18:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.EG.Esszimmer.Ein/Aus
 4/0/180:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.A.Ein/Aus
 4/0/181:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.A.Ein/Aus-Status
 4/0/19:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.EG.Esszimmer.Ein/Aus-Status
 4/0/2:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.KG.Garage.Ein/Aus
 4/0/20:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.EG.Küche.Ein/Aus
 4/0/200:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.Ein/Aus
 4/0/201:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.Ein/Aus-Status
 4/0/21:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.EG.Küche.Ein/Aus-Status
 4/0/22:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.OG.Flur.Ein/Aus
 4/0/23:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.OG.Flur.Ein/Aus-Status
 4/0/24:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.OG.Abstellraum.Ein/Aus
 4/0/25:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.OG.Abstellraum.Ein/Aus-Status
 4/0/26:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.OG.Badezimmer-Kinder.Ein/Aus
 4/0/27:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.OG.Badezimmer-Kinder.Ein/Aus-Status
 4/0/28:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.OG.Schlafzimmer-Gregory.Ein/Aus
 4/0/29:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.OG.Schlafzimmer-Gregory.Ein/Aus-Status
 4/0/3:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.KG.Garage.Ein/Aus-Status
 4/0/30:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.OG.Schlafzimmer-Luis.Ein/Aus
 4/0/31:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.OG.Schlafzimmer-Luis.Ein/Aus-Status
 4/0/32:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.OG.Schlafzimmer-Eltern.Ein/Aus
 4/0/33:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.OG.Schlafzimmer-Eltern.Ein/Aus-Status
 4/0/34:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.OG.Begehbarer-Schrank.Ein/Aus
 4/0/35:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.OG.Begehbarer-Schrank.Ein/Aus-Status
 4/0/36:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.OG.Badezimmer-Eltern.Ein/Aus
 4/0/37:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.OG.Badezimmer-Eltern.Ein/Aus-Status
 4/0/38:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.DG.Speicher.Ein/Aus
 4/0/39:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.DG.Speicher.Ein/Aus-Status
 4/0/4:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.KG.Technikraum.Ein/Aus
 4/0/40:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.A.Eingang.Ein/Aus
 4/0/41:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.A.Eingang.Ein/Aus-Status
 4/0/42:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.A.Fassade.Ein/Aus
 4/0/43:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.A.Fassade.Ein/Aus-Status
 4/0/44:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.A.Terrasse.Ein/Aus
 4/0/45:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.A.Terrasse.Ein/Aus-Status
 4/0/46:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.A.Balkon.Ein/Aus
 4/0/47:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.A.Balkon.Ein/Aus-Status
 4/0/48:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.A.Garten.Ein/Aus
 4/0/49:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.A.Garten.Ein/Aus-Status
 4/0/5:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.KG.Technikraum.Ein/Aus-Status
 4/0/50:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.A.Dach.Ein/Aus
 4/0/51:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.A.Dach.Ein/Aus-Status
 4/0/6:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.KG.Vorratsraum.Ein/Aus
 4/0/7:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.KG.Vorratsraum.Ein/Aus-Status
 4/0/8:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.KG.Hauswirtschaftsraum.Ein/Aus
 4/0/9:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.Zentral.KG.Hauswirtschaftsraum.Ein/Aus-Status
 4/1/0:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.KG.Flur.Track.Sperren
+  room: Flur
 4/1/1:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.KG.Flur.Track.Ein/Aus
+  room: Flur
 4/1/10:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.KG.Flur.Indirekt.Sperren
+  room: Flur
 4/1/100:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.KG.Technikraum.Deckenleuchte.Sperren
+  room: Technikraum
 4/1/101:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.KG.Technikraum.Deckenleuchte.Ein/Aus
+  room: Technikraum
 4/1/102:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.KG.Technikraum.Deckenleuchte.Ein/Aus-Status
+  room: Technikraum
 4/1/103:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.KG.Technikraum.Deckenleuchte.Dimmen-Relativ
+  room: Technikraum
 4/1/104:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.KG.Technikraum.Deckenleuchte.Dimmen-Absolut
+  room: Technikraum
 4/1/105:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.KG.Technikraum.Deckenleuchte.Dimmen-Status
+  room: Technikraum
 4/1/11:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.KG.Flur.Indirekt.Ein/Aus
+  room: Flur
 4/1/12:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.KG.Flur.Indirekt.Ein/Aus-Status
+  room: Flur
 4/1/13:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.KG.Flur.Indirekt.Dimmen-Relativ
+  room: Flur
 4/1/14:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.KG.Flur.Indirekt.Dimmen-Absolut
+  room: Flur
 4/1/15:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.KG.Flur.Indirekt.Dimmen-Status
+  room: Flur
 4/1/150:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.KG.Vorratsraum.Deckenleuchte.Sperren
+  room: Vorratsraum
 4/1/151:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.KG.Vorratsraum.Deckenleuchte.Ein/Aus
+  room: Vorratsraum
 4/1/152:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.KG.Vorratsraum.Deckenleuchte.Ein/Aus-Status
+  room: Vorratsraum
 4/1/153:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.KG.Vorratsraum.Deckenleuchte.Dimmen-Relativ
+  room: Vorratsraum
 4/1/154:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.KG.Vorratsraum.Deckenleuchte.Dimmen-Absolut
+  room: Vorratsraum
 4/1/155:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.KG.Vorratsraum.Deckenleuchte.Dimmen-Status
+  room: Vorratsraum
 4/1/2:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.KG.Flur.Track.Ein/Aus-Status
+  room: Flur
 4/1/20:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.KG.Flur.Bodenleuchte.Sperren
+  room: Flur
 4/1/21:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.KG.Flur.Bodenleuchte.Ein/Aus
+  room: Flur
 4/1/22:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.KG.Flur.Bodenleuchte.Ein/Aus-Status
+  room: Flur
 4/1/23:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.KG.Flur.Bodenleuchte.Dimmen-Relativ
+  room: Flur
 4/1/24:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.KG.Flur.Bodenleuchte.Dimmen-Absolut
+  room: Flur
 4/1/25:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.KG.Flur.Bodenleuchte.Dimmen-Status
+  room: Flur
 4/1/3:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.KG.Flur.Track.Dimmen-Relativ
+  room: Flur
 4/1/4:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.KG.Flur.Track.Dimmen-Absolut
+  room: Flur
 4/1/5:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.KG.Flur.Track.Dimmen-Status
+  room: Flur
 4/1/50:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.KG.Garage.Deckenleuchte.Links.Sperren
+  room: Garage
 4/1/51:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.KG.Garage.Deckenleuchte.Links.Ein/Aus
+  room: Garage
 4/1/52:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.KG.Garage.Deckenleuchte.Links.Ein/Aus-Status
+  room: Garage
 4/1/53:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.KG.Garage.Deckenleuchte.Links.Dimmen-Relativ
+  room: Garage
 4/1/54:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.KG.Garage.Deckenleuchte.Links.Dimmen-Absolut
+  room: Garage
 4/1/55:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.KG.Garage.Deckenleuchte.Links.Dimmen-Status
+  room: Garage
 4/1/60:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.KG.Garage.Deckenleuchte.Rechts.Sperren
+  room: Garage
 4/1/61:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.KG.Garage.Deckenleuchte.Rechts.Ein/Aus
+  room: Garage
 4/1/62:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.KG.Garage.Deckenleuchte.Rechts.Ein/Aus-Status
+  room: Garage
 4/1/63:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.KG.Garage.Deckenleuchte.Rechts.Dimmen-Relativ
+  room: Garage
 4/1/64:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.KG.Garage.Deckenleuchte.Rechts.Dimmen-Absolut
+  room: Garage
 4/1/65:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.KG.Garage.Deckenleuchte.Rechts.Dimmen-Status
+  room: Garage
 4/2/0:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.EG.Flur.Downlight.Diele.Sperren
+  room: Flur
 4/2/1:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Flur.Downlight.Diele.Ein/Aus
+  room: Flur
 4/2/10:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.EG.Flur.Downlight.Garderobe.Sperren
+  room: Flur
 4/2/100:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.EG.Büro.Spots.Sperren
+  room: Büro
 4/2/101:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Büro.Spots.Ein/Aus
+  room: Büro
 4/2/102:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.EG.Büro.Spots.Ein/Aus-Status
+  room: Büro
 4/2/103:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.EG.Büro.Spots.Dimmen-Relativ
+  room: Büro
 4/2/104:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Büro.Spots.Dimmen-Absolut
+  room: Büro
 4/2/105:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Büro.Spots.Dimmen-Status
+  room: Büro
 4/2/11:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Flur.Downlight.Garderobe.Ein/Aus
+  room: Flur
 4/2/110:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.EG.Büro.Stripe.Sperren
+  room: Büro
 4/2/111:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Büro.Stripe.Ein/Aus
+  room: Büro
 4/2/112:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.EG.Büro.Stripe.Ein/Aus-Status
+  room: Büro
 4/2/113:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.EG.Büro.Stripe.Dimmen-Relativ
+  room: Büro
 4/2/114:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Büro.Stripe.Dimmen-Absolut
+  room: Büro
 4/2/115:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Büro.Stripe.Dimmen-Status
+  room: Büro
 4/2/12:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.EG.Flur.Downlight.Garderobe.Ein/Aus-Status
+  room: Flur
 4/2/13:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.EG.Flur.Downlight.Garderobe.Dimmen-Relativ
+  room: Flur
 4/2/14:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Flur.Downlight.Garderobe.Dimmen-Absolut
+  room: Flur
 4/2/15:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Flur.Downlight.Garderobe.Dimmen-Status
+  room: Flur
 4/2/150:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Downlight.Sperren
+  room: Wohnzimmer
 4/2/151:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Downlight.Ein/Aus
+  room: Wohnzimmer
 4/2/152:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Downlight.Ein/Aus-Status
+  room: Wohnzimmer
 4/2/153:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Downlight.Dimmen-Relativ
+  room: Wohnzimmer
 4/2/154:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Downlight.Dimmen-Absolut
+  room: Wohnzimmer
 4/2/155:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Downlight.Dimmen-Status
+  room: Wohnzimmer
 4/2/160:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Spots.Links.Sperren
+  room: Wohnzimmer
 4/2/161:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Spots.Links.Ein/Aus
+  room: Wohnzimmer
 4/2/162:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Spots.Links.Ein/Aus-Status
+  room: Wohnzimmer
 4/2/163:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Spots.Links.Dimmen-Relativ
+  room: Wohnzimmer
 4/2/164:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Spots.Links.Dimmen-Absolut
+  room: Wohnzimmer
 4/2/165:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Spots.Links.Dimmen-Status
+  room: Wohnzimmer
 4/2/170:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Stripe.Links.Sperren
+  room: Wohnzimmer
 4/2/171:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Stripe.Links.Ein/Aus
+  room: Wohnzimmer
 4/2/172:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Stripe.Links.Ein/Aus-Status
+  room: Wohnzimmer
 4/2/173:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Stripe.Links.Dimmen-Relativ
+  room: Wohnzimmer
 4/2/174:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Stripe.Links.Dimmen-Absolut
+  room: Wohnzimmer
 4/2/175:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Stripe.Links.Dimmen-Status
+  room: Wohnzimmer
 4/2/180:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Spots.Rechts.Sperren
+  room: Wohnzimmer
 4/2/181:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Spots.Rechts.Ein/Aus
+  room: Wohnzimmer
 4/2/182:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Spots.Rechts.Ein/Aus-Status
+  room: Wohnzimmer
 4/2/183:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Spots.Rechts.Dimmen-Relativ
+  room: Wohnzimmer
 4/2/184:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Spots.Rechts.Dimmen-Absolut
+  room: Wohnzimmer
 4/2/185:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Spots.Rechts.Dimmen-Status
+  room: Wohnzimmer
 4/2/190:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Stripe.Rechts.Sperren
+  room: Wohnzimmer
 4/2/191:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Stripe.Rechts.Ein/Aus
+  room: Wohnzimmer
 4/2/192:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Stripe.Rechts.Ein/Aus-Status
+  room: Wohnzimmer
 4/2/193:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Stripe.Rechts.Dimmen-Relativ
+  room: Wohnzimmer
 4/2/194:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Stripe.Rechts.Dimmen-Absolut
+  room: Wohnzimmer
 4/2/195:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Stripe.Rechts.Dimmen-Status
+  room: Wohnzimmer
 4/2/2:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.EG.Flur.Downlight.Diele.Ein/Aus-Status
+  room: Flur
 4/2/20:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.EG.Flur.Bodenleuchte.Sperren
+  room: Flur
 4/2/200:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Indirekt.Links.Sperren
+  room: Wohnzimmer
 4/2/201:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Indirekt.Links.Ein/Aus
+  room: Wohnzimmer
 4/2/202:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Indirekt.Links.Ein/Aus-Status
+  room: Wohnzimmer
 4/2/203:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Indirekt.Links.Dimmen-Relativ
+  room: Wohnzimmer
 4/2/204:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Indirekt.Links.Dimmen-Absolut
+  room: Wohnzimmer
 4/2/205:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Indirekt.Links.Dimmen-Status
+  room: Wohnzimmer
 4/2/21:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Flur.Bodenleuchte.Ein/Aus
+  room: Flur
 4/2/210:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Indirekt.Rechts.Sperren
+  room: Wohnzimmer
 4/2/211:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Indirekt.Rechts.Ein/Aus
+  room: Wohnzimmer
 4/2/212:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Indirekt.Rechts.Ein/Aus-Status
+  room: Wohnzimmer
 4/2/213:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Indirekt.Rechts.Dimmen-Relativ
+  room: Wohnzimmer
 4/2/214:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Indirekt.Rechts.Dimmen-Absolut
+  room: Wohnzimmer
 4/2/215:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Indirekt.Rechts.Dimmen-Status
+  room: Wohnzimmer
 4/2/22:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.EG.Flur.Bodenleuchte.Ein/Aus-Status
+  room: Flur
 4/2/23:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.EG.Flur.Bodenleuchte.Dimmen-Relativ
+  room: Flur
 4/2/24:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Flur.Bodenleuchte.Dimmen-Absolut
+  room: Flur
 4/2/25:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Flur.Bodenleuchte.Dimmen-Status
+  room: Flur
 4/2/3:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.EG.Flur.Downlight.Diele.Dimmen-Relativ
+  room: Flur
 4/2/30:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.EG.Flur.Indirekt.Sperren
+  room: Flur
 4/2/31:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Flur.Indirekt.Ein/Aus
+  room: Flur
 4/2/32:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.EG.Flur.Indirekt.Ein/Aus-Status
+  room: Flur
 4/2/33:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.EG.Flur.Indirekt.Dimmen-Relativ
+  room: Flur
 4/2/34:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Flur.Indirekt.Dimmen-Absolut
+  room: Flur
 4/2/35:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Flur.Indirekt.Dimmen-Status
+  room: Flur
 4/2/4:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Flur.Downlight.Diele.Dimmen-Absolut
+  room: Flur
 4/2/5:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Flur.Downlight.Diele.Dimmen-Status
+  room: Flur
 4/2/50:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.EG.Gäste-WC.Pendelleuchte.Sperren
+  room: Gäste-WC
 4/2/51:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Gäste-WC.Pendelleuchte.Ein/Aus
+  room: Gäste-WC
 4/2/52:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.EG.Gäste-WC.Pendelleuchte.Ein/Aus-Status
+  room: Gäste-WC
 4/2/53:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.EG.Gäste-WC.Pendelleuchte.Dimmen-Relativ
+  room: Gäste-WC
 4/2/54:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Gäste-WC.Pendelleuchte.Dimmen-Absolut
+  room: Gäste-WC
 4/2/55:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Gäste-WC.Pendelleuchte.Dimmen-Status
+  room: Gäste-WC
 4/2/60:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.EG.Gäste-WC.Indirekt.Sperren
+  room: Gäste-WC
 4/2/61:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Gäste-WC.Indirekt.Ein/Aus
+  room: Gäste-WC
 4/2/62:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.EG.Gäste-WC.Indirekt.Ein/Aus-Status
+  room: Gäste-WC
 4/2/63:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.EG.Gäste-WC.Indirekt.Dimmen-Relativ
+  room: Gäste-WC
 4/2/64:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Gäste-WC.Indirekt.Dimmen-Absolut
+  room: Gäste-WC
 4/2/65:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Gäste-WC.Indirekt.Dimmen-Status
+  room: Gäste-WC
 4/3/0:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.OG.Flur.Pendelleuchte.Sperren
+  room: Flur
 4/3/1:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Flur.Pendelleuchte.Ein/Aus
+  room: Flur
 4/3/10:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.OG.Flur.Downlight.Treppe.Sperren
+  room: Flur
 4/3/100:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Kinder.Downlight.WC.Sperren
+  room: Badezimmer-Kinder
 4/3/101:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Kinder.Downlight.WC.Ein/Aus
+  room: Badezimmer-Kinder
 4/3/102:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Kinder.Downlight.WC.Ein/Aus-Status
+  room: Badezimmer-Kinder
 4/3/103:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Kinder.Downlight.WC.Dimmen-Relativ
+  room: Badezimmer-Kinder
 4/3/104:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Kinder.Downlight.WC.Dimmen-Absolut
+  room: Badezimmer-Kinder
 4/3/105:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Kinder.Downlight.WC.Dimmen-Status
+  room: Badezimmer-Kinder
 4/3/11:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Flur.Downlight.Treppe.Ein/Aus
+  room: Flur
 4/3/110:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Kinder.Downlight.Becken.Sperren
+  room: Badezimmer-Kinder
 4/3/111:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Kinder.Downlight.Becken.Ein/Aus
+  room: Badezimmer-Kinder
 4/3/112:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Kinder.Downlight.Becken.Ein/Aus-Status
+  room: Badezimmer-Kinder
 4/3/113:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Kinder.Downlight.Becken.Dimmen-Relativ
+  room: Badezimmer-Kinder
 4/3/114:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Kinder.Downlight.Becken.Dimmen-Absolut
+  room: Badezimmer-Kinder
 4/3/115:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Kinder.Downlight.Becken.Dimmen-Status
+  room: Badezimmer-Kinder
 4/3/12:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.OG.Flur.Downlight.Treppe.Ein/Aus-Status
+  room: Flur
 4/3/120:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Kinder.Indirekt.Sperren
+  room: Badezimmer-Kinder
 4/3/121:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Kinder.Indirekt.Ein/Aus
+  room: Badezimmer-Kinder
 4/3/122:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Kinder.Indirekt.Ein/Aus-Status
+  room: Badezimmer-Kinder
 4/3/123:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Kinder.Indirekt.Dimmen-Relativ
+  room: Badezimmer-Kinder
 4/3/124:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Kinder.Indirekt.Dimmen-Absolut
+  room: Badezimmer-Kinder
 4/3/125:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Kinder.Indirekt.Dimmen-Status
+  room: Badezimmer-Kinder
 4/3/13:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.OG.Flur.Downlight.Treppe.Dimmen-Relativ
+  room: Flur
 4/3/130:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Kinder.Spiegel.Sperren
+  room: Badezimmer-Kinder
 4/3/131:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Kinder.Spiegel.Ein/Aus
+  room: Badezimmer-Kinder
 4/3/132:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Kinder.Spiegel.Ein/Aus-Status
+  room: Badezimmer-Kinder
 4/3/133:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Kinder.Spiegel.Dimmen-Relativ
+  room: Badezimmer-Kinder
 4/3/134:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Kinder.Spiegel.Dimmen-Absolut
+  room: Badezimmer-Kinder
 4/3/135:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Kinder.Spiegel.Dimmen-Status
+  room: Badezimmer-Kinder
 4/3/136:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Kinder.Spiegel.Farbwert
+  room: Badezimmer-Kinder
 4/3/137:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Kinder.Spiegel.Farbwert-Status
+  room: Badezimmer-Kinder
 4/3/138:
   dpt: '7.600'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Kinder.Spiegel.Farbtemperatur
+  room: Badezimmer-Kinder
 4/3/139:
   dpt: '7.600'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Kinder.Spiegel.Farbtemperatur-Status
+  room: Badezimmer-Kinder
 4/3/14:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Flur.Downlight.Treppe.Dimmen-Absolut
+  room: Flur
 4/3/15:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Flur.Downlight.Treppe.Dimmen-Status
+  room: Flur
 4/3/150:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Gregory.Downlight.Sperren
+  room: Schlafzimmer-Gregory
 4/3/151:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Gregory.Downlight.Ein/Aus
+  room: Schlafzimmer-Gregory
 4/3/152:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Gregory.Downlight.Ein/Aus-Status
+  room: Schlafzimmer-Gregory
 4/3/153:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Gregory.Downlight.Dimmen-Relativ
+  room: Schlafzimmer-Gregory
 4/3/154:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Gregory.Downlight.Dimmen-Absolut
+  room: Schlafzimmer-Gregory
 4/3/155:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Gregory.Downlight.Dimmen-Status
+  room: Schlafzimmer-Gregory
 4/3/160:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Gregory.Stripe.Sperren
+  room: Schlafzimmer-Gregory
 4/3/161:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Gregory.Stripe.Ein/Aus
+  room: Schlafzimmer-Gregory
 4/3/162:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Gregory.Stripe.Ein/Aus-Status
+  room: Schlafzimmer-Gregory
 4/3/163:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Gregory.Stripe.Dimmen-Relativ
+  room: Schlafzimmer-Gregory
 4/3/164:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Gregory.Stripe.Dimmen-Absolut
+  room: Schlafzimmer-Gregory
 4/3/165:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Gregory.Stripe.Dimmen-Status
+  room: Schlafzimmer-Gregory
 4/3/166:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Gregory.Stripe.Farbwert
+  room: Schlafzimmer-Gregory
 4/3/167:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Gregory.Stripe.Farbwert-Status
+  room: Schlafzimmer-Gregory
 4/3/168:
   dpt: '7.600'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Gregory.Stripe.Farbtemparatur
+  room: Schlafzimmer-Gregory
 4/3/169:
   dpt: '7.600'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Gregory.Stripe.Farbtemparatur-Status
+  room: Schlafzimmer-Gregory
 4/3/170:
   dpt: '232.600'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Gregory.Stripe.Farbsteuerung
+  room: Schlafzimmer-Gregory
 4/3/171:
   dpt: '232.600'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Gregory.Stripe.Farbsteuerung-Status
+  room: Schlafzimmer-Gregory
 4/3/2:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.OG.Flur.Pendelleuchte.Ein/Aus-Status
+  room: Flur
 4/3/20:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.OG.Flur.Downlight.Galerie.Sperren
+  room: Flur
 4/3/21:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Flur.Downlight.Galerie.Ein/Aus
+  room: Flur
 4/3/22:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.OG.Flur.Downlight.Galerie.Ein/Aus-Status
+  room: Flur
 4/3/23:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.OG.Flur.Downlight.Galerie.Dimmen-Relativ
+  room: Flur
 4/3/24:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Flur.Downlight.Galerie.Dimmen-Absolut
+  room: Flur
 4/3/25:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Flur.Downlight.Galerie.Dimmen-Status
+  room: Flur
 4/3/3:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.OG.Flur.Pendelleuchte.Dimmen-Relativ
+  room: Flur
 4/3/30:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.OG.Flur.Downlight.Gang.Sperren
+  room: Flur
 4/3/31:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Flur.Downlight.Gang.Ein/Aus
+  room: Flur
 4/3/32:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.OG.Flur.Downlight.Gang.Ein/Aus-Status
+  room: Flur
 4/3/33:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.OG.Flur.Downlight.Gang.Dimmen-Relativ
+  room: Flur
 4/3/34:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Flur.Downlight.Gang.Dimmen-Absolut
+  room: Flur
 4/3/35:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Flur.Downlight.Gang.Dimmen-Status
+  room: Flur
 4/3/4:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Flur.Pendelleuchte.Dimmen-Absolut
+  room: Flur
 4/3/40:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.OG.Flur.Bodenleuchte.Sperren
+  room: Flur
 4/3/41:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Flur.Bodenleuchte.Ein/Aus
+  room: Flur
 4/3/42:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.OG.Flur.Bodenleuchte.Ein/Aus-Status
+  room: Flur
 4/3/43:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.OG.Flur.Bodenleuchte.Dimmen-Relativ
+  room: Flur
 4/3/44:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Flur.Bodenleuchte.Dimmen-Absolut
+  room: Flur
 4/3/45:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Flur.Bodenleuchte.Dimmen-Status
+  room: Flur
 4/3/5:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Flur.Pendelleuchte.Dimmen-Status
+  room: Flur
 4/3/50:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.OG.Abstellraum.Downlight.Sperren
+  room: Abstellraum
 4/3/51:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Abstellraum.Downlight.Ein/Aus
+  room: Abstellraum
 4/3/52:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.OG.Abstellraum.Downlight.Ein/Aus-Status
+  room: Abstellraum
 4/3/53:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.OG.Abstellraum.Downlight.Dimmen-Relativ
+  room: Abstellraum
 4/3/54:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Abstellraum.Downlight.Dimmen-Absolut
+  room: Abstellraum
 4/3/55:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Abstellraum.Downlight.Dimmen-Status
+  room: Abstellraum
 4/4/0:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.DG.Speicher.Deckenleuchte.Sperren
+  room: Speicher
 4/4/1:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.DG.Speicher.Deckenleuchte.Ein/Aus
+  room: Speicher
 4/4/2:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.DG.Speicher.Deckenleuchte.Ein/Aus-Status
+  room: Speicher
 4/4/3:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.DG.Speicher.Deckenleuchte.Dimmen-Relativ
+  room: Speicher
 4/4/4:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.DG.Speicher.Deckenleuchte.Dimmen-Absolut
+  room: Speicher
 4/4/5:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.DG.Speicher.Deckenleuchte.Dimmen-Status
+  room: Speicher
 4/5/0:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.A.Fassade.Front.Sperren
+  room: Fassade
 4/5/1:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.A.Fassade.Front.Ein/Aus
+  room: Fassade
 4/5/100:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.A.Terrasse.Spots.Sperren
+  room: Terrasse
 4/5/101:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.A.Terrasse.Spots.Ein/Aus
+  room: Terrasse
 4/5/102:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.A.Terrasse.Spots.Ein/Aus-Status
+  room: Terrasse
 4/5/103:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.A.Terrasse.Spots.Dimmen-Relativ
+  room: Terrasse
 4/5/104:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.A.Terrasse.Spots.Dimmen-Absolut
+  room: Terrasse
 4/5/105:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.A.Terrasse.Spots.Dimmen-Status
+  room: Terrasse
 4/5/110:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.A.Terrasse.Stripe.Sperren
+  room: Terrasse
 4/5/111:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.A.Terrasse.Stripe.Ein/Aus
+  room: Terrasse
 4/5/112:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.A.Terrasse.Stripe.Ein/Aus-Status
+  room: Terrasse
 4/5/113:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.A.Terrasse.Stripe.Dimmen-Relativ
+  room: Terrasse
 4/5/114:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.A.Terrasse.Stripe.Dimmen-Absolut
+  room: Terrasse
 4/5/115:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.A.Terrasse.Stripe.Dimmen-Status
+  room: Terrasse
 4/5/150:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.A.Balkon.Spots.Sperren
+  room: Balkon
 4/5/151:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.A.Balkon.Spots.Ein/Aus
+  room: Balkon
 4/5/152:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.A.Balkon.Spots.Ein/Aus-Status
+  room: Balkon
 4/5/153:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.A.Balkon.Spots.Dimmen-Relativ
+  room: Balkon
 4/5/154:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.A.Balkon.Spots.Dimmen-Absolut
+  room: Balkon
 4/5/155:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.A.Balkon.Spots.Dimmen-Status
+  room: Balkon
 4/5/2:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.A.Fassade.Front.Ein/Aus-Status
+  room: Fassade
 4/5/3:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.A.Fassade.Front.Dimmen-Relativ
+  room: Fassade
 4/5/4:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.A.Fassade.Front.Dimmen-Absolut
+  room: Fassade
 4/5/5:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.A.Fassade.Front.Dimmen-Status
+  room: Fassade
 4/5/50:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.A.Eingang.Briefkasten.Sperren
+  room: Eingang
 4/5/51:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.A.Eingang.Briefkasten.Ein/Aus
+  room: Eingang
 4/5/52:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.A.Eingang.Briefkasten.Ein/Aus-Status
+  room: Eingang
 4/5/53:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.A.Eingang.Briefkasten.Dimmen-Relativ
+  room: Eingang
 4/5/54:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.A.Eingang.Briefkasten.Dimmen-Absolut
+  room: Eingang
 4/5/55:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.A.Eingang.Briefkasten.Dimmen-Status
+  room: Eingang
 5/1/0:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.KG.Hauswirtschaftsraum.Deckenleuchte.Sperren
+  room: Hauswirtschaftsraum
 5/1/1:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.KG.Hauswirtschaftsraum.Deckenleuchte.Ein/Aus
+  room: Hauswirtschaftsraum
 5/1/2:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.KG.Hauswirtschaftsraum.Deckenleuchte.Ein/Aus-Status
+  room: Hauswirtschaftsraum
 5/1/3:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.KG.Hauswirtschaftsraum.Deckenleuchte.Dimmen-Relativ
+  room: Hauswirtschaftsraum
 5/1/4:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.KG.Hauswirtschaftsraum.Deckenleuchte.Dimmen-Absolut
+  room: Hauswirtschaftsraum
 5/1/5:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.KG.Hauswirtschaftsraum.Deckenleuchte.Dimmen-Status
+  room: Hauswirtschaftsraum
 5/2/0:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.EG.Esszimmer.Pendelleuchte.Sperren
+  room: Esszimmer
 5/2/1:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Esszimmer.Pendelleuchte.Ein/Aus
+  room: Esszimmer
 5/2/10:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.EG.Esszimmer.Indirekt.Sperren
+  room: Esszimmer
 5/2/100:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.EG.Küche.Küchenzeile.Sperren
+  room: Küche
 5/2/101:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Küche.Küchenzeile.Ein/Aus
+  room: Küche
 5/2/102:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.EG.Küche.Küchenzeile.Ein/Aus-Status
+  room: Küche
 5/2/103:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.EG.Küche.Küchenzeile.Dimmen-Relativ
+  room: Küche
 5/2/104:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Küche.Küchenzeile.Dimmen-Absolut
+  room: Küche
 5/2/105:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Küche.Küchenzeile.Dimmen-Status
+  room: Küche
 5/2/106:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Küche.Küchenzeile.Farbwert
+  room: Küche
 5/2/107:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Küche.Küchenzeile.Farbwert-Status
+  room: Küche
 5/2/108:
   dpt: '7.600'
+  function: Beleuchtung
   name: Beleuchtung.EG.Küche.Küchenzeile.Farbtemparatur
+  room: Küche
 5/2/109:
   dpt: '7.600'
+  function: Beleuchtung
   name: Beleuchtung.EG.Küche.Küchenzeile.Farbtemparatur-Status
+  room: Küche
 5/2/11:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Esszimmer.Indirekt.Ein/Aus
+  room: Esszimmer
 5/2/12:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.EG.Esszimmer.Indirekt.Ein/Aus-Status
+  room: Esszimmer
 5/2/13:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.EG.Esszimmer.Indirekt.Dimmen-Relativ
+  room: Esszimmer
 5/2/14:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Esszimmer.Indirekt.Dimmen-Absolut
+  room: Esszimmer
 5/2/15:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Esszimmer.Indirekt.Dimmen-Status
+  room: Esszimmer
 5/2/2:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.EG.Esszimmer.Pendelleuchte.Ein/Aus-Status
+  room: Esszimmer
 5/2/3:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.EG.Esszimmer.Pendelleuchte.Dimmen-Relativ
+  room: Esszimmer
 5/2/4:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Esszimmer.Pendelleuchte.Dimmen-Absolut
+  room: Esszimmer
 5/2/5:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Esszimmer.Pendelleuchte.Dimmen-Status
+  room: Esszimmer
 5/2/50:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.EG.Küche.Track.Sperren
+  room: Küche
 5/2/51:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Küche.Track.Ein/Aus
+  room: Küche
 5/2/52:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.EG.Küche.Track.Ein/Aus-Status
+  room: Küche
 5/2/53:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.EG.Küche.Track.Dimmen-Relativ
+  room: Küche
 5/2/54:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Küche.Track.Dimmen-Absolut
+  room: Küche
 5/2/55:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Küche.Track.Dimmen-Status
+  room: Küche
 5/2/60:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.EG.Küche.Pendelleuchte.Groß.Sperren
+  room: Küche
 5/2/61:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Küche.Pendelleuchte.Groß.Ein/Aus
+  room: Küche
 5/2/62:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.EG.Küche.Pendelleuchte.Groß.Ein/Aus-Status
+  room: Küche
 5/2/63:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.EG.Küche.Pendelleuchte.Groß.Dimmen-Relativ
+  room: Küche
 5/2/64:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Küche.Pendelleuchte.Groß.Dimmen-Absolut
+  room: Küche
 5/2/65:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Küche.Pendelleuchte.Groß.Dimmen-Status
+  room: Küche
 5/2/70:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.EG.Küche.Pendelleuchte.Klein.Sperren
+  room: Küche
 5/2/71:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Küche.Pendelleuchte.Klein.Ein/Aus
+  room: Küche
 5/2/72:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.EG.Küche.Pendelleuchte.Klein.Ein/Aus-Status
+  room: Küche
 5/2/73:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.EG.Küche.Pendelleuchte.Klein.Dimmen-Relativ
+  room: Küche
 5/2/74:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Küche.Pendelleuchte.Klein.Dimmen-Absolut
+  room: Küche
 5/2/75:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Küche.Pendelleuchte.Klein.Dimmen-Status
+  room: Küche
 5/2/80:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.EG.Küche.Indirekt.Sperren
+  room: Küche
 5/2/81:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Küche.Indirekt.Ein/Aus
+  room: Küche
 5/2/82:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.EG.Küche.Indirekt.Ein/Aus-Status
+  room: Küche
 5/2/83:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.EG.Küche.Indirekt.Dimmen-Relativ
+  room: Küche
 5/2/84:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Küche.Indirekt.Dimmen-Absolut
+  room: Küche
 5/2/85:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Küche.Indirekt.Dimmen-Status
+  room: Küche
 5/2/90:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.EG.Küche.Kücheninsel.Sperren
+  room: Küche
 5/2/91:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Küche.Kücheninsel.Ein/Aus
+  room: Küche
 5/2/92:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.EG.Küche.Kücheninsel.Ein/Aus-Status
+  room: Küche
 5/2/93:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.EG.Küche.Kücheninsel.Dimmen-Relativ
+  room: Küche
 5/2/94:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Küche.Kücheninsel.Dimmen-Absolut
+  room: Küche
 5/2/95:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Küche.Kücheninsel.Dimmen-Status
+  room: Küche
 5/2/96:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Küche.Kücheninsel.Farbwert
+  room: Küche
 5/2/97:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.EG.Küche.Kücheninsel.Farbwert-Status
+  room: Küche
 5/2/98:
   dpt: '7.600'
+  function: Beleuchtung
   name: Beleuchtung.EG.Küche.Kücheninsel.Farbtemparatur
+  room: Küche
 5/2/99:
   dpt: '7.600'
+  function: Beleuchtung
   name: Beleuchtung.EG.Küche.Kücheninsel.Farbtemparatur-Status
+  room: Küche
 5/3/0:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Luis.Downlight.Sperren
+  room: Schlafzimmer-Luis
 5/3/1:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Luis.Downlight.Ein/Aus
+  room: Schlafzimmer-Luis
 5/3/10:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Luis.Stripe.Sperren
+  room: Schlafzimmer-Luis
 5/3/100:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.OG.Begehbarer-Schrank.Deckenleuchte.Sperren
+  room: Begehbarer-Schrank
 5/3/101:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Begehbarer-Schrank.Deckenleuchte.Ein/Aus
+  room: Begehbarer-Schrank
 5/3/102:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.OG.Begehbarer-Schrank.Deckenleuchte.Ein/Aus-Status
+  room: Begehbarer-Schrank
 5/3/103:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.OG.Begehbarer-Schrank.Deckenleuchte.Dimmen-Relativ
+  room: Begehbarer-Schrank
 5/3/104:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Begehbarer-Schrank.Deckenleuchte.Dimmen-Absolut
+  room: Begehbarer-Schrank
 5/3/105:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Begehbarer-Schrank.Deckenleuchte.Dimmen-Status
+  room: Begehbarer-Schrank
 5/3/11:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Luis.Stripe.Ein/Aus
+  room: Schlafzimmer-Luis
 5/3/12:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Luis.Stripe.Ein/Aus-Status
+  room: Schlafzimmer-Luis
 5/3/13:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Luis.Stripe.Dimmen-Relativ
+  room: Schlafzimmer-Luis
 5/3/14:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Luis.Stripe.Dimmen-Absolut
+  room: Schlafzimmer-Luis
 5/3/15:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Luis.Stripe.Dimmen-Status
+  room: Schlafzimmer-Luis
 5/3/150:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Downlight.WC.Sperren
+  room: Badezimmer-Eltern
 5/3/151:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Downlight.WC.Ein/Aus
+  room: Badezimmer-Eltern
 5/3/152:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Downlight.WC.Ein/Aus-Status
+  room: Badezimmer-Eltern
 5/3/153:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Downlight.WC.Dimmen-Relativ
+  room: Badezimmer-Eltern
 5/3/154:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Downlight.WC.Dimmen-Absolut
+  room: Badezimmer-Eltern
 5/3/155:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Downlight.WC.Dimmen-Status
+  room: Badezimmer-Eltern
 5/3/16:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Luis.Stripe.Farbwert
+  room: Schlafzimmer-Luis
 5/3/160:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Downlight.Becken.Sperren
+  room: Badezimmer-Eltern
 5/3/161:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Downlight.Becken.Ein/Aus
+  room: Badezimmer-Eltern
 5/3/162:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Downlight.Becken.Ein/Aus-Status
+  room: Badezimmer-Eltern
 5/3/163:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Downlight.Becken.Dimmen-Relativ
+  room: Badezimmer-Eltern
 5/3/164:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Downlight.Becken.Dimmen-Absolut
+  room: Badezimmer-Eltern
 5/3/165:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Downlight.Becken.Dimmen-Status
+  room: Badezimmer-Eltern
 5/3/17:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Luis.Stripe.Farbwert-Status
+  room: Schlafzimmer-Luis
 5/3/170:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Indirekt.WC.Sperren
+  room: Badezimmer-Eltern
 5/3/171:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Indirekt.WC.Ein/Aus
+  room: Badezimmer-Eltern
 5/3/172:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Indirekt.WC.Ein/Aus-Status
+  room: Badezimmer-Eltern
 5/3/173:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Indirekt.WC.Dimmen-Relativ
+  room: Badezimmer-Eltern
 5/3/174:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Indirekt.WC.Dimmen-Absolut
+  room: Badezimmer-Eltern
 5/3/175:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Indirekt.WC.Dimmen-Status
+  room: Badezimmer-Eltern
 5/3/18:
   dpt: '7.600'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Luis.Stripe.Farbtemparatur
+  room: Schlafzimmer-Luis
 5/3/180:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Indirekt.Schrank.Sperren
+  room: Badezimmer-Eltern
 5/3/181:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Indirekt.Schrank.Ein/Aus
+  room: Badezimmer-Eltern
 5/3/182:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Indirekt.Schrank.Ein/Aus-Status
+  room: Badezimmer-Eltern
 5/3/183:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Indirekt.Schrank.Dimmen-Relativ
+  room: Badezimmer-Eltern
 5/3/184:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Indirekt.Schrank.Dimmen-Absolut
+  room: Badezimmer-Eltern
 5/3/185:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Indirekt.Schrank.Dimmen-Status
+  room: Badezimmer-Eltern
 5/3/19:
   dpt: '7.600'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Luis.Stripe.Farbtemparatur-Status
+  room: Schlafzimmer-Luis
 5/3/190:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.RGB.Sperren
+  room: Badezimmer-Eltern
 5/3/191:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.RGB.Ein/Aus
+  room: Badezimmer-Eltern
 5/3/192:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.RGB.Ein/Aus-Status
+  room: Badezimmer-Eltern
 5/3/193:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.RGB.Dimmen-Relativ
+  room: Badezimmer-Eltern
 5/3/194:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.RGB.Dimmen-Absolut
+  room: Badezimmer-Eltern
 5/3/195:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.RGB.Dimmen-Status
+  room: Badezimmer-Eltern
 5/3/196:
   dpt: '232.600'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.RGB.Farbsteuerung
+  room: Badezimmer-Eltern
 5/3/197:
   dpt: '232.600'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.RGB.Farbsteuerung-Status
+  room: Badezimmer-Eltern
 5/3/2:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Luis.Downlight.Ein/Aus-Status
+  room: Schlafzimmer-Luis
 5/3/20:
   dpt: '232.600'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Luis.Stripe.Farbsteuerung
+  room: Schlafzimmer-Luis
 5/3/200:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Spiegel.Sperren
+  room: Badezimmer-Eltern
 5/3/201:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Spiegel.Ein/Aus
+  room: Badezimmer-Eltern
 5/3/202:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Spiegel.Ein/Aus-Status
+  room: Badezimmer-Eltern
 5/3/203:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Spiegel.Dimmen-Relativ
+  room: Badezimmer-Eltern
 5/3/204:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Spiegel.Dimmen-Absolut
+  room: Badezimmer-Eltern
 5/3/205:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Spiegel.Dimmen-Status
+  room: Badezimmer-Eltern
 5/3/206:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Spiegel.Farbwert
+  room: Badezimmer-Eltern
 5/3/207:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Spiegel.Farbwert-Status
+  room: Badezimmer-Eltern
 5/3/208:
   dpt: '7.600'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Spiegel.Farbtemparatur
+  room: Badezimmer-Eltern
 5/3/209:
   dpt: '7.600'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Spiegel.Farbtemparatur-Status
+  room: Badezimmer-Eltern
 5/3/21:
   dpt: '232.600'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Luis.Stripe.Farbsteuerung-Status
+  room: Schlafzimmer-Luis
 5/3/210:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Schminkspiegel.Sperren
+  room: Badezimmer-Eltern
 5/3/211:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Schminkspiegel.Ein/Aus
+  room: Badezimmer-Eltern
 5/3/212:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Schminkspiegel.Ein/Aus-Status
+  room: Badezimmer-Eltern
 5/3/213:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Schminkspiegel.Dimmen-Relativ
+  room: Badezimmer-Eltern
 5/3/214:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Schminkspiegel.Dimmen-Absolut
+  room: Badezimmer-Eltern
 5/3/215:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Schminkspiegel.Dimmen-Status
+  room: Badezimmer-Eltern
 5/3/216:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Schminkspiegel.Farbwert
+  room: Badezimmer-Eltern
 5/3/217:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Schminkspiegel.Farbwert-Status
+  room: Badezimmer-Eltern
 5/3/218:
   dpt: '7.600'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Schminkspiegel.Farbtemperatur
+  room: Badezimmer-Eltern
 5/3/219:
   dpt: '7.600'
+  function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Schminkspiegel.Farbtemperatur-Status
+  room: Badezimmer-Eltern
 5/3/3:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Luis.Downlight.Dimmen-Relativ
+  room: Schlafzimmer-Luis
 5/3/4:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Luis.Downlight.Dimmen-Absolut
+  room: Schlafzimmer-Luis
 5/3/5:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Luis.Downlight.Dimmen-Status
+  room: Schlafzimmer-Luis
 5/3/50:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Downlight.Sperren
+  room: Schlafzimmer-Eltern
 5/3/51:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Downlight.Ein/Aus
+  room: Schlafzimmer-Eltern
 5/3/52:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Downlight.Ein/Aus-Status
+  room: Schlafzimmer-Eltern
 5/3/53:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Downlight.Dimmen-Relativ
+  room: Schlafzimmer-Eltern
 5/3/54:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Downlight.Dimmen-Absolut
+  room: Schlafzimmer-Eltern
 5/3/55:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Downlight.Dimmen-Status
+  room: Schlafzimmer-Eltern
 5/3/60:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Leselicht.Links.Sperren
+  room: Schlafzimmer-Eltern
 5/3/61:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Leselicht.Links.Ein/Aus
+  room: Schlafzimmer-Eltern
 5/3/62:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Leselicht.Links.Ein/Aus-Status
+  room: Schlafzimmer-Eltern
 5/3/63:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Leselicht.Links.Dimmen-Relativ
+  room: Schlafzimmer-Eltern
 5/3/64:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Leselicht.Links.Dimmen-Absolut
+  room: Schlafzimmer-Eltern
 5/3/65:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Leselicht.Links.Dimmen-Status
+  room: Schlafzimmer-Eltern
 5/3/70:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Leselicht.Rechts.Sperren
+  room: Schlafzimmer-Eltern
 5/3/71:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Leselicht.Rechts.Ein/Aus
+  room: Schlafzimmer-Eltern
 5/3/72:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Leselicht.Rechts.Ein/Aus-Status
+  room: Schlafzimmer-Eltern
 5/3/73:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Leselicht.Rechts.Dimmen-Relativ
+  room: Schlafzimmer-Eltern
 5/3/74:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Leselicht.Rechts.Dimmen-Absolut
+  room: Schlafzimmer-Eltern
 5/3/75:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Leselicht.Rechts.Dimmen-Status
+  room: Schlafzimmer-Eltern
 5/3/80:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Indirekt.TV.Sperren
+  room: Schlafzimmer-Eltern
 5/3/81:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Indirekt.TV.Ein/Aus
+  room: Schlafzimmer-Eltern
 5/3/82:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Indirekt.TV.Ein/Aus-Status
+  room: Schlafzimmer-Eltern
 5/3/83:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.TV.Indirekt.Dimmen-Relativ
+  room: Schlafzimmer-Eltern
 5/3/84:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Indirekt.TV.Dimmen-Absolut
+  room: Schlafzimmer-Eltern
 5/3/85:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Indirekt.TV.Dimmen-Status
+  room: Schlafzimmer-Eltern
 5/3/90:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Indirekt.Bett.Sperren
+  room: Schlafzimmer-Eltern
 5/3/91:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Indirekt.Bett.Ein/Aus
+  room: Schlafzimmer-Eltern
 5/3/92:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Indirekt.Bett.Ein/Aus-Status
+  room: Schlafzimmer-Eltern
 5/3/93:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Indirekt.Bett.Dimmen-Relativ
+  room: Schlafzimmer-Eltern
 5/3/94:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Indirekt.Bett.Dimmen-Absolut
+  room: Schlafzimmer-Eltern
 5/3/95:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Indirekt.Bett.Dimmen-Status
+  room: Schlafzimmer-Eltern
 5/5/0:
   dpt: '1.003'
+  function: Beleuchtung
   name: Beleuchtung.A.Garten.Hochbeet.Poller.Sperren
+  room: Garten
 5/5/1:
   dpt: '1.001'
+  function: Beleuchtung
   name: Beleuchtung.A.Garten.Hochbeet.Poller.Ein/Aus
+  room: Garten
 5/5/2:
   dpt: '1.011'
+  function: Beleuchtung
   name: Beleuchtung.A.Garten.Hochbeet.Poller.Ein/Aus-Status
+  room: Garten
 5/5/3:
   dpt: '3.007'
+  function: Beleuchtung
   name: Beleuchtung.A.Garten.Hochbeet.Poller.Dimmen-Relativ
+  room: Garten
 5/5/4:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.A.Garten.Hochbeet.Poller.Dimmen-Absolut
+  room: Garten
 5/5/5:
   dpt: '5.001'
+  function: Beleuchtung
   name: Beleuchtung.A.Garten.Hochbeet.Poller.Dimmen-Status
+  room: Garten
 6/0/120:
   dpt: '1.008'
+  function: Beschattung
   name: Beschattung.Zentral.EG.Raffstore.Innen.Fahren
 6/0/121:
   dpt: '1.007'
+  function: Beschattung
   name: Beschattung.Zentral.EG.Raffstore.Innen.Stoppen
 6/0/122:
   dpt: '1.008'
+  function: Beschattung
   name: Beschattung.Zentral.EG.Raffstore.Außen.Fahren
 6/0/123:
   dpt: '1.007'
+  function: Beschattung
   name: Beschattung.Zentral.EG.Raffstore.Außen.Stoppen
 6/0/140:
   dpt: '1.008'
+  function: Beschattung
   name: Beschattung.Zentral.OG.Raffstore.Innen.Fahren
 6/0/141:
   dpt: '1.007'
+  function: Beschattung
   name: Beschattung.Zentral.OG.Raffstore.Innen.Stoppen
 6/0/142:
   dpt: '1.008'
+  function: Beschattung
   name: Beschattung.Zentral.OG.Raffstore.Außen.Fahren
 6/0/143:
   dpt: '1.007'
+  function: Beschattung
   name: Beschattung.Zentral.OG.Raffstore.Außen.Stoppen
 6/0/144:
   dpt: '1.008'
+  function: Beschattung
   name: Beschattung.Zentral.OG.Vorhang.Fahren
 6/0/145:
   dpt: '1.017'
+  function: Beschattung
   name: Beschattung.Zentral.OG.Vorhang.Stoppen
 6/0/200:
   dpt: '1.001'
+  function: Beschattung
   name: Beschattung.Zentral.Raffstore.Außen-1.Automatik.Sperren
 6/0/201:
   dpt: '1.008'
+  function: Beschattung
   name: Beschattung.Zentral.Raffstore.Außen-1.Automatik.Fahren
 6/0/202:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.Zentral.Raffstore.Außen-1.Automatik.Position
 6/0/203:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.Zentral.Raffstore.Außen-1.Automatik.Rotation
 6/0/204:
   dpt: '9.004'
+  function: Beschattung
   name: Beschattung.Zentral.Raffstore.Außen-1.Automatik.Helligkeitsschwelle
 6/0/205:
   dpt: '9.004'
+  function: Beschattung
   name: Beschattung.Zentral.Raffstore.Außen-1.Automatik.Dämmerungsschwelle
 6/0/210:
   dpt: '1.001'
+  function: Beschattung
   name: Beschattung.Zentral.Raffstore.Außen-2.Automatik.Sperren
 6/0/211:
   dpt: '1.008'
+  function: Beschattung
   name: Beschattung.Zentral.Raffstore.Außen-2.Automatik.Fahren
 6/0/212:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.Zentral.Raffstore.Außen-2.Automatik.Position
 6/0/213:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.Zentral.Raffstore.Außen-2.Automatik.Rotation
 6/0/214:
   dpt: '9.004'
+  function: Beschattung
   name: Beschattung.Zentral.Raffstore.Außen-2.Automatik.Helligkeitsschwelle
 6/0/215:
   dpt: '9.004'
+  function: Beschattung
   name: Beschattung.Zentral.Raffstore.Außen-2.Automatik.Dämmerungsschwelle
 6/0/220:
   dpt: '1.001'
+  function: Beschattung
   name: Beschattung.Zentral.Raffstore.Innen.Automatik.Sperren
 6/0/221:
   dpt: '1.008'
+  function: Beschattung
   name: Beschattung.Zentral.Raffstore.Innen.Automatik.Fahren
 6/0/222:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.Zentral.Raffstore.Innen.Automatik.Position
 6/0/223:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.Zentral.Raffstore.Innen.Automatik.Rotation
 6/0/224:
   dpt: '9.004'
+  function: Beschattung
   name: Beschattung.Zentral.Raffstore.Innen.Automatik.Helligkeitsschwelle
 6/0/225:
   dpt: '9.004'
+  function: Beschattung
   name: Beschattung.Zentral.Raffstore.Innen.Automatik.Dämmerungsschwelle
 6/2/0:
   dpt: '1.003'
+  function: Beschattung
   name: Beschattung.EG.Büro.Raffstore.Sperren
+  room: Büro
 6/2/1:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.EG.Büro.Raffstore.Sperren-Status
+  room: Büro
 6/2/10:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.EG.Büro.Raffstore.Geschlossen-Status
+  room: Büro
 6/2/100:
   dpt: '1.003'
+  function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Rechts.Sperren
+  room: Küche
 6/2/101:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Rechts.Sperren-Status
+  room: Küche
 6/2/102:
   dpt: '1.008'
+  function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Rechts.Fahren
+  room: Küche
 6/2/103:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Rechts.Fahren-Status
+  room: Küche
 6/2/104:
   dpt: '1.007'
+  function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Rechts.Stoppen
+  room: Küche
 6/2/105:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Rechts.Position
+  room: Küche
 6/2/106:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Rechts.Position-Status
+  room: Küche
 6/2/107:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Rechts.Rotation
+  room: Küche
 6/2/108:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Rechts.Rotation-Status
+  room: Küche
 6/2/109:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Rechts.Geöffnet-Status
+  room: Küche
 6/2/11:
   dpt: '1.010'
+  function: Beschattung
   name: Beschattung.EG.Büro.Raffstore.Fahrzeit
+  room: Büro
 6/2/110:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Rechts.Geschlossen-Status
+  room: Küche
 6/2/111:
   dpt: '1.010'
+  function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Rechts.Fahrzeit
+  room: Küche
 6/2/2:
   dpt: '1.008'
+  function: Beschattung
   name: Beschattung.EG.Büro.Raffstore.Fahren
+  room: Büro
 6/2/20:
   dpt: '1.003'
+  function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Links.Sperren
+  room: Wohnzimmer
 6/2/21:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Links.Sperren-Status
+  room: Wohnzimmer
 6/2/22:
   dpt: '1.008'
+  function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Links.Fahren
+  room: Wohnzimmer
 6/2/23:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Links.Fahren-Status
+  room: Wohnzimmer
 6/2/24:
   dpt: '1.007'
+  function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Links.Stoppen
+  room: Wohnzimmer
 6/2/25:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Links.Position
+  room: Wohnzimmer
 6/2/26:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Links.Position-Status
+  room: Wohnzimmer
 6/2/27:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Links.Rotation
+  room: Wohnzimmer
 6/2/28:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Links.Rotation-Status
+  room: Wohnzimmer
 6/2/29:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Links.Geöffnet-Status
+  room: Wohnzimmer
 6/2/3:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.EG.Büro.Raffstore.Fahren-Status
+  room: Büro
 6/2/30:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Links.Geschlossen-Status
+  room: Wohnzimmer
 6/2/31:
   dpt: '1.010'
+  function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Links.Fahrzeit
+  room: Wohnzimmer
 6/2/4:
   dpt: '1.007'
+  function: Beschattung
   name: Beschattung.EG.Büro.Raffstore.Stoppen
+  room: Büro
 6/2/40:
   dpt: '1.003'
+  function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Rechts.Sperren
+  room: Wohnzimmer
 6/2/41:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Rechts.Sperren-Status
+  room: Wohnzimmer
 6/2/42:
   dpt: '1.008'
+  function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Rechts.Fahren
+  room: Wohnzimmer
 6/2/43:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Rechts.Fahren-Status
+  room: Wohnzimmer
 6/2/44:
   dpt: '1.007'
+  function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Rechts.Stoppen
+  room: Wohnzimmer
 6/2/45:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Rechts.Position
+  room: Wohnzimmer
 6/2/46:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Rechts.Position-Status
+  room: Wohnzimmer
 6/2/47:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Rechts.Rotation
+  room: Wohnzimmer
 6/2/48:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Rechts.Rotation-Status
+  room: Wohnzimmer
 6/2/49:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Rechts.Geöffnet-Status
+  room: Wohnzimmer
 6/2/5:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.EG.Büro.Raffstore.Position
+  room: Büro
 6/2/50:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Rechts.Geschlossen-Status
+  room: Wohnzimmer
 6/2/51:
   dpt: '1.010'
+  function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Rechts.Fahrzeit
+  room: Wohnzimmer
 6/2/6:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.EG.Büro.Raffstore.Position-Status
+  room: Büro
 6/2/60:
   dpt: '1.003'
+  function: Beschattung
   name: Beschattung.EG.Esszimmer.Raffstore.Sperren
+  room: Esszimmer
 6/2/61:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.EG.Esszimmer.Raffstore.Sperren-Status
+  room: Esszimmer
 6/2/62:
   dpt: '1.008'
+  function: Beschattung
   name: Beschattung.EG.Esszimmer.Raffstore.Fahren
+  room: Esszimmer
 6/2/63:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.EG.Esszimmer.Raffstore.Fahren-Status
+  room: Esszimmer
 6/2/64:
   dpt: '1.007'
+  function: Beschattung
   name: Beschattung.EG.Esszimmer.Raffstore.Stoppen
+  room: Esszimmer
 6/2/65:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.EG.Esszimmer.Raffstore.Position
+  room: Esszimmer
 6/2/66:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.EG.Esszimmer.Raffstore.Position-Status
+  room: Esszimmer
 6/2/67:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.EG.Esszimmer.Raffstore.Rotation
+  room: Esszimmer
 6/2/68:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.EG.Esszimmer.Raffstore.Rotation-Status
+  room: Esszimmer
 6/2/69:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.EG.Esszimmer.Raffstore.Geöffnet-Status
+  room: Esszimmer
 6/2/7:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.EG.Büro.Raffstore.Rotation
+  room: Büro
 6/2/70:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.EG.Esszimmer.Raffstore.Geschlossen-Status
+  room: Esszimmer
 6/2/71:
   dpt: '1.010'
+  function: Beschattung
   name: Beschattung.EG.Esszimmer.Raffstore.Fahrzeit
+  room: Esszimmer
 6/2/8:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.EG.Büro.Raffstore.Rotation-Status
+  room: Büro
 6/2/80:
   dpt: '1.003'
+  function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Links.Sperren
+  room: Küche
 6/2/81:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Links.Sperren-Status
+  room: Küche
 6/2/82:
   dpt: '1.008'
+  function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Links.Fahren
+  room: Küche
 6/2/83:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Links.Fahren-Status
+  room: Küche
 6/2/84:
   dpt: '1.007'
+  function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Links.Stoppen
+  room: Küche
 6/2/85:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Links.Position
+  room: Küche
 6/2/86:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Links.Position-Status
+  room: Küche
 6/2/87:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Links.Rotation
+  room: Küche
 6/2/88:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Links.Rotation-Status
+  room: Küche
 6/2/89:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Links.Geöffnet-Status
+  room: Küche
 6/2/9:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.EG.Büro.Raffstore.Geöffnet-Status
+  room: Büro
 6/2/90:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Links.Geschlossen-Status
+  room: Küche
 6/2/91:
   dpt: '1.010'
+  function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Links.Fahrzeit
+  room: Küche
 6/3/0:
   dpt: '1.003'
+  function: Beschattung
   name: Beschattung.OG.Flur.Raffstore.Sperren
+  room: Flur
 6/3/1:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.OG.Flur.Raffstore.Sperren-Status
+  room: Flur
 6/3/10:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.OG.Flur.Raffstore.Geschlossen-Status
+  room: Flur
 6/3/100:
   dpt: '1.003'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Raffstore.Sperren
+  room: Schlafzimmer-Luis
 6/3/101:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Raffstore.Sperren-Status
+  room: Schlafzimmer-Luis
 6/3/102:
   dpt: '1.008'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Raffstore.Fahren
+  room: Schlafzimmer-Luis
 6/3/103:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Raffstore.Fahren-Status
+  room: Schlafzimmer-Luis
 6/3/104:
   dpt: '1.007'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Raffstore.Stoppen
+  room: Schlafzimmer-Luis
 6/3/105:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Raffstore.Postion
+  room: Schlafzimmer-Luis
 6/3/106:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Raffstore.Position-Status
+  room: Schlafzimmer-Luis
 6/3/107:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Raffstore.Rotation
+  room: Schlafzimmer-Luis
 6/3/108:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Raffstore.Rotation-Status
+  room: Schlafzimmer-Luis
 6/3/109:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Raffstore.Geöffnet-Status
+  room: Schlafzimmer-Luis
 6/3/11:
   dpt: '1.010'
+  function: Beschattung
   name: Beschattung.OG.Flur.Raffstore.Fahrzeit
+  room: Flur
 6/3/110:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Raffstore.Geschlossen-Status
+  room: Schlafzimmer-Luis
 6/3/111:
   dpt: '1.010'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Raffstore.Fahrzeit
+  room: Schlafzimmer-Luis
 6/3/120:
   dpt: '1.003'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Vorhang.Sperren
+  room: Schlafzimmer-Luis
 6/3/121:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Vorhang.Sperren-Status
+  room: Schlafzimmer-Luis
 6/3/122:
   dpt: '1.008'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Vorhang.Fahren
+  room: Schlafzimmer-Luis
 6/3/123:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Vorhang.Fahren-Status
+  room: Schlafzimmer-Luis
 6/3/124:
   dpt: '1.017'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Vorhang.Stoppen
+  room: Schlafzimmer-Luis
 6/3/125:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Vorhang.Position
+  room: Schlafzimmer-Luis
 6/3/126:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Vorhang.Position-Status
+  room: Schlafzimmer-Luis
 6/3/129:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Vorhang.Geöffnet-Status
+  room: Schlafzimmer-Luis
 6/3/130:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Vorhang.Geschlossen-Status
+  room: Schlafzimmer-Luis
 6/3/131:
   dpt: '1.010'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Vorhang.Fahrzeit
+  room: Schlafzimmer-Luis
 6/3/140:
   dpt: '1.003'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Raffstore.Sperren
+  room: Schlafzimmer-Eltern
 6/3/141:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Raffstore.Sperren-Status
+  room: Schlafzimmer-Eltern
 6/3/142:
   dpt: '1.008'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Raffstore.Fahren
+  room: Schlafzimmer-Eltern
 6/3/143:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Raffstore.Fahren-Status
+  room: Schlafzimmer-Eltern
 6/3/144:
   dpt: '1.007'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Raffstore.Stoppen
+  room: Schlafzimmer-Eltern
 6/3/145:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Raffstore.Position
+  room: Schlafzimmer-Eltern
 6/3/146:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Raffstore.Position-Status
+  room: Schlafzimmer-Eltern
 6/3/147:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Raffstore.Rotation
+  room: Schlafzimmer-Eltern
 6/3/148:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Raffstore.Rotation-Status
+  room: Schlafzimmer-Eltern
 6/3/149:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Raffstore.Geöffnet-Status
+  room: Schlafzimmer-Eltern
 6/3/150:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Raffstore.Geschlossen-Status
+  room: Schlafzimmer-Eltern
 6/3/151:
   dpt: '1.010'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Raffstore.Fahrzeit
+  room: Schlafzimmer-Eltern
 6/3/160:
   dpt: '1.003'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Vorhang.Sperren
+  room: Schlafzimmer-Eltern
 6/3/161:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Vorhang.Sperren-Status
+  room: Schlafzimmer-Eltern
 6/3/162:
   dpt: '1.008'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Vorhang.Fahren
+  room: Schlafzimmer-Eltern
 6/3/163:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Vorhang.Fahren-Status
+  room: Schlafzimmer-Eltern
 6/3/164:
   dpt: '1.017'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Vorhang.Stoppen
+  room: Schlafzimmer-Eltern
 6/3/165:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Vorhang.Position
+  room: Schlafzimmer-Eltern
 6/3/166:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Vorhang.Position-Status
+  room: Schlafzimmer-Eltern
 6/3/169:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Vorhang.Geöffnet-Status
+  room: Schlafzimmer-Eltern
 6/3/170:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Vorhang.Geschlossen-Status
+  room: Schlafzimmer-Eltern
 6/3/171:
   dpt: '1.010'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Vorhang.Fahrzeit
+  room: Schlafzimmer-Eltern
 6/3/180:
   dpt: '1.003'
+  function: Beschattung
   name: Beschattung.OG.Badezimmer-Eltern.Raffstore.Sperren
+  room: Badezimmer-Eltern
 6/3/181:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.OG.Badezimmer-Eltern.Raffstore.Sperren-Status
+  room: Badezimmer-Eltern
 6/3/182:
   dpt: '1.008'
+  function: Beschattung
   name: Beschattung.OG.Badezimmer-Eltern.Raffstore.Fahren
+  room: Badezimmer-Eltern
 6/3/183:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.OG.Badezimmer-Eltern.Raffstore.Fahren-Status
+  room: Badezimmer-Eltern
 6/3/184:
   dpt: '1.007'
+  function: Beschattung
   name: Beschattung.OG.Badezimmer-Eltern.Raffstore.Stoppen
+  room: Badezimmer-Eltern
 6/3/185:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.OG.Badezimmer-Eltern.Raffstore.Position
+  room: Badezimmer-Eltern
 6/3/186:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.OG.Badezimmer-Eltern.Raffstore.Position-Status
+  room: Badezimmer-Eltern
 6/3/187:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.OG.Badezimmer-Eltern.Raffstore.Rotation
+  room: Badezimmer-Eltern
 6/3/188:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.OG.Badezimmer-Eltern.Raffstore.Rotation-Status
+  room: Badezimmer-Eltern
 6/3/189:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.OG.Badezimmer-Eltern.Raffstore.Geöffnet-Status
+  room: Badezimmer-Eltern
 6/3/190:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.OG.Badezimmer-Eltern.Raffstore.Geschlossen-Status
+  room: Badezimmer-Eltern
 6/3/191:
   dpt: '1.010'
+  function: Beschattung
   name: Beschattung.OG.Badezimmer-Eltern.Raffstore.Fahrzeit
+  room: Badezimmer-Eltern
 6/3/2:
   dpt: '1.008'
+  function: Beschattung
   name: Beschattung.OG.Flur.Raffstore.Fahren
+  room: Flur
 6/3/20:
   dpt: '1.003'
+  function: Beschattung
   name: Beschattung.OG.Abstellraum.Raffstore.Sperren
+  room: Abstellraum
 6/3/21:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.OG.Abstellraum.Raffstore.Sperren-Status
+  room: Abstellraum
 6/3/22:
   dpt: '1.008'
+  function: Beschattung
   name: Beschattung.OG.Abstellraum.Raffstore.Fahren
+  room: Abstellraum
 6/3/23:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.OG.Abstellraum.Raffstore.Fahren-Status
+  room: Abstellraum
 6/3/24:
   dpt: '1.007'
+  function: Beschattung
   name: Beschattung.OG.Abstellraum.Raffstore.Stoppen
+  room: Abstellraum
 6/3/25:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.OG.Abstellraum.Raffstore.Position
+  room: Abstellraum
 6/3/26:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.OG.Abstellraum.Raffstore.Position-Status
+  room: Abstellraum
 6/3/27:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.OG.Abstellraum.Raffstore.Rotation
+  room: Abstellraum
 6/3/28:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.OG.Abstellraum.Raffstore.Rotation-Status
+  room: Abstellraum
 6/3/29:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.OG.Abstellraum.Raffstore.Geöffnet-Status
+  room: Abstellraum
 6/3/3:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.OG.Flur.Raffstore.Fahren-Status
+  room: Flur
 6/3/30:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.OG.Abstellraum.Raffstore.Geschlossen-Status
+  room: Abstellraum
 6/3/31:
   dpt: '1.010'
+  function: Beschattung
   name: Beschattung.OG.Abstellraum.Raffstore.Fahrzeit
+  room: Abstellraum
 6/3/4:
   dpt: '1.007'
+  function: Beschattung
   name: Beschattung.OG.Flur.Raffstore.Stoppen
+  room: Flur
 6/3/40:
   dpt: '1.003'
+  function: Beschattung
   name: Beschattung.OG.Badezimmer-Kinder.Raffstore.Sperren
+  room: Badezimmer-Kinder
 6/3/41:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.OG.Badezimmer-Kinder.Raffstore.Sperren-Status
+  room: Badezimmer-Kinder
 6/3/42:
   dpt: '1.008'
+  function: Beschattung
   name: Beschattung.OG.Badezimmer-Kinder.Raffstore.Fahren
+  room: Badezimmer-Kinder
 6/3/43:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.OG.Badezimmer-Kinder.Raffstore.Fahren-Status
+  room: Badezimmer-Kinder
 6/3/44:
   dpt: '1.007'
+  function: Beschattung
   name: Beschattung.OG.Badezimmer-Kinder.Raffstore.Stoppen
+  room: Badezimmer-Kinder
 6/3/45:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.OG.Badezimmer-Kinder.Raffstore.Postion
+  room: Badezimmer-Kinder
 6/3/46:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.OG.Badezimmer-Kinder.Raffstore.Position-Status
+  room: Badezimmer-Kinder
 6/3/47:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.OG.Badezimmer-Kinder.Raffstore.Rotation
+  room: Badezimmer-Kinder
 6/3/48:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.OG.Badezimmer-Kinder.Raffstore.Rotation-Status
+  room: Badezimmer-Kinder
 6/3/49:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.OG.Badezimmer-Kinder.Raffstore.Geöffnet-Status
+  room: Badezimmer-Kinder
 6/3/5:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.OG.Flur.Raffstore.Position
+  room: Flur
 6/3/50:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.OG.Badezimmer-Kinder.Raffstore.Geschlossen-Status
+  room: Badezimmer-Kinder
 6/3/51:
   dpt: '1.010'
+  function: Beschattung
   name: Beschattung.OG.Badezimmer-Kinder.Raffstore.Fahrzeit
+  room: Badezimmer-Kinder
 6/3/6:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.OG.Flur.Raffstore.Position-Status
+  room: Flur
 6/3/60:
   dpt: '1.003'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Raffstore.Sperren
+  room: Schlafzimmer-Gregory
 6/3/61:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Raffstore.Sperren-Status
+  room: Schlafzimmer-Gregory
 6/3/62:
   dpt: '1.008'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Raffstore.Fahren
+  room: Schlafzimmer-Gregory
 6/3/63:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Raffstore.Fahren-Status
+  room: Schlafzimmer-Gregory
 6/3/64:
   dpt: '1.007'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Raffstore.Stoppen
+  room: Schlafzimmer-Gregory
 6/3/65:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Raffstore.Position
+  room: Schlafzimmer-Gregory
 6/3/66:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Raffstore.Position-Status
+  room: Schlafzimmer-Gregory
 6/3/67:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Raffstore.Rotation
+  room: Schlafzimmer-Gregory
 6/3/68:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Raffstore.Rotation-Status
+  room: Schlafzimmer-Gregory
 6/3/69:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Raffstore.Geöffnet-Status
+  room: Schlafzimmer-Gregory
 6/3/7:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.OG.Flur.Raffstore.Rotation
+  room: Flur
 6/3/70:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Raffstore.Geschlossen-Status
+  room: Schlafzimmer-Gregory
 6/3/71:
   dpt: '1.010'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Raffstore.Fahrzeit
+  room: Schlafzimmer-Gregory
 6/3/8:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.OG.Flur.Raffstore.Rotation-Status
+  room: Flur
 6/3/80:
   dpt: '1.003'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Vorhang.Sperren
+  room: Schlafzimmer-Gregory
 6/3/81:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Vorhang.Sperren-Status
+  room: Schlafzimmer-Gregory
 6/3/82:
   dpt: '1.008'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Vorhang.Fahren
+  room: Schlafzimmer-Gregory
 6/3/83:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Vorhang.Fahren-Status
+  room: Schlafzimmer-Gregory
 6/3/84:
   dpt: '1.017'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Vorhang.Stoppen
+  room: Schlafzimmer-Gregory
 6/3/85:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Vorhang.Position
+  room: Schlafzimmer-Gregory
 6/3/86:
   dpt: '5.001'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Vorhang.Position-Status
+  room: Schlafzimmer-Gregory
 6/3/89:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Vorhang.Geöffnet-Status
+  room: Schlafzimmer-Gregory
 6/3/9:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.OG.Flur.Raffstore.Geöffnet-Status
+  room: Flur
 6/3/90:
   dpt: '1.011'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Vorhang.Geschlossen-Status
+  room: Schlafzimmer-Gregory
 6/3/91:
   dpt: '1.010'
+  function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Vorhang.Fahrzeit
+  room: Schlafzimmer-Gregory
 7/0/200:
   dpt: '5.010'
+  function: Raumklima
   name: Raumklima.Zentral.KWL.Lüftermodi
 7/0/201:
   dpt: '5.010'
+  function: Raumklima
   name: Raumklima.Zentral.KWL.Lüftermodi-Status
 7/2/0:
   dpt: '1.003'
+  function: Raumklima
   name: Raumklima.EG.Flur.FBH.Sperren
+  room: Flur
 7/2/1:
   dpt: '5.001'
+  function: Raumklima
   name: Raumklima.EG.Flur.FBH.Stellwert-Status
+  room: Flur
 7/2/100:
   dpt: '1.003'
+  function: Raumklima
   name: Raumklima.EG.Küche.FBH.Sperren
+  room: Küche
 7/2/101:
   dpt: '5.001'
+  function: Raumklima
   name: Raumklima.EG.Küche.FBH.Stellwert-Status
+  room: Küche
 7/2/102:
   dpt: '9.001'
+  function: Raumklima
   name: Raumklima.EG.Küche.FBH.Soll-Temperatur
+  room: Küche
 7/2/103:
   dpt: '9.001'
+  function: Raumklima
   name: Raumklima.EG.Küche.FBH.Soll-Temperatur-Status
+  room: Küche
 7/2/104:
   dpt: '9.002'
+  function: Raumklima
   name: Raumklima.EG.Küche.FBH.Sollwertverschiebung
+  room: Küche
 7/2/105:
   dpt: '20.102'
+  function: Raumklima
   name: Raumklima.EG.Küche.FBH.HVAC
+  room: Küche
 7/2/106:
   dpt: '20.102'
+  function: Raumklima
   name: Raumklima.EG.Küche.FBH.HVAC-Status
+  room: Küche
 7/2/107:
   dpt: '1.011'
+  function: Raumklima
   name: Raumklima.EG.Küche.FBH.Aktiv
+  room: Küche
 7/2/108:
   dpt: '16.000'
+  function: Raumklima
   name: Raumklima.EG.Küche.FBH.Diagnose
+  room: Küche
 7/2/2:
   dpt: '9.001'
+  function: Raumklima
   name: Raumklima.EG.Flur.FBH.Soll-Temperatur
+  room: Flur
 7/2/20:
   dpt: '1.003'
+  function: Raumklima
   name: Raumklima.EG.Gäste-WC.FBH.Sperren
+  room: Gäste-WC
 7/2/21:
   dpt: '5.001'
+  function: Raumklima
   name: Raumklima.EG.Gäste-WC.FBH.Stellwert-Status
+  room: Gäste-WC
 7/2/22:
   dpt: '9.001'
+  function: Raumklima
   name: Raumklima.EG.Gäste-WC.FBH.Soll-Temperatur
+  room: Gäste-WC
 7/2/23:
   dpt: '9.001'
+  function: Raumklima
   name: Raumklima.EG.Gäste-WC.FBH.Soll-Temperatur-Status
+  room: Gäste-WC
 7/2/24:
   dpt: '9.002'
+  function: Raumklima
   name: Raumklima.EG.Gäste-WC.FBH.Sollwertverschiebung
+  room: Gäste-WC
 7/2/25:
   dpt: '20.102'
+  function: Raumklima
   name: Raumklima.EG.Gäste-WC.HVAC
+  room: Gäste-WC
 7/2/26:
   dpt: '20.102'
+  function: Raumklima
   name: Raumklima.EG.Gäste-WC.HVAC-Status
+  room: Gäste-WC
 7/2/27:
   dpt: '1.011'
+  function: Raumklima
   name: Raumklima.EG.Gäste-WC.FBH.Aktiv
+  room: Gäste-WC
 7/2/28:
   dpt: '16.000'
+  function: Raumklima
   name: Raumklima.EG.Gäste-WC.FBH.Diagnose
+  room: Gäste-WC
 7/2/3:
   dpt: '9.001'
+  function: Raumklima
   name: Raumklima.EG.Flur.FBH.Soll-Temperatur-Status
+  room: Flur
 7/2/4:
   dpt: '9.002'
+  function: Raumklima
   name: Raumklima.EG.Flur.FBH.Sollwertverschiebung
+  room: Flur
 7/2/40:
   dpt: '1.003'
+  function: Raumklima
   name: Raumklima.EG.Büro.FBH.Sperren
+  room: Büro
 7/2/41:
   dpt: '5.001'
+  function: Raumklima
   name: Raumklima.EG.Büro.FBH.Stellwert-Status
+  room: Büro
 7/2/42:
   dpt: '9.001'
+  function: Raumklima
   name: Raumklima.EG.Büro.FBH.Soll-Temperatur
+  room: Büro
 7/2/43:
   dpt: '9.001'
+  function: Raumklima
   name: Raumklima.EG.Büro.FBH.Soll-Temperatur-Status
+  room: Büro
 7/2/44:
   dpt: '9.002'
+  function: Raumklima
   name: Raumklima.EG.Büro.FBH.Sollwertverschiebung
+  room: Büro
 7/2/45:
   dpt: '20.102'
+  function: Raumklima
   name: Raumklima.EG.Büro.FBH.HVAC
+  room: Büro
 7/2/46:
   dpt: '20.102'
+  function: Raumklima
   name: Raumklima.EG.Büro.FBH.HVAC-Status
+  room: Büro
 7/2/47:
   dpt: '1.011'
+  function: Raumklima
   name: Raumklima.EG.Büro.FBH.Aktiv
+  room: Büro
 7/2/48:
   dpt: '16.000'
+  function: Raumklima
   name: Raumklima.EG.Büro.FBH.Diagnose
+  room: Büro
 7/2/5:
   dpt: '20.102'
+  function: Raumklima
   name: Raumklima.EG.Flur.FBH.HVAC
+  room: Flur
 7/2/6:
   dpt: '20.102'
+  function: Raumklima
   name: Raumklima.EG.Flur.FBH.HVAC-Status
+  room: Flur
 7/2/60:
   dpt: '1.003'
+  function: Raumklima
   name: Raumklima.EG.Wohnzimmer.FBH.Sperren
+  room: Wohnzimmer
 7/2/61:
   dpt: '5.001'
+  function: Raumklima
   name: Raumklima.EG.Wohnzimmer.FBH.Stellwert-Status
+  room: Wohnzimmer
 7/2/62:
   dpt: '9.001'
+  function: Raumklima
   name: Raumklima.EG.Wohnzimmer.FBH.Soll-Temperatur
+  room: Wohnzimmer
 7/2/63:
   dpt: '9.001'
+  function: Raumklima
   name: Raumklima.EG.Wohnzimmer.FBH.Soll-Temperatur-Status
+  room: Wohnzimmer
 7/2/64:
   dpt: '9.002'
+  function: Raumklima
   name: Raumklima.EG.Wohnzimmer.FBH.Sollwertverschiebung
+  room: Wohnzimmer
 7/2/65:
   dpt: '20.102'
+  function: Raumklima
   name: Raumklima.EG.Wohnzimmer.FBH.HVAC
+  room: Wohnzimmer
 7/2/66:
   dpt: '20.102'
+  function: Raumklima
   name: Raumklima.EG.Wohnzimmer.FBH.HVAC-Status
+  room: Wohnzimmer
 7/2/67:
   dpt: '1.011'
+  function: Raumklima
   name: Raumklima.EG.Wohnzimmer.FBH.Aktiv
+  room: Wohnzimmer
 7/2/68:
   dpt: '16.000'
+  function: Raumklima
   name: Raumklima.EG.Wohnzimmer.FBH.Diagnose
+  room: Wohnzimmer
 7/2/7:
   dpt: '1.011'
+  function: Raumklima
   name: Raumklima.EG.Flur.FBH.Aktiv
+  room: Flur
 7/2/8:
   dpt: '16.000'
+  function: Raumklima
   name: Raumklima.EG.Flur.FBH.Diagnose
+  room: Flur
 7/2/80:
   dpt: '1.003'
+  function: Raumklima
   name: Raumklima.EG.Esszimer.FBH.Sperren
+  room: Esszimer
 7/2/81:
   dpt: '5.001'
+  function: Raumklima
   name: Raumklima.EG.Esszimer.FBH.Stellwert-Status
+  room: Esszimer
 7/2/82:
   dpt: '9.001'
+  function: Raumklima
   name: Raumklima.EG.Esszimer.FBH.Soll-Temperatur
+  room: Esszimer
 7/2/83:
   dpt: '9.001'
+  function: Raumklima
   name: Raumklima.EG.Esszimer.FBH.Soll-Temperatur-Status
+  room: Esszimer
 7/2/84:
   dpt: '9.002'
+  function: Raumklima
   name: Raumklima.EG.Esszimer.FBH.Sollwertverschiebung
+  room: Esszimer
 7/2/85:
   dpt: '20.102'
+  function: Raumklima
   name: Raumklima.EG.Esszimer.FBH.HVAC
+  room: Esszimer
 7/2/86:
   dpt: '20.102'
+  function: Raumklima
   name: Raumklima.EG.Esszimer.FBH.HVAC-Status
+  room: Esszimer
 7/2/87:
   dpt: '1.011'
+  function: Raumklima
   name: Raumklima.EG.Esszimer.FBH.Aktiv
+  room: Esszimer
 7/2/88:
   dpt: '16.000'
+  function: Raumklima
   name: Raumklima.EG.Esszimer.FBH.Diagnose
+  room: Esszimer
 7/3/0:
   dpt: '1.003'
+  function: Raumklima
   name: Raumklima.OG.Flur.FBH.Sperren
+  room: Flur
 7/3/1:
   dpt: '5.001'
+  function: Raumklima
   name: Raumklima.OG.Flur.FBH.Stellwert-Status
+  room: Flur
 7/3/100:
   dpt: '1.003'
+  function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.FBH.Sperren
+  room: Schlafzimmer-Eltern
 7/3/101:
   dpt: '5.001'
+  function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.FBH.Stellwert-Status
+  room: Schlafzimmer-Eltern
 7/3/102:
   dpt: '9.001'
+  function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.FBH.Soll-Temperatur
+  room: Schlafzimmer-Eltern
 7/3/103:
   dpt: '9.001'
+  function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.FBH.Soll-Temperatur-Status
+  room: Schlafzimmer-Eltern
 7/3/104:
   dpt: '9.002'
+  function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.FBH.Sollwertverschiebung
+  room: Schlafzimmer-Eltern
 7/3/105:
   dpt: '20.102'
+  function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.HVAC
+  room: Schlafzimmer-Eltern
 7/3/106:
   dpt: '20.102'
+  function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.HVAC-Status
+  room: Schlafzimmer-Eltern
 7/3/107:
   dpt: '1.011'
+  function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.Aktiv
+  room: Schlafzimmer-Eltern
 7/3/108:
   dpt: '16.000'
+  function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.Diagnose
+  room: Schlafzimmer-Eltern
 7/3/120:
   dpt: '1.003'
+  function: Raumklima
   name: Raumklima.OG.Begehbarer-Schrank.FBH.Sperren
+  room: Begehbarer-Schrank
 7/3/121:
   dpt: '5.001'
+  function: Raumklima
   name: Raumklima.OG.Begehbarer-Schrank.FBH.Stellwert-Status
+  room: Begehbarer-Schrank
 7/3/122:
   dpt: '9.001'
+  function: Raumklima
   name: Raumklima.OG.Begehbarer-Schrank.FBH.Soll-Temperatur
+  room: Begehbarer-Schrank
 7/3/123:
   dpt: '9.001'
+  function: Raumklima
   name: Raumklima.OG.Begehbarer-Schrank.FBH.Soll-Temperatur-Status
+  room: Begehbarer-Schrank
 7/3/124:
   dpt: '9.002'
+  function: Raumklima
   name: Raumklima.OG.Begehbarer-Schrank.FBH.Sollwertverschiebung
+  room: Begehbarer-Schrank
 7/3/125:
   dpt: '20.102'
+  function: Raumklima
   name: Raumklima.OG.Begehbarer-Schrank.FBH.HVAC
+  room: Begehbarer-Schrank
 7/3/126:
   dpt: '20.102'
+  function: Raumklima
   name: Raumklima.OG.Begehbarer-Schrank.FBH.HVAC-Status
+  room: Begehbarer-Schrank
 7/3/127:
   dpt: '1.011'
+  function: Raumklima
   name: Raumklima.OG.Begehbarer-Schrank.FBH.Aktiv
+  room: Begehbarer-Schrank
 7/3/128:
   dpt: '16.000'
+  function: Raumklima
   name: Raumklima.OG.Begehbarer-Schrank.FBH.Diagnose
+  room: Begehbarer-Schrank
 7/3/140:
   dpt: '1.003'
+  function: Raumklima
   name: Raumklima.OG.Badezimmer-Eltern.FBH.Sperren
+  room: Badezimmer-Eltern
 7/3/141:
   dpt: '5.001'
+  function: Raumklima
   name: Raumklima.OG.Badezimmer-Eltern.FBH.Stellwert-Status
+  room: Badezimmer-Eltern
 7/3/142:
   dpt: '9.001'
+  function: Raumklima
   name: Raumklima.OG.Badezimmer-Eltern.FBH.Soll-Temperatur
+  room: Badezimmer-Eltern
 7/3/143:
   dpt: '9.001'
+  function: Raumklima
   name: Raumklima.OG.Badezimmer-Eltern.FBH.Soll-Temperatur-Status
+  room: Badezimmer-Eltern
 7/3/144:
   dpt: '9.002'
+  function: Raumklima
   name: Raumklima.OG.Badezimmer-Eltern.FBH.Sollwertverschiebung
+  room: Badezimmer-Eltern
 7/3/145:
   dpt: '20.102'
+  function: Raumklima
   name: Raumklima.OG.Badezimmer-Eltern.FBH.HVAC
+  room: Badezimmer-Eltern
 7/3/146:
   dpt: '20.102'
+  function: Raumklima
   name: Raumklima.OG.Badezimmer-Eltern.FBH.HVAC-Status
+  room: Badezimmer-Eltern
 7/3/147:
   dpt: '1.011'
+  function: Raumklima
   name: Raumklima.OG.Badezimmer-Eltern.FBH.Aktiv
+  room: Badezimmer-Eltern
 7/3/148:
   dpt: '16.000'
+  function: Raumklima
   name: Raumklima.OG.Badezimmer-Eltern.FBH.Diagnose
+  room: Badezimmer-Eltern
 7/3/2:
   dpt: '9.001'
+  function: Raumklima
   name: Raumklima.OG.Flur.FBH.Soll-Temperatur
+  room: Flur
 7/3/20:
   dpt: '1.003'
+  function: Raumklima
   name: Raumklima.OG.Abstellraum.FBH.Sperren
+  room: Abstellraum
 7/3/21:
   dpt: '5.001'
+  function: Raumklima
   name: Raumklima.OG.Abstellraum.FBH.Stellwert-Status
+  room: Abstellraum
 7/3/22:
   dpt: '9.001'
+  function: Raumklima
   name: Raumklima.OG.Abstellraum.FBH.Soll-Temperatur
+  room: Abstellraum
 7/3/23:
   dpt: '9.001'
+  function: Raumklima
   name: Raumklima.OG.Abstellraum.FBH.Soll-Temperatur-Status
+  room: Abstellraum
 7/3/24:
   dpt: '9.002'
+  function: Raumklima
   name: Raumklima.OG.Abstellraum.FBH.Sollwertverschiebung
+  room: Abstellraum
 7/3/25:
   dpt: '20.102'
+  function: Raumklima
   name: Raumklima.OG.Abstellraum.FBH.HVAC
+  room: Abstellraum
 7/3/26:
   dpt: '20.102'
+  function: Raumklima
   name: Raumklima.OG.Abstellraum.FBH.HVAC-Status
+  room: Abstellraum
 7/3/27:
   dpt: '1.011'
+  function: Raumklima
   name: Raumklima.OG.Abstellraum.FBH.Aktiv
+  room: Abstellraum
 7/3/28:
   dpt: '16.000'
+  function: Raumklima
   name: Raumklima.OG.Abstellraum.FBH.Diagnose
+  room: Abstellraum
 7/3/3:
   dpt: '9.001'
+  function: Raumklima
   name: Raumklima.OG.Flur.FBH.Soll-Temperatur-Status
+  room: Flur
 7/3/4:
   dpt: '9.002'
+  function: Raumklima
   name: Raumklima.OG.Flur.FBH.Sollwertverschiebung
+  room: Flur
 7/3/40:
   dpt: '1.003'
+  function: Raumklima
   name: Raumklima.OG.Badezimmer-Kinder.FBH.Sperren
+  room: Badezimmer-Kinder
 7/3/41:
   dpt: '5.001'
+  function: Raumklima
   name: Raumklima.OG.Badezimmer-Kinder.FBH.Stellwert-Status
+  room: Badezimmer-Kinder
 7/3/42:
   dpt: '9.001'
+  function: Raumklima
   name: Raumklima.OG.Badezimmer-Kinder.FBH.Soll-Temperatur
+  room: Badezimmer-Kinder
 7/3/43:
   dpt: '9.001'
+  function: Raumklima
   name: Raumklima.OG.Badezimmer-Kinder.FBH.Soll-Temperatur-Status
+  room: Badezimmer-Kinder
 7/3/44:
   dpt: '9.002'
+  function: Raumklima
   name: Raumklima.OG.Badezimmer-Kinder.FBH.Sollwertveränderung
+  room: Badezimmer-Kinder
 7/3/45:
   dpt: '20.102'
+  function: Raumklima
   name: Raumklima.OG.Badezimmer-Kinder.HVAC
+  room: Badezimmer-Kinder
 7/3/46:
   dpt: '20.102'
+  function: Raumklima
   name: Raumklima.OG.Badezimmer-Kinder.HVAC-Status
+  room: Badezimmer-Kinder
 7/3/47:
   dpt: '1.011'
+  function: Raumklima
   name: Raumklima.OG.Badezimmer-Kinder.Aktiv
+  room: Badezimmer-Kinder
 7/3/48:
   dpt: '16.000'
+  function: Raumklima
   name: Raumklima.OG.Badezimmer-Kinder.FBH.Diagnose
+  room: Badezimmer-Kinder
 7/3/5:
   dpt: '20.102'
+  function: Raumklima
   name: Raumklima.OG.Flur.FBH.HVAC
+  room: Flur
 7/3/6:
   dpt: '20.102'
+  function: Raumklima
   name: Raumklima.OG.Flur.FBH.HVAC-Status
+  room: Flur
 7/3/60:
   dpt: '1.003'
+  function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Gregory.FBH.Sperren
+  room: Schlafzimmer-Gregory
 7/3/61:
   dpt: '5.001'
+  function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Gregory.FBH.Stellwert-Status
+  room: Schlafzimmer-Gregory
 7/3/62:
   dpt: '9.001'
+  function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Gregory.FBH.Soll-Temperartur
+  room: Schlafzimmer-Gregory
 7/3/63:
   dpt: '9.001'
+  function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Gregory.FBH.Soll-Temperatur-Status
+  room: Schlafzimmer-Gregory
 7/3/64:
   dpt: '9.002'
+  function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Gregory.FBH.Sollwertverschiebung
+  room: Schlafzimmer-Gregory
 7/3/65:
   dpt: '20.102'
+  function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Gregory.HVAC
+  room: Schlafzimmer-Gregory
 7/3/66:
   dpt: '20.102'
+  function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Gregory.HVAC-Status
+  room: Schlafzimmer-Gregory
 7/3/67:
   dpt: '1.011'
+  function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Gregory.Aktiv
+  room: Schlafzimmer-Gregory
 7/3/68:
   dpt: '16.000'
+  function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Gregory.Diagnose
+  room: Schlafzimmer-Gregory
 7/3/7:
   dpt: '1.011'
+  function: Raumklima
   name: Raumklima.OG.Flur.FBH.Aktiv
+  room: Flur
 7/3/8:
   dpt: '16.000'
+  function: Raumklima
   name: Raumklima.OG.Flur.FBH.Diagnose
+  room: Flur
 7/3/80:
   dpt: '1.003'
+  function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Luis.FBH.Sperren
+  room: Schlafzimmer-Luis
 7/3/81:
   dpt: '5.001'
+  function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Luis.FBH.Stellwert-Status
+  room: Schlafzimmer-Luis
 7/3/82:
   dpt: '9.001'
+  function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Luis.FBH.Soll-Temperatur
+  room: Schlafzimmer-Luis
 7/3/83:
   dpt: '9.001'
+  function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Luis.FBH.Soll-Temperatur-Status
+  room: Schlafzimmer-Luis
 7/3/84:
   dpt: '9.002'
+  function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Luis.FBH.Sollwertverschiebung
+  room: Schlafzimmer-Luis
 7/3/85:
   dpt: '20.102'
+  function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Luis.FBH.HVAC
+  room: Schlafzimmer-Luis
 7/3/86:
   dpt: '20.102'
+  function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Luis.FBH.HVAC-Status
+  room: Schlafzimmer-Luis
 7/3/87:
   dpt: '1.011'
+  function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Luis.FBH.Aktiv
+  room: Schlafzimmer-Luis
 7/3/88:
   dpt: '16.000'
+  function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Luis.FBH.Diagnose
+  room: Schlafzimmer-Luis
 8/0/200:
   dpt: '1.001'
+  function: Bedienelemente
   name: Bedienelemente.Zentral.Schalter.Sperren
 8/0/201:
   dpt: '5.010'
+  function: Bedienelemente
   name: Bedienelemente.Zentral.Schalter.Farbe
 8/2/0:
   dpt: '1.001'
+  function: Bedienelemente
   name: Bedienelemente.EG.Büro.Schalter.Sperren
+  room: Büro
 8/2/1:
   dpt: '5.010'
+  function: Bedienelemente
   name: Bedienelemente.EG.Büro.Schalter.Farbe
+  room: Büro
 8/2/10:
   dpt: '1.001'
+  function: Bedienelemente
   name: Bedienelemente.EG.Büro.Schalter.Multitouch-Kurz
+  room: Büro
 8/2/16:
   dpt: '1.024'
+  function: Bedienelemente
   name: Bedienelemente.EG.Büro.Schalter.Tag/Nacht
+  room: Büro
 8/2/2:
   dpt: '1.001'
+  function: Bedienelemente
   name: Bedienelemente.EG.Büro.Schalter.Sensor-1-Kurz
+  room: Büro
 8/2/20:
   dpt: '1.001'
+  function: Bedienelemente
   name: Bedienelemente.EG.Wohnzimmer.Schalter.Sperren
+  room: Wohnzimmer
 8/2/21:
   dpt: '5.010'
+  function: Bedienelemente
   name: Bedienelemente.EG.Wohnzimmer.Schalter.Farbe
+  room: Wohnzimmer
 8/2/22:
   dpt: '1.001'
+  function: Bedienelemente
   name: Bedienelemente.EG.Wohnzimmer.Schalter.Sensor-1-Kurz
+  room: Wohnzimmer
 8/2/23:
   dpt: '3.007'
+  function: Bedienelemente
   name: Bedienelemente.EG.Wohnzimmer.Schalter.Sensor-1-Lang
+  room: Wohnzimmer
 8/2/24:
   dpt: '1.001'
+  function: Bedienelemente
   name: Bedienelemente.EG.Wohnzimmer.Schalter.Sensor-2-Kurz
+  room: Wohnzimmer
 8/2/25:
   dpt: '1.001'
+  function: Bedienelemente
   name: Bedienelemente.EG.Wohnzimmer.Schalter.Sensor-2-Lang
+  room: Wohnzimmer
 8/2/28:
   dpt: '1.009'
+  function: Bedienelemente
   name: Bedienelemente.EG.Wohnzimmer.Schalter.Sensor-4-Kurz
+  room: Wohnzimmer
 8/2/29:
   dpt: '1.009'
+  function: Bedienelemente
   name: Bedienelemente.EG.Wohnzimmer.Schalter.Sensor-4-Lang
+  room: Wohnzimmer
 8/2/3:
   dpt: '3.007'
+  function: Bedienelemente
   name: Bedienelemente.EG.Büro.Schalter.Sensor-1-Lang
+  room: Büro
 8/2/30:
   dpt: '1.001'
+  function: Bedienelemente
   name: Bedienelemente.EG.Wohnzimmer.Schalter.Multitouch-Kurz
+  room: Wohnzimmer
 8/2/36:
   dpt: '1.024'
+  function: Bedienelemente
   name: Bedienelemente.EG.Wohnzimmer.Schalter.Tag/Nacht
+  room: Wohnzimmer
 8/2/4:
   dpt: '1.001'
+  function: Bedienelemente
   name: Bedienelemente.EG.Büro.Schalter.Sensor-2-Kurz
+  room: Büro
 8/2/5:
   dpt: '1.001'
+  function: Bedienelemente
   name: Bedienelemente.EG.Büro.Schalter.Sensor-2-Lang
+  room: Büro
 8/2/8:
   dpt: '1.009'
+  function: Bedienelemente
   name: Bedienelemente.EG.Büro.Schalter.Sensor-4-Kurz
+  room: Büro
 8/2/9:
   dpt: '1.009'
+  function: Bedienelemente
   name: Bedienelemente.EG.Büro.Schalter.Sensor-4-Lang
+  room: Büro
 8/3/0:
   dpt: '1.001'
+  function: Bedienelemente
   name: Bedienelemente.OG.Abstellraum.Schalter.Sperren
+  room: Abstellraum
 8/3/1:
   dpt: '5.010'
+  function: Bedienelemente
   name: Bedienelemente.OG.Abstellraum.Schalter.Farbe
+  room: Abstellraum
 8/3/10:
   dpt: '1.001'
+  function: Bedienelemente
   name: Bedienelemente.OG.Abstellraum.Schalter.Multitouch-Kurz
+  room: Abstellraum
 8/3/100:
   dpt: '1.001'
+  function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Bett-Links.Sperren
+  room: Schlafzimmer-Eltern
 8/3/101:
   dpt: '5.010'
+  function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Bett-Links.Farbe
+  room: Schlafzimmer-Eltern
 8/3/102:
   dpt: '1.001'
+  function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Bett-Links.Sensor-1-Kurz
+  room: Schlafzimmer-Eltern
 8/3/103:
   dpt: '3.007'
+  function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Bett-Links.Sensor-1-Lang
+  room: Schlafzimmer-Eltern
 8/3/104:
   dpt: '1.001'
+  function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Bett-Links.Sensor-2-Kurz
+  room: Schlafzimmer-Eltern
 8/3/105:
   dpt: '1.001'
+  function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Bett-Links.Sensor-2-Lang
+  room: Schlafzimmer-Eltern
 8/3/110:
   dpt: '1.001'
+  function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Bett-Links.Multitouch-Kurz
+  room: Schlafzimmer-Eltern
 8/3/111:
   dpt: '1.008'
+  function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Bett-Links.Multitouch-Lang-1
+  room: Schlafzimmer-Eltern
 8/3/112:
   dpt: '1.017'
+  function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Bett-Links.Multitouch-Lang-2
+  room: Schlafzimmer-Eltern
 8/3/116:
   dpt: '1.024'
+  function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Bett-Links.Tag/Nacht
+  room: Schlafzimmer-Eltern
 8/3/120:
   dpt: '1.001'
+  function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Bett-Rechts.Sperren
+  room: Schlafzimmer-Eltern
 8/3/121:
   dpt: '5.010'
+  function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Bett-Rechts.Farbe
+  room: Schlafzimmer-Eltern
 8/3/122:
   dpt: '1.001'
+  function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Bett-Rechts.Sensor-1-Kurz
+  room: Schlafzimmer-Eltern
 8/3/123:
   dpt: '3.007'
+  function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Bett-Rechts.Sensor-1-Lang
+  room: Schlafzimmer-Eltern
 8/3/124:
   dpt: '1.001'
+  function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Bett-Rechts.Sensor-2-Kurz
+  room: Schlafzimmer-Eltern
 8/3/125:
   dpt: '1.001'
+  function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Bett-Rechts.Sensor-2-Lang
+  room: Schlafzimmer-Eltern
 8/3/130:
   dpt: '1.001'
+  function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Bett-Rechts.Multitouch-Kurz
+  room: Schlafzimmer-Eltern
 8/3/131:
   dpt: '1.008'
+  function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Bett-Rechts.Multitouch-Lang-1
+  room: Schlafzimmer-Eltern
 8/3/132:
   dpt: '1.017'
+  function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Bett-Rechts.Multitouch-Lang-2
+  room: Schlafzimmer-Eltern
 8/3/136:
   dpt: '1.024'
+  function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Bett-Rechts.Tag/Nacht
+  room: Schlafzimmer-Eltern
 8/3/140:
   dpt: '1.001'
+  function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Eltern.Schalter.Sperren
+  room: Badezimmer-Eltern
 8/3/141:
   dpt: '5.010'
+  function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Eltern.Schalter.Farbe
+  room: Badezimmer-Eltern
 8/3/142:
   dpt: '1.009'
+  function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Eltern.Schalter.Sensor-1-Kurz
+  room: Badezimmer-Eltern
 8/3/143:
   dpt: '3.007'
+  function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Eltern.Schalter.Sensor-1-Lang
+  room: Badezimmer-Eltern
 8/3/144:
   dpt: '1.001'
+  function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Eltern.Schalter.Sensor-2-Kurz
+  room: Badezimmer-Eltern
 8/3/145:
   dpt: '1.001'
+  function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Eltern.Schalter.Sensor-2-Lang
+  room: Badezimmer-Eltern
 8/3/148:
   dpt: '1.009'
+  function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Eltern.Schalter.Sensor-4-Kurz
+  room: Badezimmer-Eltern
 8/3/149:
   dpt: '1.009'
+  function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Eltern.Schalter.Sensor-4-Lang
+  room: Badezimmer-Eltern
 8/3/150:
   dpt: '1.001'
+  function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Eltern.Schalter.Multitouch-Kurz
+  room: Badezimmer-Eltern
 8/3/153:
   dpt: '1.001'
+  function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Eltern.Schalter.Multitouch-RGB-Rot
+  room: Badezimmer-Eltern
 8/3/156:
   dpt: '1.024'
+  function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Eltern.Schalter.Tag/Nacht
+  room: Badezimmer-Eltern
 8/3/16:
   dpt: '1.024'
+  function: Bedienelemente
   name: Bedienelemente.OG.Abstellraum.Schalter.Tag/Nacht
+  room: Abstellraum
 8/3/2:
   dpt: '1.001'
+  function: Bedienelemente
   name: Bedienelemente.OG.Abstellraum.Schalter.Sensor-1-Kurz
+  room: Abstellraum
 8/3/20:
   dpt: '1.001'
+  function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Kinder.Schalter.Sperren
+  room: Badezimmer-Kinder
 8/3/21:
   dpt: '5.010'
+  function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Kinder.Schalter.Farbe
+  room: Badezimmer-Kinder
 8/3/22:
   dpt: '1.001'
+  function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Kinder.Schalter.Sensor-1-Kurz
+  room: Badezimmer-Kinder
 8/3/23:
   dpt: '3.007'
+  function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Kinder.Schalter.Sensor-1-Lang
+  room: Badezimmer-Kinder
 8/3/24:
   dpt: '1.001'
+  function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Kinder.Schalter.Sensor-2-Kurz
+  room: Badezimmer-Kinder
 8/3/25:
   dpt: '1.001'
+  function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Kinder.Schalter.Sensor-2-Lang
+  room: Badezimmer-Kinder
 8/3/28:
   dpt: '1.009'
+  function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Kinder.Schalter.Sensor-4-Kurz
+  room: Badezimmer-Kinder
 8/3/29:
   dpt: '1.009'
+  function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Kinder.Schalter.Sensor-4-Lang
+  room: Badezimmer-Kinder
 8/3/3:
   dpt: '3.007'
+  function: Bedienelemente
   name: Bedienelemente.OG.Abstellraum.Schalter.Sensor-1-Lang
+  room: Abstellraum
 8/3/30:
   dpt: '1.001'
+  function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Kinder.Schalter.Multitouch-Kurz
+  room: Badezimmer-Kinder
 8/3/36:
   dpt: '1.024'
+  function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Kinder.Schalter.Tag/Nacht
+  room: Badezimmer-Kinder
 8/3/4:
   dpt: '1.001'
+  function: Bedienelemente
   name: Bedienelemente.OG.Abstellraum.Schalter.Sensor-2-Kurz
+  room: Abstellraum
 8/3/40:
   dpt: '1.001'
+  function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Gregory.Schalter.Sperren
+  room: Schlafzimmer-Gregory
 8/3/41:
   dpt: '5.010'
+  function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Gregory.Schalter.Farbe
+  room: Schlafzimmer-Gregory
 8/3/42:
   dpt: '1.001'
+  function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Gregory.Schalter.Sensor-1-Kurz
+  room: Schlafzimmer-Gregory
 8/3/43:
   dpt: '3.007'
+  function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Gregory.Schalter.Sensor-1-Lang
+  room: Schlafzimmer-Gregory
 8/3/44:
   dpt: '1.001'
+  function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Gregory.Schalter.Sensor-2-Kurz
+  room: Schlafzimmer-Gregory
 8/3/45:
   dpt: '1.001'
+  function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Gregory.Schalter.Sensor-2-Lang
+  room: Schlafzimmer-Gregory
 8/3/48:
   dpt: '1.009'
+  function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Gregory.Schalter.Sensor-4-Kurz
+  room: Schlafzimmer-Gregory
 8/3/49:
   dpt: '1.009'
+  function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Gregory.Schalter.Sensor-4-Lang
+  room: Schlafzimmer-Gregory
 8/3/5:
   dpt: '1.001'
+  function: Bedienelemente
   name: Bedienelemente.OG.Abstellraum.Schalter.Sensor-2-Lang
+  room: Abstellraum
 8/3/50:
   dpt: '1.001'
+  function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Gregory.Schalter.Multitouch-Kurz
+  room: Schlafzimmer-Gregory
 8/3/51:
   dpt: '1.008'
+  function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Gregory.Schalter.Multitouch-Lang-1
+  room: Schlafzimmer-Gregory
 8/3/52:
   dpt: '1.017'
+  function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Gregory.Schalter.Multitouch-Lang-2
+  room: Schlafzimmer-Gregory
 8/3/56:
   dpt: '1.024'
+  function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Gregory.Schalter.Tag/Nacht
+  room: Schlafzimmer-Gregory
 8/3/60:
   dpt: '1.001'
+  function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Luis.Schalter.Sperren
+  room: Schlafzimmer-Luis
 8/3/61:
   dpt: '5.005'
+  function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Luis.Schalter.Farbe
+  room: Schlafzimmer-Luis
 8/3/62:
   dpt: '1.001'
+  function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Luis.Schalter.Sensor-1-Kurz
+  room: Schlafzimmer-Luis
 8/3/63:
   dpt: '3.007'
+  function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Luis.Schalter.Sensor-1-Lang
+  room: Schlafzimmer-Luis
 8/3/64:
   dpt: '1.001'
+  function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Luis.Schalter.Sensor-2-Kurz
+  room: Schlafzimmer-Luis
 8/3/65:
   dpt: '1.001'
+  function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Luis.Schalter.Sensor-2-Lang
+  room: Schlafzimmer-Luis
 8/3/68:
   dpt: '1.009'
+  function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Luis.Schalter.Sensor-4-Kurz
+  room: Schlafzimmer-Luis
 8/3/69:
   dpt: '1.009'
+  function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Luis.Schalter.Sensor-4-Lang
+  room: Schlafzimmer-Luis
 8/3/70:
   dpt: '1.001'
+  function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Luis.Schalter.Multitouch-Kurz
+  room: Schlafzimmer-Luis
 8/3/71:
   dpt: '1.009'
+  function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Luis.Schalter.Multitouch-Lang-1
+  room: Schlafzimmer-Luis
 8/3/72:
   dpt: '1.009'
+  function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Luis.Schalter.Multitouch-Lang-2
+  room: Schlafzimmer-Luis
 8/3/76:
   dpt: '1.024'
+  function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Luis.Schalter.Tag/Nacht
+  room: Schlafzimmer-Luis
 8/3/8:
   dpt: '1.009'
+  function: Bedienelemente
   name: Bedienelemente.OG.Abstellraum.Schalter.Sensor-4-Kurz
+  room: Abstellraum
 8/3/80:
   dpt: '1.001'
+  function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Sperren
+  room: Schlafzimmer-Eltern
 8/3/81:
   dpt: '5.010'
+  function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Farbe
+  room: Schlafzimmer-Eltern
 8/3/82:
   dpt: '1.001'
+  function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Sensor-1-Kurz
+  room: Schlafzimmer-Eltern
 8/3/83:
   dpt: '3.007'
+  function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Sensor-1-Lang
+  room: Schlafzimmer-Eltern
 8/3/84:
   dpt: '1.001'
+  function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Sensor-2-Kurz
+  room: Schlafzimmer-Eltern
 8/3/85:
   dpt: '1.001'
+  function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Sensor-2-Lang
+  room: Schlafzimmer-Eltern
 8/3/88:
   dpt: '1.009'
+  function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Sensor-4-Kurz
+  room: Schlafzimmer-Eltern
 8/3/89:
   dpt: '1.009'
+  function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Sensor-4-Lang
+  room: Schlafzimmer-Eltern
 8/3/9:
   dpt: '1.009'
+  function: Bedienelemente
   name: Bedienelemente.OG.Abstellraum.Schalter.Sensor-4-Lang
+  room: Abstellraum
 8/3/90:
   dpt: '1.001'
+  function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Multitouch-Kurz
+  room: Schlafzimmer-Eltern
 8/3/91:
   dpt: '1.009'
+  function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Multitouch-Lang-1
+  room: Schlafzimmer-Eltern
 8/3/92:
   dpt: '1.009'
+  function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Multitouch-Lang-2
+  room: Schlafzimmer-Eltern
 8/3/96:
   dpt: '1.024'
+  function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Tag/Nacht
+  room: Schlafzimmer-Eltern
 9/0/180:
   dpt: '9.004'
+  function: Sensorik
   name: Sensorik.Zentral.A.Helligkeit-SO
 9/0/181:
   dpt: '9.004'
+  function: Sensorik
   name: Sensorik.Zentral.A.Helligkeit-NW
 9/0/182:
   dpt: '9.004'
+  function: Sensorik
   name: Sensorik.Zentral.A.Helligkeit-Alle
 9/0/183:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.Zentral.A.Temperatur-Alle
 9/1/100:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.KG.Vorratsraum.Sensor.VOC-Alarm-1
+  room: Vorratsraum
 9/1/101:
   dpt: '9.008'
+  function: Sensorik
   name: Sensorik.KG.Vorratsraum.Sensor.CO2
+  room: Vorratsraum
 9/1/102:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.KG.Vorratsraum.Sensor.CO2-Alarm-1
+  room: Vorratsraum
 9/1/103:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.KG.Vorratsraum.Sensor.CO2-Alarm-2
+  room: Vorratsraum
 9/1/104:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.KG.Vorratsraum.Sensor.CO2-Alarm-3
+  room: Vorratsraum
 9/1/105:
   dpt: '14.058'
+  function: Sensorik
   name: Sensorik.KG.Vorratsraum.Sensor.Luftdruck-Relativ
+  room: Vorratsraum
 9/1/106:
   dpt: '14.058'
+  function: Sensorik
   name: Sensorik.KG.Vorratsraum.Sensor.Luftdruck-Absolut
+  room: Vorratsraum
 9/1/107:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.KG.Vorratsraum.Sensor.Luftdruck-Alarm-1
+  room: Vorratsraum
 9/1/121:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.KG.Hauswirtschaftsraum.Sensor.Temperatur
+  room: Hauswirtschaftsraum
 9/1/122:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.KG.Hauswirtschaftsraum.Sensor.Temperatur-Alarm-1
+  room: Hauswirtschaftsraum
 9/1/123:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.KG.Hauswirtschaftsraum.Sensor.Temperatur-Alarm-2
+  room: Hauswirtschaftsraum
 9/1/124:
   dpt: '9.007'
+  function: Sensorik
   name: Sensorik.KG.Hauswirtschaftsraum.Sensor.Luftfeuchtigkeit
+  room: Hauswirtschaftsraum
 9/1/125:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.KG.Hauswirtschaftsraum.Sensor.Luftfeuchtigkeit-Alarm-1
+  room: Hauswirtschaftsraum
 9/1/126:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.KG.Hauswirtschaftsraum.Sensor.Luftfeuchtigkeit-Alarm-2
+  room: Hauswirtschaftsraum
 9/1/127:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.KG.Hauswirtschaftsraum.Sensor.Taupunkt
+  room: Hauswirtschaftsraum
 9/1/128:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.KG.Hauswirtschaftsraum.Sensor.Taupunkt-Alarm-1
+  room: Hauswirtschaftsraum
 9/1/129:
   dpt: '9.008'
+  function: Sensorik
   name: Sensorik.KG.Hauswirtschaftsraum.Sensor.VOC
+  room: Hauswirtschaftsraum
 9/1/130:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.KG.Hauswirtschaftsraum.Sensor.VOC-Alarm-1
+  room: Hauswirtschaftsraum
 9/1/131:
   dpt: '9.008'
+  function: Sensorik
   name: Sensorik.KG.Hauswirtschaftsraum.Sensor.CO2
+  room: Hauswirtschaftsraum
 9/1/132:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.KG.Hauswirtschaftsraum.Sensor.CO2-Alarm-1
+  room: Hauswirtschaftsraum
 9/1/133:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.KG.Hauswirtschaftsraum.Sensor.CO2-Alarm-2
+  room: Hauswirtschaftsraum
 9/1/134:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.KG.Hauswirtschaftsraum.Sensor.CO2-Alarm-3
+  room: Hauswirtschaftsraum
 9/1/135:
   dpt: '14.058'
+  function: Sensorik
   name: Sensorik.KG.Hauswirtschaftsraum.Sensor.Luftdruck-Relativ
+  room: Hauswirtschaftsraum
 9/1/136:
   dpt: '14.058'
+  function: Sensorik
   name: Sensorik.KG.Hauswirtschaftsraum.Sensor.Luftdruck-Absolut
+  room: Hauswirtschaftsraum
 9/1/137:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.KG.Hauswirtschaftsraum.Sensor.Luftdruck-Alarm-1
+  room: Hauswirtschaftsraum
 9/1/20:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.KG.Flur.BWM.Decke.Temperatur
+  room: Flur
 9/1/21:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.KG.Flur.BWM.Wand.Temperatur
+  room: Flur
 9/1/31:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.KG.Garage.Sensor.Temperatur
+  room: Garage
 9/1/32:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.KG.Garage.Sensor.Temperatur-Alarm-1
+  room: Garage
 9/1/33:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.KG.Garage.Sensor.Temperatur-Alarm-2
+  room: Garage
 9/1/34:
   dpt: '9.007'
+  function: Sensorik
   name: Sensorik.KG.Garage.Sensor.Luftfeuchtigkeit
+  room: Garage
 9/1/35:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.KG.Garage.Sensor.Luftfeuchtigkeit-Alarm-1
+  room: Garage
 9/1/36:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.KG.Garage.Sensor.Luftfeuchtigkeit-Alarm-2
+  room: Garage
 9/1/37:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.KG.Garage.Sensor.Taupunkt
+  room: Garage
 9/1/38:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.KG.Garage.Sensor.Taupunkt-Alarm-1
+  room: Garage
 9/1/39:
   dpt: '9.008'
+  function: Sensorik
   name: Sensorik.KG.Garage.Sensor.VOC
+  room: Garage
 9/1/40:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.KG.Garage.Sensor.VOC-Alarm-1
+  room: Garage
 9/1/41:
   dpt: '9.008'
+  function: Sensorik
   name: Sensorik.KG.Garage.Sensor.CO2
+  room: Garage
 9/1/42:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.KG.Garage.Sensor.CO2-Alarm-1
+  room: Garage
 9/1/43:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.KG.Garage.Sensor.CO2-Alarm-2
+  room: Garage
 9/1/44:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.KG.Garage.Sensor.CO2-Alarm-3
+  room: Garage
 9/1/45:
   dpt: '14.058'
+  function: Sensorik
   name: Sensorik.KG.Garage.Sensor.Luftdruck-Relativ
+  room: Garage
 9/1/46:
   dpt: '14.058'
+  function: Sensorik
   name: Sensorik.KG.Garage.Sensor.Luftdruck-Absolut
+  room: Garage
 9/1/47:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.KG.Garage.Sensor.Luftdruck-Alarm-1
+  room: Garage
 9/1/61:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.KG.Technikraum.Sensor.Temperatur
+  room: Technikraum
 9/1/62:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.KG.Technikraum.Sensor.Temperatur-Alarm-1
+  room: Technikraum
 9/1/63:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.KG.Technikraum.Sensor.Temperatur-Alarm-2
+  room: Technikraum
 9/1/64:
   dpt: '9.007'
+  function: Sensorik
   name: Sensorik.KG.Technikraum.Sensor.Luftfeuchtigkeit
+  room: Technikraum
 9/1/65:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.KG.Technikraum.Sensor.Luftfeuchtigkeit-Alarm-1
+  room: Technikraum
 9/1/66:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.KG.Technikraum.Sensor.Luftfeuchtigkeit-Alarm-2
+  room: Technikraum
 9/1/67:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.KG.Technikraum.Sensor.Taupunkt
+  room: Technikraum
 9/1/68:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.KG.Technikraum.Sensor.Taupunkt-Alarm-1
+  room: Technikraum
 9/1/69:
   dpt: '9.008'
+  function: Sensorik
   name: Sensorik.KG.Technikraum.Sensor.VOC
+  room: Technikraum
 9/1/70:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.KG.Technikraum.Sensor.VOC-Alarm-1
+  room: Technikraum
 9/1/71:
   dpt: '9.008'
+  function: Sensorik
   name: Sensorik.KG.Technikraum.Sensor.CO2
+  room: Technikraum
 9/1/72:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.KG.Technikraum.Sensor.CO2-Alarm-1
+  room: Technikraum
 9/1/73:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.KG.Technikraum.Sensor.CO2-Alarm-2
+  room: Technikraum
 9/1/74:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.KG.Technikraum.Sensor.CO2-Alarm-3
+  room: Technikraum
 9/1/75:
   dpt: '14.058'
+  function: Sensorik
   name: Sensorik.KG.Technikraum.Sensor.Luftdruck-Relativ
+  room: Technikraum
 9/1/76:
   dpt: '14.058'
+  function: Sensorik
   name: Sensorik.KG.Technikraum.Sensor.Luftdruck-Absolut
+  room: Technikraum
 9/1/77:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.KG.Technikraum.Sensor.Luftdruck-Alarm-1
+  room: Technikraum
 9/1/91:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.KG.Vorratsraum.Sensor.Temperatur
+  room: Vorratsraum
 9/1/92:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.KG.Vorratsraum.Sensor.Temperatur-Alarm-1
+  room: Vorratsraum
 9/1/93:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.KG.Vorratsraum.Sensor.Temperatur-Alarm-2
+  room: Vorratsraum
 9/1/94:
   dpt: '9.007'
+  function: Sensorik
   name: Sensorik.KG.Vorratsraum.Sensor.Luftfeuchtigkeit
+  room: Vorratsraum
 9/1/95:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.KG.Vorratsraum.Sensor.Luftfeuchtigkeit-Alarm-1
+  room: Vorratsraum
 9/1/96:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.KG.Vorratsraum.Sensor.Luftfeuchtigkeit-Alarm-2
+  room: Vorratsraum
 9/1/97:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.KG.Vorratsraum.Sensor.Taupunkt
+  room: Vorratsraum
 9/1/98:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.KG.Vorratsraum.Sensor.Taupunkt-Alarm-1
+  room: Vorratsraum
 9/1/99:
   dpt: '9.008'
+  function: Sensorik
   name: Sensorik.KG.Vorratsraum.Sensor.VOC
+  room: Vorratsraum
 9/2/101:
   dpt: '9.008'
+  function: Sensorik
   name: Sensorik.EG.Wohnzimmer.Sensor.CO2
+  room: Wohnzimmer
 9/2/102:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.EG.Wohnzimmer.Sensor.CO2-Alarm-1
+  room: Wohnzimmer
 9/2/103:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.EG.Wohnzimmer.Sensor.CO2-Alarm-2
+  room: Wohnzimmer
 9/2/104:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.EG.Wohnzimmer.Sensor.CO2-Alarm-3
+  room: Wohnzimmer
 9/2/110:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.EG.Wohnzimmer.Schalter.Temperatur
+  room: Wohnzimmer
 9/2/121:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.EG.Esszimmer.Sensor.Temperatur
+  room: Esszimmer
 9/2/122:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.EG.Esszimmer.Sensor.Temperatur-Alarm-1
+  room: Esszimmer
 9/2/123:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.EG.Esszimmer.Sensor.Temperatur-Alarm-2
+  room: Esszimmer
 9/2/124:
   dpt: '9.007'
+  function: Sensorik
   name: Sensorik.EG.Esszimmer.Sensor.Luftfeuchtigkeit
+  room: Esszimmer
 9/2/125:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.EG.Esszimmer.Sensor.Luftfeuchtigkeit-Alarm-1
+  room: Esszimmer
 9/2/126:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.EG.Esszimmer.Sensor.Luftfeuchtigkeit-Alarm-2
+  room: Esszimmer
 9/2/127:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.EG.Esszimmer.Sensor.Taupunkt
+  room: Esszimmer
 9/2/128:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.EG.Esszimmer.Sensor.Taupunkt-Alarm-1
+  room: Esszimmer
 9/2/131:
   dpt: '9.008'
+  function: Sensorik
   name: Sensorik.EG.Esszimmer.Sensor.CO2
+  room: Esszimmer
 9/2/132:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.EG.Esszimmer.Sensor.CO2-Alarm-1
+  room: Esszimmer
 9/2/133:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.EG.Esszimmer.Sensor.CO2-Alarm-2
+  room: Esszimmer
 9/2/134:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.EG.Esszimmer.Sensor.CO2-Alarm-3
+  room: Esszimmer
 9/2/151:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.EG.Küche.Sensor.Temperatur
+  room: Küche
 9/2/152:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.EG.Küche.Sensor.Temperatur-Alarm-1
+  room: Küche
 9/2/153:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.EG.Küche.Sensor.Temperatur-Alarm-2
+  room: Küche
 9/2/154:
   dpt: '9.007'
+  function: Sensorik
   name: Sensorik.EG.Küche.Sensor.Luftfeuchtigkeit
+  room: Küche
 9/2/155:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.EG.Küche.Sensor.Luftfeuchtigkeit-Alarm-1
+  room: Küche
 9/2/156:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.EG.Küche.Sensor.Luftfeuchtigkeit-Alarm-2
+  room: Küche
 9/2/157:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.EG.Küche.Sensor.Taupunkt
+  room: Küche
 9/2/158:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.EG.Küche.Sensor.Taupunkt-Alarm-1
+  room: Küche
 9/2/161:
   dpt: '9.008'
+  function: Sensorik
   name: Sensorik.EG.Küche.Sensor.CO2
+  room: Küche
 9/2/162:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.EG.Küche.Sensor.CO2-Alarm-1
+  room: Küche
 9/2/163:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.EG.Küche.Sensor.CO2-Alarm-2
+  room: Küche
 9/2/164:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.EG.Küche.Sensor.CO2-Alarm-3
+  room: Küche
 9/2/20:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.EG.Flur.BWM.Eingang.Temperatur
+  room: Flur
 9/2/21:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.EG.Flur.BWM.Diele.Temperatur
+  room: Flur
 9/2/22:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.EG.Flur.BWM.Garderobe.Temperatur
+  room: Flur
 9/2/31:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.EG.Gäste-WC.Sensor.Temperatur
+  room: Gäste-WC
 9/2/32:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.EG.Gäste-WC.Sensor.Temperatur-Alarm-1
+  room: Gäste-WC
 9/2/33:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.EG.Gäste-WC.Sensor.Temperatur-Alarm-2
+  room: Gäste-WC
 9/2/34:
   dpt: '9.007'
+  function: Sensorik
   name: Sensorik.EG.Gäste-WC.Sensor.Luftfeuchtigkeit
+  room: Gäste-WC
 9/2/35:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.EG.Gäste-WC.Sensor.Luftfeuchtigkeit-Alarm-1
+  room: Gäste-WC
 9/2/36:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.EG.Gäste-WC.Sensor.Luftfeuchtigkeit-Alarm-2
+  room: Gäste-WC
 9/2/37:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.EG.Gäste-WC.Sensor.Taupunkt
+  room: Gäste-WC
 9/2/38:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.EG.Gäste-WC.Sensor.Taupunkt-Alarm-1
+  room: Gäste-WC
 9/2/41:
   dpt: '9.008'
+  function: Sensorik
   name: Sensorik.EG.Gäste-WC.Sensor.CO2
+  room: Gäste-WC
 9/2/42:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.EG.Gäste-WC.Sensor.CO2-Alarm-1
+  room: Gäste-WC
 9/2/43:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.EG.Gäste-WC.Sensor.CO2-Alarm-2
+  room: Gäste-WC
 9/2/44:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.EG.Gäste-WC.Sensor.CO2-Alarm-3
+  room: Gäste-WC
 9/2/50:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.EG.Gäste-WC.BWM.Temperatur
+  room: Gäste-WC
 9/2/61:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.EG.Büro.Sensor.Temperatur
+  room: Büro
 9/2/62:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.EG.Büro.Sensor.Temperatur-Alarm-1
+  room: Büro
 9/2/63:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.EG.Büro.Sensor.Temperatur-Alarm-2
+  room: Büro
 9/2/64:
   dpt: '9.007'
+  function: Sensorik
   name: Sensorik.EG.Büro.Sensor.Luftfeuchtigkeit
+  room: Büro
 9/2/65:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.EG.Büro.Sensor.Luftfeuchtigkeit-Alarm-1
+  room: Büro
 9/2/66:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.EG.Büro.Sensor.Luftfeuchtigkeit-Alarm-2
+  room: Büro
 9/2/67:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.EG.Büro.Sensor.Taupunkt
+  room: Büro
 9/2/68:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.EG.Büro.Sensor.Taupunkt-Alarm-1
+  room: Büro
 9/2/71:
   dpt: '9.008'
+  function: Sensorik
   name: Sensorik.EG.Büro.Sensor.CO2
+  room: Büro
 9/2/72:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.EG.Büro.Sensor.CO2-Alarm-1
+  room: Büro
 9/2/73:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.EG.Büro.Sensor.CO2-Alarm-2
+  room: Büro
 9/2/74:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.EG.Büro.Sensor.CO2-Alarm-3
+  room: Büro
 9/2/80:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.EG.Büro.Schalter.Temperatur
+  room: Büro
 9/2/91:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.EG.Wohnzimmer.Sensor.Temperatur
+  room: Wohnzimmer
 9/2/92:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.EG.Wohnzimmer.Sensor.Temperatur-Alarm-1
+  room: Wohnzimmer
 9/2/93:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.EG.Wohnzimmer.Sensor.Temperatur-Alarm-2
+  room: Wohnzimmer
 9/2/94:
   dpt: '9.007'
+  function: Sensorik
   name: Sensorik.EG.Wohnzimmer.Sensor.Luftfeuchtigkeit
+  room: Wohnzimmer
 9/2/95:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.EG.Wohnzimmer.Sensor.Luftfeuchtigkeit-Alarm-1
+  room: Wohnzimmer
 9/2/96:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.EG.Wohnzimmer.Sensor.Luftfeuchtigkeit-Alarm-2
+  room: Wohnzimmer
 9/2/97:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.EG.Wohnzimmer.Sensor.Taupunkt
+  room: Wohnzimmer
 9/2/98:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.EG.Wohnzimmer.Sensor.Taupunkt-Alarm-1
+  room: Wohnzimmer
 9/3/100:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Gregory.Sensor.VOC-Alarm-1
+  room: Schlafzimmer-Gregory
 9/3/101:
   dpt: '9.008'
+  function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Gregory.Sensor.CO2
+  room: Schlafzimmer-Gregory
 9/3/102:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Gregory.Sensor.CO2-Alarm-1
+  room: Schlafzimmer-Gregory
 9/3/103:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Gregory.Sensor.CO2-Alarm-2
+  room: Schlafzimmer-Gregory
 9/3/104:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Gregory.Sensor.CO2-Alarm-3
+  room: Schlafzimmer-Gregory
 9/3/110:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Gregory.Schalter.Temperatur
+  room: Schlafzimmer-Gregory
 9/3/121:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Luis.Sensor.Temperatur
+  room: Schlafzimmer-Luis
 9/3/122:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Luis.Sensor.Temperatur-Alarm-1
+  room: Schlafzimmer-Luis
 9/3/123:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Luis.Sensor.Temperatur-Alarm-2
+  room: Schlafzimmer-Luis
 9/3/124:
   dpt: '9.007'
+  function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Luis.Sensor.Luftfeuchtigkeit
+  room: Schlafzimmer-Luis
 9/3/125:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Luis.Sensor.Luftfeuchtigkeit-Alarm-1
+  room: Schlafzimmer-Luis
 9/3/126:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Luis.Sensor.Luftfeuchtigkeit-Alarm-2
+  room: Schlafzimmer-Luis
 9/3/127:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Luis.Sensor.Taupunkt
+  room: Schlafzimmer-Luis
 9/3/128:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Luis.Sensor.Taupunkt-Alarm-1
+  room: Schlafzimmer-Luis
 9/3/130:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Luis.Sensor.VOC-Alarm-1
+  room: Schlafzimmer-Luis
 9/3/131:
   dpt: '9.008'
+  function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Luis.Sensor.CO2
+  room: Schlafzimmer-Luis
 9/3/132:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Luis.Sensor.CO2-Alarm-1
+  room: Schlafzimmer-Luis
 9/3/133:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Luis.Sensor.CO2-Alarm-2
+  room: Schlafzimmer-Luis
 9/3/134:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Luis.Sensor.CO2-Alarm-3
+  room: Schlafzimmer-Luis
 9/3/140:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Luis.Schalter.Temperatur
+  room: Schlafzimmer-Luis
 9/3/151:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Eltern.Sensor.Temperatur
+  room: Schlafzimmer-Eltern
 9/3/152:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Eltern.Sensor.Temperatur-Alarm-1
+  room: Schlafzimmer-Eltern
 9/3/153:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Eltern.Sensor.Temperatur-Alarm-2
+  room: Schlafzimmer-Eltern
 9/3/154:
   dpt: '9.007'
+  function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Eltern.Sensor.Luftfeuchtigkeit
+  room: Schlafzimmer-Eltern
 9/3/155:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Eltern.Sensor.Luftfeuchtigkeit-Alarm-1
+  room: Schlafzimmer-Eltern
 9/3/156:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Eltern.Sensor.Luftfeuchtigkeit-Alarm-2
+  room: Schlafzimmer-Eltern
 9/3/157:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Eltern.Sensor.Taupunkt
+  room: Schlafzimmer-Eltern
 9/3/158:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Eltern.Sensor.Taupunkt-Alarm-1
+  room: Schlafzimmer-Eltern
 9/3/160:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Eltern.Sensor.VOC-Alarm-1
+  room: Schlafzimmer-Eltern
 9/3/161:
   dpt: '9.008'
+  function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Eltern.Sensor.CO2
+  room: Schlafzimmer-Eltern
 9/3/162:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Eltern.Sensor.CO2-Alarm-1
+  room: Schlafzimmer-Eltern
 9/3/163:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Eltern.Sensor.CO2-Alarm-2
+  room: Schlafzimmer-Eltern
 9/3/164:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Eltern.Sensor.CO2-Alarm-3
+  room: Schlafzimmer-Eltern
 9/3/170:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Eltern.Schalter.Temperatur
+  room: Schlafzimmer-Eltern
 9/3/171:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Eltern.Schalter.Bett-Links.Temperatur
+  room: Schlafzimmer-Eltern
 9/3/172:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Eltern.Schalter.Bett-Rechts.Temperatur
+  room: Schlafzimmer-Eltern
 9/3/173:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Eltern.BWM.Temperatur
+  room: Schlafzimmer-Eltern
 9/3/183:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.OG.Begehbarer-Schrank.Sensor.Temperatur-Alarm-2
+  room: Begehbarer-Schrank
 9/3/20:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.OG.Flur.BWM.Treppe.Temperatur
+  room: Flur
 9/3/200:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.OG.Begehbarer-Schrank.BWM.Temperatur
+  room: Begehbarer-Schrank
 9/3/21:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.OG.Flur.BWM.Gang.Temperatur
+  room: Flur
 9/3/211:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.OG.Badezimmer-Eltern.Sensor.Temperartur
+  room: Badezimmer-Eltern
 9/3/212:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.OG.Badezimmer-Eltern.Sensor.Temperatur-Alarm-1
+  room: Badezimmer-Eltern
 9/3/213:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.OG.Badezimmer-Eltern.Sensor.Temperatur-Alarm-2
+  room: Badezimmer-Eltern
 9/3/214:
   dpt: '9.007'
+  function: Sensorik
   name: Sensorik.OG.Badezimmer-Eltern.Sensor.Luftfeuchtigkeit
+  room: Badezimmer-Eltern
 9/3/215:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.OG.Badezimmer-Eltern.Sensor.Luftfeuchtigkeit-Alarm-1
+  room: Badezimmer-Eltern
 9/3/216:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.OG.Badezimmer-Eltern.Sensor.Luftfeuchtigkeit-Alarm-2
+  room: Badezimmer-Eltern
 9/3/217:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.OG.Badezimmer-Eltern.Sensor.Taupunkt
+  room: Badezimmer-Eltern
 9/3/218:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.OG.Badezimmer-Eltern.Sensor.Taupunkt-Alarm-1
+  room: Badezimmer-Eltern
 9/3/220:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.OG.Badezimmer-Eltern.Sensor.VOC-Alarm-1
+  room: Badezimmer-Eltern
 9/3/221:
   dpt: '9.008'
+  function: Sensorik
   name: Sensorik.OG.Badezimmer-Eltern.Sensor.CO2
+  room: Badezimmer-Eltern
 9/3/222:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.OG.Badezimmer-Eltern.Sensor.CO2-Alarm-1
+  room: Badezimmer-Eltern
 9/3/223:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.OG.Badezimmer-Eltern.Sensor.CO2-Alarm-2
+  room: Badezimmer-Eltern
 9/3/224:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.OG.Badezimmer-Eltern.Sensor.CO2-Alarm-3
+  room: Badezimmer-Eltern
 9/3/230:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.OG.Badezimmer-Eltern.Schalter.Temperartur
+  room: Badezimmer-Eltern
 9/3/231:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.OG.Badezimmer-Eltern.BWM.Temperartur
+  room: Badezimmer-Eltern
 9/3/31:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.OG.Abstellraum.Sensor.Temperatur
+  room: Abstellraum
 9/3/32:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.OG.Abstellraum.Sensor.Temperatur-Alarm-1
+  room: Abstellraum
 9/3/33:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.OG.Abstellraum.Sensor.Temperatur-Alarm-2
+  room: Abstellraum
 9/3/34:
   dpt: '9.007'
+  function: Sensorik
   name: Sensorik.OG.Abstellraum.Sensor.Luftfeuchtigkeit
+  room: Abstellraum
 9/3/35:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.OG.Abstellraum.Sensor.Luftfeuchtigkeit-Alarm-1
+  room: Abstellraum
 9/3/36:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.OG.Abstellraum.Sensor.Luftfeuchtigkeit-Alarm-2
+  room: Abstellraum
 9/3/37:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.OG.Abstellraum.Sensor.Taupunkt
+  room: Abstellraum
 9/3/38:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.OG.Abstellraum.Sensor.Taupunkt-Alarm-1
+  room: Abstellraum
 9/3/40:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.OG.Abstellraum.Sensor.VOC-Alarm-1
+  room: Abstellraum
 9/3/41:
   dpt: '9.008'
+  function: Sensorik
   name: Sensorik.OG.Abstellraum.Sensor.CO2
+  room: Abstellraum
 9/3/42:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.OG.Abstellraum.Sensor.CO2-Alarm-1
+  room: Abstellraum
 9/3/43:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.OG.Abstellraum.Sensor.CO2-Alarm-2
+  room: Abstellraum
 9/3/44:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.OG.Abstellraum.Sensor.CO2-Alarm-3
+  room: Abstellraum
 9/3/50:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.OG.Abstellraum.Schalter.Temperatur
+  room: Abstellraum
 9/3/61:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.OG.Badezimmer-Kinder.Sensor.Temperatur
+  room: Badezimmer-Kinder
 9/3/62:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.OG.Badezimmer-Kinder.Sensor.Temperatur-Alarm-1
+  room: Badezimmer-Kinder
 9/3/63:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.OG.Badezimmer-Kinder.Sensor.Temperatur-Alarm-2
+  room: Badezimmer-Kinder
 9/3/64:
   dpt: '9.007'
+  function: Sensorik
   name: Sensorik.OG.Badezimmer-Kinder.Sensor.Luftfeuchtigkeit
+  room: Badezimmer-Kinder
 9/3/65:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.OG.Badezimmer-Kinder.Sensor.Luftfeuchtigkeit-Alarm-1
+  room: Badezimmer-Kinder
 9/3/66:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.OG.Badezimmer-Kinder.Sensor.Luftfeuchtigkeit-Alarm-2
+  room: Badezimmer-Kinder
 9/3/67:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.OG.Badezimmer-Kinder.Sensor.Taupunkt
+  room: Badezimmer-Kinder
 9/3/68:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.OG.Badezimmer-Kinder.Sensor.Taupunkt-Alarm-1
+  room: Badezimmer-Kinder
 9/3/70:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.OG.Badezimmer-Kinder.Sensor.VOC-Alarm-1
+  room: Badezimmer-Kinder
 9/3/71:
   dpt: '9.008'
+  function: Sensorik
   name: Sensorik.OG.Badezimmer-Kinder.Sensor.CO2
+  room: Badezimmer-Kinder
 9/3/72:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.OG.Badezimmer-Kinder.Sensor.CO2-Alarm-1
+  room: Badezimmer-Kinder
 9/3/73:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.OG.Badezimmer-Kinder.Sensor.CO2-Alarm-2
+  room: Badezimmer-Kinder
 9/3/74:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.OG.Badezimmer-Kinder.Sensor.CO2-Alarm-3
+  room: Badezimmer-Kinder
 9/3/80:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.OG.Badezimmer-Kinder.Schalter.Temperatur
+  room: Badezimmer-Kinder
 9/3/81:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.OG.Badezimmer-Kinder.BWM.Temperatur
+  room: Badezimmer-Kinder
 9/3/91:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Gregory.Sensor.Temperatur
+  room: Schlafzimmer-Gregory
 9/3/92:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Gregory.Sensor.Temperatur-Alarm-1
+  room: Schlafzimmer-Gregory
 9/3/93:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Gregory.Sensor.Temperatur-Alarm-2
+  room: Schlafzimmer-Gregory
 9/3/94:
   dpt: '9.007'
+  function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Gregory.Sensor.Luftfeuchtigkeit
+  room: Schlafzimmer-Gregory
 9/3/95:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Gregory.Sensor.Luftfeuchtigkeit-Alarm-1
+  room: Schlafzimmer-Gregory
 9/3/96:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Gregory.Sensor.Luftfeuchtigkeit-Alarm-2
+  room: Schlafzimmer-Gregory
 9/3/97:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Gregory.Sensor.Taupunkt
+  room: Schlafzimmer-Gregory
 9/3/98:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Gregory.Sensor.Taupunkt-Alarm-1
+  room: Schlafzimmer-Gregory
 9/4/1:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.DG.Speicher.Sensor.Temperatur
+  room: Speicher
 9/4/10:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.DG.Speicher.Sensor.VOC-Alarm-1
+  room: Speicher
 9/4/11:
   dpt: '9.008'
+  function: Sensorik
   name: Sensorik.DG.Speicher.Sensor.CO2
+  room: Speicher
 9/4/12:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.DG.Speicher.Sensor.CO2-Alarm-1
+  room: Speicher
 9/4/13:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.DG.Speicher.Sensor.CO2-Alarm-2
+  room: Speicher
 9/4/14:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.DG.Speicher.Sensor.CO2-Alarm-3
+  room: Speicher
 9/4/15:
   dpt: '14.058'
+  function: Sensorik
   name: Sensorik.DG.Speicher.Sensor.Luftdruck-Relativ
+  room: Speicher
 9/4/16:
   dpt: '14.058'
+  function: Sensorik
   name: Sensorik.DG.Speicher.Sensor.Luftdruck-Absolut
+  room: Speicher
 9/4/17:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.DG.Speicher.Sensor.Luftdruck-Alarm-1
+  room: Speicher
 9/4/2:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.DG.Speicher.Sensor.Temperatur-Alarm-1
+  room: Speicher
 9/4/3:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.DG.Speicher.Sensor.Temperatur-Alarm-2
+  room: Speicher
 9/4/4:
   dpt: '9.007'
+  function: Sensorik
   name: Sensorik.DG.Speicher.Sensor.Luftfeuchtigkeit
+  room: Speicher
 9/4/5:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.DG.Speicher.Sensor.Luftfeuchtigkeit-Alarm-1
+  room: Speicher
 9/4/6:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.DG.Speicher.Sensor.Luftfeuchtigkeit-Alarm-2
+  room: Speicher
 9/4/7:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.DG.Speicher.Sensor.Taupunkt
+  room: Speicher
 9/4/8:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.DG.Speicher.Sensor.Taupunkt-Alarm-1
+  room: Speicher
 9/4/9:
   dpt: '9.008'
+  function: Sensorik
   name: Sensorik.DG.Speicher.Sensor.VOC
+  room: Speicher
 9/5/1:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.A.Fassade.Außensensor.Temperatur
+  room: Fassade
 9/5/10:
   dpt: '9.004'
+  function: Sensorik
   name: Sensorik.A.Fassade.Außensensor.Helligkeit-Mitte
+  room: Fassade
 9/5/101:
   dpt: '9.007'
+  function: Sensorik
   name: Sensorik.A.DachAußensensor.SO.Luftfeuchtigkeit
+  room: DachAußensensor
 9/5/102:
   dpt: '9.007'
+  function: Sensorik
   name: Sensorik.A.Dach.Außensensor.SO.Luftfeuchtigkeit-Alle
+  room: Dach
 9/5/103:
   dpt: '1.001'
+  function: Sensorik
   name: Sensorik.A.Dach.Außensensor.SO.Luftfeuchtigkeit-Alarm-1
+  room: Dach
 9/5/104:
   dpt: '1.001'
+  function: Sensorik
   name: Sensorik.A.Dach.Außensensor.SO.Luftfeuchtigkeit-Alarm-2
+  room: Dach
 9/5/105:
   dpt: '1.001'
+  function: Sensorik
   name: Sensorik.A.Dach.Außensensor.SO.Luftfeuchtigkeit-Status
+  room: Dach
 9/5/106:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.A.Dach.Außensensor.SO.Taupunkt
+  room: Dach
 9/5/108:
   dpt: '14.058'
+  function: Sensorik
   name: Sensorik.A.Dach.Außensensor.SO.Luftdruck-Relativ
+  room: Dach
 9/5/109:
   dpt: '14.058'
+  function: Sensorik
   name: Sensorik.A.Dach.Außensensor.SO.Luftdruck-Absolut
+  room: Dach
 9/5/11:
   dpt: '9.004'
+  function: Sensorik
   name: Sensorik.A.Fassade.Außensensor.Helligkeit-Rechts
+  room: Fassade
 9/5/110:
   dpt: '1.001'
+  function: Sensorik
   name: Sensorik.A.Dach.Außensensor.SO.Luftdruck-Alarm-1
+  room: Dach
 9/5/111:
   dpt: '1.001'
+  function: Sensorik
   name: Sensorik.A.Dach.Außensensor.SO.Luftdruck-Status
+  room: Dach
 9/5/12:
   dpt: '9.004'
+  function: Sensorik
   name: Sensorik.A.Fassade.Außensensor.Helligkeit-Alle
+  room: Fassade
 9/5/121:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.A.Dach.Außensensor.NW.Temperatur
+  room: Dach
 9/5/122:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.A.Dach.Außensensor.NW.Temperatur-Alle
+  room: Dach
 9/5/123:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.A.Dach.Außensensor.NW.Temperatur-Alarm-1
+  room: Dach
 9/5/124:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.A.Dach.Außensensor.NW.Temperatur-Alarm-2
+  room: Dach
 9/5/125:
   dpt: '1.001'
+  function: Sensorik
   name: Sensorik.A.Dach.Außensensor.NW.Temperatur-Status
+  room: Dach
 9/5/129:
   dpt: '9.004'
+  function: Sensorik
   name: Sensorik.A.Dach.Außensensor.NW.Helligkeit-Links
+  room: Dach
 9/5/130:
   dpt: '9.004'
+  function: Sensorik
   name: Sensorik.A.Dach.Außensensor.NW.Helligkeit-Mitte
+  room: Dach
 9/5/131:
   dpt: '9.004'
+  function: Sensorik
   name: Sensorik.A.Dach.Außensensor.NW.Helligkeit-Rechts
+  room: Dach
 9/5/132:
   dpt: '9.004'
+  function: Sensorik
   name: Sensorik.A.Dach.Außensensor.NW.Helligkeit-Alle
+  room: Dach
 9/5/2:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.A.Fassade.Außensensor.Temperatur-Alle
+  room: Fassade
 9/5/3:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.A.Fassade.Außensensor.Temperatur-Alarm-1
+  room: Fassade
 9/5/4:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.A.Fassade.Außensensor.Temperatur-Alarm-2
+  room: Fassade
 9/5/41:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.A.Dach.Wetterstation.Temperatur
+  room: Dach
 9/5/43:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.A.Dach.Wetterstation.Temperatur-Alarm-1
+  room: Dach
 9/5/44:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.A.Dach.Wetterstation.Temperatur-Alarm-2
+  room: Dach
 9/5/45:
   dpt: '1.001'
+  function: Sensorik
   name: Sensorik.A.Dach.Wetterstation.Temperatur-Status
+  room: Dach
 9/5/46:
   dpt: '9.005'
+  function: Sensorik
   name: Sensorik.A.Dach.Wetterstation.Windgeschwindigkeit
+  room: Dach
 9/5/47:
   dpt: '1.001'
+  function: Sensorik
   name: Sensorik.A.Dach.Wetterstation.Windgeschwindigkeit-Alarm-1
+  room: Dach
 9/5/48:
   dpt: '1.005'
+  function: Sensorik
   name: Sensorik.A.Dach.Wetterstation.Windgeschwindigkeit-Alarm-Erweitert-1
+  room: Dach
 9/5/49:
   dpt: '9.004'
+  function: Sensorik
   name: Sensorik.A.Dach.Wetterstation.Helligkeit-Links
+  room: Dach
 9/5/5:
   dpt: '1.001'
+  function: Sensorik
   name: Sensorik.A.Fassade.Außensensor.Temperatur-Status
+  room: Fassade
 9/5/50:
   dpt: '9.004'
+  function: Sensorik
   name: Sensorik.A.Dach.Wetterstation.Helligkeit-Mitte
+  room: Dach
 9/5/51:
   dpt: '9.004'
+  function: Sensorik
   name: Sensorik.A.Dach.Wetterstation.Helligkeit-Rechts
+  room: Dach
 9/5/52:
   dpt: '9.004'
+  function: Sensorik
   name: Sensorik.A.Dach.Wetterstation.Helligkeit-Alle
+  room: Dach
 9/5/53:
   dpt: '1.001'
+  function: Sensorik
   name: Sensorik.A.Dach.Wetterstation.Regen
+  room: Dach
 9/5/54:
   dpt: '1.001'
+  function: Sensorik
   name: Sensorik.A.Dach.Wetterstation.Regen-Alarm-1
+  room: Dach
 9/5/55:
   dpt: '1.001'
+  function: Sensorik
   name: Sensorik.A.Dach.Wetterstation.Frost
+  room: Dach
 9/5/56:
   dpt: '1.001'
+  function: Sensorik
   name: Sensorik.A.Dach.Wetterstation.Frost-Alarm-1
+  room: Dach
 9/5/57:
   dpt: '14.007'
+  function: Sensorik
   name: Sensorik.A.Dach.Wetterstation.Azimut
+  room: Dach
 9/5/58:
   dpt: '14.007'
+  function: Sensorik
   name: Sensorik.A.Dach.Wetterstation.Elevation
+  room: Dach
 9/5/59:
   dpt: '14.007'
+  function: Sensorik
   name: Sensorik.A.Dach.Wetterstation.GPS-Breitengrad
+  room: Dach
 9/5/60:
   dpt: '14.007'
+  function: Sensorik
   name: Sensorik.A.Dach.Wetterstation.GPS-Längengrad
+  room: Dach
 9/5/81:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.A.Dach.Außensensor.SO.Temperatur
+  room: Dach
 9/5/82:
   dpt: '9.001'
+  function: Sensorik
   name: Sensorik.A.Dach.Außensensor.SO.Temperatur-Alle
+  room: Dach
 9/5/83:
   dpt: '1.001'
+  function: Sensorik
   name: Sensorik.A.Dach.Außensensor.SO.Temperatur-Alarm-1
+  room: Dach
 9/5/84:
   dpt: '1.001'
+  function: Sensorik
   name: Sensorik.A.Dach.Außensensor.SO.Temperatur-Alarm-2
+  room: Dach
 9/5/85:
   dpt: '1.001'
+  function: Sensorik
   name: Sensorik.A.Dach.Außensensor.SO.Temperatur-Status
+  room: Dach
 9/5/9:
   dpt: '9.004'
+  function: Sensorik
   name: Sensorik.A.Fassade.Außensensor.Helligkeit-Links
+  room: Fassade

--- a/kubernetes/applications/knx-nats-bridge/base/kustomization.yaml
+++ b/kubernetes/applications/knx-nats-bridge/base/kustomization.yaml
@@ -16,11 +16,11 @@ helmCharts:
       - monitoring.coreos.com/v1
 
 configMapGenerator:
-  - name: knx-nats-bridge-mapping
+  - name: knx-nats-bridge-catalog
     options:
       disableNameSuffixHash: true
     files:
-      - ga-mapping.yaml=config/ga-mapping.yaml
+      - knx-catalog.yaml=config/knx-catalog.yaml
 
 labels:
   - includeSelectors: false

--- a/kubernetes/applications/knx-nats-bridge/base/values.yaml
+++ b/kubernetes/applications/knx-nats-bridge/base/values.yaml
@@ -5,7 +5,7 @@ deployment:
   enabled: true
   image:
     repository: ghcr.io/alexander-zimmermann/knx-nats-bridge
-    tag: 0.1.4
+    tag: 0.3.1
     pullPolicy: IfNotPresent
 
   # KNX tunnel allows only one connection per credential; never run two replicas.
@@ -27,8 +27,8 @@ deployment:
     # NKey seed mounted as a file from the synced Secret (Kyverno clones from `nats` namespace)
     NATS_NKEY_SEED_FILE:
       value: /etc/knx-nats-bridge/nkey-seed
-    KNX_NATS_MAPPING_PATH:
-      value: /etc/knx-nats-bridge/ga-mapping.yaml
+    KNX_NATS_CATALOG_PATH:
+      value: /etc/knx-nats-bridge/knx-catalog.yaml
     KNX_NATS_UNMAPPED_POLICY:
       value: skip
     LOG_FORMAT:
@@ -39,17 +39,17 @@ deployment:
       value: Europe/Berlin
 
   volumes:
-    mapping:
+    catalog:
       configMap:
-        name: knx-nats-bridge-mapping
+        name: knx-nats-bridge-catalog
     nats-credentials:
       secret:
         secretName: knx-nats-bridge-credentials
 
   volumeMounts:
-    mapping:
-      mountPath: /etc/knx-nats-bridge/ga-mapping.yaml
-      subPath: ga-mapping.yaml
+    catalog:
+      mountPath: /etc/knx-nats-bridge/knx-catalog.yaml
+      subPath: knx-catalog.yaml
     nats-credentials:
       mountPath: /etc/knx-nats-bridge/nkey-seed
       subPath: nkey-seed

--- a/kubernetes/applications/timescaledb/base/scripts/bootstrap.sql
+++ b/kubernetes/applications/timescaledb/base/scripts/bootstrap.sql
@@ -383,6 +383,30 @@ SELECT add_retention_policy('warp_charge_tracker', INTERVAL '365 days');
 SELECT add_retention_policy('warp_meter',          INTERVAL '365 days');
 
 -- =========================================================
+-- KNX catalog — GA → name/room/function/description lookup,
+-- populated by the iot-mcp-bridge import-knx-catalog Job from
+-- the knx-nats-bridge ConfigMap. The `knx_catalog_view` view
+-- joins `knx` against the catalog so MCP tools can filter / group by
+-- room or function in plain SQL.
+-- =========================================================
+CREATE TABLE IF NOT EXISTS knx_catalog (
+    ga          TEXT PRIMARY KEY,
+    name        TEXT NOT NULL,
+    room        TEXT,
+    function    TEXT,
+    description TEXT,
+    dpt         TEXT NOT NULL,
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS knx_catalog_room_idx     ON knx_catalog (room) WHERE room IS NOT NULL;
+CREATE INDEX IF NOT EXISTS knx_catalog_function_idx ON knx_catalog (function);
+
+CREATE OR REPLACE VIEW knx_catalog_view AS
+SELECT k.time, k.ga, k.knx_main, k.knx_middle, k.knx_sub, k.dpt, k.value,
+       n.name AS ga_name, n.room, n.function, n.description
+FROM knx k LEFT JOIN knx_catalog n USING (ga);
+
+-- =========================================================
 -- Transfer ownership from `postgres` (CNPG runs initdb as superuser)
 -- to the application user `homelab`, so it can issue table-level GRANTs.
 -- =========================================================
@@ -395,5 +419,9 @@ BEGIN
     END LOOP;
     FOR r IN SELECT view_name FROM timescaledb_information.continuous_aggregates LOOP
         EXECUTE format('ALTER MATERIALIZED VIEW public.%I OWNER TO homelab', r.view_name);
+    END LOOP;
+    -- Plain views need their own loop — pg_views excludes hypertable views.
+    FOR r IN SELECT viewname FROM pg_views WHERE schemaname = 'public' LOOP
+        EXECUTE format('ALTER VIEW public.%I OWNER TO homelab', r.viewname);
     END LOOP;
 END$$;

--- a/kubernetes/components/admission-controller/base/clusterpolicy-secrets.yaml
+++ b/kubernetes/components/admission-controller/base/clusterpolicy-secrets.yaml
@@ -380,3 +380,45 @@ spec:
         clone:
           namespace: timescaledb
           name: timescaledb-db-iot-mcp-bridge-ro-secret
+
+    # Syncs CNPG-managed timescaledb admin-user secret into iot-mcp-bridge so
+    # the import-knx-catalog Job can write to the `knx_catalog` table (the
+    # read-only role used by the running server has SELECT-only privileges).
+    - name: sync-timescaledb-db-app-secret
+      match:
+        any:
+          - resources:
+              kinds:
+                - Namespace
+              names:
+                - iot-mcp-bridge
+      generate:
+        apiVersion: v1
+        kind: Secret
+        name: timescaledb-db-app
+        namespace: iot-mcp-bridge
+        synchronize: true
+        clone:
+          namespace: timescaledb
+          name: timescaledb-db-app
+
+    # Syncs the KNX catalog ConfigMap (GA → name/room/function/description)
+    # from knx-nats-bridge into iot-mcp-bridge so the import-knx-catalog Job
+    # can mount it.
+    - name: sync-knx-nats-bridge-catalog-configmap
+      match:
+        any:
+          - resources:
+              kinds:
+                - Namespace
+              names:
+                - iot-mcp-bridge
+      generate:
+        apiVersion: v1
+        kind: ConfigMap
+        name: knx-nats-bridge-catalog
+        namespace: iot-mcp-bridge
+        synchronize: true
+        clone:
+          namespace: knx-nats-bridge
+          name: knx-nats-bridge-catalog

--- a/scripts/knx_enrich_catalog.py
+++ b/scripts/knx_enrich_catalog.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["pyyaml>=6.0"]
+# ///
+"""Project-specific enrichment of the raw knx-catalog.yaml.
+
+The upstream `knxproj-to-yaml` tool (in the knx-nats-bridge repo) only
+emits what ETS itself defines. This post-processor adds the conventions
+specific to this project's ETS naming:
+
+* Normalise ETS Building-style room names (`4 - LivingRoom (E4)` ->
+  `LivingRoom`) so they match GA-name segments.
+* Drop ETS auto-generated descriptions that just repeat
+  ``<space-name> <function-name>`` — they carry no real information.
+* Backfill `room` for GAs that don't sit in an ETS Function but follow
+  the dotted naming convention `<Function>.<Floor>.<Room>.<Detail>`.
+* Backfill `function` from the first dotted name segment when ETS doesn't
+  carry a Function for the GA.
+
+Run in-place over the file produced by `knxproj-to-yaml`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# --- Project-specific configuration -----------------------------------------
+# Floor tokens at segment[1] of a dotted GA name. When a name matches
+# `<Function>.<Floor>.<Room>.<Detail>`, segment[2] is the room. Tokens listed
+# in `_NON_ROOM_FLOORS` exclude the floor from room extraction (e.g. central
+# scenes / general entries that don't belong to a single room).
+_FLOOR_TOKENS = {"OG", "EG", "KG", "DG", "A", "Zentral"}
+_NON_ROOM_FLOORS = {"Zentral"}
+
+# Strip ETS' Building-numbering style: `4 - LivingRoom (E4)` -> `LivingRoom`.
+# Keeps the inner name only; leaves anything that doesn't match untouched.
+_ROOM_NORMALISE_RE = re.compile(r"^\s*\d+\s*-\s*(.+?)\s*\([^)]*\)\s*$")
+# ----------------------------------------------------------------------------
+
+
+def _normalise_room(room: str) -> str:
+    m = _ROOM_NORMALISE_RE.match(room)
+    return m.group(1).strip() if m else room.strip()
+
+
+def _room_from_name(name: str) -> str | None:
+    parts = name.split(".")
+    if len(parts) < 3:
+        return None
+    if parts[1] not in _FLOOR_TOKENS:
+        return None
+    if parts[1] in _NON_ROOM_FLOORS:
+        return None
+    return parts[2]
+
+
+def _function_from_name(name: str) -> str | None:
+    if "." not in name:
+        return None
+    return name.split(".", 1)[0]
+
+
+def _is_auto_description(desc: str, room: str | None, function: str | None) -> bool:
+    """Detect ETS auto-generated `<space> <function>` descriptions.
+
+    ETS prefills a Function's description with the space-name + the
+    function-name in either of two forms:
+
+        "<room> <function>"
+        "<n> - <room> (<id>) <function>"   (Building-numbered style)
+
+    Both add no information beyond what room/function already carry, so we
+    drop them. Comparison is case-insensitive and whitespace-tolerant.
+    """
+    if not desc:
+        return False
+    norm = " ".join(desc.split()).lower()
+    parts: list[str] = []
+    if room:
+        parts.append(room.strip().lower())
+    if function:
+        parts.append(function.strip().lower())
+    if norm == " ".join(parts):
+        return True
+    if room and function:
+        pattern = re.compile(
+            r"^\s*\d+\s*-\s*"
+            + re.escape(room.strip())
+            + r"\s*\([^)]*\)\s+"
+            + re.escape(function.strip())
+            + r"\s*$",
+            re.IGNORECASE,
+        )
+        if pattern.match(desc.strip()):
+            return True
+    return False
+
+
+def enrich(catalog: dict[str, Any]) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    for ga, entry in catalog.items():
+        if not isinstance(entry, dict):
+            out[ga] = entry
+            continue
+        e = dict(entry)
+
+        # Match ETS auto-descriptions BEFORE normalising the room — the
+        # boilerplate uses the raw ETS-Building-style room name
+        original_room = e.get("room")
+        normalised_room = _normalise_room(str(original_room)) if original_room else None
+        desc = str(e.get("description") or "")
+        candidates = [r for r in (original_room, normalised_room) if r]
+        if desc and any(
+            _is_auto_description(desc, r, e.get("function")) for r in candidates
+        ):
+            del e["description"]
+
+        if normalised_room is not None:
+            e["room"] = normalised_room
+
+        name = str(e.get("name") or "")
+        if "room" not in e:
+            room = _room_from_name(name)
+            if room:
+                e["room"] = room
+        if "function" not in e:
+            fn = _function_from_name(name)
+            if fn:
+                e["function"] = fn
+
+        out[ga] = e
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Apply project-specific enrichment to a raw knx-catalog.yaml"
+    )
+    parser.add_argument("path", type=Path, help="Path to knx-catalog.yaml (modified in place)")
+    args = parser.parse_args(argv)
+
+    raw = yaml.safe_load(args.path.read_text(encoding="utf-8")) or {}
+    if not isinstance(raw, dict):
+        print(f"error: {args.path} top-level must be a mapping", file=sys.stderr)
+        return 2
+
+    enriched = enrich(raw)
+
+    args.path.write_text(
+        yaml.safe_dump(enriched, sort_keys=True, allow_unicode=True, default_flow_style=False),
+        encoding="utf-8",
+    )
+
+    total = len(enriched)
+    with_room = sum(1 for e in enriched.values() if isinstance(e, dict) and "room" in e)
+    with_function = sum(1 for e in enriched.values() if isinstance(e, dict) and "function" in e)
+    with_description = sum(
+        1 for e in enriched.values() if isinstance(e, dict) and "description" in e
+    )
+    print(
+        f"enriched {total} entries (room={with_room}, "
+        f"function={with_function}, description={with_description})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tasks/cluster.yaml
+++ b/tasks/cluster.yaml
@@ -5,7 +5,6 @@ tasks:
     desc: "register machine classes"
     summary: |
       Register Machine Classes in Omni.
-      Underlying command: omnictl apply
     sources:
       - "cluster/homelab-machine-classes.yaml"
     preconditions:
@@ -22,7 +21,6 @@ tasks:
     summary: |
       Sync local cluster template with Omni.
       Arguments: [env] (default: prod)
-      Underlying command: omnictl cluster template sync
     vars:
       ENVIRONMENT: "{{if gt (len .CLI_ARGS_LIST) 0}}{{index .CLI_ARGS_LIST 0}}{{else}}prod{{end}}"
       MANIFEST: "homelab-cluster-{{.ENVIRONMENT}}.yaml"
@@ -44,7 +42,6 @@ tasks:
     summary: |
       Show status of the cluster in Omni.
       Arguments: [env] (default: prod)
-      Underlying command: omnictl cluster status
     vars:
       ENVIRONMENT: "{{if gt (len .CLI_ARGS_LIST) 0}}{{index .CLI_ARGS_LIST 0}}{{else}}prod{{end}}"
     requires:
@@ -62,7 +59,6 @@ tasks:
     summary: |
       Download kubeconfig and talosconfig.
       Arguments: [env] (default: prod)
-      Underlying command: omnictl kubeconfig / talosconfig
     vars:
       ENVIRONMENT: "{{if gt (len .CLI_ARGS_LIST) 0}}{{index .CLI_ARGS_LIST 0}}{{else}}prod{{end}}"
     requires:

--- a/tasks/infrastructure.yaml
+++ b/tasks/infrastructure.yaml
@@ -5,7 +5,6 @@ tasks:
     desc: "initialize tofu modules"
     summary: |
       Initialize OpenTofu modules.
-      Underlying command: tofu init
     preconditions:
       - sh: command -v tofu
         msg: "OpenTofu (tofu) is not installed"
@@ -22,7 +21,6 @@ tasks:
     desc: "apply infrastructure resources"
     summary: |
       Create or update infrastructure resources.
-      Underlying command: tofu apply
     sources:
       - tfplan
     generates:
@@ -39,7 +37,6 @@ tasks:
     desc: "destroy infrastructure resources"
     summary: |
       Destroy all infrastructure resources.
-      Underlying command: tofu destroy
     preconditions:
       - sh: command -v tofu
         msg: "OpenTofu (tofu) is not installed"
@@ -52,7 +49,6 @@ tasks:
     desc: "show infrastructure drift"
     summary: |
       Check for configuration drift.
-      Underlying command: tofu plan
     generates:
       - tfplan
     preconditions:
@@ -67,7 +63,6 @@ tasks:
     desc: "show infrastructure outputs"
     summary: |
       Display infrastructure outputs.
-      Underlying command: tofu output
     preconditions:
       - sh: command -v tofu
         msg: "OpenTofu (tofu) is not installed"

--- a/tasks/knx.yaml
+++ b/tasks/knx.yaml
@@ -1,0 +1,67 @@
+version: "3"
+
+# Tasks for the KNX catalog pipeline. Paths come from Taskfile.yaml vars:
+#   KNX_BRIDGE_DIR    — sibling repo holding knxproj-to-yaml and the schema
+#   KNX_CATALOG_PATH  — destination ConfigMap source file in lares
+#   SCRIPTS_DIR       — lares scripts/
+
+tasks:
+  catalog:
+    desc: "rebuild knx-catalog.yaml from an ETS project export [path/to/project.knxproj]"
+    summary: |
+      Run the full pipeline — extract the raw catalog from the .knxproj via
+      xknxproject, then apply project-specific enrichment.
+      Arguments: [path/to/project.knxproj]
+      Pass KNXPROJ_PASSWORD=… for encrypted projects.
+    cmds:
+      - task: generate-catalog
+        vars:
+          CLI_ARGS: "{{.CLI_ARGS}}"
+      - task: enrich-catalog
+
+  generate-catalog:
+    desc: "extract raw knx-catalog.yaml from an ETS project export (no enrichment) [path/to/project.knxproj]"
+    summary: |
+      Run knxproj-to-yaml against the supplied .knxproj and write the raw catalog into the ConfigMap
+      source file.
+      Arguments: [path/to/project.knxproj]
+      Pass KNXPROJ_PASSWORD=… for encrypted projects.
+    vars:
+      KNXPROJ: "{{index .CLI_ARGS_LIST 0}}"
+    requires:
+      vars:
+        - KNXPROJ
+    preconditions:
+      - sh: test -f "{{.KNXPROJ}}"
+        msg: "'{{.KNXPROJ}}' not found"
+    cmds:
+      - uv run --directory {{.KNX_BRIDGE_DIR}} --extra tools knxproj-to-yaml
+        --input {{.KNXPROJ}}
+        --output {{.KNX_CATALOG_PATH}}
+        {{if .KNXPROJ_PASSWORD}}--password '{{.KNXPROJ_PASSWORD}}'{{end}}
+
+  enrich-catalog:
+    desc: "apply project-specific enrichment to knx-catalog.yaml"
+    summary: |
+      Normalise ETS Building-style room names, backfill missing room/function from the dotted GA
+      name, and drop ETS auto-generated descriptions. Configuration (floor tokens, regex) lives in
+      scripts/knx_enrich_catalog.py.
+    vars:
+      ENRICH_SCRIPT: "{{.SCRIPTS_DIR}}/knx_enrich_catalog.py"
+    cmds:
+      - "{{.ENRICH_SCRIPT}} {{.KNX_CATALOG_PATH}}"
+
+  validate-catalog:
+    desc: "validate knx-catalog.yaml against the JSON-Schema"
+    summary: |
+      Check the rendered ConfigMap source against the upstream JSON-Schema.
+    vars:
+      SCHEMA: "{{.KNX_BRIDGE_DIR}}/src/knx_nats_bridge/_schemas/knx-catalog.schema.json"
+    cmds:
+      - >
+        uv run --directory {{.KNX_BRIDGE_DIR}} python -c
+        "import json, yaml, jsonschema;
+        schema = json.load(open('{{.SCHEMA}}'));
+        data   = yaml.safe_load(open('{{.KNX_CATALOG_PATH}}'));
+        jsonschema.validate(data, schema);
+        print(f'OK: {len(data)} entries valid')"

--- a/tasks/kubernetes.yaml
+++ b/tasks/kubernetes.yaml
@@ -8,7 +8,6 @@ tasks:
       - Creates the sealed-secrets-controller namespace
       - Injects the Sealed Secrets master key
       - Injects DHI registry credentials into sealed-secrets-controller and kube-system
-      Underlying command: kubectl apply
     preconditions:
       - sh: command -v kubectl
         msg: "kubectl is not installed"
@@ -34,7 +33,6 @@ tasks:
     summary: |
       Delete all managed namespaces and wait for termination.
       Force-removes finalizers on stuck namespaces.
-      Underlying command: kubectl delete ns
     vars:
       COMPONENTS_DIR: "kubernetes/components"
       MANAGED_NAMESPACES:
@@ -70,7 +68,6 @@ tasks:
     desc: "verify cluster health"
     summary: |
       Verify cluster health and connectivity.
-      Underlying command: kubectl get nodes/pods, cilium status
     preconditions:
       - sh: command -v kubectl
         msg: "kubectl is not installed"
@@ -85,7 +82,6 @@ tasks:
     desc: "show admin credentials"
     summary: |
       Show important cluster secrets (ArgoCD admin).
-      Underlying command: kubectl get secret
     vars:
       ARGOCD_PASSWORD:
         sh: kubectl get secret/argocd-initial-admin-secret -n gitops-controller -o jsonpath='{.data.password}' | base64 -d
@@ -100,7 +96,6 @@ tasks:
     summary: |
       Seals a secret.yaml and writes sealed-secret.yaml into the same directory.
       Arguments: [path/to/secret.yaml]
-      Underlying command: kubeseal --cert master-key.yaml
     vars:
       INPUT: "{{index .CLI_ARGS_LIST 0}}"
       DIR:
@@ -128,7 +123,6 @@ tasks:
     summary: |
       Decrypts a sealed-secret.yaml back to plaintext secret.yaml in the same directory.
       Arguments: [path/to/sealed-secret.yaml]
-      Underlying command: kubeseal --recovery-unseal --recovery-private-key master-key.yaml
     vars:
       INPUT: "{{index .CLI_ARGS_LIST 0}}"
       DIR:


### PR DESCRIPTION
## Summary

Wires homelab #751 — Phase 1 reactive analysis — into the cluster: the iot-mcp-bridge MCP server gets a Postgres-backed KNX catalog so its domain tools (`query_room_climate`, `query_knx_events`, `query_heating_cycles`, …) can filter and group GAs by room/function in plain SQL.

## What's in the PR

**TimescaleDB**
- bootstrap.sql now declares `knx_catalog` (ga PK + name/room/function/description/dpt) and the `knx_catalog_view` view that LEFT JOINs `knx` against the catalog. Owner-fix loop extended to plain views.

**knx-nats-bridge (image 0.3.1)**
- ConfigMap renamed `knx-nats-bridge-mapping` → `knx-nats-bridge-catalog`
- `config/ga-mapping.yaml` → `config/knx-catalog.yaml`, regenerated from `Steinroth.knxproj` via the upstream `knxproj-to-yaml` tool plus a project-specific enrichment step (see `scripts/knx_enrich_catalog.py`)
- Catalog stats: 2254 GAs, 84% with `room`, 100% with `function`

**iot-mcp-bridge (image 0.5.1)**
- New PostSync hook `import-knx-catalog-job.yaml` that runs the bundled `iot_mcp_bridge.cli.import_knx_catalog` CLI — idempotent UPSERT plus tombstone-purge of GAs that disappear from the YAML

**Kyverno** (`clusterpolicy-secrets.yaml`)
- Two new clone rules:
  - `Secret/timescaledb-db-app` → iot-mcp-bridge ns (admin DB creds for the importer)
  - `ConfigMap/knx-nats-bridge-catalog` → iot-mcp-bridge ns

**Taskfile**
- New `tasks/knx.yaml` with `knx:catalog` / `knx:generate-catalog` / `knx:enrich-catalog` / `knx:validate-catalog`. Paths centralised at the parent Taskfile.yaml as `KNX_BRIDGE_DIR` / `KNX_CATALOG_PATH`.
- `*.knxproj` added to `.gitignore` so ETS exports stay out of the repo.
- Stylistic cleanup: drop the `Underlying command:` boilerplate line from cluster.yaml / infrastructure.yaml / kubernetes.yaml so all four taskfiles share one style.

**scripts/knx_enrich_catalog.py**
- In-place post-processor for the raw catalog. Project-specific (floor tokens, ETS-Building-style room normaliser, name-segment fallback, drop ETS auto-generated descriptions). Will graduate into the upstream tool in a follow-up; see notes at top of the script.

## Manual step before / after merge

bootstrap.sql is the canonical schema, but CNPG only runs it on initdb. Apply the new schema to the live cluster once with `psql`:

\`\`\`sh
PGPASSWORD=\$(kubectl -n timescaledb get secret timescaledb-db-app \\
    -o jsonpath='{.data.password}' | base64 -d) \\
kubectl -n timescaledb exec -i timescaledb-1 -- \\
    psql 'host=timescaledb-db-rw user=homelab dbname=homelab sslmode=disable' <<'SQL'
CREATE TABLE IF NOT EXISTS knx_catalog (
    ga          TEXT PRIMARY KEY,
    name        TEXT NOT NULL,
    room        TEXT,
    function    TEXT,
    description TEXT,
    dpt         TEXT NOT NULL,
    updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
);
CREATE INDEX IF NOT EXISTS knx_catalog_room_idx     ON knx_catalog (room) WHERE room IS NOT NULL;
CREATE INDEX IF NOT EXISTS knx_catalog_function_idx ON knx_catalog (function);

CREATE OR REPLACE VIEW knx_catalog_view AS
SELECT k.time, k.ga, k.knx_main, k.knx_middle, k.knx_sub, k.dpt, k.value,
       n.name AS ga_name, n.room, n.function, n.description
FROM knx k LEFT JOIN knx_catalog n USING (ga);

ALTER TABLE knx_catalog OWNER TO homelab;
ALTER VIEW  knx_catalog_view OWNER TO homelab;
SQL
\`\`\`

## Test plan

- [ ] `task knx:validate-catalog` green (catalog passes the JSON-Schema)
- [ ] After merge: ArgoCD syncs Kyverno (wave 0) → iot-mcp-bridge (wave 30, with the importer PostSync)
- [ ] `kubectl -n iot-mcp-bridge logs job/iot-mcp-bridge-import-knx-catalog` shows ≈ 2254 imported rows
- [ ] `psql -c "SELECT count(*) FROM knx_catalog; SELECT * FROM knx_catalog_view LIMIT 1"` returns sensible results
- [ ] Smoke prompts in claude.ai:
  - „Wie viel kWh hat die Heizung diese Woche genutzt?" → `query_heating_cycles`
  - „Klima im Schlafzimmer letzte 24h" → `query_room_climate`
  - „KNX-Events Küche 18-20 Uhr" → `query_knx_events`
  - „Korrelation Wallbox-Ladung vs PV-Erzeugung gestern?" → `correlate_events`

🤖 Generated with [Claude Code](https://claude.com/claude-code)