### PR TITLE
feat(external-dns): per-environment target via kustomize replacements

### DIFF
--- a/kubernetes/applications/alloy/base/ingress-route.yaml
+++ b/kubernetes/applications/alloy/base/ingress-route.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: alloy
   annotations:
     # ExternalDNS configuration for Cloudflare
-    external-dns.alpha.kubernetes.io/target: udm-pro.zimmermann.sh
+    external-dns.alpha.kubernetes.io/target: PLACEHOLDER
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
     kubernetes.io/ingress.class: traefik
     # Homepage Service Discovery

--- a/kubernetes/applications/alloy/overlays/dev/kustomization.yaml
+++ b/kubernetes/applications/alloy/overlays/dev/kustomization.yaml
@@ -30,6 +30,14 @@ replacements:
           delimiter: "//"
           index: 1
 
+  # Rewrite external-dns target annotation to dev UDM Pro
+  - sourceValue: udm-pro.zimmermann.phd
+    targets:
+      - select:
+          kind: IngressRoute
+        fieldPaths:
+          - metadata.annotations.[external-dns.alpha.kubernetes.io/target]
+
 patches:
   # Alloy Operator: Manages the lifecycle of Alloy instances
   - target:

--- a/kubernetes/applications/alloy/overlays/prod/kustomization.yaml
+++ b/kubernetes/applications/alloy/overlays/prod/kustomization.yaml
@@ -30,6 +30,14 @@ replacements:
           delimiter: "//"
           index: 1
 
+  # Rewrite external-dns target annotation to prod UDM Pro
+  - sourceValue: udm-pro.zimmermann.sh
+    targets:
+      - select:
+          kind: IngressRoute
+        fieldPaths:
+          - metadata.annotations.[external-dns.alpha.kubernetes.io/target]
+
 patches:
   # Alloy Operator: Manages the lifecycle of Alloy instances
   - target:

--- a/kubernetes/applications/authentik/base/ingress-route.yaml
+++ b/kubernetes/applications/authentik/base/ingress-route.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
   annotations:
     # ExternalDNS configuration for Cloudflare
-    external-dns.alpha.kubernetes.io/target: udm-pro.zimmermann.sh
+    external-dns.alpha.kubernetes.io/target: PLACEHOLDER
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
     kubernetes.io/ingress.class: traefik
     # Homepage Service Discovery

--- a/kubernetes/applications/authentik/overlays/dev/kustomization.yaml
+++ b/kubernetes/applications/authentik/overlays/dev/kustomization.yaml
@@ -155,6 +155,14 @@ replacements:
         fieldPaths:
           - spec.plugins.0.parameters.serverName
 
+  # Rewrite external-dns target annotation to dev UDM Pro
+  - sourceValue: udm-pro.zimmermann.phd
+    targets:
+      - select:
+          kind: IngressRoute
+        fieldPaths:
+          - metadata.annotations.[external-dns.alpha.kubernetes.io/target]
+
 patches:
   # Authentik server manages API access and primary logic
   - target:

--- a/kubernetes/applications/authentik/overlays/prod/kustomization.yaml
+++ b/kubernetes/applications/authentik/overlays/prod/kustomization.yaml
@@ -155,6 +155,14 @@ replacements:
         fieldPaths:
           - spec.plugins.0.parameters.serverName
 
+  # Rewrite external-dns target annotation to prod UDM Pro
+  - sourceValue: udm-pro.zimmermann.sh
+    targets:
+      - select:
+          kind: IngressRoute
+        fieldPaths:
+          - metadata.annotations.[external-dns.alpha.kubernetes.io/target]
+
 patches:
   # Authentik server manages API access and primary logic
   - target:

--- a/kubernetes/applications/external-services/base/ingress-route.yaml
+++ b/kubernetes/applications/external-services/base/ingress-route.yaml
@@ -5,7 +5,7 @@ metadata:
   name: proxmox
   annotations:
     # ExternalDNS configuration for Cloudflare
-    external-dns.alpha.kubernetes.io/target: udm-pro.zimmermann.sh
+    external-dns.alpha.kubernetes.io/target: PLACEHOLDER
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
     kubernetes.io/ingress.class: traefik
     # Gatus — automated status page discovery (probes via /_gatus path with CF Access Service Token)
@@ -60,7 +60,7 @@ metadata:
   name: backup
   annotations:
     # ExternalDNS configuration for Cloudflare
