### PR TITLE
fix(redpanda-connect): pin canned_acl on aws_s3 outputs (4.90.3 compat)

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/streams/ems_esp.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/ems_esp.yaml
@@ -170,6 +170,7 @@ output:
             ]
       - aws_s3:
           bucket: nats-archive
+          canned_acl: private
           region: us-east-1
           endpoint: http://rustfs-svc.rustfs.svc.cluster.local:9000
           force_path_style_urls: true

--- a/kubernetes/applications/redpanda-connect/base/streams/knx.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/knx.yaml
@@ -69,6 +69,7 @@ output:
             ]
       - aws_s3:
           bucket: nats-archive
+          canned_acl: private
           region: us-east-1
           endpoint: http://rustfs-svc.rustfs.svc.cluster.local:9000
           force_path_style_urls: true

--- a/kubernetes/applications/redpanda-connect/base/streams/solaredge_inverter.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/solaredge_inverter.yaml
@@ -97,6 +97,7 @@ output:
             ]
       - aws_s3:
           bucket: nats-archive
+          canned_acl: private
           region: us-east-1
           endpoint: http://rustfs-svc.rustfs.svc.cluster.local:9000
           force_path_style_urls: true

--- a/kubernetes/applications/redpanda-connect/base/streams/solaredge_powerflow.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/solaredge_powerflow.yaml
@@ -109,6 +109,7 @@ output:
             ]
       - aws_s3:
           bucket: nats-archive
+          canned_acl: private
           region: us-east-1
           endpoint: http://rustfs-svc.rustfs.svc.cluster.local:9000
           force_path_style_urls: true

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_charge_manager.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_charge_manager.yaml
@@ -42,6 +42,7 @@ output:
             ]
       - aws_s3:
           bucket: nats-archive
+          canned_acl: private
           region: us-east-1
           endpoint: http://rustfs-svc.rustfs.svc.cluster.local:9000
           force_path_style_urls: true

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_charge_tracker.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_charge_tracker.yaml
@@ -79,6 +79,7 @@ output:
       # Cold archive: original NATS payload as Parquet on RustFS
       - aws_s3:
           bucket: nats-archive
+          canned_acl: private
           region: us-east-1
           endpoint: http://rustfs-svc.rustfs.svc.cluster.local:9000
           force_path_style_urls: true

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_evse.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_evse.yaml
@@ -68,6 +68,7 @@ output:
             ]
       - aws_s3:
           bucket: nats-archive
+          canned_acl: private
           region: us-east-1
           endpoint: http://rustfs-svc.rustfs.svc.cluster.local:9000
           force_path_style_urls: true

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_meter.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_meter.yaml
@@ -79,6 +79,7 @@ output:
             ]
       - aws_s3:
           bucket: nats-archive
+          canned_acl: private
           region: us-east-1
           endpoint: http://rustfs-svc.rustfs.svc.cluster.local:9000
           force_path_style_urls: true

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_system.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_system.yaml
@@ -66,6 +66,7 @@ output:
             ]
       - aws_s3:
           bucket: nats-archive
+          canned_acl: private
           region: us-east-1
           endpoint: http://rustfs-svc.rustfs.svc.cluster.local:9000
           force_path_style_urls: true


### PR DESCRIPTION
## Summary
- Chart bump #853 (3.2.5 → 3.2.6) raised the connect image from 4.89.2 → 4.90.3. The new release validates `canned_acl` more strictly: an unset field falls through as an empty string and crashes stream init with `invalid object canned ACL value:` — pod went into CrashLoopBackOff.
- Pin `canned_acl: private` on every aws_s3 output (matches the prior implicit S3 default; no functional change).

## Test plan
- [ ] After merge: pod `Running`; `kubectl logs deploy/redpanda-connect -n redpanda-connect` shows all 9 streams init without errors.
- [ ] Live parquet writes resume to `nats-archive/<table>/YYYY/MM/DD/HH/<uuid>.parquet`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)