### PR TITLE
fix(pve-exporter): mount writable /tmp for gunicorn workers

### DIFF
--- a/kubernetes/applications/pve-exporter/base/values.yaml
+++ b/kubernetes/applications/pve-exporter/base/values.yaml
@@ -21,12 +21,18 @@ deployment:
     config:
       configMap:
         name: pve-exporter-config
+    # gunicorn needs a writable tmpdir for its worker lifecycle files; the
+    # chart's containerSecurityContext defaults to readOnlyRootFilesystem.
+    tmp:
+      emptyDir: {}
 
   volumeMounts:
     config:
       mountPath: /etc/pve.yml
       subPath: pve.yml
       readOnly: true
+    tmp:
+      mountPath: /tmp
 
   ports:
     - containerPort: 9221


### PR DESCRIPTION
The stakater/application chart defaults `readOnlyRootFilesystem: true`, so gunicorn cannot create its worker lifecycle files in any of the default tempdir candidates:

  FileNotFoundError: [Errno 2] No usable temporary directory found in
  ['/tmp', '/var/tmp', '/usr/tmp', '/']

Mount an emptyDir on /tmp.