-    external-dns.alpha.kubernetes.io/target: udm-pro.zimmermann.sh
+    external-dns.alpha.kubernetes.io/target: PLACEHOLDER
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
     kubernetes.io/ingress.class: traefik
     # Gatus — automated status page discovery (probes via /_gatus path with CF Access Service Token)
@@ -111,7 +111,7 @@ metadata:
   name: omni
   annotations:
     # ExternalDNS configuration for Cloudflare
-    external-dns.alpha.kubernetes.io/target: udm-pro.zimmermann.sh
+    external-dns.alpha.kubernetes.io/target: PLACEHOLDER
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
     kubernetes.io/ingress.class: traefik
     # Gatus — automated status page discovery (probes via /_gatus path with CF Access Service Token)
@@ -164,7 +164,7 @@ metadata:
   name: ai-pro-1
   annotations:
     # ExternalDNS configuration for Cloudflare
-    external-dns.alpha.kubernetes.io/target: udm-pro.zimmermann.sh
+    external-dns.alpha.kubernetes.io/target: PLACEHOLDER
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
     kubernetes.io/ingress.class: traefik
 
@@ -193,7 +193,7 @@ metadata:
   name: ai-pro-2
   annotations:
     # ExternalDNS configuration for Cloudflare
-    external-dns.alpha.kubernetes.io/target: udm-pro.zimmermann.sh
+    external-dns.alpha.kubernetes.io/target: PLACEHOLDER
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
     kubernetes.io/ingress.class: traefik
 
@@ -222,7 +222,7 @@ metadata:
   name: ai-pro-3
   annotations:
     # ExternalDNS configuration for Cloudflare
-    external-dns.alpha.kubernetes.io/target: udm-pro.zimmermann.sh
+    external-dns.alpha.kubernetes.io/target: PLACEHOLDER
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
     kubernetes.io/ingress.class: traefik
 
@@ -251,7 +251,7 @@ metadata:
   name: ai-pro-4
   annotations:
     # ExternalDNS configuration for Cloudflare
-    external-dns.alpha.kubernetes.io/target: udm-pro.zimmermann.sh
+    external-dns.alpha.kubernetes.io/target: PLACEHOLDER
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
     kubernetes.io/ingress.class: traefik
 
@@ -280,7 +280,7 @@ metadata:
   name: dali-1
   annotations:
     # ExternalDNS configuration for Cloudflare
-    external-dns.alpha.kubernetes.io/target: udm-pro.zimmermann.sh
+    external-dns.alpha.kubernetes.io/target: PLACEHOLDER
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
     kubernetes.io/ingress.class: traefik
 
@@ -309,7 +309,7 @@ metadata:
   name: dali-2
   annotations:
     # ExternalDNS configuration for Cloudflare
-    external-dns.alpha.kubernetes.io/target: udm-pro.zimmermann.sh
+    external-dns.alpha.kubernetes.io/target: PLACEHOLDER
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
     kubernetes.io/ingress.class: traefik
 spec:
@@ -337,7 +337,7 @@ metadata:
   name: ems-esp
   annotations:
     # ExternalDNS configuration for Cloudflare
-    external-dns.alpha.kubernetes.io/target: udm-pro.zimmermann.sh
+    external-dns.alpha.kubernetes.io/target: PLACEHOLDER
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
     kubernetes.io/ingress.class: traefik
     # Gatus — automated status page discovery (probes via /_gatus path with CF Access Service Token;
@@ -389,7 +389,7 @@ metadata:
   name: fritzbox
   annotations:
     # ExternalDNS configuration for Cloudflare
-    external-dns.alpha.kubernetes.io/target: udm-pro.zimmermann.sh
+    external-dns.alpha.kubernetes.io/target: PLACEHOLDER
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
     kubernetes.io/ingress.class: traefik
     # Gatus — automated status page discovery (probes via /_gatus path with CF Access Service Token;
@@ -440,7 +440,7 @@ metadata:
   name: knx-ip
   annotations:
     # ExternalDNS configuration for Cloudflare
-    external-dns.alpha.kubernetes.io/target: udm-pro.zimmermann.sh
+    external-dns.alpha.kubernetes.io/target: PLACEHOLDER
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
     kubernetes.io/ingress.class: traefik
     # Gatus — automated status page discovery (probes via /_gatus path with CF Access Service Token;
@@ -493,7 +493,7 @@ metadata:
   name: verso
   annotations:
     # ExternalDNS configuration for Cloudflare
