### PR TITLE
chore(values): drop redundant applicationName comment

### DIFF
--- a/kubernetes/applications/iot-mcp-bridge/base/values.yaml
+++ b/kubernetes/applications/iot-mcp-bridge/base/values.yaml
@@ -1,4 +1,3 @@
-# Override chart's default resource naming (`application`)
 applicationName: iot-mcp-bridge
 
 deployment:

--- a/kubernetes/applications/knx-nats-bridge/base/values.yaml
+++ b/kubernetes/applications/knx-nats-bridge/base/values.yaml
@@ -1,4 +1,3 @@
-# Override chart's default resource naming (`application`)
 applicationName: knx-nats-bridge
 
 deployment:

--- a/kubernetes/applications/kromgo/base/values.yaml
+++ b/kubernetes/applications/kromgo/base/values.yaml
@@ -1,4 +1,3 @@
-# Override chart's default resource naming (`application`) — everything gets prefixed `kromgo`
 applicationName: kromgo
 
 deployment:


### PR DESCRIPTION
## Summary
- Remove the boilerplate `# Override chart's default resource naming (...)` comment immediately above `applicationName:` from `iot-mcp-bridge`, `knx-nats-bridge`, and `kromgo` values.yaml — the field name is self-explanatory.

## Test plan
- [ ] Pure comment removal; rendered manifests should be byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)