### PR TITLE
fix(infra): grow PBS datastore to 256G and switch NFS secondary to automount

### DIFF
--- a/infrastructure/manifest/30-cloud-init/ci-vendor-config.yaml
+++ b/infrastructure/manifest/30-cloud-init/ci-vendor-config.yaml
@@ -238,7 +238,7 @@ ci_vendor_config:
           "storage.zimmermann.eu.com:/var/nfs/shared/proxmox",
           "/mnt/datastore-secondary",
           "nfs",
-          "defaults,_netdev,noauto,nofail,vers=3,rw,nolock,x-systemd.after=cloud-init-network.service",
+          "defaults,_netdev,nofail,vers=3,rw,nolock,x-systemd.automount,x-systemd.idle-timeout=600,x-systemd.after=cloud-init-network.service",
           "0",
           "0",
         ]
@@ -255,8 +255,9 @@ ci_vendor_config:
       - ["localectl", "set-locale", "LANG=de_DE.UTF-8"]
       ## Set permissions for data disk and config directory
       - ["chown", "-R", "backup:backup", "/mnt/datastore-primary"]
-      ## Mount NFS (noauto — requires nfs-common to be installed first)
-      - ["mount", "/mnt/datastore-secondary"]
+      ## Trigger NFS automount (will reconnect after reboots via systemd)
+      - ["systemctl", "daemon-reload"]
+      - ["ls", "/mnt/datastore-secondary"]
       ## Setup PBS
       - ["bash", "/usr/local/bin/pbs-bootstrap.sh"]
       ## Systemd services

--- a/infrastructure/manifest/50-fleet/fleet-vm.yaml
+++ b/infrastructure/manifest/50-fleet/fleet-vm.yaml
@@ -15,7 +15,7 @@ fleet_vm:
     vm_id: 1003
     disks:
       - disk_interface: scsi1
-        disk_size: 128
+        disk_size: 256
       - disk_interface: scsi2
         disk_size: 8
 


### PR DESCRIPTION
## Summary

- Bump `backup_server_01` scsi1 from 128 → 256 GiB so the PBS NVMe datastore has headroom for prune/GC churn (was 90% full with one VM's snapshots).
- Replace `noauto` + cloud-init `runcmd` mount with `x-systemd.automount,x-systemd.idle-timeout=600` for `/mnt/datastore-secondary` (NFS). `runcmd` only fires on first boot, so subsequent reboots left the mount empty and PBS errored with `unable to open chunk store at "/mnt/datastore-secondary/.chunks"`.

Closes #692

## Live changes already applied

- `qm resize 1003 scsi1 256G` on pve-1 (tofu state in sync)
- `growpart /dev/sdc 1` + `resize2fs /dev/sdc1` on backup-01 → 252 G / 45 % used
- `/etc/fstab` patched in-place to match the new cloud-init template
- VM rebooted, automount verified (`systemd-1 on /mnt/datastore-secondary type autofs`)

## Test plan

- [x] PBS GUI no longer shows chunk store error for datastore-secondary
- [x] `df -h /mnt/datastore-primary` → 252 G, ~45 % used
- [x] `mount | grep datastore-secondary` → autofs + nfs entries present
- [x] `systemctl is-active proxmox-backup proxmox-backup-proxy` → both active
- [ ] Confirm next scheduled backup (tonight) succeeds on both datastores

🤖 Generated with [Claude Code](https://claude.com/claude-code)