### PR TITLE
chore(rustfs): add influxdb-archive bucket

### DIFF
--- a/kubernetes/applications/rustfs/base/initialize-buckets-job.yaml
+++ b/kubernetes/applications/rustfs/base/initialize-buckets-job.yaml
@@ -51,7 +51,7 @@ spec:
               done
           env:
             - name: BUCKETS
-              value: "authentik-backups longhorn-backups timescaledb-backups nats-archive"
+              value: "authentik-backups longhorn-backups timescaledb-backups nats-archive influxdb-archive"
             - name: RCLONE_CONFIG_RUSTFS_TYPE
               value: s3
             - name: RCLONE_CONFIG_RUSTFS_PROVIDER


### PR DESCRIPTION
Adds a new RustFS bucket "influxdb-archive" alongside the existing nats-archive bucket. The new bucket is the forensic-archive target for the InfluxDB 2 → TimescaleDB migration (#759), mirroring the role nats-archive plays for the live NATS streams: a row-level dump of all source fields/tags as raw JSON payloads, kept in case we later realise a column was forgotten during promotion to public.<table>.

The InfluxDB 2 loader runs locally on the Mac and uploads daily parquet files (zstd) following the same path schema as Phase A:

  s3://influxdb-archive/<target-table>/<YYYY>/<MM>/<DD>/daily.parquet