### PR TITLE
fix(pbs): drop OTel metrics-server bootstrap step (PBS has no metric …

### DIFF
--- a/infrastructure/templates/30-cloud-init/proxmox-backup-server/pbs-bootstrap.conf.tftpl
+++ b/infrastructure/templates/30-cloud-init/proxmox-backup-server/pbs-bootstrap.conf.tftpl
@@ -18,10 +18,6 @@ PBS_HOMEPAGE_PASSWORD="${pbs_homepage_password}"
 PBS_METRICS_USERNAME="${pbs_metrics_username}"
 PBS_METRICS_PASSWORD="${pbs_metrics_password}"
 
-## OpenTelemetry metrics server (push to Alloy receiver)
-METRICS_OTLP_HOST="${metrics_otlp_host}"
-METRICS_OTLP_PORT="${metrics_otlp_port}"
-
 ## Define primary datastore (local - nvme)
 DATASTORE_PRIMARY_NAME="datastore-primary"
 DATASTORE_PRIMARY_PATH="/mnt/datastore-primary"

--- a/infrastructure/templates/30-cloud-init/proxmox-backup-server/pbs-bootstrap.sh
+++ b/infrastructure/templates/30-cloud-init/proxmox-backup-server/pbs-bootstrap.sh
@@ -155,31 +155,6 @@ setup_acl() {
 }
 
 ###############################################################################
-## Helper: Metrics server setup (OpenTelemetry → Alloy receiver)
-###############################################################################
-setup_metrics_server() {
-  local name="${1}"
-  local host="${2}"
-  local port="${3}"
-
-  ## Check if metrics server is already configured
-  if proxmox-backup-manager metrics list | grep -qw "${name}"; then
-    info "Metrics server ${name} already configured."
-    return 0
-  fi
-
-  ## Create OpenTelemetry metrics server
-  info "Configuring OTel metrics server ${name} -> ${host}:${port}..."
-  proxmox-backup-manager metrics create opentelemetry "${name}" \
-    --host "${host}" \
-    --port "${port}" \
-    --enable true \
-    || die "Failed to create OTel metrics server ${name}."
-
-  success "Metrics server ${name} configured."
-}
-
-###############################################################################
 ## Helper: Datastore setup
 ###############################################################################
 setup_datastore() {
@@ -462,10 +437,6 @@ create_user "${PBS_METRICS_USERNAME}" "${PBS_METRICS_PASSWORD}"
 setup_acl "${PBS_METRICS_USERNAME}" "Audit" "/"
 create_api_token "${PBS_METRICS_USERNAME}" "metrics"
 setup_acl "${PBS_METRICS_USERNAME}" "Audit" "/" "metrics"
-
-## Configure OpenTelemetry metrics server (push to alloy-receiver)
-info "Setting up OTel metrics server..."
-setup_metrics_server "alloy-otel" "${METRICS_OTLP_HOST}" "${METRICS_OTLP_PORT}"
 
 ## Setup data retention
 info "Setting up data retention for datastores..."


### PR DESCRIPTION
…server)

PBS 4.2.0 has no built-in metric server — `proxmox-backup-manager metrics …` does not exist; only PVE has the OpenTelemetry/InfluxDB metric server feature. The previous bootstrap step ran fine on PVE- shaped expectations and aborted on PBS at:

  Setting up OTel metrics server...
  Error: no such command 'metrics'

PBS host gauges and datastore details are already covered by the prometheus-pve-exporter scrape (`pbs` module produces `pve_disk_*` and `pve_cpu_usage_ratio` for `id="node/backup-01"` plus storage stats), so no coverage is lost — the OTel push for PBS was redundant.

Drop the `setup_metrics_server` helper, its invocation, and the METRICS_OTLP_* env vars. The `metrics@pbs` user / token / ACL block stays in place; the exporter still needs it.