### PR TITLE
fix(gatus): satisfy PodSecurity restricted on gatus and sidecar

### DIFF
--- a/kubernetes/applications/gatus/base/values.yaml
+++ b/kubernetes/applications/gatus/base/values.yaml
@@ -1,4 +1,3 @@
-# Override chart's default resource naming (`application`) — everything gets prefixed `gatus`
 applicationName: gatus
 
 deployment:
@@ -28,6 +27,16 @@ deployment:
         limits:
           cpu: 100m
           memory: 64Mi
+      # Distroless image ships without USER — pin non-root identity to satisfy PodSecurity restricted
+      securityContext:
+        runAsUser: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        readOnlyRootFilesystem: true
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
 
   env:
     # Directory mode: Gatus merges all YAMLs in /config (static config.yaml + sidecar-written gatus-sidecar.yaml)
@@ -110,10 +119,16 @@ deployment:
     runAsGroup: 65534
     runAsNonRoot: true
     readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
 
   # Pod-level fsGroup so mounted volumes (emptyDir + ConfigMap subPath) are group-readable by the non-root user
   securityContext:
     fsGroup: 65534
+    seccompProfile:
+      type: RuntimeDefault
 
 # LoadBalancer with BGP advertisement via Cilium — static IP injected per environment via overlay
 service:


### PR DESCRIPTION
## Summary
- Add `allowPrivilegeEscalation: false` and `capabilities.drop: [ALL]` to both the `gatus` container and the `gatus-sidecar` init container
- Set `seccompProfile.type: RuntimeDefault` at pod level
- Pin the sidecar to UID/GID 65534 with `runAsNonRoot: true` and `readOnlyRootFilesystem: true` (the distroless image ships without a USER directive, so PodSecurity restricted otherwise rejects the pod)

Surfaced when restarting `deploy/gatus` triggered a `Warning: would violate PodSecurity "restricted:latest"` from the API server. Currently the namespace is enforced at `baseline`, so this is preventive — the warning would become a rejection on a future bump.

## Test plan
- [x] `kustomize build --enable-helm kubernetes/applications/gatus/overlays/prod` renders all three securityContexts
- [ ] ArgoCD sync of `gatus` succeeds and pods come up Ready
- [ ] Status page still serves and the sidecar continues writing `/config/gatus-sidecar.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)