### PR TITLE
fix(cluster): cap kube-apiserver memory via GOMEMLIMIT (#894)

### DIFF
--- a/cluster/patches/control-plane-settings.yaml
+++ b/cluster/patches/control-plane-settings.yaml
@@ -10,7 +10,7 @@ cluster:
       GOMEMLIMIT: "2500MiB"
     resources:
       limits:
-        memory: "3GiB"
+        memory: "3Gi"
   ## Expose metrics endpoints on all interfaces (default: 127.0.0.1)
   ## Required for Prometheus ServiceMonitor scraping from within the cluster
   controllerManager:

--- a/cluster/patches/control-plane-settings.yaml
+++ b/cluster/patches/control-plane-settings.yaml
@@ -2,12 +2,12 @@
 ## Control plane patches
 ###############################################################################
 cluster:
-  ## kube-apiserver memory tuning. CPs only have ~3.8 GiB RAM; without
-  ## GOMEMLIMIT Go GC fills available memory and OOMs during RSS spikes
+  ## kube-apiserver memory tuning. CPs only have ~3.8 GiB RAM; without a
+  ## memory limit Go GC fills available memory and OOMs during RSS spikes
   ## (e.g. OpenAPI schema rebuilds against large CRDs via ArgoCD diff).
+  ## Talos auto-injects GOMEMLIMIT=0.95*limit when resources.limits.memory
+  ## is set, so we only need to declare the limit.
   apiServer:
-    env:
-      GOMEMLIMIT: "2500MiB"
     resources:
       limits:
         memory: "3Gi"

--- a/cluster/patches/control-plane-settings.yaml
+++ b/cluster/patches/control-plane-settings.yaml
@@ -2,6 +2,15 @@
 ## Control plane patches
 ###############################################################################
 cluster:
+  ## kube-apiserver memory tuning. CPs only have ~3.8 GiB RAM; without
+  ## GOMEMLIMIT Go GC fills available memory and OOMs during RSS spikes
+  ## (e.g. OpenAPI schema rebuilds against large CRDs via ArgoCD diff).
+  apiServer:
+    env:
+      GOMEMLIMIT: "2500MiB"
+    resources:
+      limits:
+        memory: "3GiB"
   ## Expose metrics endpoints on all interfaces (default: 127.0.0.1)
   ## Required for Prometheus ServiceMonitor scraping from within the cluster
   controllerManager:


### PR DESCRIPTION
CPs have ~3.8 GiB RAM; without GOMEMLIMIT Go GC grows lazily and OOMs during RSS spikes (e.g. OpenAPI schema rebuilds against large CRDs through ArgoCD server-side diff). Sets GOMEMLIMIT=2500MiB and a hard container limit of 3GiB so GC pressures earlier and the kubelet kills the apiserver before it drags the whole node into a probe-timeout spiral.