### PR TITLE
feat(infra): attach knx-license USB mapping to windows_01

### DIFF
--- a/infrastructure/manifest/50-fleet/fleet-vm.yaml
+++ b/infrastructure/manifest/50-fleet/fleet-vm.yaml
@@ -31,3 +31,5 @@ fleet_vm:
     template_id: vm_windows_11_25h2
     vm_id: 1100
     wait_for_agent: false
+    usb_devices:
+      - mapping: "knx-license"


### PR DESCRIPTION
## Summary
- Add `usb_devices: [{mapping: "knx-license"}]` to `windows_01` in `fleet-vm.yaml` so the previously orphaned cluster-level USB mapping is actually consumed by a VM (ETS host).
- PVE-side `usb0` was switched from `host=2a07:0102` to `mapping=knx-license` out-of-band (root@pam required for USB updates on existing VMs); refresh-only apply has already pulled the mapping into the Terraform state, so `tofu plan` is no-op after this PR merges.

Closes #693

## Test plan
- [x] `tofu plan` clean (no changes)
- [x] `qm config 1100` shows `usb0: mapping=knx-license`
- [ ] ETS in `windows_01` recognises the KNX License Stick after the next reboot

🤖 Generated with [Claude Code](https://claude.com/claude-code)