### PR TITLE
fix(helm): prepare gatus and homepage values for stakater application…

### DIFF
--- a/kubernetes/applications/gatus/base/values.yaml
+++ b/kubernetes/applications/gatus/base/values.yaml
@@ -2,6 +2,8 @@ applicationName: gatus
 
 deployment:
   enabled: true
+  # gatus-sidecar reads IngressRoutes via the SA token; v7 flipped the chart default to false
+  automountServiceAccountToken: true
   image:
     repository: ghcr.io/twin/gatus
     tag: v5.35.0
@@ -157,5 +159,5 @@ serviceMonitor:
 # ServiceAccount bound to ClusterRole in rbac.yaml (needed by sidecar to watch IngressRoutes cluster-wide)
 rbac:
   serviceAccount:
-    enabled: true
+    create: true
     name: gatus

--- a/kubernetes/applications/homepage/base/values.yaml
+++ b/kubernetes/applications/homepage/base/values.yaml
@@ -2,6 +2,8 @@ applicationName: homepage
 
 deployment:
   enabled: true
+  # Kubernetes widget queries the cluster API via the SA token; v7 flipped the chart default to false
+  automountServiceAccountToken: true
   replicas: 1
   # Recreate avoids Multi-Attach errors on the homepage-images RWO PVC — old pod must terminate before new one starts.
   strategy:
@@ -134,5 +136,5 @@ service:
 # ServiceAccount bound to ClusterRole in rbac.yaml (needed for the Kubernetes widget that lists pods/nodes/services).
 rbac:
   serviceAccount:
-    enabled: true
+    create: true
     name: homepage


### PR DESCRIPTION
… v7+v8

Rename rbac.serviceAccount.enabled to .create (v7) and explicitly enable automountServiceAccountToken (v7 flipped the default to false). Both pods authenticate to the cluster API via their SA token — gatus-sidecar watches IngressRoutes, the homepage Kubernetes widget queries pods/nodes/services — so the v7 default would silently break them once #917 lands.