### PR TITLE
fix(cilium): allocate LB IPs to alloy-operator services via dedicated…

### DIFF
--- a/kubernetes/components/cilium/base/bgp-lb-ip-pool.yaml
+++ b/kubernetes/components/cilium/base/bgp-lb-ip-pool.yaml
@@ -10,3 +10,22 @@ spec:
   serviceSelector:
     matchLabels:
       bgp.cilium.io/ip-pool: default
+
+---
+apiVersion: cilium.io/v2
+kind: CiliumLoadBalancerIPPool
+
+# The alloy-operator-rendered Service does not honour custom labels (chart
+# limitation), so the standard `bgp.cilium.io/ip-pool: default` selector cannot
+# match it. This dedicated pool selects on labels the operator-managed Service
+# already carries.
+metadata:
+  name: alloy-bgp-ip-pool
+
+spec:
+  blocks:
+    - cidr: PLACEHOLDER
+  serviceSelector:
+    matchLabels:
+      app.kubernetes.io/part-of: alloy
+      app.kubernetes.io/managed-by: Helm

--- a/kubernetes/components/cilium/overlays/dev/kustomization.yaml
+++ b/kubernetes/components/cilium/overlays/dev/kustomization.yaml
@@ -39,3 +39,8 @@ replacements:
           name: default-bgp-ip-pool
         fieldPaths:
           - spec.blocks.0.cidr
+      - select:
+          kind: CiliumLoadBalancerIPPool
+          name: alloy-bgp-ip-pool
+        fieldPaths:
+          - spec.blocks.0.cidr

--- a/kubernetes/components/cilium/overlays/prod/kustomization.yaml
+++ b/kubernetes/components/cilium/overlays/prod/kustomization.yaml
@@ -39,3 +39,8 @@ replacements:
           name: default-bgp-ip-pool
         fieldPaths:
           - spec.blocks.0.cidr
+      - select:
+          kind: CiliumLoadBalancerIPPool
+          name: alloy-bgp-ip-pool
+        fieldPaths:
+          - spec.blocks.0.cidr


### PR DESCRIPTION
… pool

The default `default-bgp-ip-pool` selects services via `bgp.cilium.io/ip-pool: default` — a label the alloy-operator-rendered Service does not carry (chart limitation, mirrors the BGP advertisement issue). Result: alloy-receiver requested its static LB IP via annotation but stayed `<pending>` because no pool accepted it.

Add a second `alloy-bgp-ip-pool` in the same file (CiliumLoadBalancerIPPool has only one serviceSelector, so we cannot extend the existing pool the way the BGPAdvertisement was extended). The new pool selects on labels the operator-managed Service already carries
(`app.kubernetes.io/part-of=alloy` + `managed-by=Helm`) and shares the same CIDR via overlay replacements.