-    external-dns.alpha.kubernetes.io/target: udm-pro.zimmermann.sh
+    external-dns.alpha.kubernetes.io/target: PLACEHOLDER
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
     kubernetes.io/ingress.class: traefik
 
@@ -522,7 +522,7 @@ metadata:
   name: warp
   annotations:
     # ExternalDNS configuration for Cloudflare
-    external-dns.alpha.kubernetes.io/target: udm-pro.zimmermann.sh
+    external-dns.alpha.kubernetes.io/target: PLACEHOLDER
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
     kubernetes.io/ingress.class: traefik
 

--- a/kubernetes/applications/external-services/overlays/dev/kustomization.yaml
+++ b/kubernetes/applications/external-services/overlays/dev/kustomization.yaml
@@ -296,3 +296,11 @@ replacements:
         options:
           delimiter: "`"
           index: 1
+
+  # Rewrite external-dns target annotation to dev UDM Pro (applies to all IngressRoutes above)
+  - sourceValue: udm-pro.zimmermann.phd
+    targets:
+      - select:
+          kind: IngressRoute
+        fieldPaths:
+          - metadata.annotations.[external-dns.alpha.kubernetes.io/target]

--- a/kubernetes/applications/external-services/overlays/prod/kustomization.yaml
+++ b/kubernetes/applications/external-services/overlays/prod/kustomization.yaml
@@ -296,3 +296,11 @@ replacements:
         options:
           delimiter: "`"
           index: 1
+
+  # Rewrite external-dns target annotation to prod UDM Pro (applies to all IngressRoutes above)
+  - sourceValue: udm-pro.zimmermann.sh
+    targets:
+      - select:
+          kind: IngressRoute
+        fieldPaths:
+          - metadata.annotations.[external-dns.alpha.kubernetes.io/target]

--- a/kubernetes/applications/gatus/base/ingress-route.yaml
+++ b/kubernetes/applications/gatus/base/ingress-route.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: gatus
   annotations:
     # ExternalDNS configuration for Cloudflare
-    external-dns.alpha.kubernetes.io/target: udm-pro.zimmermann.sh
+    external-dns.alpha.kubernetes.io/target: PLACEHOLDER
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
     kubernetes.io/ingress.class: traefik
     # Homepage Service Discovery

--- a/kubernetes/applications/gatus/overlays/dev/kustomization.yaml
+++ b/kubernetes/applications/gatus/overlays/dev/kustomization.yaml
@@ -58,3 +58,11 @@ replacements:
           name: gatus-db
         fieldPaths:
           - spec.postgresql.parameters.max_wal_size
+
+  # Rewrite external-dns target annotation to dev UDM Pro
+  - sourceValue: udm-pro.zimmermann.phd
+    targets:
+      - select:
+          kind: IngressRoute
+        fieldPaths:
+          - metadata.annotations.[external-dns.alpha.kubernetes.io/target]

--- a/kubernetes/applications/gatus/overlays/prod/kustomization.yaml
+++ b/kubernetes/applications/gatus/overlays/prod/kustomization.yaml
@@ -59,6 +59,14 @@ replacements:
         fieldPaths:
           - spec.postgresql.parameters.max_wal_size
 
+  # Rewrite external-dns target annotation to prod UDM Pro
+  - sourceValue: udm-pro.zimmermann.sh
+    targets:
+      - select:
+          kind: IngressRoute
+        fieldPaths:
+          - metadata.annotations.[external-dns.alpha.kubernetes.io/target]
+
 patches:
   # Gatus service with static IP and BGP advertisement
   - target:

--- a/kubernetes/applications/grafana/base/ingress-route.yaml
+++ b/kubernetes/applications/grafana/base/ingress-route.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: grafana
   annotations:
     # ExternalDNS configuration for Cloudflare
-    external-dns.alpha.kubernetes.io/target: udm-pro.zimmermann.sh
+    external-dns.alpha.kubernetes.io/target: PLACEHOLDER
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
     kubernetes.io/ingress.class: traefik
     # Homepage Service Discovery

--- a/kubernetes/applications/grafana/overlays/dev/kustomization.yaml
+++ b/kubernetes/applications/grafana/overlays/dev/kustomization.yaml
@@ -92,6 +92,14 @@ replacements:
           delimiter: "/"
           index: 2
 
