### PR TITLE
chore(rustfs): bump memory limit 512Mi → 1Gi

### DIFF
--- a/kubernetes/applications/rustfs/overlays/prod/kustomization.yaml
+++ b/kubernetes/applications/rustfs/overlays/prod/kustomization.yaml
@@ -63,7 +63,7 @@ patches:
             memory: 128Mi
           limits:
             cpu: 200m
-            memory: 512Mi
+            memory: 1Gi
 
   # RustFS API service with static IP and BGP advertisement
   - target:


### PR DESCRIPTION
Idle baseline is 440Mi (86% of the old 512Mi limit) and has been stable since the pod started 7 days ago, so this is the real steady-state, not a leak. Headroom of ~72Mi is too tight for upcoming uploads and for any compactor or multi-client spike. Doubling the limit gives sustainable headroom without touching the request side.