### PR TITLE
fix(cilium): split LB pool ranges so alloy pool can coexist with default

### DIFF
--- a/kubernetes/applications/alloy/overlays/prod/kustomization.yaml
+++ b/kubernetes/applications/alloy/overlays/prod/kustomization.yaml
@@ -155,4 +155,4 @@ patches:
         value: LoadBalancer
       - op: add
         path: /spec/service/annotations/io.cilium~1lb-ipam-ips
-        value: "192.168.10.21"
+        value: "192.168.10.200"

--- a/kubernetes/components/cilium/base/bgp-lb-ip-pool.yaml
+++ b/kubernetes/components/cilium/base/bgp-lb-ip-pool.yaml
@@ -6,7 +6,8 @@ metadata:
 
 spec:
   blocks:
-    - cidr: PLACEHOLDER
+    - start: PLACEHOLDER
+      stop: PLACEHOLDER
   serviceSelector:
     matchLabels:
       bgp.cilium.io/ip-pool: default
@@ -18,13 +19,15 @@ kind: CiliumLoadBalancerIPPool
 # The alloy-operator-rendered Service does not honour custom labels (chart
 # limitation), so the standard `bgp.cilium.io/ip-pool: default` selector cannot
 # match it. This dedicated pool selects on labels the operator-managed Service
-# already carries.
+# already carries; ranges are kept disjoint from default-bgp-ip-pool because
+# Cilium rejects pools with overlapping CIDRs even if the selectors disjoint.
 metadata:
   name: alloy-bgp-ip-pool
 
 spec:
   blocks:
-    - cidr: PLACEHOLDER
+    - start: PLACEHOLDER
+      stop: PLACEHOLDER
   serviceSelector:
     matchLabels:
       app.kubernetes.io/part-of: alloy

--- a/kubernetes/components/cilium/overlays/dev/kustomization.yaml
+++ b/kubernetes/components/cilium/overlays/dev/kustomization.yaml
@@ -31,16 +31,33 @@ replacements:
           delimiter: "//"
           index: 1
 
-  # Inject BGP IP Pool CIDR
-  - sourceValue: 192.168.11.0/24
+  # Inject BGP IP Pool ranges. default and alloy pools must be disjoint
+  # (Cilium rejects overlapping CIDRs even with disjoint serviceSelectors).
+  - sourceValue: 192.168.11.0
     targets:
       - select:
           kind: CiliumLoadBalancerIPPool
           name: default-bgp-ip-pool
         fieldPaths:
-          - spec.blocks.0.cidr
+          - spec.blocks.0.start
+  - sourceValue: 192.168.11.199
+    targets:
+      - select:
+          kind: CiliumLoadBalancerIPPool
+          name: default-bgp-ip-pool
+        fieldPaths:
+          - spec.blocks.0.stop
+  - sourceValue: 192.168.11.200
+    targets:
       - select:
           kind: CiliumLoadBalancerIPPool
           name: alloy-bgp-ip-pool
         fieldPaths:
-          - spec.blocks.0.cidr
+          - spec.blocks.0.start
+  - sourceValue: 192.168.11.255
+    targets:
+      - select:
+          kind: CiliumLoadBalancerIPPool
+          name: alloy-bgp-ip-pool
+        fieldPaths:
+          - spec.blocks.0.stop

--- a/kubernetes/components/cilium/overlays/prod/kustomization.yaml
+++ b/kubernetes/components/cilium/overlays/prod/kustomization.yaml
@@ -31,16 +31,33 @@ replacements:
           delimiter: "//"
           index: 1
 
-  # Inject BGP IP Pool CIDR
-  - sourceValue: 192.168.10.0/24
+  # Inject BGP IP Pool ranges. default and alloy pools must be disjoint
+  # (Cilium rejects overlapping CIDRs even with disjoint serviceSelectors).
+  - sourceValue: 192.168.10.0
     targets:
       - select:
           kind: CiliumLoadBalancerIPPool
           name: default-bgp-ip-pool
         fieldPaths:
-          - spec.blocks.0.cidr
+          - spec.blocks.0.start
+  - sourceValue: 192.168.10.199
+    targets:
+      - select:
+          kind: CiliumLoadBalancerIPPool
+          name: default-bgp-ip-pool
+        fieldPaths:
+          - spec.blocks.0.stop
+  - sourceValue: 192.168.10.200
+    targets:
       - select:
           kind: CiliumLoadBalancerIPPool
           name: alloy-bgp-ip-pool
         fieldPaths:
-          - spec.blocks.0.cidr
+          - spec.blocks.0.start
+  - sourceValue: 192.168.10.255
+    targets:
+      - select:
+          kind: CiliumLoadBalancerIPPool
+          name: alloy-bgp-ip-pool
+        fieldPaths:
+          - spec.blocks.0.stop


### PR DESCRIPTION
Cilium rejects pools with overlapping CIDRs even when the serviceSelectors are disjoint (`Pool conflicts since range … overlaps range … from IP Pool 'default-bgp-ip-pool'`). Switch both pools from a shared `cidr` to disjoint `start`/`stop` ranges:

- default-bgp-ip-pool: .0 – .199
- alloy-bgp-ip-pool:   .200 – .255

Also move the alloy-receiver requested IP from 192.168.10.21 to 192.168.10.200 so it falls inside the alloy pool's range.

Note: the DNS A record for telemetry.zimmermann.eu.com must be repointed from .21 to .200 alongside this change.