### PR TITLE
chore(renovate): pass DHI hostRules so dhi.io image lookups succeed

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -56,6 +56,7 @@ jobs:
           RENOVATE_DRY_RUN: ${{ inputs.dryRun }}
           RENOVATE_PLATFORM: github
           RENOVATE_PLATFORM_COMMIT: "true"
+          RENOVATE_HOST_RULES: '[{"matchHost":"dhi.io","username":"${{ secrets.DHI_USER }}","password":"${{ secrets.DHI_PASS }}"}]'
         with:
           token: ${{ steps.app-token.outputs.token }}
           renovate-version: ${{ inputs.version || 'latest' }}


### PR DESCRIPTION
Renovate failed to resolve dhi.io/kubectl and dhi.io/curl because the runner had no credentials for Docker Hardened Images. Inject the DHI_USER/DHI_PASS secrets via RENOVATE_HOST_RULES.