### PR TITLE
fix(redpanda-connect): rename canned_acl → object_canned_acl

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/streams/ems_esp.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/ems_esp.yaml
@@ -170,7 +170,7 @@ output:
             ]
       - aws_s3:
           bucket: nats-archive
-          canned_acl: private
+          object_canned_acl: private
           region: us-east-1
           endpoint: http://rustfs-svc.rustfs.svc.cluster.local:9000
           force_path_style_urls: true

--- a/kubernetes/applications/redpanda-connect/base/streams/knx.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/knx.yaml
@@ -69,7 +69,7 @@ output:
             ]
       - aws_s3:
           bucket: nats-archive
-          canned_acl: private
+          object_canned_acl: private
           region: us-east-1
           endpoint: http://rustfs-svc.rustfs.svc.cluster.local:9000
           force_path_style_urls: true

--- a/kubernetes/applications/redpanda-connect/base/streams/solaredge_inverter.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/solaredge_inverter.yaml
@@ -97,7 +97,7 @@ output:
             ]
       - aws_s3:
           bucket: nats-archive
-          canned_acl: private
+          object_canned_acl: private
           region: us-east-1
           endpoint: http://rustfs-svc.rustfs.svc.cluster.local:9000
           force_path_style_urls: true

--- a/kubernetes/applications/redpanda-connect/base/streams/solaredge_powerflow.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/solaredge_powerflow.yaml
@@ -109,7 +109,7 @@ output:
             ]
       - aws_s3:
           bucket: nats-archive
-          canned_acl: private
+          object_canned_acl: private
           region: us-east-1
           endpoint: http://rustfs-svc.rustfs.svc.cluster.local:9000
           force_path_style_urls: true

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_charge_manager.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_charge_manager.yaml
@@ -42,7 +42,7 @@ output:
             ]
       - aws_s3:
           bucket: nats-archive
-          canned_acl: private
+          object_canned_acl: private
           region: us-east-1
           endpoint: http://rustfs-svc.rustfs.svc.cluster.local:9000
           force_path_style_urls: true

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_charge_tracker.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_charge_tracker.yaml
@@ -79,7 +79,7 @@ output:
       # Cold archive: original NATS payload as Parquet on RustFS
       - aws_s3:
           bucket: nats-archive
-          canned_acl: private
+          object_canned_acl: private
           region: us-east-1
           endpoint: http://rustfs-svc.rustfs.svc.cluster.local:9000
           force_path_style_urls: true

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_evse.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_evse.yaml
@@ -68,7 +68,7 @@ output:
             ]
       - aws_s3:
           bucket: nats-archive
-          canned_acl: private
+          object_canned_acl: private
           region: us-east-1
           endpoint: http://rustfs-svc.rustfs.svc.cluster.local:9000
           force_path_style_urls: true

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_meter.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_meter.yaml
@@ -79,7 +79,7 @@ output:
             ]
       - aws_s3:
           bucket: nats-archive
-          canned_acl: private
+          object_canned_acl: private
           region: us-east-1
           endpoint: http://rustfs-svc.rustfs.svc.cluster.local:9000
           force_path_style_urls: true

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_system.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_system.yaml
@@ -66,7 +66,7 @@ output:
             ]
       - aws_s3:
           bucket: nats-archive
-          canned_acl: private
+          object_canned_acl: private
           region: us-east-1
           endpoint: http://rustfs-svc.rustfs.svc.cluster.local:9000
           force_path_style_urls: true


### PR DESCRIPTION
The aws_s3 output field is `object_canned_acl`, not `canned_acl` — got caught by the lint check on pod start. Also dedupe the line that briefly got inserted twice. Value remains `private`.