### PR TITLE
chore(crowdsec-db): upgrade PostgreSQL 16.1 → 18.3

### DIFF
--- a/kubernetes/applications/crowdsec/base/database.yaml
+++ b/kubernetes/applications/crowdsec/base/database.yaml
@@ -13,7 +13,7 @@ spec:
     - name: dhi-registry-secret
 
   # PostgreSQL version and configuration
-  imageName: ghcr.io/cloudnative-pg/postgresql:16.1
+  imageName: ghcr.io/cloudnative-pg/postgresql:18.3
 
   # Rolling update process is managed by Kubernetes
   primaryUpdateStrategy: unsupervised


### PR DESCRIPTION
## Summary
- Second of four CNPG cluster bumps from PG16.1 → PG18.3 tracked under #682
- crowdsec-db has no Barman backup configured — failure mode is recreate-from-scratch (crowdsec re-enrolls from console)
- Operator (`cloudnative-pg` 1.28.2) handles the in-place `pg_upgrade --link`

Refs #682. Follows #885 (gatus-db).

## Test plan
- [ ] After Argo sync: `kubectl -n crowdsec get cluster crowdsec-db` reports healthy and `status.pgDataImageInfo.majorVersion == 18`
- [ ] Both pods running on the new image: `kubectl -n crowdsec get pods -l cnpg.io/cluster=crowdsec-db -o jsonpath='{.items[*].spec.containers[?(@.name=="postgres")].image}'`
- [ ] LAPI healthy and machines enumerate: `kubectl -n crowdsec exec deploy/crowdsec-lapi -- cscli machines list`

🤖 Generated with [Claude Code](https://claude.com/claude-code)