### PR TITLE
chore(wiki-js-db): upgrade PostgreSQL 16.1 → 18.3

### DIFF
--- a/kubernetes/applications/wiki-js/base/database.yaml
+++ b/kubernetes/applications/wiki-js/base/database.yaml
@@ -13,7 +13,7 @@ spec:
     - name: dhi-registry-secret
 
   # PostgreSQL version and configuration
-  imageName: ghcr.io/cloudnative-pg/postgresql:16.1
+  imageName: ghcr.io/cloudnative-pg/postgresql:18.3
 
   # Rolling update process is managed by Kubernetes
   primaryUpdateStrategy: unsupervised


### PR DESCRIPTION
## Summary
- Third of four CNPG cluster bumps from PG16.1 → PG18.3 tracked under #682
- On-demand Barman backup `wiki-js-db-pre-pg18-20260510203318` (backupId `20260510T203319`) was taken to `s3://wiki-js-backups` on rustfs immediately before this change as the rollback safety net
- Operator (`cloudnative-pg` 1.28.2) handles the in-place `pg_upgrade --link`
- Single-instance cluster, so brief downtime — no replica to fail over to

Refs #682. Follows #885 (gatus-db), #886 (crowdsec-db).

## Test plan
- [ ] After Argo sync: `kubectl -n wiki-js get cluster wiki-js-db` reports healthy and `status.pgDataImageInfo.majorVersion == 18`
- [ ] Pod running on the new image: `kubectl -n wiki-js get pods -l cnpg.io/cluster=wiki-js-db -o jsonpath='{.items[*].spec.containers[?(@.name=="postgres")].image}'`
- [ ] Wiki.js HTTP 200 on landing page; `kubectl -n wiki-js logs deploy/wiki-js --tail=50` clean of DB errors
- [ ] Tomorrow's 02:00 UTC ScheduledBackup completes: `kubectl -n wiki-js get backups.postgresql.cnpg.io --sort-by=.metadata.creationTimestamp | tail -3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)