+  # Rewrite external-dns target annotation to dev UDM Pro
+  - sourceValue: udm-pro.zimmermann.phd
+    targets:
+      - select:
+          kind: IngressRoute
+        fieldPaths:
+          - metadata.annotations.[external-dns.alpha.kubernetes.io/target]
+
 patches:
   # Configure resources for Grafana Instance containers (main container & dashboard/datasource sidecars)
   - target:

--- a/kubernetes/applications/grafana/overlays/prod/kustomization.yaml
+++ b/kubernetes/applications/grafana/overlays/prod/kustomization.yaml
@@ -92,6 +92,14 @@ replacements:
           delimiter: "/"
           index: 2
 
+  # Rewrite external-dns target annotation to prod UDM Pro
+  - sourceValue: udm-pro.zimmermann.sh
+    targets:
+      - select:
+          kind: IngressRoute
+        fieldPaths:
+          - metadata.annotations.[external-dns.alpha.kubernetes.io/target]
+
 patches:
   # Configure resources for Grafana Instance containers (main container & dashboard/datasource sidecars)
   - target:

--- a/kubernetes/applications/homepage/base/ingress-route.yaml
+++ b/kubernetes/applications/homepage/base/ingress-route.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: homepage
   annotations:
     # ExternalDNS configuration for Cloudflare
-    external-dns.alpha.kubernetes.io/target: udm-pro.zimmermann.sh
+    external-dns.alpha.kubernetes.io/target: PLACEHOLDER
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
     kubernetes.io/ingress.class: traefik
     # Homepage Service Discovery

--- a/kubernetes/applications/homepage/overlays/dev/kustomization.yaml
+++ b/kubernetes/applications/homepage/overlays/dev/kustomization.yaml
@@ -55,3 +55,11 @@ replacements:
           name: homepage-images
         fieldPaths:
           - spec.resources.requests.storage
+
+  # Rewrite external-dns target annotation to dev UDM Pro
+  - sourceValue: udm-pro.zimmermann.phd
+    targets:
+      - select:
+          kind: IngressRoute
+        fieldPaths:
+          - metadata.annotations.[external-dns.alpha.kubernetes.io/target]

--- a/kubernetes/applications/homepage/overlays/prod/kustomization.yaml
+++ b/kubernetes/applications/homepage/overlays/prod/kustomization.yaml
@@ -56,6 +56,14 @@ replacements:
         fieldPaths:
           - spec.resources.requests.storage
 
+  # Rewrite external-dns target annotation to prod UDM Pro
+  - sourceValue: udm-pro.zimmermann.sh
+    targets:
+      - select:
+          kind: IngressRoute
+        fieldPaths:
+          - metadata.annotations.[external-dns.alpha.kubernetes.io/target]
+
 patches:
   # Homepage service with static IP and BGP advertisement
   - target:

--- a/kubernetes/applications/iot-mcp-bridge/base/ingress-route.yaml
+++ b/kubernetes/applications/iot-mcp-bridge/base/ingress-route.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: iot-mcp-bridge
   annotations:
     # ExternalDNS configuration for Cloudflare
-    external-dns.alpha.kubernetes.io/target: udm-pro.zimmermann.sh
+    external-dns.alpha.kubernetes.io/target: PLACEHOLDER
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
     kubernetes.io/ingress.class: traefik
 

--- a/kubernetes/applications/iot-mcp-bridge/overlays/dev/kustomization.yaml
+++ b/kubernetes/applications/iot-mcp-bridge/overlays/dev/kustomization.yaml
@@ -46,3 +46,11 @@ replacements:
           name: iot-mcp-bridge
         fieldPaths:
           - spec.template.spec.containers.0.env.[name=MCP_AUTH_RESOURCE_URL].value
+
+  # Rewrite external-dns target annotation to dev UDM Pro
+  - sourceValue: udm-pro.zimmermann.phd
+    targets:
+      - select:
+          kind: IngressRoute
+        fieldPaths:
+          - metadata.annotations.[external-dns.alpha.kubernetes.io/target]

--- a/kubernetes/applications/iot-mcp-bridge/overlays/prod/kustomization.yaml
+++ b/kubernetes/applications/iot-mcp-bridge/overlays/prod/kustomization.yaml
@@ -46,3 +46,11 @@ replacements:
           name: iot-mcp-bridge
         fieldPaths:
           - spec.template.spec.containers.0.env.[name=MCP_AUTH_RESOURCE_URL].value
