### PR TITLE
fix(grafana): move TimescaleDB datasource database field into jsonData

### DIFF
--- a/kubernetes/applications/grafana/base/datasources.yaml
+++ b/kubernetes/applications/grafana/base/datasources.yaml
@@ -62,11 +62,11 @@ spec:
     type: postgres
     access: proxy
     url: timescaledb-db-pooler.timescaledb.svc.cluster.local:5432
-    database: homelab
     user: grafana_ro
     isDefault: false
     editable: false
     jsonData:
+      database: homelab
       sslmode: disable
       postgresVersion: 1800
       timescaledb: true


### PR DESCRIPTION
Grafana 12.x reports "no default database configured for this data source" when the `database` field sits at the datasource top level for the postgres type — it now expects `jsonData.database`.