### PR TITLE
fix(pve): drop removed VM 1001 from daily backup job

### DIFF
--- a/infrastructure/manifest/00-cluster/pve-cluster-backup-jobs.yaml
+++ b/infrastructure/manifest/00-cluster/pve-cluster-backup-jobs.yaml
@@ -5,5 +5,4 @@ pve_cluster_backup_jobs:
     mode: snapshot
     compress: zstd
     vmids:
-      - 1001 # ubuntu_01
       - 1100 # windows_01


### PR DESCRIPTION
## Summary
- Remove VM `1001` (ubuntu_01) from `daily-backup` vmids; the VM no longer exists, so the Proxmox backup job plan was drifting.

## Test plan
- [ ] `tofu plan` shows `proxmox_backup_job.this` vmid drops `1001` and matches desired state
- [ ] Next scheduled daily backup runs without referencing the missing VM

🤖 Generated with [Claude Code](https://claude.com/claude-code)