### PR TITLE
feat(warp-charge-tracker): unpack last_charges array + dedupe republished rows

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/streams/warp_charge_tracker.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_charge_tracker.yaml
@@ -13,6 +13,15 @@ input:
 
 pipeline:
   processors:
+    # `warp.charge_tracker.last_charges` is published as a JSON *array* of completed
+    # charges. Split each element into its own message so the downstream mapping can
+    # extract typed columns per charge. Other subjects (state, current_charge) are
+    # single objects and pass through unchanged.
+    - switch:
+        - check: 'meta("nats_subject") == "warp.charge_tracker.last_charges" && this.type() == "array"'
+          processors:
+            - unarchive:
+                format: json_array
     - mapping: |
         let evt = this
         let parts = meta("nats_subject").split(".")
@@ -76,7 +85,10 @@ output:
               this.first_charge_timestamp,
               this.generator_state,
             ]
-      # Cold archive: original NATS payload as Parquet on RustFS
+      # Cold archive: original NATS payload as Parquet on RustFS. After the
+      # array-unarchive above, last_charges entries land here as individual charge
+      # objects (one parquet row per completed charge) rather than the original
+      # array — by design the typed and archived views stay aligned.
       - aws_s3:
           bucket: nats-archive
           object_canned_acl: private

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_charge_tracker.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_charge_tracker.yaml
@@ -56,6 +56,12 @@ output:
           init_statement: |
             SET timezone = 'UTC';
           query: |
+            -- For `last_charges` entries the publish timestamp is meaningless
+            -- (WARP republishes the same array periodically). Use the per-charge
+            -- timestamp_minutes ($9) instead; for state/current_charge fall back
+            -- to the NATS receive time ($1). The partial unique index on
+            -- (time, timestamp_minutes) WHERE sub_topic = 'charge_tracker.last_charges'
+            -- dedupes the inevitable republished duplicates.
             INSERT INTO warp_charge_tracker (
               time, sub_topic,
               user_id, charge_duration, energy_charged, tracked_charges,
@@ -64,12 +70,20 @@ output:
               generator_state
             )
             VALUES (
-              $1, $2,
+              CASE
+                WHEN $2 = 'charge_tracker.last_charges' AND $9::numeric IS NOT NULL
+                  THEN to_timestamp($9::numeric * 60)
+                ELSE $1::timestamptz
+              END,
+              $2,
               $3, $4, $5, $6,
               $7, $8, $9,
               $10, $11,
               ($12::numeric)::smallint
             )
+            ON CONFLICT (time, timestamp_minutes)
+              WHERE sub_topic = 'charge_tracker.last_charges'
+              DO NOTHING
           args_mapping: |
             root = [
               this.time,

--- a/kubernetes/applications/timescaledb/base/scripts/bootstrap.sql
+++ b/kubernetes/applications/timescaledb/base/scripts/bootstrap.sql
@@ -263,6 +263,14 @@ CREATE TABLE warp_charge_tracker (
 SELECT create_hypertable('warp_charge_tracker', 'time', chunk_time_interval => INTERVAL '1 day');
 CREATE INDEX ON warp_charge_tracker (sub_topic, time DESC);
 CREATE INDEX ON warp_charge_tracker (user_id, time DESC) WHERE user_id IS NOT NULL;
+-- WARP republishes warp.charge_tracker.last_charges periodically with the same
+-- historical charges. After the array-unarchive in redpanda-connect, the stream
+-- uses to_timestamp(timestamp_minutes * 60) as the row's `time`, so
+-- (time, timestamp_minutes) uniquely identifies a completed charge — the
+-- partial unique index lets INSERT ... ON CONFLICT DO NOTHING drop repeats.
+CREATE UNIQUE INDEX IF NOT EXISTS warp_charge_tracker_last_charges_unique
+    ON warp_charge_tracker (time, timestamp_minutes)
+    WHERE sub_topic = 'charge_tracker.last_charges';
 
 -- warp.meter.all_values (86 floats), warp.meters.<N>.values (39 floats), warp.meters.<N>.update
 -- Typed: phase V/A/W (positions 0-8 confirmed via Telegraf XPath).


### PR DESCRIPTION
## Summary

- `warp.charge_tracker.last_charges` is published by WARP as a JSON *array* of completed charges; the redpanda-connect pipeline now runs `unarchive: json_array` (guarded by a `switch` so other subjects pass through) so each charge lands as its own row.
- `time` for unpacked charges is computed in the INSERT via `CASE … to_timestamp(timestamp_minutes * 60)` — the NATS receive time is meaningless for historical charges and shifts on every republish.
- WARP republishes the same `last_charges` array on every state tick, so the table would otherwise grow with duplicates indefinitely. Adds a partial unique index `warp_charge_tracker_last_charges_unique` on `(time, timestamp_minutes) WHERE sub_topic = 'charge_tracker.last_charges'` plus `ON CONFLICT … DO NOTHING` on the INSERT.
- Cold archive (RustFS / Parquet) now stores one row per charge instead of the original array, keeping hot and cold tiers aligned.

Confirmed on the live DB via Homelab MCP: 266 existing `charge_tracker.last_charges` rows all have NULL typed columns (bloblang tried to read `.user_id` on the array and got null for everything). They get cleaned up as part of rollout.

## Rollout (manual via VPN — psql, argocd, nats CLI)

```sql
-- 1) Drop the garbage rows (all 266 have NULL typed cols)
DELETE FROM warp_charge_tracker WHERE sub_topic = 'charge_tracker.last_charges';

-- 2) Apply the partial unique index (same statement that's now in bootstrap.sql)
CREATE UNIQUE INDEX IF NOT EXISTS warp_charge_tracker_last_charges_unique
  ON warp_charge_tracker (time, timestamp_minutes)
  WHERE sub_topic = 'charge_tracker.last_charges';
```

```bash
# 3) ArgoCD picks up the new stream config; force-sync if needed
argocd app sync redpanda-connect

# 4) Reset the durable consumer so JetStream replays last_charges from
#    the start of retention through the corrected pipeline
nats consumer rm WARP redpanda-connect-warp-charge-tracker
```

## Test plan
- [ ] Apply rollout steps in order
- [ ] `SELECT COUNT(*) FROM warp_charge_tracker WHERE sub_topic = 'charge_tracker.last_charges' AND timestamp_minutes IS NOT NULL` returns > 0 (was 0 before)
- [ ] Grafana energy-wallbox: "Ladevorgänge im aktuellen Monat" / "im letzten Monat" tables render rows
- [ ] Re-publishing the same array doesn't grow the row count

🤖 Generated with [Claude Code](https://claude.com/claude-code)