### PR TITLE
fix(solaredge2mqtt): allow root start so entrypoint can switch users

### DIFF
--- a/kubernetes/applications/solaredge2mqtt/base/values.yaml
+++ b/kubernetes/applications/solaredge2mqtt/base/values.yaml
@@ -46,16 +46,12 @@ deployment:
       cpu: 200m
       memory: 256Mi
 
-  # Image runs as root by default — pin a non-root UID so the chart's runAsNonRoot default holds.
+  # Image entrypoint runs as root, chown's /app/cache, then `su`'s to the solaredge2mqtt
+  # user (UID 1000). The chart's runAsNonRoot default would block kubelet startup —
+  # turn it off; readOnlyRootFilesystem must also stay false for the chown to succeed.
   containerSecurityContext:
-    runAsUser: 65534
-    runAsGroup: 65534
-    runAsNonRoot: true
-    readOnlyRootFilesystem: true
-
-  # Pod-level fsGroup so the mounted ConfigMap, Secret and emptyDir are group-writable for nobody.
-  securityContext:
-    fsGroup: 65534
+    runAsNonRoot: false
+    readOnlyRootFilesystem: false
 
 # No Service / no Probes — solaredge2mqtt is an outbound-only MQTT publisher.
 service:


### PR DESCRIPTION
## Summary
- Follow-up to #859. The migrated pods crashed because the image's entrypoint runs as root, `chown`s the cache dir, then `su`'s to the internal `solaredge2mqtt` user (UID 1000) — both the chart's `runAsNonRoot: true` default and a `runAsUser=1000` pin break that flow.
- Drop the UID pin and `runAsNonRoot`; keep `readOnlyRootFilesystem: false`. Final process runs as `solaredge2mqtt` (UID 1000), exactly as it did pre-migration.

## Test plan
- [x] Verified end-to-end with a test pod (real entrypoint): "Switching to solaredge2mqtt user..." succeeds, app loads config.
- [ ] After merge: both `solaredge2mqtt-1` and `solaredge2mqtt-2` pods Running; MQTT broker shows fresh messages from both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)