+
+  # Rewrite external-dns target annotation to prod UDM Pro
+  - sourceValue: udm-pro.zimmermann.sh
+    targets:
+      - select:
+          kind: IngressRoute
+        fieldPaths:
+          - metadata.annotations.[external-dns.alpha.kubernetes.io/target]

--- a/kubernetes/applications/kromgo/base/ingress-route.yaml
+++ b/kubernetes/applications/kromgo/base/ingress-route.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: kromgo
   annotations:
     # ExternalDNS configuration for Cloudflare
-    external-dns.alpha.kubernetes.io/target: udm-pro.zimmermann.sh
+    external-dns.alpha.kubernetes.io/target: PLACEHOLDER
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
     kubernetes.io/ingress.class: traefik
 

--- a/kubernetes/applications/kromgo/overlays/dev/kustomization.yaml
+++ b/kubernetes/applications/kromgo/overlays/dev/kustomization.yaml
@@ -21,3 +21,11 @@ replacements:
         options:
           delimiter: "`"
           index: 1
+
+  # Rewrite external-dns target annotation to dev UDM Pro
+  - sourceValue: udm-pro.zimmermann.phd
+    targets:
+      - select:
+          kind: IngressRoute
+        fieldPaths:
+          - metadata.annotations.[external-dns.alpha.kubernetes.io/target]

--- a/kubernetes/applications/kromgo/overlays/prod/kustomization.yaml
+++ b/kubernetes/applications/kromgo/overlays/prod/kustomization.yaml
@@ -22,6 +22,14 @@ replacements:
           delimiter: "`"
           index: 1
 
+  # Rewrite external-dns target annotation to prod UDM Pro
+  - sourceValue: udm-pro.zimmermann.sh
+    targets:
+      - select:
+          kind: IngressRoute
+        fieldPaths:
+          - metadata.annotations.[external-dns.alpha.kubernetes.io/target]
+
 patches:
   # kromgo service with static IP and BGP advertisement
   - target:

--- a/kubernetes/applications/nats/base/ingress-route-tcp.yaml
+++ b/kubernetes/applications/nats/base/ingress-route-tcp.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: nats
   annotations:
     # ExternalDNS configuration for Cloudflare (no proxy — TCP traffic)
-    external-dns.alpha.kubernetes.io/target: udm-pro.zimmermann.sh
+    external-dns.alpha.kubernetes.io/target: PLACEHOLDER
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "false"
     kubernetes.io/ingress.class: traefik
 

--- a/kubernetes/applications/nats/overlays/dev/kustomization.yaml
+++ b/kubernetes/applications/nats/overlays/dev/kustomization.yaml
@@ -36,6 +36,14 @@ replacements:
         fieldPaths:
           - spec.volumeClaimTemplates.0.spec.resources.requests.storage
 
+  # Rewrite external-dns target annotation to dev UDM Pro
+  - sourceValue: udm-pro.zimmermann.phd
+    targets:
+      - select:
+          kind: IngressRouteTCP
+        fieldPaths:
+          - metadata.annotations.[external-dns.alpha.kubernetes.io/target]
+
 patches:
   # NATS container resource limits
   - target:

--- a/kubernetes/applications/nats/overlays/prod/kustomization.yaml
+++ b/kubernetes/applications/nats/overlays/prod/kustomization.yaml
@@ -36,6 +36,14 @@ replacements:
         fieldPaths:
           - spec.volumeClaimTemplates.0.spec.resources.requests.storage
 
+  # Rewrite external-dns target annotation to prod UDM Pro
+  - sourceValue: udm-pro.zimmermann.sh
+    targets:
+      - select:
+          kind: IngressRouteTCP
+        fieldPaths:
+          - metadata.annotations.[external-dns.alpha.kubernetes.io/target]
+
 patches:
   # NATS container resource limits
   - target:

--- a/kubernetes/applications/node-red/base/ingress-route.yaml
+++ b/kubernetes/applications/node-red/base/ingress-route.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: node-red
   annotations:
     # ExternalDNS configuration for Cloudflare
-    external-dns.alpha.kubernetes.io/target: udm-pro.zimmermann.sh
+    external-dns.alpha.kubernetes.io/target: PLACEHOLDER
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
     kubernetes.io/ingress.class: traefik
     # Homepage Service Discovery

