### PR TITLE
chore(gatus-db): upgrade PostgreSQL 16.1 → 18.3 in place

### DIFF
--- a/kubernetes/applications/gatus/base/database.yaml
+++ b/kubernetes/applications/gatus/base/database.yaml
@@ -9,7 +9,7 @@ spec:
   instances: 2
 
   # PostgreSQL version and configuration
-  imageName: ghcr.io/cloudnative-pg/postgresql:16.1
+  imageName: ghcr.io/cloudnative-pg/postgresql:18.3
 
   # Rolling update process is managed by Kubernetes
   primaryUpdateStrategy: unsupervised


### PR DESCRIPTION
## Summary
- First of four CNPG cluster bumps from PG16.1 → PG18.3 tracked under #682
- Operator (`cloudnative-pg` 1.28.2) performs the major upgrade in place via `pg_upgrade --link` when `imageName` changes
- Gatus first because it has no Barman backup and its data is regeneratable (long-term SLO history lives in Prometheus); failure mode is recreate-from-scratch

Refs #682.

## Test plan
- [ ] After Argo sync: `kubectl -n gatus get cluster gatus-db` reports healthy and `status.pgDataImageInfo.majorVersion == 18`
- [ ] Both pods running on the new image: `kubectl -n gatus get pods -l cnpg.io/cluster=gatus-db -o jsonpath='{.items[*].spec.containers[?(@.name=="postgres")].image}'`
- [ ] Gatus app reconnects: `kubectl -n gatus logs -l app.kubernetes.io/name=gatus --tail=50` shows no DB errors
- [ ] Gatus UI reachable; checks back to green

🤖 Generated with [Claude Code](https://claude.com/claude-code)