### PR TITLE
fix(smtprelay): pin non-root UID for stakater chart hardening

### DIFF
--- a/kubernetes/applications/smtprelay/base/values.yaml
+++ b/kubernetes/applications/smtprelay/base/values.yaml
@@ -50,6 +50,18 @@ deployment:
       cpu: 200m
       memory: 256Mi
 
+  # grafana/smtprelay image ships without a non-root USER — pin UID/GID explicitly so
+  # the chart's runAsNonRoot default is satisfied. Listening on 2525 is non-privileged.
+  containerSecurityContext:
+    runAsUser: 65534
+    runAsGroup: 65534
+    runAsNonRoot: true
+    readOnlyRootFilesystem: true
+
+  # Pod-level fsGroup so the mounted ConfigMap and Secret are group-readable by the non-root user.
+  securityContext:
+    fsGroup: 65534
+
 # LoadBalancer with BGP advertisement via Cilium — static IP injected per environment via overlay
 service:
   enabled: true


### PR DESCRIPTION
## Summary
- Follow-up to #854 — the migrated smtprelay pod failed to start with `CreateContainerConfigError` because the chart's default `runAsNonRoot: true` had no UID to fall back on (`grafana/smtprelay` image ships without a `USER` directive).
- Pin `runAsUser`/`runAsGroup=65534` (nobody) and add pod `fsGroup`, matching the gatus/kromgo pattern. `readOnlyRootFilesystem: true` is kept; listening on 2525 is non-privileged.

## Test plan
- [x] Verified end-to-end with a hardened test pod (`kubectl run` with the same securityContext): smtprelay starts cleanly and prints `--help`.
- [ ] After merge: confirm ArgoCD reconciles `smtprelay-prod`, pod becomes `Running`, and a triggered Authentik / Alertmanager mail is delivered through the relay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)