### PR TITLE
feat(grafana): refresh dashboard tags and disambiguate duplicate titles

### DIFF
--- a/kubernetes/applications/grafana/base/dashboards/energy-meter.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/energy-meter.yaml
@@ -2552,9 +2552,8 @@ spec:
       "refresh": "5m",
       "schemaVersion": 41,
       "tags": [
-        "influxdb",
-        "knx",
-        "telegraf"
+        "timescaledb",
+        "knx"
       ],
       "templating": {
         "list": []

--- a/kubernetes/applications/grafana/base/dashboards/hvac-ventilation.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/hvac-ventilation.yaml
@@ -1599,8 +1599,7 @@ spec:
       "refresh": "10s",
       "schemaVersion": 40,
       "tags": [
-        "Influxdb",
-        "telegraf",
+        "timescaledb",
         "knx"
       ],
       "templating": {

--- a/kubernetes/applications/grafana/base/dashboards/knx-sensor-attic.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/knx-sensor-attic.yaml
@@ -650,8 +650,7 @@ spec:
       "refresh": "5m",
       "schemaVersion": 39,
       "tags": [
-        "influxdb",
-        "telegraf",
+        "timescaledb",
         "knx"
       ],
       "templating": {

--- a/kubernetes/applications/grafana/base/dashboards/knx-sensor-basement.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/knx-sensor-basement.yaml
@@ -3953,8 +3953,7 @@ spec:
       "refresh": "",
       "schemaVersion": 39,
       "tags": [
-        "InfluxDB",
-        "telegraf",
+        "timescaledb",
         "knx"
       ],
       "templating": {
@@ -3966,7 +3965,7 @@ spec:
       },
       "timepicker": {},
       "timezone": "",
-      "title": "1. Kellergeschoss",
+      "title": "1. Kellergeschoss — Strom",
       "uid": "2zZVkZn7k",
       "version": 63,
       "weekStart": ""

--- a/kubernetes/applications/grafana/base/dashboards/knx-sensor-basement2.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/knx-sensor-basement2.yaml
@@ -2579,8 +2579,7 @@ spec:
       "refresh": "5m",
       "schemaVersion": 39,
       "tags": [
-        "Influxdb",
-        "telegraf",
+        "timescaledb",
         "knx"
       ],
       "templating": {
@@ -2592,7 +2591,7 @@ spec:
       },
       "timepicker": {},
       "timezone": "",
-      "title": "1. Kellergeschoss",
+      "title": "1. Kellergeschoss — Klima",
       "uid": "fGuhSLM7k",
       "version": 34,
       "weekStart": ""

--- a/kubernetes/applications/grafana/base/dashboards/knx-sensor-exterior.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/knx-sensor-exterior.yaml
@@ -1690,9 +1690,8 @@ spec:
       "refresh": "",
       "schemaVersion": 39,
       "tags": [
-        "influxdb",
-        "knx",
-        "telegraf"
+        "timescaledb",
+        "knx"
       ],
       "templating": {
         "list": []

--- a/kubernetes/applications/grafana/base/dashboards/knx-sensor-ground-floor.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/knx-sensor-ground-floor.yaml
@@ -3886,8 +3886,7 @@ spec:
       "refresh": "",
       "schemaVersion": 39,
       "tags": [
-        "InfluxDB",
-        "telegraf",
+        "timescaledb",
         "knx"
       ],
       "templating": {
@@ -3899,7 +3898,7 @@ spec:
       },
       "timepicker": {},
       "timezone": "",
-      "title": "2. Erdgeschoss",
+      "title": "2. Erdgeschoss — Strom",
       "uid": "2xEu1c7nz",
       "version": 51,
       "weekStart": ""

--- a/kubernetes/applications/grafana/base/dashboards/knx-sensor-ground-floor2.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/knx-sensor-ground-floor2.yaml
@@ -2250,8 +2250,7 @@ spec:
       "refresh": "",
       "schemaVersion": 39,
       "tags": [
-        "influxdb",
-        "telegraf",
+        "timescaledb",
         "knx"
       ],
       "templating": {
@@ -2263,7 +2262,7 @@ spec:
       },
       "timepicker": {},
       "timezone": "",
-      "title": "2. Erdgeschoss",
+      "title": "2. Erdgeschoss — Heizung & Klima",
       "uid": "EtFiKlGnz",
       "version": 25,
       "weekStart": ""

--- a/kubernetes/applications/grafana/base/dashboards/knx-sensor-upper-floor.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/knx-sensor-upper-floor.yaml
@@ -2824,8 +2824,7 @@ spec:
       "refresh": "",
       "schemaVersion": 39,
       "tags": [
-        "influxdb",
-        "telegraf",
+        "timescaledb",
         "knx"
       ],
       "templating": {


### PR DESCRIPTION
- Replace stale `influxdb` / `telegraf` tags with `timescaledb` on the 9 migrated dashboards (energy-meter, hvac-ventilation, all 7 KNX sensors). `knx` tag preserved where present.
- Rename duplicate basement / ground-floor titles so each pair has a distinct label in the Grafana UI:
    knx-sensor-basement      → "1. Kellergeschoss — Strom"
    knx-sensor-basement2     → "1. Kellergeschoss — Klima"
    knx-sensor-ground-floor  → "2. Erdgeschoss — Strom"
    knx-sensor-ground-floor2 → "2. Erdgeschoss — Heizung & Klima"