--- a/kubernetes/applications/node-red/overlays/dev/kustomization.yaml
+++ b/kubernetes/applications/node-red/overlays/dev/kustomization.yaml
@@ -56,3 +56,11 @@ replacements:
           name: node-red-data
         fieldPaths:
           - spec.resources.requests.storage
+
+  # Rewrite external-dns target annotation to dev UDM Pro
+  - sourceValue: udm-pro.zimmermann.phd
+    targets:
+      - select:
+          kind: IngressRoute
+        fieldPaths:
+          - metadata.annotations.[external-dns.alpha.kubernetes.io/target]

--- a/kubernetes/applications/node-red/overlays/prod/kustomization.yaml
+++ b/kubernetes/applications/node-red/overlays/prod/kustomization.yaml
@@ -57,6 +57,14 @@ replacements:
         fieldPaths:
           - spec.template.spec.containers.0.env.[name=NODE_RED_CALLBACK_URL].value
 
+  # Rewrite external-dns target annotation to prod UDM Pro
+  - sourceValue: udm-pro.zimmermann.sh
+    targets:
+      - select:
+          kind: IngressRoute
+        fieldPaths:
+          - metadata.annotations.[external-dns.alpha.kubernetes.io/target]
+
 patches:
   # node-red service with static IP and BGP advertisement
   - target:

--- a/kubernetes/applications/prometheus/base/ingress-route.yaml
+++ b/kubernetes/applications/prometheus/base/ingress-route.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: prometheus
   annotations:
     # ExternalDNS configuration for Cloudflare
-    external-dns.alpha.kubernetes.io/target: udm-pro.zimmermann.sh
+    external-dns.alpha.kubernetes.io/target: PLACEHOLDER
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
     kubernetes.io/ingress.class: traefik
     # Homepage Service Discovery
@@ -57,7 +57,7 @@ metadata:
   namespace: prometheus
   annotations:
     # ExternalDNS configuration for Cloudflare
-    external-dns.alpha.kubernetes.io/target: udm-pro.zimmermann.sh
+    external-dns.alpha.kubernetes.io/target: PLACEHOLDER
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
     kubernetes.io/ingress.class: traefik
     # Homepage annotations

--- a/kubernetes/applications/prometheus/overlays/dev/kustomization.yaml
+++ b/kubernetes/applications/prometheus/overlays/dev/kustomization.yaml
@@ -85,6 +85,14 @@ replacements:
         fieldPaths:
           - spec.retentionSize
 
+  # Rewrite external-dns target annotation to dev UDM Pro (applies to prometheus and alertmanager IngressRoutes)
+  - sourceValue: udm-pro.zimmermann.phd
+    targets:
+      - select:
+          kind: IngressRoute
+        fieldPaths:
+          - metadata.annotations.[external-dns.alpha.kubernetes.io/target]
+
 patches:
   # Prometheus Operator: Deploy with standardized resources and GOMEMLIMIT
   - target:

--- a/kubernetes/applications/prometheus/overlays/prod/kustomization.yaml
+++ b/kubernetes/applications/prometheus/overlays/prod/kustomization.yaml
@@ -85,6 +85,14 @@ replacements:
         fieldPaths:
           - spec.retentionSize
 
+  # Rewrite external-dns target annotation to prod UDM Pro (applies to prometheus and alertmanager IngressRoutes)
+  - sourceValue: udm-pro.zimmermann.sh
+    targets:
+      - select:
+          kind: IngressRoute
+        fieldPaths:
+          - metadata.annotations.[external-dns.alpha.kubernetes.io/target]
+
 patches:
   # Prometheus Operator: Deploy with standardized resources and GOMEMLIMIT
   - target:

--- a/kubernetes/applications/rustfs/base/ingress-route.yaml
+++ b/kubernetes/applications/rustfs/base/ingress-route.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: rustfs
   annotations:
     # ExternalDNS configuration for Cloudflare
-    external-dns.alpha.kubernetes.io/target: udm-pro.zimmermann.sh
+    external-dns.alpha.kubernetes.io/target: PLACEHOLDER
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
     kubernetes.io/ingress.class: traefik
     # Homepage Service Discovery

--- a/kubernetes/applications/rustfs/overlays/dev/kustomization.yaml
+++ b/kubernetes/applications/rustfs/overlays/dev/kustomization.yaml
@@ -46,6 +46,14 @@ replacements:
         fieldPaths:
           - spec.resources.requests.storage
 
