### PR TITLE
fix(pve-exporter): pass token via PVE_TOKEN_VALUE_PBS env var

### DIFF
--- a/kubernetes/applications/pve-exporter/base/config/pve-exporter.yaml
+++ b/kubernetes/applications/pve-exporter/base/config/pve-exporter.yaml
@@ -1,6 +1,5 @@
 pbs:
   user: metrics@pbs
   token_name: metrics
-  token_value: ${PVE_TOKEN}
   service: pbs
   verify_ssl: false

--- a/kubernetes/applications/pve-exporter/base/values.yaml
+++ b/kubernetes/applications/pve-exporter/base/values.yaml
@@ -10,8 +10,10 @@ deployment:
   args:
     - --config.file=/etc/pve.yml
 
+  # PVE_<FIELD>_<MODULE> env vars override the YAML config; ${...} in
+  # pve.yml is not interpolated.
   env:
-    PVE_TOKEN:
+    PVE_TOKEN_VALUE_PBS:
       valueFrom:
         secretKeyRef:
           name: pve-exporter-credentials


### PR DESCRIPTION
prometheus-pve-exporter does not interpolate `${...}` placeholders in pve.yml — `token_value: ${PVE_TOKEN}` was sent verbatim to PBS, hence the persistent 401s after the token rotation. The exporter does, however, read `PVE_<FIELD>_<MODULE>` env vars and merges them on top of the file config.

Drop `token_value` from the ConfigMap and rename the env var to `PVE_TOKEN_VALUE_PBS`; the SealedSecret stays unchanged (secretKeyRef.key is still `PVE_TOKEN`).