### PR TITLE
feat(grafana): organize dashboards into 4 domain folders

### DIFF
--- a/kubernetes/applications/grafana/base/dashboards/energy-inverter.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/energy-inverter.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: grafana
 
 spec:
+  folder: "Energie"
   instanceSelector:
     matchLabels:
       homelab.app: grafana

--- a/kubernetes/applications/grafana/base/dashboards/energy-meter.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/energy-meter.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: grafana
 
 spec:
+  folder: "Energie"
   instanceSelector:
     matchLabels:
       homelab.app: grafana

--- a/kubernetes/applications/grafana/base/dashboards/energy-wallbox.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/energy-wallbox.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: grafana
 
 spec:
+  folder: "Energie"
   instanceSelector:
     matchLabels:
       homelab.app: grafana

--- a/kubernetes/applications/grafana/base/dashboards/hvac-heating-unit.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/hvac-heating-unit.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: grafana
 
 spec:
+  folder: "Smart Home"
   instanceSelector:
     matchLabels:
       homelab.app: grafana

--- a/kubernetes/applications/grafana/base/dashboards/hvac-ventilation.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/hvac-ventilation.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: grafana
 
 spec:
+  folder: "Smart Home"
   instanceSelector:
     matchLabels:
       homelab.app: grafana

--- a/kubernetes/applications/grafana/base/dashboards/k8s-gatus.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/k8s-gatus.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: grafana
 
 spec:
+  folder: "Kubernetes"
   instanceSelector:
     matchLabels:
       homelab.app: grafana

--- a/kubernetes/applications/grafana/base/dashboards/k8s-traefik.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/k8s-traefik.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: grafana
 
 spec:
+  folder: "Netzwerk"
   instanceSelector:
     matchLabels:
       homelab.app: grafana

--- a/kubernetes/applications/grafana/base/dashboards/knx-alarm-attic.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/knx-alarm-attic.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: grafana
 
 spec:
+  folder: "Smart Home"
   instanceSelector:
     matchLabels:
       homelab.app: grafana

--- a/kubernetes/applications/grafana/base/dashboards/knx-alarm-basement.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/knx-alarm-basement.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: grafana
 
 spec:
+  folder: "Smart Home"
   instanceSelector:
     matchLabels:
       homelab.app: grafana

--- a/kubernetes/applications/grafana/base/dashboards/knx-alarm-exterior.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/knx-alarm-exterior.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: grafana
 
 spec:
+  folder: "Smart Home"
   instanceSelector:
     matchLabels:
       homelab.app: grafana

--- a/kubernetes/applications/grafana/base/dashboards/knx-alarm-ground-floor.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/knx-alarm-ground-floor.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: grafana
 
 spec:
+  folder: "Smart Home"
   instanceSelector:
     matchLabels:
       homelab.app: grafana

--- a/kubernetes/applications/grafana/base/dashboards/knx-alarm-upper-floor.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/knx-alarm-upper-floor.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: grafana
 
 spec:
+  folder: "Smart Home"
   instanceSelector:
     matchLabels:
       homelab.app: grafana

--- a/kubernetes/applications/grafana/base/dashboards/knx-sensor-attic.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/knx-sensor-attic.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: grafana
 
 spec:
+  folder: "Smart Home"
   instanceSelector:
     matchLabels:
       homelab.app: grafana

--- a/kubernetes/applications/grafana/base/dashboards/knx-sensor-basement.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/knx-sensor-basement.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: grafana
 
 spec:
+  folder: "Smart Home"
   instanceSelector:
     matchLabels:
       homelab.app: grafana

--- a/kubernetes/applications/grafana/base/dashboards/knx-sensor-basement2.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/knx-sensor-basement2.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: grafana
 
 spec:
+  folder: "Smart Home"
   instanceSelector:
     matchLabels:
       homelab.app: grafana

--- a/kubernetes/applications/grafana/base/dashboards/knx-sensor-exterior.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/knx-sensor-exterior.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: grafana
 
 spec:
+  folder: "Smart Home"
   instanceSelector:
     matchLabels:
       homelab.app: grafana

--- a/kubernetes/applications/grafana/base/dashboards/knx-sensor-ground-floor.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/knx-sensor-ground-floor.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: grafana
 
 spec:
+  folder: "Smart Home"
   instanceSelector:
     matchLabels:
       homelab.app: grafana

--- a/kubernetes/applications/grafana/base/dashboards/knx-sensor-ground-floor2.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/knx-sensor-ground-floor2.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: grafana
 
 spec:
+  folder: "Smart Home"
   instanceSelector:
     matchLabels:
       homelab.app: grafana

--- a/kubernetes/applications/grafana/base/dashboards/knx-sensor-upper-floor.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/knx-sensor-upper-floor.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: grafana
 
 spec:
+  folder: "Smart Home"
   instanceSelector:
     matchLabels:
       homelab.app: grafana

--- a/kubernetes/applications/grafana/base/dashboards/network-unifi-ap.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/network-unifi-ap.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: grafana
 
 spec:
+  folder: "Netzwerk"
   instanceSelector:
     matchLabels:
       homelab.app: grafana

--- a/kubernetes/applications/grafana/base/dashboards/network-unifi-client.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/network-unifi-client.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: grafana
 
 spec:
+  folder: "Netzwerk"
   instanceSelector:
     matchLabels:
       homelab.app: grafana


### PR DESCRIPTION
Each GrafanaDashboard CR now declares spec.folder, so the operator creates and populates these folders on reconcile:

- Smart Home: hvac + all KNX alarms / sensors (14 dashboards)
- Energie:    energy-meter, energy-inverter, energy-wallbox
- Netzwerk:   network-unifi-{ap,client}, k8s-traefik
- Kubernetes: k8s-gatus

External dashboards bundled with their app chart (Cilium, CloudNativePG, fritz-exporter, gatus, homepage, iot-mcp-bridge, knx-nats-bridge, kromgo, node-red, smtprelay, unpoller) are not retagged here.