### PR TITLE
fix(pve-exporter): pin numeric UID so runAsNonRoot can verify the user

### DIFF
--- a/kubernetes/applications/pve-exporter/base/values.yaml
+++ b/kubernetes/applications/pve-exporter/base/values.yaml
@@ -62,6 +62,13 @@ deployment:
       cpu: 200m
       memory: 256Mi
 
+  # Image's USER directive is the literal string "prometheus" (UID 101); pin
+  # the numeric UID so PodSecurity restricted's runAsNonRoot can verify it.
+  containerSecurityContext:
+    runAsUser: 101
+    runAsGroup: 101
+    runAsNonRoot: true
+
 service:
   enabled: true
   type: ClusterIP


### PR DESCRIPTION
The prompve/prometheus-pve-exporter image's `USER prometheus` directive uses the literal string "prometheus" (UID 101) rather than a numeric ID, which trips PodSecurity restricted's runAsNonRoot check:

  Error: container has runAsNonRoot and image has non-numeric user
  (prometheus), cannot verify user is non-root

Pin runAsUser=101/runAsGroup=101 in containerSecurityContext, mirroring the pattern used for gatus.