+  # Rewrite external-dns target annotation to dev UDM Pro
+  - sourceValue: udm-pro.zimmermann.phd
+    targets:
+      - select:
+          kind: IngressRoute
+        fieldPaths:
+          - metadata.annotations.[external-dns.alpha.kubernetes.io/target]
+
 patches:
   # RustFS server manages distributed storage and API access
   - target:

--- a/kubernetes/applications/rustfs/overlays/prod/kustomization.yaml
+++ b/kubernetes/applications/rustfs/overlays/prod/kustomization.yaml
@@ -46,6 +46,14 @@ replacements:
         fieldPaths:
           - spec.resources.requests.storage
 
+  # Rewrite external-dns target annotation to prod UDM Pro
+  - sourceValue: udm-pro.zimmermann.sh
+    targets:
+      - select:
+          kind: IngressRoute
+        fieldPaths:
+          - metadata.annotations.[external-dns.alpha.kubernetes.io/target]
+
 patches:
   # RustFS server manages distributed storage and API access.
   - target:

--- a/kubernetes/applications/wiki-js/base/ingress-route.yaml
+++ b/kubernetes/applications/wiki-js/base/ingress-route.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: wiki-js
   annotations:
     # ExternalDNS configuration for Cloudflare
-    external-dns.alpha.kubernetes.io/target: udm-pro.zimmermann.sh
+    external-dns.alpha.kubernetes.io/target: PLACEHOLDER
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
     kubernetes.io/ingress.class: traefik
     # Homepage Service Discovery

--- a/kubernetes/applications/wiki-js/overlays/dev/kustomization.yaml
+++ b/kubernetes/applications/wiki-js/overlays/dev/kustomization.yaml
@@ -75,6 +75,14 @@ replacements:
         fieldPaths:
           - spec.plugins.0.parameters.serverName
 
+  # Rewrite external-dns target annotation to dev UDM Pro
+  - sourceValue: udm-pro.zimmermann.phd
+    targets:
+      - select:
+          kind: IngressRoute
+        fieldPaths:
+          - metadata.annotations.[external-dns.alpha.kubernetes.io/target]
+
 patches:
   # Wiki.js Deployment resources
   - target:

--- a/kubernetes/applications/wiki-js/overlays/prod/kustomization.yaml
+++ b/kubernetes/applications/wiki-js/overlays/prod/kustomization.yaml
@@ -75,6 +75,14 @@ replacements:
         fieldPaths:
           - spec.plugins.0.parameters.serverName
 
+  # Rewrite external-dns target annotation to prod UDM Pro
+  - sourceValue: udm-pro.zimmermann.sh
+    targets:
+      - select:
+          kind: IngressRoute
+        fieldPaths:
+          - metadata.annotations.[external-dns.alpha.kubernetes.io/target]
+
 patches:
   # Wiki.js Deployment resources
   - target:

--- a/kubernetes/components/cilium/base/ingress-route.yaml
+++ b/kubernetes/components/cilium/base/ingress-route.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: cilium
   annotations:
     # ExternalDNS configuration for Cloudflare
-    external-dns.alpha.kubernetes.io/target: udm-pro.zimmermann.sh
+    external-dns.alpha.kubernetes.io/target: PLACEHOLDER
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
     kubernetes.io/ingress.class: traefik
     # Homepage Service Discovery

--- a/kubernetes/components/cilium/overlays/dev/kustomization.yaml
+++ b/kubernetes/components/cilium/overlays/dev/kustomization.yaml
@@ -61,3 +61,11 @@ replacements:
           name: alloy-bgp-ip-pool
         fieldPaths:
           - spec.blocks.0.stop
+
+  # Rewrite external-dns target annotation to dev UDM Pro
+  - sourceValue: udm-pro.zimmermann.phd
+    targets:
+      - select:
+          kind: IngressRoute
+        fieldPaths:
+          - metadata.annotations.[external-dns.alpha.kubernetes.io/target]

--- a/kubernetes/components/cilium/overlays/prod/kustomization.yaml
+++ b/kubernetes/components/cilium/overlays/prod/kustomization.yaml
@@ -61,3 +61,11 @@ replacements:
           name: alloy-bgp-ip-pool
         fieldPaths:
           - spec.blocks.0.stop
+
+  # Rewrite external-dns target annotation to prod UDM Pro
+  - sourceValue: udm-pro.zimmermann.sh
+    targets:
+      - select:
+          kind: IngressRoute
+        fieldPaths:
+          - metadata.annotations.[external-dns.alpha.kubernetes.io/target]

