### PR TITLE
fix(knx-nats-bridge): server-side apply for the catalog ConfigMap

### DIFF
--- a/kubernetes/applications/knx-nats-bridge/base/kustomization.yaml
+++ b/kubernetes/applications/knx-nats-bridge/base/kustomization.yaml
@@ -29,3 +29,5 @@ labels:
 
 commonAnnotations:
   argocd.argoproj.io/sync-wave: "10"
+  argocd.argoproj.io/compare-options: ServerSideDiff=true
+  argocd.argoproj.io/sync-options: ServerSideApply=true


### PR DESCRIPTION
## Summary

After Phase 1 landed, ArgoCD's auto-sync of `knx-nats-bridge-prod` keeps failing on the catalog ConfigMap:

\`\`\`
ConfigMap "knx-nats-bridge-catalog" is invalid: metadata.annotations: Too long: may not be more than 262144 bytes
\`\`\`

The catalog has ~2.2k group addresses. Client-side apply stuffs the full rendered manifest into `last-applied-configuration`, which exceeds the 256 KB annotation cap Kubernetes enforces.

Fix: same pair of annotations the other heavy apps already use:

- `argocd.argoproj.io/sync-options: ServerSideApply=true` — SSA tracks fields per manager, no annotation size limit
- `argocd.argoproj.io/compare-options: ServerSideDiff=true` — required for a meaningful diff under SSA

Pattern matches `cilium`, `gitops-controller`, `cert-manager`, `admission-controller`.

## Test plan

- [ ] `argocd app sync knx-nats-bridge-prod` no longer fails with the annotation-size error
- [ ] `kubectl -n knx-nats-bridge get configmap knx-nats-bridge-catalog` keeps the data, only the field-manager metadata changes
- [ ] After the next `task knx:catalog` regeneration, the ArgoCD sync goes through cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)