### PR TITLE
feat(grafana): migrate 4 dashboards from InfluxDB to TimescaleDB

### DIFF
--- a/kubernetes/applications/grafana/base/dashboards/energy-inverter.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/energy-inverter.yaml
@@ -54,8 +54,8 @@ spec:
         },
         {
           "datasource": {
-            "type": "influxdb",
-            "uid": "sRCk9Y9nk"
+            "type": "postgres",
+            "uid": "timescaledb"
           },
           "description": "",
           "fieldConfig": {
@@ -188,10 +188,13 @@ spec:
           "targets": [
             {
               "datasource": {
-                "type": "influxdb",
-                "uid": "1ZZNC9BGk"
+                "type": "postgres",
+                "uid": "timescaledb"
               },
-              "query": "import \"date\"\n\nitems = [\n  \"grid_delivery\",\n  \"consumer_used_battery_production\",\n  \"consumer_used_pv_production\",\n]\n\nfrom(bucket: \"${sebucket}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"energy\")\n  |> filter(fn: (r) => contains(value: r._field, set: items))\n  |> aggregateWindow(every: ${agg}, fn: sum, createEmpty: false)\n  |> group()\n  |> pivot(rowKey: [\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")\n  |> map(fn: (r) => ({\n      _time: r._time,\n      \"Grid delivery\": r.grid_delivery,\n      \"Battery used\": r.consumer_used_battery_production,\n      \"Direct used\": r.consumer_used_pv_production\n  }))\n  |> map(fn: (r) => ({r with _time: date.truncate(t: date.sub(d: 1s, from: r._time), unit: ${agg})}))\n  |> keep(columns: [\"_time\", \"Grid delivery\", \"Battery used\", \"Direct used\"])",
+              "editorMode": "code",
+              "format": "table",
+              "rawQuery": true,
+              "rawSql": "SELECT time_bucket('${agg}'::interval, time) - INTERVAL '1 second' AS _time, avg(grid_delivery) * EXTRACT(EPOCH FROM INTERVAL '${agg}') / 3600 AS \"Grid delivery\", avg(consumer_used_battery_production) * EXTRACT(EPOCH FROM INTERVAL '${agg}') / 3600 AS \"Battery used\", avg(consumer_used_pv_production) * EXTRACT(EPOCH FROM INTERVAL '${agg}') / 3600 AS \"Direct used\" FROM solaredge_powerflow WHERE $__timeFilter(time) GROUP BY 1 ORDER BY 1;",
               "refId": "A"
             }
           ],
@@ -220,8 +223,8 @@ spec:
         },
         {
           "datasource": {
-            "type": "influxdb",
-            "uid": "1ZZNC9BGk"
+            "type": "postgres",
+            "uid": "timescaledb"
           },
           "description": "",
           "fieldConfig": {
@@ -370,10 +373,13 @@ spec:
           "targets": [
             {
               "datasource": {
-                "type": "influxdb",
-                "uid": "1ZZNC9BGk"
+                "type": "postgres",
+                "uid": "timescaledb"
               },
-              "query": "import \"date\"\n\nitems = [\n  \"grid_delivery\",\n  \"grid_consumption\",\n  \"consumer_used_battery_production\",\n  \"consumer_used_pv_production\",\n  \"inverter_consumption\"\n]\n\nfrom(bucket: \"${sebucket}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"energy\")\n  |> filter(fn: (r) => contains(value: r._field, set: items))\n  |> aggregateWindow(every: ${agg}, fn: sum, createEmpty: false)\n  |> group()\n  |> pivot(rowKey: [\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")\n  |> map(fn: (r) => ({\n      _time: r._time,\n      \"Inverter\": r.inverter_consumption,\n      \"Direct\": r.consumer_used_pv_production,\n      \"Battery\": r.consumer_used_battery_production,\n      \"Grid\": r.grid_consumption - r.inverter_consumption,\n  }))\n  |> map(fn: (r) => ({r with _time: date.truncate(t: date.sub(d: 1s, from: r._time), unit: ${agg})}))\n  |> keep(columns: [\"_time\", \"Grid\", \"Direct\", \"Battery\", \"Inverter\"])",
+              "editorMode": "code",
+              "format": "table",
+              "rawQuery": true,
+              "rawSql": "SELECT time_bucket('${agg}'::interval, time) - INTERVAL '1 second' AS _time, (avg(grid_consumption) - avg(inverter_consumption)) * EXTRACT(EPOCH FROM INTERVAL '${agg}') / 3600 AS \"Grid\", avg(consumer_used_pv_production) * EXTRACT(EPOCH FROM INTERVAL '${agg}') / 3600 AS \"Direct\", avg(consumer_used_battery_production) * EXTRACT(EPOCH FROM INTERVAL '${agg}') / 3600 AS \"Battery\", avg(inverter_consumption) * EXTRACT(EPOCH FROM INTERVAL '${agg}') / 3600 AS \"Inverter\" FROM solaredge_powerflow WHERE $__timeFilter(time) GROUP BY 1 ORDER BY 1;",
               "refId": "A"
             }
           ],
@@ -399,8 +405,8 @@ spec:
         },
         {
           "datasource": {
-            "type": "influxdb",
-            "uid": "1ZZNC9BGk"
+            "type": "postgres",
+            "uid": "timescaledb"
           },
           "description": "",
           "fieldConfig": {
@@ -531,10 +537,13 @@ spec:
           "targets": [
             {
               "datasource": {
-                "type": "influxdb",
-                "uid": "1ZZNC9BGk"
+                "type": "postgres",
+                "uid": "timescaledb"
               },
-              "query": "import \"date\"\nimport \"math\"\n\nitems = [\n  \"grid_delivery\",\n  \"consumer_used_battery_production\",\n  \"inverter_production\",\n  ]\n\nfrom(bucket: \"${sebucket}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"energy\")\n  |> filter(fn: (r) => contains(value: r._field, set: items))\n  |> aggregateWindow(every: ${agg}, fn: sum, createEmpty: false)\n  |> group()\n  |> pivot(rowKey: [\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")\n  |> map(fn: (r) => ({\n      _time: r._time,\n      \"Grid delivery\":\n        math.round(x: r.grid_delivery / r.inverter_production * 100.0),\n      \"Battery used\":\n        math.round(x: r.consumer_used_battery_production / r.inverter_production * 100.0)\n  }))\n  |> map(fn: (r) => ({r with \"Direct used\": \n    if 100.0 - r[\"Grid delivery\"] - r[\"Battery used\"] < 0 then\n      0.0\n    else\n      100.0 - r[\"Grid delivery\"] - r[\"Battery used\"]}))\n  |> map(fn: (r) => ({r with _time: date.truncate(t: date.sub(d: 1s, from: r._time), unit: ${agg})}))\n  |> keep(columns: [\"_time\", \"Battery used\", \"Grid delivery\", \"Direct used\"])",
+              "editorMode": "code",
+              "format": "table",
+              "rawQuery": true,
+              "rawSql": "WITH agg AS (SELECT time_bucket('${agg}'::interval, time) AS bucket, avg(grid_delivery) AS gd, avg(consumer_used_battery_production) AS bu, avg(inverter_production) AS ip FROM solaredge_powerflow WHERE $__timeFilter(time) AND inverter_production > 0 GROUP BY 1) SELECT bucket - INTERVAL '1 second' AS _time, round(bu / ip * 100.0) AS \"Battery used\", round(gd / ip * 100.0) AS \"Grid delivery\", GREATEST(0, 100.0 - round(gd / ip * 100.0) - round(bu / ip * 100.0)) AS \"Direct used\" FROM agg ORDER BY bucket;",
               "refId": "A"
             }
           ],
@@ -559,8 +568,8 @@ spec:
         },
         {
           "datasource": {
-            "type": "influxdb",
-            "uid": "1ZZNC9BGk"
+            "type": "postgres",
+            "uid": "timescaledb"
           },
           "description": "",
           "fieldConfig": {
@@ -692,10 +701,13 @@ spec:
           "targets": [
             {
               "datasource": {
-                "type": "influxdb",
-                "uid": "1ZZNC9BGk"
+                "type": "postgres",
+                "uid": "timescaledb"
               },
-              "query": "import \"date\"\nimport \"math\"\n\nitems = [\n  \"grid_consumption\",\n  \"consumer_used_pv_production\",\n  \"consumer_used_battery_production\",\n  \"consumer_total\",\n]\n\nfrom(bucket: \"${sebucket}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"energy\")\n  |> filter(fn: (r) => contains(value: r._field, set: items))\n  |> aggregateWindow(every: ${agg}, fn: sum, createEmpty: false)\n  |> group()\n  |> pivot(rowKey: [\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")\n  |> map(fn: (r) => ({\n      _time: r._time,\n      \"Grid\": \n        if r.consumer_total > 0.0  then\n          math.round(x: (r.grid_consumption / r.consumer_total * 100.0))\n        else\n          0.0,\n      \"Battery\":\n          math.round(x: (r.consumer_used_battery_production / r.consumer_total * 100.0))\n  }))\n  |> map(fn: (r) => ({r with \"Direct\": \n    if 100.0 - r.Grid - r.Battery < 0 then\n      0.0\n    else\n      100.0 - r.Grid - r.Battery}))\n  |> map(fn: (r) => ({r with _time: date.truncate(t: date.sub(d: 1s, from: r._time), unit: ${agg})}))\n  |> keep(columns: [\"_time\", \"Grid\", \"Direct\", \"Battery\"])",
+              "editorMode": "code",
+              "format": "table",
+              "rawQuery": true,
+              "rawSql": "WITH agg AS (SELECT time_bucket('${agg}'::interval, time) AS bucket, avg(grid_consumption) AS gc, avg(consumer_used_pv_production) AS pv, avg(consumer_used_battery_production) AS bu, avg(consumer_total) AS ct FROM solaredge_powerflow WHERE $__timeFilter(time) GROUP BY 1) SELECT bucket - INTERVAL '1 second' AS _time, CASE WHEN ct > 0 THEN round(gc / ct * 100.0) ELSE 0 END AS \"Grid\", GREATEST(0, 100.0 - CASE WHEN ct > 0 THEN round(gc / ct * 100.0) ELSE 0 END - round(bu / NULLIF(ct, 0) * 100.0)) AS \"Direct\", round(bu / NULLIF(ct, 0) * 100.0) AS \"Battery\" FROM agg ORDER BY bucket;",
               "refId": "A"
             }
           ],
@@ -720,8 +732,8 @@ spec:
         },
         {
           "datasource": {
-            "type": "influxdb",
-            "uid": "1ZZNC9BGk"
+            "type": "postgres",
+            "uid": "timescaledb"
           },
           "description": "",
           "fieldConfig": {
@@ -867,19 +879,25 @@ spec:
           "targets": [
             {
               "datasource": {
-                "type": "influxdb",
-                "uid": "1ZZNC9BGk"
+                "type": "postgres",
+                "uid": "timescaledb"
               },
-              "query": "import \"date\"\n\nfrom(bucket: \"${sebucket}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"energy\")\n  |> filter(fn: (r) => r[\"_field\"] == \"pv_production\")\n  |> aggregateWindow(every: ${agg}, fn: sum, createEmpty: false)\n  |> map(fn: (r) => ({r with _time: date.truncate(t: date.sub(d: 1s, from: r._time), unit: ${agg}), _value: if exists r._value then r._value else 0.0}))\n  |> set(key: \"_field\", value: \"Production\")\n  |> keep(columns: [\"_time\", \"_field\" \"_value\"])",
+              "editorMode": "code",
+              "format": "table",
+              "rawQuery": true,
+              "rawSql": "SELECT time_bucket('${agg}'::interval, time) - INTERVAL '1 second' AS _time, avg(pv_production) * EXTRACT(EPOCH FROM INTERVAL '${agg}') / 3600 AS \"Production\" FROM solaredge_powerflow WHERE $__timeFilter(time) AND pv_production IS NOT NULL GROUP BY 1 ORDER BY 1;",
               "refId": "A"
             },
             {
               "datasource": {
-                "type": "influxdb",
-                "uid": "1ZZNC9BGk"
+                "type": "postgres",
+                "uid": "timescaledb"
               },
               "hide": false,
-              "query": "import \"date\"\nimport \"timezone\"\n\noption location = timezone.location(name: \"Europe/Berlin\")\n\nfrom(bucket: \"${sebucket}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"forecast\")\n  |> filter(fn: (r) => r[\"_field\"] == \"energy\")\n  |> aggregateWindow(every: ${agg}, fn: sum, createEmpty: true)\n  |> map(fn: (r) => ({r with _time: date.truncate(t: date.sub(d: 1s, from: r._time), unit: ${agg})}))",
+              "editorMode": "code",
+              "format": "table",
+              "rawQuery": true,
+              "rawSql": "SELECT NULL::timestamptz AS _time, NULL::numeric AS _value WHERE false;",
               "refId": "B"
             }
           ],
@@ -888,8 +906,8 @@ spec:
         },
         {
           "datasource": {
-            "type": "influxdb",
-            "uid": "1ZZNC9BGk"
+            "type": "postgres",
+            "uid": "timescaledb"
           },
           "description": "",
           "fieldConfig": {
@@ -1029,19 +1047,25 @@ spec:
           "targets": [
             {
               "datasource": {
-                "type": "influxdb",
-                "uid": "1ZZNC9BGk"
+                "type": "postgres",
+                "uid": "timescaledb"
               },
-              "query": "import \"date\"\n\nfrom(bucket: \"${sebucket}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"powerflow\")\n  |> filter(fn: (r) => r[\"_field\"] == \"pv_production\")\n  |> filter(fn: (r) => r.agg_type == \"mean\")\n  |> aggregateWindow(every: ${agg}, fn: mean, createEmpty: false)\n  |> map(fn: (r) => ({r with _time: date.truncate(t: date.sub(d: 1s, from: r._time), unit: ${agg})}))\n  |> set(key: \"_field\", value: \"Power\")\n  |> keep(columns: [\"_time\", \"_field\" \"_value\"])",
+              "editorMode": "code",
+              "format": "table",
+              "rawQuery": true,
+              "rawSql": "SELECT time_bucket('${agg}'::interval, time) - INTERVAL '1 second' AS _time, avg(pv_production) AS \"Power\" FROM solaredge_powerflow WHERE $__timeFilter(time) AND pv_production IS NOT NULL GROUP BY 1 ORDER BY 1;",
               "refId": "A"
             },
             {
               "datasource": {
-                "type": "influxdb",
-                "uid": "1ZZNC9BGk"
+                "type": "postgres",
+                "uid": "timescaledb"
               },
               "hide": false,
-              "query": "import \"date\"\nimport \"timezone\"\n\noption location = timezone.location(name: \"Europe/Berlin\")\n\nfrom(bucket: \"${sebucket}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"forecast\")\n  |> filter(fn: (r) => r[\"_field\"] == \"power\")\n  |> aggregateWindow(every: ${agg}, fn: mean, createEmpty: true)\n  |> map(fn: (r) => ({r with _time: date.truncate(t: date.sub(d: 1s, from: r._time), unit: ${agg}), _value: if exists r._value then r._value else 0.0}))",
+              "editorMode": "code",
+              "format": "table",
+              "rawQuery": true,
+              "rawSql": "SELECT NULL::timestamptz AS _time, NULL::numeric AS _value WHERE false;",
               "refId": "B"
             }
           ],
@@ -1050,8 +1074,8 @@ spec:
         },
         {
           "datasource": {
-            "type": "influxdb",
-            "uid": "1ZZNC9BGk"
+            "type": "postgres",
+            "uid": "timescaledb"
           },
           "description": "",
           "fieldConfig": {
@@ -1174,10 +1198,13 @@ spec:
           "targets": [
             {
               "datasource": {
-                "type": "influxdb",
-                "uid": "1ZZNC9BGk"
+                "type": "postgres",
+                "uid": "timescaledb"
               },
-              "query": "import \"date\"\n\nfrom(bucket: \"${sebucket}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"energy\")\n  |> filter(fn: (r) => r[\"_field\"] == \"grid_consumption\" or r[\"_field\"] == \"grid_delivery\" )\n  |> aggregateWindow(every: ${agg}, fn: sum, createEmpty: false)\n  |> map(fn: (r) => ({r with _time: date.truncate(t: date.sub(d: 1s, from: r._time), unit: ${agg})}))\n  |> map(fn: (r)=>({r with _field: if r._field == \"grid_consumption\" then \"Consumption\" else \"Delivery\"}))\n  |> group()\n  |> pivot(rowKey: [\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")",
+              "editorMode": "code",
+              "format": "table",
+              "rawQuery": true,
+              "rawSql": "SELECT time_bucket('${agg}'::interval, time) - INTERVAL '1 second' AS _time, avg(grid_consumption) * EXTRACT(EPOCH FROM INTERVAL '${agg}') / 3600 AS \"Consumption\", avg(grid_delivery) * EXTRACT(EPOCH FROM INTERVAL '${agg}') / 3600 AS \"Delivery\" FROM solaredge_powerflow WHERE $__timeFilter(time) GROUP BY 1 ORDER BY 1;",
               "refId": "A"
             }
           ],
@@ -1186,8 +1213,8 @@ spec:
         },
         {
           "datasource": {
-            "type": "influxdb",
-            "uid": "1ZZNC9BGk"
+            "type": "postgres",
+            "uid": "timescaledb"
           },
           "description": "",
           "fieldConfig": {
@@ -1277,10 +1304,13 @@ spec:
           "targets": [
             {
               "datasource": {
-                "type": "influxdb",
-                "uid": "1ZZNC9BGk"
+                "type": "postgres",
+                "uid": "timescaledb"
               },
-              "query": "import \"date\"\nimport \"timezone\"\n\nfrom(bucket: \"${sebucket}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"battery\")\n  |> filter(fn: (r) => r[\"_field\"] == \"state_of_charge\")\n  |> filter(fn: (r) => r.agg_type == \"mean\")\n  |> filter(fn: (r) => r._value >= 0)\n  |> aggregateWindow(every: ${agg}, fn: mean, createEmpty: false)\n  |> map(fn: (r) => ({r with _time: date.truncate(t: date.sub(d: 1s, from: r._time), unit: ${agg})}))\n  |> set(key: \"_field\", value: \"SoC\")\n  |> keep(columns: [\"_time\", \"_field\" \"_value\"])",
+              "editorMode": "code",
+              "format": "table",
+              "rawQuery": true,
+              "rawSql": "SELECT NULL::timestamptz AS _time, NULL::numeric AS _value WHERE false;",
               "refId": "A"
             }
           ],
@@ -1289,8 +1319,8 @@ spec:
         },
         {
           "datasource": {
-            "type": "influxdb",
-            "uid": "1ZZNC9BGk"
+            "type": "postgres",
+            "uid": "timescaledb"
           },
           "description": "",
           "fieldConfig": {
@@ -1405,10 +1435,13 @@ spec:
           "targets": [
             {
               "datasource": {
-                "type": "influxdb",
-                "uid": "1ZZNC9BGk"
+                "type": "postgres",
+                "uid": "timescaledb"
               },
-              "query": "import \"date\"\n\nfrom(bucket: \"${sebucket}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"energy\")\n  |> filter(fn: (r) => r[\"_field\"] == \"grid_consumption\" or r[\"_field\"] == \"grid_delivery\")\n  |> aggregateWindow(every: 1h, fn: sum, createEmpty: false)\n  |> map(fn: (r) => ({r with hour: date.hour(t: r._time)}))\n  |> group(columns: [\"_field\", \"hour\"], mode: \"by\")\n  |> mean()\n  |> map(fn: (r) => ({r with _name: if r.hour < 10 then \"0\" + string(v: r.hour) else string(v: r.hour)}))\n  |> map(fn: (r) => ({r with _field: if r._field == \"grid_consumption\" then \"Consumption\" else \"Delivery\" }))\n  |> group()\n  |> pivot(rowKey: [\"_name\"], columnKey:[\"_field\"], valueColumn: \"_value\")",
+              "editorMode": "code",
+              "format": "table",
+              "rawQuery": true,
+              "rawSql": "WITH hourly AS (SELECT time_bucket('1 hour', time) AS bucket, avg(grid_consumption) AS gc, avg(grid_delivery) AS gd FROM solaredge_powerflow WHERE $__timeFilter(time) GROUP BY 1) SELECT to_char(EXTRACT(HOUR FROM bucket)::int, 'FM00') AS _name, avg(gc) AS \"Consumption\", avg(gd) AS \"Delivery\" FROM hourly GROUP BY 1 ORDER BY 1;",
               "refId": "A"
             }
           ],
@@ -1417,8 +1450,8 @@ spec:
         },
         {
           "datasource": {
-            "type": "influxdb",
-            "uid": "1ZZNC9BGk"
+            "type": "postgres",
+            "uid": "timescaledb"
           },
           "description": "",
           "fieldConfig": {
@@ -1533,11 +1566,14 @@ spec:
           "targets": [
             {
               "datasource": {
-                "type": "influxdb",
-                "uid": "1ZZNC9BGk"
+                "type": "postgres",
+                "uid": "timescaledb"
               },
               "hide": false,
-              "query": "import \"date\"\n\nweekdays = [\"Montag\", \"Dienstag\", \"Mittwoch\", \"Donnerstag\", \"Freitag\", \"Samstag\", \"Sonntag\"]\n\nfrom(bucket: \"${sebucket}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"energy\")\n  |> filter(fn: (r) => r[\"_field\"] == \"grid_consumption\" or r[\"_field\"] == \"grid_delivery\")\n  |> aggregateWindow(every: 1d, fn: sum, createEmpty: false)\n  |> map(fn: (r) => ({r with _time: date.sub(d: 1s, from: r._time)}))\n  |> map(fn: (r) => ({r with weekday: date.weekDay(t: r._time)}))\n  |> map(fn: (r) => ({r with weekday: if r.weekday == 0 then 7 else r.weekday}))\n  |> group(columns: [\"_field\", \"weekday\"])\n  |> mean()\n  |> sort(columns: [\"weekday\"])\n  |> map(fn: (r) => ({r with _name: weekdays[r.weekday - 1]}))\n  |> map(fn: (r) => ({r with _field: if r._field == \"grid_consumption\" then \"Consumption\" else \"Delivery\" }))\n  |> group()\n  |> pivot(rowKey: [\"_name\"], columnKey:[\"_field\"], valueColumn: \"_value\")",
+              "editorMode": "code",
+              "format": "table",
+              "rawQuery": true,
+              "rawSql": "WITH daily AS (SELECT time_bucket('1 day', time) AS bucket, avg(grid_consumption) * 24 AS gc, avg(grid_delivery) * 24 AS gd FROM solaredge_powerflow WHERE $__timeFilter(time) GROUP BY 1), by_dow AS (SELECT EXTRACT(ISODOW FROM bucket)::int AS dow, avg(gc) AS gc, avg(gd) AS gd FROM daily GROUP BY 1) SELECT (ARRAY['Montag','Dienstag','Mittwoch','Donnerstag','Freitag','Samstag','Sonntag'])[dow] AS _name, gc AS \"Consumption\", gd AS \"Delivery\" FROM by_dow ORDER BY dow;",
               "refId": "A"
             }
           ],
@@ -1563,30 +1599,30 @@ spec:
               {
                 "selected": true,
                 "text": "1h",
-                "value": "1h"
+                "value": "1 hour"
               },
               {
                 "selected": false,
                 "text": "1d",
-                "value": "1d"
+                "value": "1 day"
               },
               {
                 "selected": false,
                 "text": "1w",
-                "value": "1w"
+                "value": "1 week"
               },
               {
                 "selected": false,
                 "text": "1mo",
-                "value": "1mo"
+                "value": "1 month"
               },
               {
                 "selected": false,
                 "text": "1y",
-                "value": "1y"
+                "value": "1 year"
               }
             ],
-            "query": "1h,1d,1w,1mo,1y",
+            "query": "1 hour,1 day,1 week,1 month,1 year",
             "type": "custom"
           },
           {

--- a/kubernetes/applications/grafana/base/dashboards/energy-wallbox.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/energy-wallbox.yaml
@@ -48,8 +48,8 @@ spec:
         },
         {
           "datasource": {
-            "type": "influxdb",
-            "uid": "sRCk9Y9nk"
+            "type": "postgres",
+            "uid": "timescaledb"
           },
           "fieldConfig": {
             "defaults": {
@@ -131,7 +131,10 @@ spec:
           "pluginVersion": "12.2.0-16629863581",
           "targets": [
             {
-              "query": "from(bucket: \"telegraf/autogen\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"warp\")\n  |> filter(fn: (r) => r[\"_field\"] == \"charger_state\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)",
+              "editorMode": "code",
+              "format": "time_series",
+              "rawQuery": true,
+              "rawSql": "SELECT $__timeGroup(time, '$__interval') AS time, last(charger_state, time) AS \"Ladecontroller\" FROM warp_evse WHERE $__timeFilter(time) AND charger_state IS NOT NULL GROUP BY 1 ORDER BY 1;",
               "refId": "A"
             }
           ],
@@ -140,8 +143,8 @@ spec:
         },
         {
           "datasource": {
-            "type": "influxdb",
-            "uid": "sRCk9Y9nk"
+            "type": "postgres",
+            "uid": "timescaledb"
           },
           "fieldConfig": {
             "defaults": {
@@ -223,7 +226,10 @@ spec:
           "pluginVersion": "12.2.0-16629863581",
           "targets": [
             {
-              "query": "from(bucket: \"telegraf/autogen\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"warp\")\n  |> filter(fn: (r) => r[\"_field\"] == \"error_state\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)",
+              "editorMode": "code",
+              "format": "time_series",
+              "rawQuery": true,
+              "rawSql": "SELECT $__timeGroup(time, '$__interval') AS time, last(error_state, time) AS \"Fehlerzustand\" FROM warp_evse WHERE $__timeFilter(time) AND error_state IS NOT NULL GROUP BY 1 ORDER BY 1;",
               "refId": "A"
             }
           ],
@@ -232,8 +238,8 @@ spec:
         },
         {
           "datasource": {
-            "type": "influxdb",
-            "uid": "sRCk9Y9nk"
+            "type": "postgres",
+            "uid": "timescaledb"
           },
           "fieldConfig": {
             "defaults": {
@@ -485,7 +491,10 @@ spec:
           "pluginVersion": "12.2.0-16629863581",
           "targets": [
             {
-              "query": "import \"timezone\"\nimport \"date\"\n\noption location = timezone.location(name: \"Europe/Berlin\")\n\ntempTime = date.truncate(t: now(), unit: 1h)\n\nfrom(bucket: \"telegraf/autogen\")\n  |> range(start: date.sub(from: tempTime, d: 12h), stop: tempTime)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"warp\")\n  |> filter(fn: (r) => r[\"_field\"] == \"error_state\" or r[\"_field\"] == \"contactor_error\" or r[\"_field\"] == \"dc_fault_current_state\")\n  |> aggregateWindow(every: 1h, offset: -1h, fn:last, createEmpty: false)",
+              "editorMode": "code",
+              "format": "time_series",
+              "rawQuery": true,
+              "rawSql": "SELECT time_bucket('1 hour', time) AS time, last(error_state, time) AS \"error_state\", last(contactor_error, time) AS \"contactor_error\", last(dc_fault_current_state, time) AS \"dc_fault_current_state\" FROM warp_evse WHERE time >= date_trunc('hour', now()) - INTERVAL '12 hours' AND time < date_trunc('hour', now()) GROUP BY 1 ORDER BY 1;",
               "refId": "A"
             }
           ],
@@ -495,8 +504,8 @@ spec:
         },
         {
           "datasource": {
-            "type": "influxdb",
-            "uid": "sRCk9Y9nk"
+            "type": "postgres",
+            "uid": "timescaledb"
           },
           "fieldConfig": {
             "defaults": {
@@ -588,7 +597,10 @@ spec:
           "pluginVersion": "12.2.0-16629863581",
           "targets": [
             {
-              "query": "from(bucket: \"telegraf/autogen\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"warp\")\n  |> filter(fn: (r) => r[\"_field\"] == \"dc_fault_current_state\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)",
+              "editorMode": "code",
+              "format": "time_series",
+              "rawQuery": true,
+              "rawSql": "SELECT $__timeGroup(time, '$__interval') AS time, last(dc_fault_current_state, time) AS \"DC-Fehler\" FROM warp_evse WHERE $__timeFilter(time) AND dc_fault_current_state IS NOT NULL GROUP BY 1 ORDER BY 1;",
               "refId": "A"
             }
           ],
@@ -597,8 +609,8 @@ spec:
         },
         {
           "datasource": {
-            "type": "influxdb",
-            "uid": "sRCk9Y9nk"
+            "type": "postgres",
+            "uid": "timescaledb"
           },
           "fieldConfig": {
             "defaults": {
@@ -724,7 +736,10 @@ spec:
           "pluginVersion": "12.2.0-16629863581",
           "targets": [
             {
-              "query": "from(bucket: \"telegraf/autogen\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"warp\")\n  |> filter(fn: (r) => r[\"_field\"] == \"contactor_error\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)",
+              "editorMode": "code",
+              "format": "time_series",
+              "rawQuery": true,
+              "rawSql": "SELECT $__timeGroup(time, '$__interval') AS time, last(contactor_error, time) AS \"Schützfehler\" FROM warp_evse WHERE $__timeFilter(time) AND contactor_error IS NOT NULL GROUP BY 1 ORDER BY 1;",
               "refId": "A"
             }
           ],
@@ -746,8 +761,8 @@ spec:
         },
         {
           "datasource": {
-            "type": "influxdb",
-            "uid": "sRCk9Y9nk"
+            "type": "postgres",
+            "uid": "timescaledb"
           },
           "fieldConfig": {
             "defaults": {
@@ -798,7 +813,10 @@ spec:
           "pluginVersion": "12.2.0-16629863581",
           "targets": [
             {
-              "query": "from(bucket: \"telegraf/autogen\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"warp\")\n  |> filter(fn: (r) => r[\"_field\"] == \"tracked_charges\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)",
+              "editorMode": "code",
+              "format": "time_series",
+              "rawQuery": true,
+              "rawSql": "SELECT $__timeGroup(time, '$__interval') AS time, last(tracked_charges, time) AS \"Ladevorgänge Gesamt\" FROM warp_charge_tracker WHERE $__timeFilter(time) AND tracked_charges IS NOT NULL GROUP BY 1 ORDER BY 1;",
               "refId": "A"
             }
           ],
@@ -807,8 +825,8 @@ spec:
         },
         {
           "datasource": {
-            "type": "influxdb",
-            "uid": "sRCk9Y9nk"
+            "type": "postgres",
+            "uid": "timescaledb"
           },
           "fieldConfig": {
             "defaults": {
@@ -953,16 +971,22 @@ spec:
           "pluginVersion": "12.2.0-16629863581",
           "targets": [
             {
-              "query": "import \"timezone\"\nimport \"date\"\n\noption location = timezone.location(name: \"Europe/Berlin\")\n\nfrom(bucket: \"telegraf/autogen\")\n  |> range(start: date.truncate(t: now(), unit: 1mo), stop: now())\n  |> filter(fn: (r) => r[\"_measurement\"] == \"warp\")\n  |> filter(fn: (r) => r[\"topic\"] == \"warp/charge_tracker/last_charges\")\n  |> filter(fn: (r) => r[\"_field\"] == \"charge_duration\")\n  |> drop(columns: [\"host\", \"topic\", \"user_id\", \"timestamp\"])",
+              "editorMode": "code",
+              "format": "time_series",
+              "rawQuery": true,
+              "rawSql": "SELECT time AS _time, charge_duration AS _value FROM warp_charge_tracker WHERE time >= date_trunc('month', now() AT TIME ZONE 'Europe/Berlin') AND sub_topic = 'charge_tracker.last_charges' AND charge_duration IS NOT NULL ORDER BY time;",
               "refId": "A"
             },
             {
               "datasource": {
-                "type": "influxdb",
-                "uid": "sRCk9Y9nk"
+                "type": "postgres",
+                "uid": "timescaledb"
               },
               "hide": false,
-              "query": "import \"timezone\"\nimport \"date\"\n\noption location = timezone.location(name: \"Europe/Berlin\")\n\nfrom(bucket: \"telegraf/autogen\")\n  |> range(start: date.truncate(t: now(), unit: 1mo), stop: now())\n  |> filter(fn: (r) => r[\"_measurement\"] == \"warp\")\n  |> filter(fn: (r) => r[\"topic\"] == \"warp/charge_tracker/last_charges\")\n  |> filter(fn: (r) => r[\"_field\"] == \"energy_charged\")\n  |> drop(columns: [\"host\", \"topic\", \"user_id\", \"timestamp\"])\n  |> map(fn: (r) => ({r with _cost: float(v: r._value) * 0.2937}))",
+              "editorMode": "code",
+              "format": "time_series",
+              "rawQuery": true,
+              "rawSql": "SELECT time AS _time, energy_charged AS _value, energy_charged * 0.2937 AS _cost FROM warp_charge_tracker WHERE time >= date_trunc('month', now() AT TIME ZONE 'Europe/Berlin') AND sub_topic = 'charge_tracker.last_charges' AND energy_charged IS NOT NULL ORDER BY time;",
               "refId": "B"
             }
           ],
@@ -979,8 +1003,8 @@ spec:
         },
         {
           "datasource": {
-            "type": "influxdb",
-            "uid": "sRCk9Y9nk"
+            "type": "postgres",
+            "uid": "timescaledb"
           },
           "fieldConfig": {
             "defaults": {
@@ -1125,16 +1149,22 @@ spec:
           "pluginVersion": "12.2.0-16629863581",
           "targets": [
             {
-              "query": "import \"timezone\"\nimport \"date\"\n\noption location = timezone.location(name: \"Europe/Berlin\")\n\nfrom(bucket: \"telegraf/autogen\")\n  |> range(start: date.truncate(t: -1mo, unit: 1mo), stop: date.truncate(t: now(), unit: 1mo))  \n  |> filter(fn: (r) => r[\"_measurement\"] == \"warp\")\n  |> filter(fn: (r) => r[\"topic\"] == \"warp/charge_tracker/last_charges\")\n  |> filter(fn: (r) => r[\"_field\"] == \"charge_duration\")\n  |> drop(columns: [\"host\", \"topic\", \"user_id\", \"timestamp\"])",
+              "editorMode": "code",
+              "format": "time_series",
+              "rawQuery": true,
+              "rawSql": "SELECT time AS _time, charge_duration AS _value FROM warp_charge_tracker WHERE time >= date_trunc('month', now() AT TIME ZONE 'Europe/Berlin') - INTERVAL '1 month' AND time < date_trunc('month', now() AT TIME ZONE 'Europe/Berlin') AND sub_topic = 'charge_tracker.last_charges' AND charge_duration IS NOT NULL ORDER BY time;",
               "refId": "A"
             },
             {
               "datasource": {
-                "type": "influxdb",
-                "uid": "sRCk9Y9nk"
+                "type": "postgres",
+                "uid": "timescaledb"
               },
               "hide": false,
-              "query": "import \"timezone\"\nimport \"date\"\n\noption location = timezone.location(name: \"Europe/Berlin\")\n\nfrom(bucket: \"telegraf/autogen\")\n  |> range(start: date.truncate(t: -1mo, unit: 1mo), stop: date.truncate(t: now(), unit: 1mo))  \n  |> filter(fn: (r) => r[\"_measurement\"] == \"warp\")\n  |> filter(fn: (r) => r[\"topic\"] == \"warp/charge_tracker/last_charges\")\n  |> filter(fn: (r) => r[\"_field\"] == \"energy_charged\")\n  |> drop(columns: [\"host\", \"topic\", \"user_id\", \"timestamp\"])\n  |> map(fn: (r) => ({r with _cost: float(v: r._value) * 0.2937}))",
+              "editorMode": "code",
+              "format": "time_series",
+              "rawQuery": true,
+              "rawSql": "SELECT time AS _time, energy_charged AS _value, energy_charged * 0.2937 AS _cost FROM warp_charge_tracker WHERE time >= date_trunc('month', now() AT TIME ZONE 'Europe/Berlin') - INTERVAL '1 month' AND time < date_trunc('month', now() AT TIME ZONE 'Europe/Berlin') AND sub_topic = 'charge_tracker.last_charges' AND energy_charged IS NOT NULL ORDER BY time;",
               "refId": "B"
             }
           ],
@@ -1151,8 +1181,8 @@ spec:
         },
         {
           "datasource": {
-            "type": "influxdb",
-            "uid": "sRCk9Y9nk"
+            "type": "postgres",
+            "uid": "timescaledb"
           },
           "fieldConfig": {
             "defaults": {
@@ -1203,7 +1233,10 @@ spec:
           "pluginVersion": "12.2.0-16629863581",
           "targets": [
             {
-              "query": "import \"timezone\"\nimport \"date\"\n\noption location = timezone.location(name: \"Europe/Berlin\")\n\n\nfrom(bucket: \"telegraf/autogen\")\n  |> range(start: date.truncate(t: now(), unit: 1mo), stop: now())\n  |> filter(fn: (r) => r[\"_measurement\"] == \"warp\")\n  |> filter(fn: (r) => r[\"_field\"] == \"tracked_charges\")\n  |> spread()",
+              "editorMode": "code",
+              "format": "time_series",
+              "rawQuery": true,
+              "rawSql": "SELECT now() AS time, COALESCE(max(tracked_charges) - min(tracked_charges), 0) AS value FROM warp_charge_tracker WHERE time >= date_trunc('month', now() AT TIME ZONE 'Europe/Berlin') AND tracked_charges IS NOT NULL;",
               "refId": "A"
             }
           ],
@@ -1212,8 +1245,8 @@ spec:
         },
         {
           "datasource": {
-            "type": "influxdb",
-            "uid": "sRCk9Y9nk"
+            "type": "postgres",
+            "uid": "timescaledb"
           },
           "fieldConfig": {
             "defaults": {
@@ -1264,7 +1297,10 @@ spec:
           "pluginVersion": "12.2.0-16629863581",
           "targets": [
             {
-              "query": "import \"timezone\"\nimport \"date\"\n\noption location = timezone.location(name: \"Europe/Berlin\")\n\n  from(bucket: \"telegraf/autogen\")\n    |> range(start: date.truncate(t: -1mo, unit: 1mo), stop: date.truncate(t: now(), unit: 1mo))  \n    |> filter(fn: (r) => r[\"_measurement\"] == \"warp\")\n    |> filter(fn: (r) => r[\"_field\"] == \"tracked_charges\")\n    |> spread()\n\n\n\n",
+              "editorMode": "code",
+              "format": "time_series",
+              "rawQuery": true,
+              "rawSql": "SELECT now() AS time, COALESCE(max(tracked_charges) - min(tracked_charges), 0) AS value FROM warp_charge_tracker WHERE time >= date_trunc('month', now() AT TIME ZONE 'Europe/Berlin') - INTERVAL '1 month' AND time < date_trunc('month', now() AT TIME ZONE 'Europe/Berlin') AND tracked_charges IS NOT NULL;",
               "refId": "A"
             }
           ],
@@ -1286,8 +1322,8 @@ spec:
         },
         {
           "datasource": {
-            "type": "influxdb",
-            "uid": "sRCk9Y9nk"
+            "type": "postgres",
+            "uid": "timescaledb"
           },
           "description": "",
           "fieldConfig": {
@@ -1392,10 +1428,13 @@ spec:
           "targets": [
             {
               "datasource": {
-                "type": "influxdb",
-                "uid": "sRCk9Y9nk"
+                "type": "postgres",
+                "uid": "timescaledb"
               },
-              "query": "from(bucket: \"telegraf/autogen\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"warp\")\n  |> filter(fn: (r) => r[\"_field\"] == \"power_L1\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
+              "editorMode": "code",
+              "format": "time_series",
+              "rawQuery": true,
+              "rawSql": "SELECT $__timeGroup(time, '$__interval') AS time, avg(power_l1) AS \"L1\" FROM warp_meter WHERE $__timeFilter(time) AND meter_id = 0 AND power_l1 IS NOT NULL GROUP BY 1 ORDER BY 1;",
               "refId": "A"
             }
           ],
@@ -1404,8 +1443,8 @@ spec:
         },
         {
           "datasource": {
-            "type": "influxdb",
-            "uid": "sRCk9Y9nk"
+            "type": "postgres",
+            "uid": "timescaledb"
           },
           "description": "",
           "fieldConfig": {
@@ -1510,10 +1549,13 @@ spec:
           "targets": [
             {
               "datasource": {
-                "type": "influxdb",
-                "uid": "sRCk9Y9nk"
+                "type": "postgres",
+                "uid": "timescaledb"
               },
-              "query": "from(bucket: \"telegraf/autogen\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"warp\")\n  |> filter(fn: (r) => r[\"_field\"] == \"power_L2\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
+              "editorMode": "code",
+              "format": "time_series",
+              "rawQuery": true,
+              "rawSql": "SELECT $__timeGroup(time, '$__interval') AS time, avg(power_l2) AS \"L2\" FROM warp_meter WHERE $__timeFilter(time) AND meter_id = 0 AND power_l2 IS NOT NULL GROUP BY 1 ORDER BY 1;",
               "refId": "A"
             }
           ],
@@ -1522,8 +1564,8 @@ spec:
         },
         {
           "datasource": {
-            "type": "influxdb",
-            "uid": "sRCk9Y9nk"
+            "type": "postgres",
+            "uid": "timescaledb"
           },
           "description": "",
           "fieldConfig": {
@@ -1628,10 +1670,13 @@ spec:
           "targets": [
             {
               "datasource": {
-                "type": "influxdb",
-                "uid": "sRCk9Y9nk"
+                "type": "postgres",
+                "uid": "timescaledb"
               },
-              "query": "from(bucket: \"telegraf/autogen\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"warp\")\n  |> filter(fn: (r) => r[\"_field\"] == \"power_L3\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
+              "editorMode": "code",
+              "format": "time_series",
+              "rawQuery": true,
+              "rawSql": "SELECT $__timeGroup(time, '$__interval') AS time, avg(power_l3) AS \"L3\" FROM warp_meter WHERE $__timeFilter(time) AND meter_id = 0 AND power_l3 IS NOT NULL GROUP BY 1 ORDER BY 1;",
               "refId": "A"
             }
           ],
@@ -1640,8 +1685,8 @@ spec:
         },
         {
           "datasource": {
-            "type": "influxdb",
-            "uid": "sRCk9Y9nk"
+            "type": "postgres",
+            "uid": "timescaledb"
           },
           "description": "",
           "fieldConfig": {
@@ -1746,10 +1791,13 @@ spec:
           "targets": [
             {
               "datasource": {
-                "type": "influxdb",
-                "uid": "sRCk9Y9nk"
+                "type": "postgres",
+                "uid": "timescaledb"
               },
-              "query": "from(bucket: \"telegraf/autogen\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"warp\")\n  |> filter(fn: (r) => r[\"_field\"] == \"current_L1\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
+              "editorMode": "code",
+              "format": "time_series",
+              "rawQuery": true,
+              "rawSql": "SELECT $__timeGroup(time, '$__interval') AS time, avg(current_l1) AS \"L1\" FROM warp_meter WHERE $__timeFilter(time) AND meter_id = 0 AND current_l1 IS NOT NULL GROUP BY 1 ORDER BY 1;",
               "refId": "A"
             }
           ],
@@ -1758,8 +1806,8 @@ spec:
         },
         {
           "datasource": {
-            "type": "influxdb",
-            "uid": "sRCk9Y9nk"
+            "type": "postgres",
+            "uid": "timescaledb"
           },
           "description": "",
           "fieldConfig": {
@@ -1864,10 +1912,13 @@ spec:
           "targets": [
             {
               "datasource": {
-                "type": "influxdb",
-                "uid": "sRCk9Y9nk"
+                "type": "postgres",
+                "uid": "timescaledb"
               },
-              "query": "from(bucket: \"telegraf/autogen\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"warp\")\n  |> filter(fn: (r) => r[\"_field\"] == \"current_L2\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
+              "editorMode": "code",
+              "format": "time_series",
+              "rawQuery": true,
+              "rawSql": "SELECT $__timeGroup(time, '$__interval') AS time, avg(current_l2) AS \"L2\" FROM warp_meter WHERE $__timeFilter(time) AND meter_id = 0 AND current_l2 IS NOT NULL GROUP BY 1 ORDER BY 1;",
               "refId": "A"
             }
           ],
@@ -1876,8 +1927,8 @@ spec:
         },
         {
           "datasource": {
-            "type": "influxdb",
-            "uid": "sRCk9Y9nk"
+            "type": "postgres",
+            "uid": "timescaledb"
           },
           "description": "",
           "fieldConfig": {
@@ -1982,10 +2033,13 @@ spec:
           "targets": [
             {
               "datasource": {
-                "type": "influxdb",
-                "uid": "sRCk9Y9nk"
+                "type": "postgres",
+                "uid": "timescaledb"
               },
-              "query": "from(bucket: \"telegraf/autogen\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"warp\")\n  |> filter(fn: (r) => r[\"_field\"] == \"current_L3\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
+              "editorMode": "code",
+              "format": "time_series",
+              "rawQuery": true,
+              "rawSql": "SELECT $__timeGroup(time, '$__interval') AS time, avg(current_l3) AS \"L3\" FROM warp_meter WHERE $__timeFilter(time) AND meter_id = 0 AND current_l3 IS NOT NULL GROUP BY 1 ORDER BY 1;",
               "refId": "A"
             }
           ],
@@ -1994,8 +2048,8 @@ spec:
         },
         {
           "datasource": {
-            "type": "influxdb",
-            "uid": "sRCk9Y9nk"
+            "type": "postgres",
+            "uid": "timescaledb"
           },
           "description": "",
           "fieldConfig": {
@@ -2100,10 +2154,13 @@ spec:
           "targets": [
             {
               "datasource": {
-                "type": "influxdb",
-                "uid": "sRCk9Y9nk"
+                "type": "postgres",
+                "uid": "timescaledb"
               },
-              "query": "from(bucket: \"telegraf/autogen\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"warp\")\n  |> filter(fn: (r) => r[\"_field\"] == \"voltage_L1\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
+              "editorMode": "code",
+              "format": "time_series",
+              "rawQuery": true,
+              "rawSql": "SELECT $__timeGroup(time, '$__interval') AS time, avg(voltage_l1) AS \"L1\" FROM warp_meter WHERE $__timeFilter(time) AND meter_id = 0 AND voltage_l1 IS NOT NULL GROUP BY 1 ORDER BY 1;",
               "refId": "A"
             }
           ],
@@ -2112,8 +2169,8 @@ spec:
         },
         {
           "datasource": {
-            "type": "influxdb",
-            "uid": "sRCk9Y9nk"
+            "type": "postgres",
+            "uid": "timescaledb"
           },
           "description": "",
           "fieldConfig": {
@@ -2218,10 +2275,13 @@ spec:
           "targets": [
             {
               "datasource": {
-                "type": "influxdb",
-                "uid": "sRCk9Y9nk"
+                "type": "postgres",
+                "uid": "timescaledb"
               },
-              "query": "from(bucket: \"telegraf/autogen\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"warp\")\n  |> filter(fn: (r) => r[\"_field\"] == \"voltage_L2\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
+              "editorMode": "code",
+              "format": "time_series",
+              "rawQuery": true,
+              "rawSql": "SELECT $__timeGroup(time, '$__interval') AS time, avg(voltage_l2) AS \"L2\" FROM warp_meter WHERE $__timeFilter(time) AND meter_id = 0 AND voltage_l2 IS NOT NULL GROUP BY 1 ORDER BY 1;",
               "refId": "A"
             }
           ],
@@ -2230,8 +2290,8 @@ spec:
         },
         {
           "datasource": {
-            "type": "influxdb",
-            "uid": "sRCk9Y9nk"
+            "type": "postgres",
+            "uid": "timescaledb"
           },
           "description": "",
           "fieldConfig": {
@@ -2336,10 +2396,13 @@ spec:
           "targets": [
             {
               "datasource": {
-                "type": "influxdb",
-                "uid": "sRCk9Y9nk"
+                "type": "postgres",
+                "uid": "timescaledb"
               },
-              "query": "from(bucket: \"telegraf/autogen\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"warp\")\n  |> filter(fn: (r) => r[\"_field\"] == \"voltage_L3\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
+              "editorMode": "code",
+              "format": "time_series",
+              "rawQuery": true,
+              "rawSql": "SELECT $__timeGroup(time, '$__interval') AS time, avg(voltage_l3) AS \"L3\" FROM warp_meter WHERE $__timeFilter(time) AND meter_id = 0 AND voltage_l3 IS NOT NULL GROUP BY 1 ORDER BY 1;",
               "refId": "A"
             }
           ],

--- a/kubernetes/applications/grafana/base/dashboards/hvac-heating-unit.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/hvac-heating-unit.yaml
@@ -42,8 +42,8 @@ spec:
       "panels": [
         {
           "datasource": {
-            "type": "influxdb",
-            "uid": "sRCk9Y9nk"
+            "type": "postgres",
+            "uid": "timescaledb"
           },
           "fieldConfig": {
             "defaults": {
@@ -118,10 +118,13 @@ spec:
           "targets": [
             {
               "datasource": {
-                "type": "influxdb",
-                "uid": "sRCk9Y9nk"
+                "type": "postgres",
+                "uid": "timescaledb"
               },
-              "query": "from(bucket: v.defaultBucket)\n  |> range(start: v.timeRangeStart, stop:v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"ems-esp\")\n  |> filter(fn: (r) => r[\"_field\"] == \"curtemp\")\n  |> map(fn: (r) => ({ r with _field: \"Warmwassertemperatur\"}))\n  |> aggregateWindow(every: 1m, fn: mean)",
+              "editorMode": "code",
+              "format": "time_series",
+              "rawQuery": true,
+              "rawSql": "SELECT $__timeGroup(time, '$__interval') AS time, avg(curtemp) AS \"Warmwassertemperatur\" FROM ems_esp WHERE $__timeFilter(time) AND curtemp IS NOT NULL GROUP BY 1 ORDER BY 1;",
               "refId": "A"
             }
           ],
@@ -130,8 +133,8 @@ spec:
         },
         {
           "datasource": {
-            "type": "influxdb",
-            "uid": "sRCk9Y9nk"
+            "type": "postgres",
+            "uid": "timescaledb"
           },
           "fieldConfig": {
             "defaults": {
@@ -198,10 +201,13 @@ spec:
           "targets": [
             {
               "datasource": {
-                "type": "influxdb",
-                "uid": "sRCk9Y9nk"
+                "type": "postgres",
+                "uid": "timescaledb"
               },
-              "query": "from(bucket: v.defaultBucket)\n  |> range(start: v.timeRangeStart, stop:v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"ems-esp\")\n  |> filter(fn: (r) => r[\"_field\"] == \"heatingpump\")\n  |> map(fn: (r) => ({ r with _field: \"Heizkreispumpe\"}))",
+              "editorMode": "code",
+              "format": "time_series",
+              "rawQuery": true,
+              "rawSql": "SELECT $__timeGroup(time, '$__interval') AS time, last(heatingpump, time) AS \"Heizkreispumpe\" FROM ems_esp WHERE $__timeFilter(time) AND heatingpump IS NOT NULL GROUP BY 1 ORDER BY 1;",
               "refId": "Heizkreispumpe"
             }
           ],
@@ -210,8 +216,8 @@ spec:
         },
         {
           "datasource": {
-            "type": "influxdb",
-            "uid": "sRCk9Y9nk"
+            "type": "postgres",
+            "uid": "timescaledb"
           },
           "fieldConfig": {
             "defaults": {
@@ -278,11 +284,14 @@ spec:
           "targets": [
             {
               "datasource": {
-                "type": "influxdb",
-                "uid": "sRCk9Y9nk"
+                "type": "postgres",
+                "uid": "timescaledb"
               },
               "hide": false,
-              "query": "from(bucket: v.defaultBucket)\n  |> range(start: v.timeRangeStart, stop:v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"ems-esp\")\n  |> filter(fn: (r) => r[\"_field\"] == \"pumpstatus\")\n  |> map(fn: (r) => ({ r with _field: \"Mischerpumpe\"}))",
+              "editorMode": "code",
+              "format": "time_series",
+              "rawQuery": true,
+              "rawSql": "SELECT $__timeGroup(time, '$__interval') AS time, last(pumpstatus, time) AS \"Mischerpumpe\" FROM ems_esp WHERE $__timeFilter(time) AND pumpstatus IS NOT NULL GROUP BY 1 ORDER BY 1;",
               "refId": "Mischerpumpe"
             }
           ],
@@ -291,8 +300,8 @@ spec:
         },
         {
           "datasource": {
-            "type": "influxdb",
-            "uid": "sRCk9Y9nk"
+            "type": "postgres",
+            "uid": "timescaledb"
           },
           "fieldConfig": {
             "defaults": {
@@ -388,14 +397,17 @@ spec:
               "aggregation": "Last",
               "alias": "Heating",
               "datasource": {
-                "type": "influxdb",
-                "uid": "sRCk9Y9nk"
+                "type": "postgres",
+                "uid": "timescaledb"
               },
               "decimals": 2,
               "displayAliasType": "Warning / Critical",
               "displayType": "Regular",
               "displayValueWithAlias": "Never",
-              "query": "from(bucket: v.defaultBucket)\n  |> range(start: v.timeRangeStart, stop:v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"ems-esp\")\n  |> filter(fn: (r) => r[\"_field\"] == \"heatingactive\")\n  |> drop(columns: [\"host\", \"topic\", \"_measurement\"])\n  |> map(fn: (r) => ({ r with _field: \"Heizung\"}))\n  |> aggregateWindow(every: 1m, fn: last)",
+              "editorMode": "code",
+              "format": "time_series",
+              "rawQuery": true,
+              "rawSql": "SELECT $__timeGroup(time, '$__interval') AS time, last(heatingactive, time) AS \"Heizung\" FROM ems_esp WHERE $__timeFilter(time) AND heatingactive IS NOT NULL GROUP BY 1 ORDER BY 1;",
               "refId": "Heizung",
               "units": "none",
               "valueHandler": "Number Threshold"
@@ -405,15 +417,18 @@ spec:
               "aggregation": "Last",
               "alias": "Heating",
               "datasource": {
-                "type": "influxdb",
-                "uid": "sRCk9Y9nk"
+                "type": "postgres",
+                "uid": "timescaledb"
               },
               "decimals": 2,
               "displayAliasType": "Warning / Critical",
               "displayType": "Regular",
               "displayValueWithAlias": "Never",
               "hide": false,
-              "query": "from(bucket: v.defaultBucket)\n  |> range(start: v.timeRangeStart, stop:v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"ems-esp\")\n  |> filter(fn: (r) => r[\"_field\"] == \"charging\")\n  |> drop(columns: [\"host\", \"topic\", \"_measurement\"])\n  |> map(fn: (r) => ({ r with _field: \"Warmwasser\"}))\n  |> aggregateWindow(every: 1m, fn: last)",
+              "editorMode": "code",
+              "format": "time_series",
+              "rawQuery": true,
+              "rawSql": "SELECT $__timeGroup(time, '$__interval') AS time, last(charging, time) AS \"Warmwasser\" FROM ems_esp WHERE $__timeFilter(time) AND charging IS NOT NULL GROUP BY 1 ORDER BY 1;",
               "refId": "Warmwasser",
               "units": "none",
               "valueHandler": "Number Threshold"
@@ -424,8 +439,8 @@ spec:
         },
         {
           "datasource": {
-            "type": "influxdb",
-            "uid": "sRCk9Y9nk"
+            "type": "postgres",
+            "uid": "timescaledb"
           },
           "fieldConfig": {
             "defaults": {
@@ -525,10 +540,13 @@ spec:
           "targets": [
             {
               "datasource": {
-                "type": "influxdb",
-                "uid": "sRCk9Y9nk"
+                "type": "postgres",
+                "uid": "timescaledb"
               },
-              "query": "from(bucket: v.defaultBucket)\n  |> range(start: v.timeRangeStart, stop:v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"ems-esp\")\n  |> filter(fn: (r) => r[\"_field\"] == \"outdoortemp\")\n  |> drop(columns: [\"host\", \"topic\", \"_measurement\"])\n  |> map(fn: (r) => ({ r with _field: \"Außentemperatur\"}))\n  |> aggregateWindow(every: 1m, fn: mean)",
+              "editorMode": "code",
+              "format": "time_series",
+              "rawQuery": true,
+              "rawSql": "SELECT $__timeGroup(time, '$__interval') AS time, avg(outdoortemp) AS \"Außentemperatur\" FROM ems_esp WHERE $__timeFilter(time) AND outdoortemp IS NOT NULL GROUP BY 1 ORDER BY 1;",
               "refId": "A"
             }
           ],
@@ -537,8 +555,8 @@ spec:
         },
         {
           "datasource": {
-            "type": "influxdb",
-            "uid": "sRCk9Y9nk"
+            "type": "postgres",
+            "uid": "timescaledb"
           },
           "fieldConfig": {
             "defaults": {
@@ -588,10 +606,13 @@ spec:
           "targets": [
             {
               "datasource": {
-                "type": "influxdb",
-                "uid": "sRCk9Y9nk"
+                "type": "postgres",
+                "uid": "timescaledb"
               },
-              "query": "from(bucket: v.defaultBucket)\n  |> range(start: v.timeRangeStart, stop:v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"ems-esp\")\n  |> filter(fn: (r) => r[\"_field\"] == \"syspress\")\n  |> map(fn: (r) => ({ r with _field: \"Druck\"}))\n  |> aggregateWindow(every: 5m, fn: last)",
+              "editorMode": "code",
+              "format": "time_series",
+              "rawQuery": true,
+              "rawSql": "SELECT $__timeGroup(time, '$__interval') AS time, last(syspress, time) AS \"Druck\" FROM ems_esp WHERE $__timeFilter(time) AND syspress IS NOT NULL GROUP BY 1 ORDER BY 1;",
               "refId": "A"
             }
           ],
@@ -600,8 +621,8 @@ spec:
         },
         {
           "datasource": {
-            "type": "influxdb",
-            "uid": "sRCk9Y9nk"
+            "type": "postgres",
+            "uid": "timescaledb"
           },
           "fieldConfig": {
             "defaults": {
@@ -651,10 +672,13 @@ spec:
           "targets": [
             {
               "datasource": {
-                "type": "influxdb",
-                "uid": "sRCk9Y9nk"
+                "type": "postgres",
+                "uid": "timescaledb"
               },
-              "query": "from(bucket: v.defaultBucket)\n  |> range(start: v.timeRangeStart, stop:v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"ems-esp\")\n  |> filter(fn: (r) => r[\"_field\"] == \"curflow\")\n  |> map(fn: (r) => ({ r with _field: \"Druck\"}))\n  |> aggregateWindow(every: 5m, fn: last)",
+              "editorMode": "code",
+              "format": "time_series",
+              "rawQuery": true,
+              "rawSql": "SELECT $__timeGroup(time, '$__interval') AS time, last(curflow, time) AS \"Druck\" FROM ems_esp WHERE $__timeFilter(time) AND curflow IS NOT NULL GROUP BY 1 ORDER BY 1;",
               "refId": "A"
             }
           ],
@@ -663,8 +687,8 @@ spec:
         },
         {
           "datasource": {
-            "type": "influxdb",
-            "uid": "sRCk9Y9nk"
+            "type": "postgres",
+            "uid": "timescaledb"
           },
           "fieldConfig": {
             "defaults": {
@@ -810,37 +834,49 @@ spec:
           "targets": [
             {
               "datasource": {
-                "type": "influxdb",
-                "uid": "sRCk9Y9nk"
+                "type": "postgres",
+                "uid": "timescaledb"
               },
               "hide": false,
-              "query": "from(bucket: v.defaultBucket)\n  |> range(start: v.timeRangeStart, stop:v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"ems-esp\")\n  |> filter(fn: (r) => r[\"_field\"] == \"setflowtemp\")\n  |> map(fn: (r) => ({ r with _field: \"Soll Temperatur\"}))\n  |> aggregateWindow(every: 1m, fn: mean)",
+              "editorMode": "code",
+              "format": "time_series",
+              "rawQuery": true,
+              "rawSql": "SELECT $__timeGroup(time, '$__interval') AS time, avg(setflowtemp) AS \"Soll Temperatur\" FROM ems_esp WHERE $__timeFilter(time) AND setflowtemp IS NOT NULL GROUP BY 1 ORDER BY 1;",
               "refId": "Soll Temperatur"
             },
             {
               "datasource": {
-                "type": "influxdb",
-                "uid": "sRCk9Y9nk"
+                "type": "postgres",
+                "uid": "timescaledb"
               },
-              "query": "from(bucket: v.defaultBucket)\n  |> range(start: v.timeRangeStart, stop:v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"ems-esp\")\n  |> filter(fn: (r) => r[\"_field\"] == \"curflowtemp\")\n  |> drop(columns: [\"host\", \"topic\", \"_measurement\"])\n  |> map(fn: (r) => ({ r with _field: \"Ist Temperatur\"}))\n  |> aggregateWindow(every: 1m, fn: mean)",
+              "editorMode": "code",
+              "format": "time_series",
+              "rawQuery": true,
+              "rawSql": "SELECT $__timeGroup(time, '$__interval') AS time, avg(curflowtemp) AS \"Ist Temperatur\" FROM ems_esp WHERE $__timeFilter(time) AND curflowtemp IS NOT NULL GROUP BY 1 ORDER BY 1;",
               "refId": "Ist Temperatur"
             },
             {
               "datasource": {
-                "type": "influxdb",
-                "uid": "sRCk9Y9nk"
+                "type": "postgres",
+                "uid": "timescaledb"
               },
               "hide": false,
-              "query": "from(bucket: v.defaultBucket)\n  |> range(start: v.timeRangeStart, stop:v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"ems-esp\")\n  |> filter(fn: (r) => r[\"_field\"] == \"rettemp\")\n  |> drop(columns: [\"host\", \"topic\", \"_measurement\"])\n  |> map(fn: (r) => ({ r with _field: \"Rücklauf\"}))\n  |> aggregateWindow(every: 1m, fn: mean)",
+              "editorMode": "code",
+              "format": "time_series",
+              "rawQuery": true,
+              "rawSql": "SELECT $__timeGroup(time, '$__interval') AS time, avg(rettemp) AS \"Rücklauf\" FROM ems_esp WHERE $__timeFilter(time) AND rettemp IS NOT NULL GROUP BY 1 ORDER BY 1;",
               "refId": "Rücklauf"
             },
             {
               "datasource": {
-                "type": "influxdb",
-                "uid": "sRCk9Y9nk"
+                "type": "postgres",
+                "uid": "timescaledb"
               },
               "hide": false,
-              "query": "from(bucket: v.defaultBucket)\n  |> range(start: v.timeRangeStart, stop:v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"ems-esp\")\n  |> filter(fn: (r) => r[\"_field\"] == \"switchtemp\")\n  |> drop(columns: [\"host\", \"topic\", \"_measurement\"])\n  |> map(fn: (r) => ({ r with _field: \"Hydraulische Weiche\"}))\n  |> aggregateWindow(every: 1m, fn: mean)",
+              "editorMode": "code",
+              "format": "time_series",
+              "rawQuery": true,
+              "rawSql": "SELECT $__timeGroup(time, '$__interval') AS time, avg(switchtemp) AS \"Hydraulische Weiche\" FROM ems_esp WHERE $__timeFilter(time) AND switchtemp IS NOT NULL GROUP BY 1 ORDER BY 1;",
               "refId": "Hydraulische Weiche"
             }
           ],
@@ -849,8 +885,8 @@ spec:
         },
         {
           "datasource": {
-            "type": "influxdb",
-            "uid": "sRCk9Y9nk"
+            "type": "postgres",
+            "uid": "timescaledb"
           },
           "fieldConfig": {
             "defaults": {
@@ -968,20 +1004,26 @@ spec:
           "targets": [
             {
               "datasource": {
-                "type": "influxdb",
-                "uid": "sRCk9Y9nk"
+                "type": "postgres",
+                "uid": "timescaledb"
               },
               "hide": false,
-              "query": "from(bucket: v.defaultBucket)\n  |> range(start: v.timeRangeStart, stop:v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"ems-esp\")\n  |> filter(fn: (r) => r[\"_field\"] == \"settemp\")\n  |> filter(fn: (r) => r[\"topic\"] == \"ems-esp/boiler_data_dhw\")\n  |> drop(columns: [\"host\", \"topic\",\"_measurement\"])\n  |> map(fn: (r) => ({ r with _field: \"Soll Temperatur\"}))\n  |> aggregateWindow(every: 1m, fn: mean)",
+              "editorMode": "code",
+              "format": "time_series",
+              "rawQuery": true,
+              "rawSql": "SELECT $__timeGroup(time, '$__interval') AS time, avg(settemp) AS \"Soll Temperatur\" FROM ems_esp WHERE $__timeFilter(time) AND settemp IS NOT NULL AND topic = 'boiler_data_dhw' GROUP BY 1 ORDER BY 1;",
               "refId": "Soll Temperatur"
             },
             {
               "datasource": {
-                "type": "influxdb",
-                "uid": "sRCk9Y9nk"
+                "type": "postgres",
+                "uid": "timescaledb"
               },
               "hide": false,
-              "query": "from(bucket: v.defaultBucket)\r\n  |> range(start: v.timeRangeStart, stop:v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"ems-esp\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"curtemp\")\r\n  |> filter(fn: (r) => r[\"topic\"] == \"ems-esp/boiler_data_dhw\")\r\n  |> drop(columns: [\"host\", \"topic\",\"_measurement\"])\r\n  |> map(fn: (r) => ({ r with _field: \"Ist Temperatur\"}))\r\n  |> aggregateWindow(every: 1m, fn: mean)",
+              "editorMode": "code",
+              "format": "time_series",
+              "rawQuery": true,
+              "rawSql": "SELECT $__timeGroup(time, '$__interval') AS time, avg(curtemp) AS \"Ist Temperatur\" FROM ems_esp WHERE $__timeFilter(time) AND curtemp IS NOT NULL AND topic = 'boiler_data_dhw' GROUP BY 1 ORDER BY 1;",
               "refId": "Ist Temperatur"
             }
           ],
@@ -990,8 +1032,8 @@ spec:
         },
         {
           "datasource": {
-            "type": "influxdb",
-            "uid": "sRCk9Y9nk"
+            "type": "postgres",
+            "uid": "timescaledb"
           },
           "fieldConfig": {
             "defaults": {
@@ -1118,20 +1160,26 @@ spec:
           "targets": [
             {
               "datasource": {
-                "type": "influxdb",
-                "uid": "sRCk9Y9nk"
+                "type": "postgres",
+                "uid": "timescaledb"
               },
               "hide": false,
-              "query": "from(bucket: v.defaultBucket)\n  |> range(start: v.timeRangeStart, stop:v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"ems-esp\")\n  |> filter(fn: (r) => r[\"_field\"] == \"flowsettemp\")\n  |> drop(columns: [\"host\", \"topic\",\"_measurement\"])\n  |> map(fn: (r) => ({ r with _field: \"Soll Temperatur\"}))\n  |> aggregateWindow(every: 1m, fn: mean)",
+              "editorMode": "code",
+              "format": "time_series",
+              "rawQuery": true,
+              "rawSql": "SELECT $__timeGroup(time, '$__interval') AS time, avg(flowsettemp) AS \"Soll Temperatur\" FROM ems_esp WHERE $__timeFilter(time) AND flowsettemp IS NOT NULL GROUP BY 1 ORDER BY 1;",
               "refId": "Soll Temperatur"
             },
             {
               "datasource": {
-                "type": "influxdb",
-                "uid": "sRCk9Y9nk"
+                "type": "postgres",
+                "uid": "timescaledb"
               },
               "hide": false,
-              "query": "from(bucket: v.defaultBucket)\n  |> range(start: v.timeRangeStart, stop:v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"ems-esp\")\n  |> filter(fn: (r) => r[\"_field\"] == \"flowtemphc\")\n  |> drop(columns: [\"host\", \"topic\",\"_measurement\"])\n  |> map(fn: (r) => ({ r with _field: \"Ist Temperatur\"}))\n  |> aggregateWindow(every: 1m, fn: mean)",
+              "editorMode": "code",
+              "format": "time_series",
+              "rawQuery": true,
+              "rawSql": "SELECT $__timeGroup(time, '$__interval') AS time, avg(flowtemphc) AS \"Ist Temperatur\" FROM ems_esp WHERE $__timeFilter(time) AND flowtemphc IS NOT NULL GROUP BY 1 ORDER BY 1;",
               "refId": "Ist Temperatur"
             }
           ],
@@ -1140,8 +1188,8 @@ spec:
         },
         {
           "datasource": {
-            "type": "influxdb",
-            "uid": "sRCk9Y9nk"
+            "type": "postgres",
+            "uid": "timescaledb"
           },
           "fieldConfig": {
             "defaults": {
@@ -1209,10 +1257,13 @@ spec:
           "targets": [
             {
               "datasource": {
-                "type": "influxdb",
-                "uid": "sRCk9Y9nk"
+                "type": "postgres",
+                "uid": "timescaledb"
               },
-              "query": "from(bucket: v.defaultBucket)\n  |> range(start: v.timeRangeStart, stop:v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"ems-esp\")\n  |> filter(fn: (r) => r[\"_field\"] == \"curburnpow\")\n  |> map(fn: (r) => ({ r with _field: \"power\"}))\n  |> aggregateWindow(every: 1m, fn: last)",
+              "editorMode": "code",
+              "format": "time_series",
+              "rawQuery": true,
+              "rawSql": "SELECT $__timeGroup(time, '$__interval') AS time, last(curburnpow, time) AS \"power\" FROM ems_esp WHERE $__timeFilter(time) AND curburnpow IS NOT NULL GROUP BY 1 ORDER BY 1;",
               "refId": "A"
             }
           ],
@@ -1221,8 +1272,8 @@ spec:
         },
         {
           "datasource": {
-            "type": "influxdb",
-            "uid": "sRCk9Y9nk"
+            "type": "postgres",
+            "uid": "timescaledb"
           },
           "fieldConfig": {
             "defaults": {
@@ -1319,11 +1370,14 @@ spec:
           "targets": [
             {
               "datasource": {
-                "type": "influxdb",
-                "uid": "sRCk9Y9nk"
+                "type": "postgres",
+                "uid": "timescaledb"
               },
               "hide": false,
-              "query": "from(bucket: v.defaultBucket)\n  |> range(start: v.timeRangeStart, stop:v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"ems-esp\")\n  |> filter(fn: (r) => r[\"_field\"] == \"curburnpow\")\n  |> drop(columns: [\"host\", \"topic\", \"_measurement\"])\n  |> map(fn: (r) => ({r with _field: \"Brennerleistung\"}))\n  |> aggregateWindow(every: 1m, fn: mean)",
+              "editorMode": "code",
+              "format": "time_series",
+              "rawQuery": true,
+              "rawSql": "SELECT $__timeGroup(time, '$__interval') AS time, avg(curburnpow) AS \"Brennerleistung\" FROM ems_esp WHERE $__timeFilter(time) AND curburnpow IS NOT NULL GROUP BY 1 ORDER BY 1;",
               "refId": "A"
             }
           ],
@@ -1332,8 +1386,8 @@ spec:
         },
         {
           "datasource": {
-            "type": "influxdb",
-            "uid": "sRCk9Y9nk"
+            "type": "postgres",
+            "uid": "timescaledb"
           },
           "fieldConfig": {
             "defaults": {
@@ -1388,10 +1442,13 @@ spec:
           "targets": [
             {
               "datasource": {
-                "type": "influxdb",
-                "uid": "sRCk9Y9nk"
+                "type": "postgres",
+                "uid": "timescaledb"
               },
-              "query": "from(bucket: v.defaultBucket)\n  |> range(start: v.timeRangeStart, stop:v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"ems-esp\")\n  |> filter(fn: (r) => r[\"_field\"] == \"valvestatus\")\n  |> map(fn: (r) => ({ r with _field: \"Fußbodenheizung\"}))",
+              "editorMode": "code",
+              "format": "time_series",
+              "rawQuery": true,
+              "rawSql": "SELECT $__timeGroup(time, '$__interval') AS time, last(valvestatus, time) AS \"Fußbodenheizung\" FROM ems_esp WHERE $__timeFilter(time) AND valvestatus IS NOT NULL GROUP BY 1 ORDER BY 1;",
               "refId": "Fußbodenheizung"
             }
           ],
@@ -1400,8 +1457,8 @@ spec:
         },
         {
           "datasource": {
-            "type": "influxdb",
-            "uid": "sRCk9Y9nk"
+            "type": "postgres",
+            "uid": "timescaledb"
           },
           "fieldConfig": {
             "defaults": {
@@ -1498,19 +1555,25 @@ spec:
           "targets": [
             {
               "datasource": {
-                "type": "influxdb",
-                "uid": "sRCk9Y9nk"
+                "type": "postgres",
+                "uid": "timescaledb"
               },
               "hide": false,
-              "query": "from(bucket: v.defaultBucket)\n  |> range(start: v.timeRangeStart, stop:v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"ems-esp\")\n  |> filter(fn: (r) => r[\"_field\"] == \"valvestatus\")\n  |> filter(fn: (r) => r[\"topic\"] == \"ems-esp/mixer_data_hc1\")\n  |> drop(columns: [\"host\", \"topic\", \"_measurement\"])\n  |> map(fn: (r) => ({ r with _field: \"Ventilöffnung\"}))\n  |> aggregateWindow(every: 1m, fn: mean)",
+              "editorMode": "code",
+              "format": "time_series",
+              "rawQuery": true,
+              "rawSql": "SELECT $__timeGroup(time, '$__interval') AS time, avg(valvestatus) AS \"Ventilöffnung\" FROM ems_esp WHERE $__timeFilter(time) AND valvestatus IS NOT NULL AND topic = 'mixer_data_hc1' GROUP BY 1 ORDER BY 1;",
               "refId": "Fußbodenheizung"
             },
             {
               "datasource": {
-                "type": "influxdb",
-                "uid": "sRCk9Y9nk"
+                "type": "postgres",
+                "uid": "timescaledb"
               },
-              "query": "from(bucket: v.defaultBucket)\n  |> range(start: v.timeRangeStart, stop:v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"ems-esp\")\n  |> filter(fn: (r) => r[\"_field\"] == \"valvestatus\")\n  |> filter(fn: (r) => r[\"topic\"] == \"ems-esp/mixer_data_hc2\")\n  |> drop(columns: [\"host\", \"topic\", \"_measurement\"])\n  |> map(fn: (r) => ({ r with _field: \"Heizkörper\"}))\n  |> aggregateWindow(every: 1m, fn: mean)",
+              "editorMode": "code",
+              "format": "time_series",
+              "rawQuery": true,
+              "rawSql": "SELECT $__timeGroup(time, '$__interval') AS time, avg(valvestatus) AS \"Heizkörper\" FROM ems_esp WHERE $__timeFilter(time) AND valvestatus IS NOT NULL AND topic = 'mixer_data_hc2' GROUP BY 1 ORDER BY 1;",
               "refId": "Heizkörper"
             }
           ],

--- a/kubernetes/applications/grafana/base/dashboards/hvac-ventilation.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/hvac-ventilation.yaml
@@ -41,8 +41,8 @@ spec:
       "panels": [
         {
           "datasource": {
-            "type": "influxdb",
-            "uid": "sRCk9Y9nk"
+            "type": "postgres",
+            "uid": "timescaledb"
           },
           "fieldConfig": {
             "defaults": {
@@ -116,7 +116,10 @@ spec:
           "pluginVersion": "11.4.0",
           "targets": [
             {
-              "query": "from(bucket: \"telegraf/autogen\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"Versorgungstechnik.KWL.Lüftermodi-Status\")\n  |> drop(columns: [\"host\", \"groupaddress\", \"source\"])\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)",
+              "editorMode": "code",
+              "format": "time_series",
+              "rawQuery": true,
+              "rawSql": "SELECT time, value FROM knx WHERE knx_name = 'Versorgungstechnik.KWL.Lüftermodi-Status' AND time > now() - INTERVAL '1 hour' ORDER BY time DESC LIMIT 1;",
               "refId": "A"
             }
           ],
@@ -125,8 +128,8 @@ spec:
         },
         {
           "datasource": {
-            "type": "influxdb",
-            "uid": "sRCk9Y9nk"
+            "type": "postgres",
+            "uid": "timescaledb"
           },
           "fieldConfig": {
             "defaults": {
@@ -175,7 +178,10 @@ spec:
           "pluginVersion": "11.4.0",
           "targets": [
             {
-              "query": "from(bucket: \"telegraf/autogen\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"Versorgungstechnik.KWL.Filter-Betriebsstunden\")\n  |> drop(columns: [\"host\", \"groupaddress\", \"source\"])\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)",
+              "editorMode": "code",
+              "format": "time_series",
+              "rawQuery": true,
+              "rawSql": "SELECT time, value FROM knx WHERE knx_name = 'Versorgungstechnik.KWL.Filter-Betriebsstunden' AND time > now() - INTERVAL '1 hour' ORDER BY time DESC LIMIT 1;",
               "refId": "A"
             }
           ],
@@ -184,8 +190,8 @@ spec:
         },
         {
           "datasource": {
-            "type": "influxdb",
-            "uid": "sRCk9Y9nk"
+            "type": "postgres",
+            "uid": "timescaledb"
           },
           "fieldConfig": {
             "defaults": {
@@ -252,7 +258,10 @@ spec:
           "pluginVersion": "11.4.0",
           "targets": [
             {
-              "query": "from(bucket: \"telegraf/autogen\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"Versorgungstechnik.KWL.Filterwechsel-Status\")\n  |> drop(columns: [\"host\", \"groupaddress\", \"source\"])\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)",
+              "editorMode": "code",
+              "format": "time_series",
+              "rawQuery": true,
+              "rawSql": "SELECT time, value FROM knx WHERE knx_name = 'Versorgungstechnik.KWL.Filterwechsel-Status' AND time > now() - INTERVAL '1 hour' ORDER BY time DESC LIMIT 1;",
               "refId": "A"
             }
           ],
@@ -261,8 +270,8 @@ spec:
         },
         {
           "datasource": {
-            "type": "influxdb",
-            "uid": "sRCk9Y9nk"
+            "type": "postgres",
+            "uid": "timescaledb"
           },
           "fieldConfig": {
             "defaults": {
@@ -329,7 +338,10 @@ spec:
           "pluginVersion": "11.4.0",
           "targets": [
             {
-              "query": "from(bucket: \"telegraf/autogen\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"Versorgungstechnik.KWL.Wartungsmodus-Status\")\n  |> drop(columns: [\"host\", \"groupaddress\", \"source\"])\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)",
+              "editorMode": "code",
+              "format": "time_series",
+              "rawQuery": true,
+              "rawSql": "SELECT time, value FROM knx WHERE knx_name = 'Versorgungstechnik.KWL.Wartungsmodus-Status' AND time > now() - INTERVAL '1 hour' ORDER BY time DESC LIMIT 1;",
               "refId": "A"
             }
           ],
@@ -338,8 +350,8 @@ spec:
         },
         {
           "datasource": {
-            "type": "influxdb",
-            "uid": "sRCk9Y9nk"
+            "type": "postgres",
+            "uid": "timescaledb"
           },
           "fieldConfig": {
             "defaults": {
@@ -406,7 +418,10 @@ spec:
           "pluginVersion": "11.4.0",
           "targets": [
             {
-              "query": "from(bucket: \"telegraf/autogen\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"Versorgungstechnik.KWL.Status\")\n  |> drop(columns: [\"host\", \"groupaddress\", \"source\"])\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)",
+              "editorMode": "code",
+              "format": "time_series",
+              "rawQuery": true,
+              "rawSql": "SELECT time, value FROM knx WHERE knx_name = 'Versorgungstechnik.KWL.Status' AND time > now() - INTERVAL '1 hour' ORDER BY time DESC LIMIT 1;",
               "refId": "A"
             }
           ],
@@ -415,8 +430,8 @@ spec:
         },
         {
           "datasource": {
-            "type": "influxdb",
-            "uid": "sRCk9Y9nk"
+            "type": "postgres",
+            "uid": "timescaledb"
           },
           "fieldConfig": {
             "defaults": {
@@ -493,7 +508,10 @@ spec:
           "pluginVersion": "11.4.0",
           "targets": [
             {
-              "query": "from(bucket: \"telegraf/autogen\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"Versorgungstechnik.KWL.ComfoConnect-Status\")\n  |> drop(columns: [\"host\", \"groupaddress\", \"source\"])\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)",
+              "editorMode": "code",
+              "format": "time_series",
+              "rawQuery": true,
+              "rawSql": "SELECT time, value FROM knx WHERE knx_name = 'Versorgungstechnik.KWL.ComfoConnect-Status' AND time > now() - INTERVAL '1 hour' ORDER BY time DESC LIMIT 1;",
               "refId": "A"
             }
           ],
@@ -502,8 +520,8 @@ spec:
         },
         {
           "datasource": {
-            "type": "influxdb",
-            "uid": "sRCk9Y9nk"
+            "type": "postgres",
+            "uid": "timescaledb"
           },
           "fieldConfig": {
             "defaults": {
@@ -606,10 +624,13 @@ spec:
           "targets": [
             {
               "datasource": {
-                "type": "influxdb",
-                "uid": "sRCk9Y9nk"
+                "type": "postgres",
+                "uid": "timescaledb"
               },
-              "query": "from(bucket: \"telegraf/autogen\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"Versorgungstechnik.KWL.Luftstrom\")\n  |> drop(columns: [\"host\", \"groupaddress\", \"source\"])\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
+              "editorMode": "code",
+              "format": "time_series",
+              "rawQuery": true,
+              "rawSql": "SELECT $__timeGroup(time, '$__interval') AS time, avg(value) AS value FROM knx WHERE $__timeFilter(time) AND knx_name = 'Versorgungstechnik.KWL.Luftstrom' GROUP BY 1 ORDER BY 1;",
               "refId": "A"
             }
           ],
@@ -618,8 +639,8 @@ spec:
         },
         {
           "datasource": {
-            "type": "influxdb",
-            "uid": "sRCk9Y9nk"
+            "type": "postgres",
+            "uid": "timescaledb"
           },
           "fieldConfig": {
             "defaults": {
@@ -722,10 +743,13 @@ spec:
           "targets": [
             {
               "datasource": {
-                "type": "influxdb",
-                "uid": "sRCk9Y9nk"
+                "type": "postgres",
+                "uid": "timescaledb"
               },
-              "query": "from(bucket: \"telegraf/autogen\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"Versorgungstechnik.KWL.Temperatur-Außenluft\")\n  |> drop(columns: [\"host\", \"groupaddress\", \"source\"])\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
+              "editorMode": "code",
+              "format": "time_series",
+              "rawQuery": true,
+              "rawSql": "SELECT $__timeGroup(time, '$__interval') AS time, avg(value) AS value FROM knx WHERE $__timeFilter(time) AND knx_name = 'Versorgungstechnik.KWL.Temperatur-Außenluft' GROUP BY 1 ORDER BY 1;",
               "refId": "A"
             }
           ],
@@ -734,8 +758,8 @@ spec:
         },
         {
           "datasource": {
-            "type": "influxdb",
-            "uid": "sRCk9Y9nk"
+            "type": "postgres",
+            "uid": "timescaledb"
           },
           "fieldConfig": {
             "defaults": {
@@ -838,10 +862,13 @@ spec:
           "targets": [
             {
               "datasource": {
-                "type": "influxdb",
-                "uid": "sRCk9Y9nk"
+                "type": "postgres",
+                "uid": "timescaledb"
               },
-              "query": "from(bucket: \"telegraf/autogen\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"Versorgungstechnik.KWL.Temperatur-Fortluft\")\n  |> drop(columns: [\"host\", \"groupaddress\", \"source\"])\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
+              "editorMode": "code",
+              "format": "time_series",
+              "rawQuery": true,
+              "rawSql": "SELECT $__timeGroup(time, '$__interval') AS time, avg(value) AS value FROM knx WHERE $__timeFilter(time) AND knx_name = 'Versorgungstechnik.KWL.Temperatur-Fortluft' GROUP BY 1 ORDER BY 1;",
               "refId": "A"
             }
           ],
@@ -850,8 +877,8 @@ spec:
         },
         {
           "datasource": {
-            "type": "influxdb",
-            "uid": "sRCk9Y9nk"
+            "type": "postgres",
+            "uid": "timescaledb"
           },
           "fieldConfig": {
             "defaults": {
@@ -954,10 +981,13 @@ spec:
           "targets": [
             {
               "datasource": {
-                "type": "influxdb",
-                "uid": "sRCk9Y9nk"
+                "type": "postgres",
+                "uid": "timescaledb"
               },
-              "query": "from(bucket: \"telegraf/autogen\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"Versorgungstechnik.KWL.Temperatur-Zuluft\")\n  |> drop(columns: [\"host\", \"groupaddress\", \"source\"])\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
+              "editorMode": "code",
+              "format": "time_series",
+              "rawQuery": true,
+              "rawSql": "SELECT $__timeGroup(time, '$__interval') AS time, avg(value) AS value FROM knx WHERE $__timeFilter(time) AND knx_name = 'Versorgungstechnik.KWL.Temperatur-Zuluft' GROUP BY 1 ORDER BY 1;",
               "refId": "A"
             }
           ],
@@ -966,8 +996,8 @@ spec:
         },
         {
           "datasource": {
-            "type": "influxdb",
-            "uid": "sRCk9Y9nk"
+            "type": "postgres",
+            "uid": "timescaledb"
           },
           "fieldConfig": {
             "defaults": {
@@ -1070,10 +1100,13 @@ spec:
           "targets": [
             {
               "datasource": {
-                "type": "influxdb",
-                "uid": "sRCk9Y9nk"
+                "type": "postgres",
+                "uid": "timescaledb"
               },
-              "query": "from(bucket: \"telegraf/autogen\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"Versorgungstechnik.KWL.Temperatur-Abluft\")\n  |> drop(columns: [\"host\", \"groupaddress\", \"source\"])\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
+              "editorMode": "code",
+              "format": "time_series",
+              "rawQuery": true,
+              "rawSql": "SELECT $__timeGroup(time, '$__interval') AS time, avg(value) AS value FROM knx WHERE $__timeFilter(time) AND knx_name = 'Versorgungstechnik.KWL.Temperatur-Abluft' GROUP BY 1 ORDER BY 1;",
               "refId": "A"
             }
           ],
@@ -1082,8 +1115,8 @@ spec:
         },
         {
           "datasource": {
-            "type": "influxdb",
-            "uid": "sRCk9Y9nk"
+            "type": "postgres",
+            "uid": "timescaledb"
           },
           "description": "",
           "fieldConfig": {
@@ -1187,10 +1220,13 @@ spec:
           "targets": [
             {
               "datasource": {
-                "type": "influxdb",
-                "uid": "sRCk9Y9nk"
+                "type": "postgres",
+                "uid": "timescaledb"
               },
-              "query": "from(bucket: \"telegraf/autogen\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"Versorgungstechnik.KWL.Luftfeuchtigkeit-Außenluft\")\n  |> drop(columns: [\"host\", \"groupaddress\", \"source\"])\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
+              "editorMode": "code",
+              "format": "time_series",
+              "rawQuery": true,
+              "rawSql": "SELECT $__timeGroup(time, '$__interval') AS time, avg(value) AS value FROM knx WHERE $__timeFilter(time) AND knx_name = 'Versorgungstechnik.KWL.Luftfeuchtigkeit-Außenluft' GROUP BY 1 ORDER BY 1;",
               "refId": "A"
             }
           ],
@@ -1199,8 +1235,8 @@ spec:
         },
         {
           "datasource": {
-            "type": "influxdb",
-            "uid": "sRCk9Y9nk"
+            "type": "postgres",
+            "uid": "timescaledb"
           },
           "description": "",
           "fieldConfig": {
@@ -1304,10 +1340,13 @@ spec:
           "targets": [
             {
               "datasource": {
-                "type": "influxdb",
-                "uid": "sRCk9Y9nk"
+                "type": "postgres",
+                "uid": "timescaledb"
               },
-              "query": "from(bucket: \"telegraf/autogen\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"Versorgungstechnik.KWL.Luftfeuchtigkeit-Fortluft\")\n  |> drop(columns: [\"host\", \"groupaddress\", \"source\"])\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
+              "editorMode": "code",
+              "format": "time_series",
+              "rawQuery": true,
+              "rawSql": "SELECT $__timeGroup(time, '$__interval') AS time, avg(value) AS value FROM knx WHERE $__timeFilter(time) AND knx_name = 'Versorgungstechnik.KWL.Luftfeuchtigkeit-Fortluft' GROUP BY 1 ORDER BY 1;",
               "refId": "A"
             }
           ],
@@ -1316,8 +1355,8 @@ spec:
         },
         {
           "datasource": {
-            "type": "influxdb",
-            "uid": "sRCk9Y9nk"
+            "type": "postgres",
+            "uid": "timescaledb"
           },
           "description": "",
           "fieldConfig": {
@@ -1421,10 +1460,13 @@ spec:
           "targets": [
             {
               "datasource": {
-                "type": "influxdb",
-                "uid": "sRCk9Y9nk"
+                "type": "postgres",
+                "uid": "timescaledb"
               },
-              "query": "from(bucket: \"telegraf/autogen\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"Versorgungstechnik.KWL.Luftfeuchtigkeit-Zuluft\")\n  |> drop(columns: [\"host\", \"groupaddress\", \"source\"])\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
+              "editorMode": "code",
+              "format": "time_series",
+              "rawQuery": true,
+              "rawSql": "SELECT $__timeGroup(time, '$__interval') AS time, avg(value) AS value FROM knx WHERE $__timeFilter(time) AND knx_name = 'Versorgungstechnik.KWL.Luftfeuchtigkeit-Zuluft' GROUP BY 1 ORDER BY 1;",
               "refId": "A"
             }
           ],
@@ -1433,8 +1475,8 @@ spec:
         },
         {
           "datasource": {
-            "type": "influxdb",
-            "uid": "sRCk9Y9nk"
+            "type": "postgres",
+            "uid": "timescaledb"
           },
           "description": "",
           "fieldConfig": {
@@ -1538,10 +1580,13 @@ spec:
           "targets": [
             {
               "datasource": {
-                "type": "influxdb",
-                "uid": "sRCk9Y9nk"
+                "type": "postgres",
+                "uid": "timescaledb"
               },
-              "query": "from(bucket: \"telegraf/autogen\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"Versorgungstechnik.KWL.Luftfeuchtigkeit-Abluft\")\n  |> drop(columns: [\"host\", \"groupaddress\", \"source\"])\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
+              "editorMode": "code",
+              "format": "time_series",
+              "rawQuery": true,
+              "rawSql": "SELECT $__timeGroup(time, '$__interval') AS time, avg(value) AS value FROM knx WHERE $__timeFilter(time) AND knx_name = 'Versorgungstechnik.KWL.Luftfeuchtigkeit-Abluft' GROUP BY 1 ORDER BY 1;",
               "refId": "A"
             }
           ],


### PR DESCRIPTION
Continues #802 with energy-inverter, energy-wallbox, hvac-heating-unit and hvac-ventilation. Same datasource (uid `timescaledb`) and SQL idioms as the energy-meter PoC; table mapping per dashboard:

- hvac-ventilation: `knx` (KWL group addresses, knx_name-keyed).
- hvac-heating-unit: `ems_esp` (boiler / DHW / mixer typed columns; `topic` column replaces the InfluxDB `topic` tag — values like `boiler_data_dhw`, `mixer_data_hc1` etc. with the `ems-esp/` prefix stripped per redpanda-connect ingest).
- energy-wallbox: state panels → `warp_evse`, charge-tracker panels → `warp_charge_tracker`, per-phase panels → `warp_meter` filtered to `meter_id = 0` (wallbox internal meter; revisit if a different meter_id turns out to be the wallbox).
- energy-inverter: instantaneous-power panels → `solaredge_powerflow` directly; energy-bucket panels approximate Wh via `avg(field) * EXTRACT(EPOCH FROM INTERVAL '${agg}') / 3600` because the solaredge2mqtt `energy` topic isn't ingested into TSDB yet. Two panels reference data we don't ingest at all — battery `state_of_charge` and the `forecast` measurement — and now run a no-row SQL stub until those topics are wired up. `${agg}` template variable values switched from Influx-flavor (`1mo`, `1y`) to PG-compatible interval strings (`1 month`, `1 year`).