### PR TITLE
fix(csi-nfs): keep csi-nfs-node off control-plane nodes (#894)

### DIFF
--- a/kubernetes/components/csi-nfs-controller/base/values.yaml
+++ b/kubernetes/components/csi-nfs-controller/base/values.yaml
@@ -1,3 +1,9 @@
 externalSnapshotter:
   # Enable volume snapshot controller
   enabled: true
+
+node:
+  # Override the chart default (`operator: Exists`, which tolerates every taint).
+  # CPs are tainted node-role.kubernetes.io/control-plane:NoSchedule and never
+  # host workloads with NFS PVCs, so the node DS has nothing to mount there.
+  tolerations: []


### PR DESCRIPTION
The chart default node tolerations (operator: Exists) make csi-nfs-node tolerate every taint, including node-role.kubernetes.io/control-plane. CPs never host workloads with NFS PVCs, so the DS has nothing to mount there but still costs ~150-260 MiB per CP. Override to an empty toleration list so the standard NoSchedule taint keeps the pod off CPs.