### PR TITLE
ci(issue-labeler): skip Renovate dashboard edits and pin its label

### DIFF
--- a/.github/workflows/issue-labeler.yaml
+++ b/.github/workflows/issue-labeler.yaml
@@ -15,6 +15,7 @@ jobs:
   label-issue:
     name: Label Issue
     runs-on: ubuntu-latest
+    if: github.actor != 'homelab-zimmermann-renovate-bot[bot]'
     permissions:
       issues: write
     steps:

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -17,6 +17,7 @@
     ":timezone(Europe/Berlin)"
   ],
   "dependencyDashboardTitle": "Renovate Dashboard 🤖",
+  "dependencyDashboardLabels": ["area/renovate"],
   "suppressNotifications": ["prEditedNotification", "prIgnoreNotification"],
   "ignorePaths": ["**/resources/**", "**/deprecated/**"],
   "ignoreDeps": ["alexellis/arkade-get"],


### PR DESCRIPTION
## Summary
- Issue-labeler re-applied a flood of `area/*` and `topic/*` labels on every Renovate dashboard edit, because the dependency list contained matching keywords (`kubernetes`, `helm`, `kustomize`, `terraform`, `proxmox`, `argocd`, `gitops`, `github`, `action`, `workflow`, …).
- Guard the job with `if: github.actor != 'homelab-zimmermann-renovate-bot[bot]'` so the labeler skips bot-driven edits.
- Set `dependencyDashboardLabels: ["area/renovate"]` so Renovate pins a sensible label on the dashboard issue itself.

## Test plan
- [ ] Next Renovate run edits the dashboard → no new `area/*` / `topic/*` labels appear; `area/renovate` stays.
- [ ] Manually editing a normal issue still triggers the labeler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)