--- a/kubernetes/components/csi-block-storage-controller/base/ingress-route.yaml
+++ b/kubernetes/components/csi-block-storage-controller/base/ingress-route.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: csi-block-storage-controller
   annotations:
     # ExternalDNS configuration for Cloudflare
-    external-dns.alpha.kubernetes.io/target: udm-pro.zimmermann.sh
+    external-dns.alpha.kubernetes.io/target: PLACEHOLDER
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
     kubernetes.io/ingress.class: traefik
     # Homepage Service Discovery

--- a/kubernetes/components/csi-block-storage-controller/overlays/dev/kustomization.yaml
+++ b/kubernetes/components/csi-block-storage-controller/overlays/dev/kustomization.yaml
@@ -39,6 +39,14 @@ replacements:
           delimiter: "//"
           index: 1
 
+  # Rewrite external-dns target annotation to dev UDM Pro
+  - sourceValue: udm-pro.zimmermann.phd
+    targets:
+      - select:
+          kind: IngressRoute
+        fieldPaths:
+          - metadata.annotations.[external-dns.alpha.kubernetes.io/target]
+
 patches:
   # Longhorn Driver Deployer resources
   - target:

--- a/kubernetes/components/csi-block-storage-controller/overlays/prod/kustomization.yaml
+++ b/kubernetes/components/csi-block-storage-controller/overlays/prod/kustomization.yaml
@@ -48,6 +48,14 @@ replacements:
           delimiter: "//"
           index: 1
 
+  # Rewrite external-dns target annotation to prod UDM Pro
+  - sourceValue: udm-pro.zimmermann.sh
+    targets:
+      - select:
+          kind: IngressRoute
+        fieldPaths:
+          - metadata.annotations.[external-dns.alpha.kubernetes.io/target]
+
 patches:
   # Longhorn Driver Deployer resources
   - target:

--- a/kubernetes/components/gitops-controller/base/ingress-route.yaml
+++ b/kubernetes/components/gitops-controller/base/ingress-route.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: gitops-controller
   annotations:
     # ExternalDNS configuration for Cloudflare
-    external-dns.alpha.kubernetes.io/target: udm-pro.zimmermann.sh
+    external-dns.alpha.kubernetes.io/target: PLACEHOLDER
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
     kubernetes.io/ingress.class: traefik
     # Homepage Service Discovery

--- a/kubernetes/components/gitops-controller/overlays/dev/kustomization.yaml
+++ b/kubernetes/components/gitops-controller/overlays/dev/kustomization.yaml
@@ -40,3 +40,11 @@ replacements:
         options:
           delimiter: "/"
           index: 2
+
+  # Rewrite external-dns target annotation to dev UDM Pro
+  - sourceValue: udm-pro.zimmermann.phd
+    targets:
+      - select:
+          kind: IngressRoute
+        fieldPaths:
+          - metadata.annotations.[external-dns.alpha.kubernetes.io/target]

--- a/kubernetes/components/gitops-controller/overlays/prod/kustomization.yaml
+++ b/kubernetes/components/gitops-controller/overlays/prod/kustomization.yaml
@@ -40,3 +40,11 @@ replacements:
         options:
           delimiter: "/"
           index: 2
+
+  # Rewrite external-dns target annotation to prod UDM Pro
+  - sourceValue: udm-pro.zimmermann.sh
+    targets:
+      - select:
+          kind: IngressRoute
+        fieldPaths:
+          - metadata.annotations.[external-dns.alpha.kubernetes.io/target]


### PR DESCRIPTION
Replace the hardcoded `external-dns.alpha.kubernetes.io/target: udm-pro.zimmermann.sh` in every base IngressRoute/IngressRouteTCP with `PLACEHOLDER`, and inject the correct UDM Pro hostname per environment via a kustomize replacement in each overlay:
  - prod  -> udm-pro.zimmermann.sh
  - dev   -> udm-pro.zimmermann.phd

This makes `*.zimmermann.phd` CNAMEs in the dev cluster point to `udm-pro.zimmermann.phd` as intended, instead of leaking the prod UDM hostname. Affects homepage, grafana, alloy, authentik, external-services (14 routes), node-red, nats (TCP), rustfs, prometheus (prom+alertmanager), gatus, wiki-js, kromgo, iot-mcp-bridge, plus the cilium hubble, longhorn UI and argocd-server component IngressRoutes.

Closes #680