### PR TITLE
fix(alloy): expose alloy-receiver as LoadBalancer with BGP advertisement

### DIFF
--- a/kubernetes/applications/alloy/base/values.yaml
+++ b/kubernetes/applications/alloy/base/values.yaml
@@ -55,13 +55,6 @@ collectors:
     presets:
       - clustered
       - statefulset
-    # Expose Alloy Metrics service via Cilium/BGP-announced LoadBalancer
-    alloy:
-      service:
-        type: LoadBalancer
-        labels:
-          bgp.cilium.io/ip-pool: default
-          bgp.cilium.io/advertise-service: default
 
   # Alloy Singleton: Per-cluster tasks like event processing
   alloy-singleton:
@@ -80,13 +73,10 @@ collectors:
     includeDestinations:
       - loki
       - prometheus
-    # Expose Alloy Receiver via Cilium/BGP-announced LoadBalancer
+    service:
+      type: LoadBalancer
+      annotations: {}
     alloy:
-      service:
-        type: LoadBalancer
-        labels:
-          bgp.cilium.io/ip-pool: default
-          bgp.cilium.io/advertise-service: default
       # Syslog: TCP 601 / UDP 514 (RFC5424). OTLP HTTP: 4318 (rustfs metrics push).
       extraPorts:
         - name: syslog-tcp
@@ -165,18 +155,20 @@ collectors:
           relabel_rules = discovery.relabel.syslog.rules
       }
 
-      // OTLP/HTTP receiver for rustfs metrics; forwarded to the chart-rendered
-      // otelcol.exporter.prometheus.prometheus exporter for remote-write.
-      otelcol.receiver.otlp "rustfs" {
+      // OTLP/HTTP receiver for external push sources (rustfs, PVE/PBS metric
+      // servers). The chart renders otelcol.exporter.prometheus.prometheus
+      // which translates OTel attributes (service.name -> job, host.name ->
+      // instance) before forwarding to remote-write.
+      otelcol.receiver.otlp "ingress" {
           http {
               endpoint = "0.0.0.0:4318"
           }
           output {
-              metrics = [otelcol.processor.batch.rustfs.input]
+              metrics = [otelcol.processor.batch.ingress.input]
           }
       }
 
-      otelcol.processor.batch "rustfs" {
+      otelcol.processor.batch "ingress" {
           output {
               metrics = [otelcol.exporter.prometheus.prometheus.input]
           }

--- a/kubernetes/applications/alloy/overlays/prod/kustomization.yaml
+++ b/kubernetes/applications/alloy/overlays/prod/kustomization.yaml
@@ -145,20 +145,14 @@ patches:
           - name: GOMEMLIMIT
             value: "241591910"
 
-  # Alloy metrics service with static IP and BGP advertisement
+  # Alloy receiver service with static IP and BGP advertisement
   - target:
-      kind: Service
-      name: alloy-alloy-metrics
-    patch: |-
-      - op: add
-        path: /metadata/annotations/io.cilium~1lb-ipam-ips
-        value: "192.168.10.22"
-
-  # Alloy Receiver: Syslog service with static IP
-  - target:
-      kind: Service
+      kind: Alloy
       name: alloy-alloy-receiver
     patch: |-
+      - op: test
+        path: /spec/service/type
+        value: LoadBalancer
       - op: add
-        path: /metadata/annotations/io.cilium~1lb-ipam-ips
+        path: /spec/service/annotations/io.cilium~1lb-ipam-ips
         value: "192.168.10.21"

--- a/kubernetes/components/cilium/base/bgp-advertisement.yaml
+++ b/kubernetes/components/cilium/base/bgp-advertisement.yaml
@@ -15,3 +15,15 @@ spec:
       selector:
         matchLabels:
           bgp.cilium.io/advertise-service: default
+
+    # The alloy-operator-rendered Service does not honour custom labels (chart
+    # limitation), so the standard advertise-service selector cannot match it.
+    # This entry targets labels the operator-managed Service already carries.
+    - advertisementType: Service
+      service:
+        addresses:
+          - LoadBalancerIP
+      selector:
+        matchLabels:
+          app.kubernetes.io/part-of: alloy
+          app.kubernetes.io/managed-by: Helm


### PR DESCRIPTION
The receiver-collector's `service.type: LoadBalancer` was nested under `alloy:` instead of beside it; the chart silently ignored the wrong key, so the operator-managed Service stayed ClusterIP and the static-IP JSON patches in the prod overlay never had a target. As a result no external client (rustfs OTLP push, future PVE/PBS metric pushes, external syslog senders) could ever have actually reached the receiver on its advertised LoadBalancer IP.

Fix:
- Move `service:` to top-level under each collector in base values.yaml per upstream alloy chart's structure; receiver gets type=LoadBalancer with empty annotations, ready for env-specific overrides.
- prod overlay patches the static IP onto spec.service.annotations of the Alloy CR (operator propagates to the Service); replaces the dead Service-targeted JSON patches.
- Rename `otelcol.receiver.otlp "rustfs"` to `"ingress"` to reflect that the same OTLP endpoint will accept multiple push sources.

The alloy-operator-rendered Service does not honour custom labels (chart limitation), so the standard `bgp.cilium.io/advertise-service: default` selector cannot match it. Add a second advertisement entry on the existing CiliumBGPAdvertisement that matches labels the operator-managed Service already carries (`app.kubernetes.io/part-of=alloy` + `managed-by=Helm`).