### PR TITLE
chore(authentik-db): upgrade PostgreSQL 16.1 → 18.3

### DIFF
--- a/kubernetes/applications/authentik/base/database.yaml
+++ b/kubernetes/applications/authentik/base/database.yaml
@@ -13,7 +13,7 @@ spec:
     - name: dhi-registry-secret
 
   # PostgreSQL version and configuration
-  imageName: ghcr.io/cloudnative-pg/postgresql:16.1
+  imageName: ghcr.io/cloudnative-pg/postgresql:18.3
 
   # Rolling update process is managed by Kubernetes
   primaryUpdateStrategy: unsupervised


### PR DESCRIPTION
## Summary
- Fourth and final CNPG cluster bump from PG16.1 → PG18.3, closes #682
- On-demand Barman backup `authentik-db-pre-pg18-20260511061734` (backupId `20260511T061735`) was taken to `s3://authentik-backups` on rustfs immediately before this change as the rollback safety net
- Operator (`cloudnative-pg` 1.28.2) handles the in-place `pg_upgrade --link`
- Two-instance cluster, so the operator can fail over to the replica while pg_upgrade runs on the primary
- Highest blast radius of the four — Authentik is the OIDC provider for the rest of the stack

Closes #682. Follows #885 (gatus-db), #886 (crowdsec-db), #887 (wiki-js-db).

## Test plan
- [ ] After Argo sync: `kubectl -n authentik get cluster authentik-db` reports healthy and `status.pgDataImageInfo.majorVersion == 18`
- [ ] Both pods running on the new image: `kubectl -n authentik get pods -l cnpg.io/cluster=authentik-db -o jsonpath='{.items[*].spec.containers[?(@.name=="postgres")].image}'`
- [ ] Authentik server reconnects: `kubectl -n authentik logs deploy/authentik-server --tail=50` clean of DB errors
- [ ] Full OIDC round-trip works — log into ArgoCD or Grafana via Authentik
- [ ] Tomorrow's 02:00 UTC ScheduledBackup completes: `kubectl -n authentik get backups.postgresql.cnpg.io --sort-by=.metadata.creationTimestamp | tail -3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)