### PR TITLE
fix(knx): apply 2026q2 ETS catalog restructuring

### DIFF
--- a/kubernetes/applications/knx-nats-bridge/base/config/knx-catalog.yaml
+++ b/kubernetes/applications/knx-nats-bridge/base/config/knx-catalog.yaml
@@ -386,2731 +386,1907 @@
   function: Allgemein
   name: Allgemein.A.Garten.Alles-Aus
   room: Garten
-10/1/0:
-  dpt: '1.003'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Flur.KNX.Decke.Sperren
-  room: Flur
-10/1/1:
-  dpt: '1.011'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Flur.KNX.Decke.Sperren-Status
-  room: Flur
-10/1/10:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Flur.KNX.Decke.Slave
-  room: Flur
-10/1/100:
-  dpt: '1.003'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Garage.EMA.Sperren
-  room: Garage
-10/1/101:
-  dpt: '1.011'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Garage.EMA.Sperren-Staus
-  room: Garage
-10/1/102:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Garage.EMA.Ein/Aus
-  room: Garage
-10/1/106:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Garage.EMA.HLK
-  room: Garage
-10/1/107:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Garage.EMA.Präsenz
-  room: Garage
-10/1/109:
-  dpt: '1.024'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Garage.EMA.Tag/Nacht
-  room: Garage
-10/1/120:
-  dpt: '1.003'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Technikraum.KNX.Sperren
-  room: Technikraum
-10/1/121:
-  dpt: '1.011'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Technikraum.KNX.Sperren-Status
-  room: Technikraum
-10/1/122:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Technikraum.KNX.Ein/Aus
-  room: Technikraum
-10/1/123:
-  dpt: '5.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Technikraum.KNX.Dimmen
-  room: Technikraum
-10/1/124:
-  dpt: '9.004'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Technikraum.KNX.Schaltschwelle
-  room: Technikraum
-10/1/126:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Technikraum.KNX.HLK
-  room: Technikraum
-10/1/127:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Technikraum.KNX.Präsenz
-  room: Technikraum
-10/1/128:
-  dpt: '9.004'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Technikraum.KNX.Helligkeit
-  room: Technikraum
-10/1/129:
-  dpt: '1.024'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Technikraum.KNX.Tag/Nacht
-  room: Technikraum
-10/1/130:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Technikraum.KNX.Slave
-  room: Technikraum
-10/1/140:
-  dpt: '1.003'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Vorratsraum.KNX.Sperren
-  room: Vorratsraum
-10/1/141:
-  dpt: '1.011'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Vorratsraum.KNX.Sperren-Status
-  room: Vorratsraum
-10/1/142:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Vorratsraum.KNX.Ein/Aus
-  room: Vorratsraum
-10/1/143:
-  dpt: '5.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Vorratsraum.KNX.Dimmen
-  room: Vorratsraum
-10/1/144:
-  dpt: '9.004'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Vorratsraum.KNX.Schaltschwelle
-  room: Vorratsraum
-10/1/146:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Vorratsraum.KNX.HLK
-  room: Vorratsraum
-10/1/147:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Vorratsraum.KNX.Präsenz
-  room: Vorratsraum
-10/1/148:
-  dpt: '9.004'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Vorratsraum.KNX.Helligkeit
-  room: Vorratsraum
-10/1/149:
-  dpt: '1.024'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Vorratsraum.KNX.Tag/Nacht
-  room: Vorratsraum
-10/1/150:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Vorratsraum.KNX.Slave
-  room: Vorratsraum
-10/1/160:
-  dpt: '1.003'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Hauswirtschaftsraum.KNX.Sperren
-  room: Hauswirtschaftsraum
-10/1/161:
-  dpt: '1.011'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Hauswirtschaftsraum.KNX.Sperren-Status
-  room: Hauswirtschaftsraum
-10/1/162:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Hauswirtschaftsraum.KNX.Ein/Aus
-  room: Hauswirtschaftsraum
-10/1/163:
-  dpt: '5.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Hauswirtschaftsraum.KNX.Dimmen
-  room: Hauswirtschaftsraum
-10/1/164:
-  dpt: '9.004'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Hauswirtschaftsraum.KNX.Schaltschwelle
-  room: Hauswirtschaftsraum
-10/1/166:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Hauswirtschaftsraum.KNX.HLK
-  room: Hauswirtschaftsraum
-10/1/167:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Hauswirtschaftsraum.KNX.Präsenz
-  room: Hauswirtschaftsraum
-10/1/168:
-  dpt: '9.004'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Hauswirtschaftsraum.KNX.Helligkeit
-  room: Hauswirtschaftsraum
-10/1/169:
-  dpt: '1.024'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Hauswirtschaftsraum.KNX.Tag/Nacht
-  room: Hauswirtschaftsraum
-10/1/170:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Hauswirtschaftsraum.KNX.Slave
-  room: Hauswirtschaftsraum
-10/1/2:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Flur.KNX.Decke.Ein/Aus
-  room: Flur
-10/1/20:
-  dpt: '1.003'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Flur.KNX.Wand.Sperren
-  room: Flur
-10/1/21:
-  dpt: '1.011'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Flur.KNX.Wand.Sperren-Status
-  room: Flur
-10/1/22:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Flur.KNX.Wand.Ein/Aus
-  room: Flur
-10/1/23:
-  dpt: '5.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Flur.KNX.Wand.Dimmen
-  room: Flur
-10/1/25:
-  dpt: '1.011'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Flur.KNX.Wand.Schaltschwelle-Status
-  room: Flur
-10/1/26:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Flur.KNX.Wand.HLK
-  room: Flur
-10/1/27:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Flur.KNX.Wand.Präsenz
-  room: Flur
-10/1/28:
-  dpt: '9.004'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Flur.KNX.Wand.Helligkeit
-  room: Flur
-10/1/29:
-  dpt: '1.024'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Flur.KNX.Wand.Tag/Nacht
-  room: Flur
-10/1/3:
-  dpt: '5.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Flur.KNX.Decke.Dimmen
-  room: Flur
-10/1/30:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Flur.KNX.Wand.Slave
-  room: Flur
-10/1/40:
-  dpt: '1.003'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Flur.EMA.Sperren
-  room: Flur
-10/1/41:
-  dpt: '1.011'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Flur.EMA.Sperren-Status
-  room: Flur
-10/1/42:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Flur.EMA.Ein/Aus
-  room: Flur
-10/1/46:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Flur.EMA.HLK
-  room: Flur
-10/1/47:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Flur.EMA.Präsenz
-  room: Flur
-10/1/49:
-  dpt: '1.024'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Flur.EMA.Tag/Nacht
-  room: Flur
-10/1/5:
-  dpt: '1.011'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Flur.KNX.Decke.Schaltschwelle-Status
-  room: Flur
-10/1/6:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Flur.KNX.Decke.HLK
-  room: Flur
-10/1/60:
-  dpt: '1.003'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Garage.KNX.Decke.Sperren
-  room: Garage
-10/1/61:
-  dpt: '1.011'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Garage.KNX.Decke.Sperren-Status
-  room: Garage
-10/1/62:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Garage.KNX.Decke.Ein/Aus
-  room: Garage
-10/1/63:
-  dpt: '5.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Garage.KNX.Decke.Dimmen
-  room: Garage
-10/1/64:
-  dpt: '9.004'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Garage.KNX.Decke.Schaltschwelle
-  room: Garage
-10/1/66:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Garage.KNX.Decke.HLK
-  room: Garage
-10/1/67:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Garage.KNX.Decke.Präsenz
-  room: Garage
-10/1/68:
-  dpt: '9.004'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Garage.KNX.Decke.Helligkeit
-  room: Garage
-10/1/69:
-  dpt: '1.024'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Garage.KNX.Decke.Tag/Nacht
-  room: Garage
-10/1/7:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Flur.KNX.Decke.Präsenz
-  room: Flur
-10/1/70:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Garage.KNX.Decke.Slave
-  room: Garage
-10/1/8:
-  dpt: '9.004'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Flur.KNX.Decke.Helligkeit
-  room: Flur
-10/1/82:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Garage.KNX.Wand.Ein/Aus
-  room: Garage
-10/1/83:
-  dpt: '5.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Garage.KNX.Wand.Dimmen
-  room: Garage
-10/1/86:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Garage.KNX.Wand.HLK
-  room: Garage
-10/1/87:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Garage.KNX.Wand.Präsenz
-  room: Garage
-10/1/88:
-  dpt: '9.004'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Garage.KNX.Wand.Helligkeit
-  room: Garage
-10/1/89:
-  dpt: '1.024'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Garage.KNX.Wand.Tag/Nacht
-  room: Garage
-10/1/9:
-  dpt: '1.024'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Flur.KNX.Decke.Tag/Nacht
-  room: Flur
-10/1/90:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.KG.Garage.KNX.Wand.Slave
-  room: Garage
-10/2/0:
-  dpt: '1.003'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.EG.Flur.KNX.Eingang.Sperren
-  room: Flur
-10/2/1:
-  dpt: '1.011'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.EG.Flur.KNX.Eingang.Sperren-Status
-  room: Flur
-10/2/10:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.EG.Flur.KNX.Eingang.Slave
-  room: Flur
-10/2/100:
-  dpt: '1.003'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.EG.Büro.EMA.Sperren
-  room: Büro
-10/2/101:
-  dpt: '1.011'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.EG.Büro.EMA.Sperren-Status
-  room: Büro
-10/2/102:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.EG.Büro.EMA.Ein/Aus
-  room: Büro
-10/2/106:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.EG.Büro.EMA.HLK
-  room: Büro
-10/2/107:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.EG.Büro.EMA.Präsenz
-  room: Büro
-10/2/109:
-  dpt: '1.024'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.EG.Büro.EMA.Tag/Nacht
-  room: Büro
-10/2/120:
-  dpt: '1.003'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.EG.Wohnzimmer.EMA.Sperren
-  room: Wohnzimmer
-10/2/121:
-  dpt: '1.011'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.EG.Wohnzimmer.EMA.Sperren-Status
-  room: Wohnzimmer
-10/2/122:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.EG.Wohnzimmer.EMA.Ein/Aus
-  room: Wohnzimmer
-10/2/126:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.EG.Wohnzimmer.EMA.HLK
-  room: Wohnzimmer
-10/2/127:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.EG.Wohnzimmer.EMA.Präsenz
-  room: Wohnzimmer
-10/2/129:
-  dpt: '1.024'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.EG.Wohnzimmer.EMA.Tag/Nacht
-  room: Wohnzimmer
-10/2/140:
-  dpt: '1.003'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.EG.Esszimmer.EMA.Sperren
-  room: Esszimmer
-10/2/141:
-  dpt: '1.011'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.EG.Esszimmer.EMA.Sperren-Status
-  room: Esszimmer
-10/2/142:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.EG.Esszimmer.EMA.Ein/Aus
-  room: Esszimmer
-10/2/146:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.EG.Esszimmer.EMA.HLK
-  room: Esszimmer
-10/2/147:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.EG.Esszimmer.EMA.Präsenz
-  room: Esszimmer
-10/2/149:
-  dpt: '1.024'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.EG.Esszimmer.EMA.Tag/Nacht
-  room: Esszimmer
-10/2/2:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.EG.Flur.KNX.Eingang.Ein/Aus
-  room: Flur
-10/2/20:
-  dpt: '1.003'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.EG.Flur.KNX.Diele.Sperren
-  room: Flur
-10/2/21:
-  dpt: '1.011'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.EG.Flur.KNX.Diele.Sperren-Status
-  room: Flur
-10/2/22:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.EG.Flur.KNX.Diele.Ein/Aus
-  room: Flur
-10/2/23:
-  dpt: '5.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.EG.Flur.KNX.Diele.Dimmen
-  room: Flur
-10/2/25:
-  dpt: '1.011'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.EG.Flur.KNX.Diele.Schaltschwelle-Status
-  room: Flur
-10/2/26:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.EG.Flur.KNX.Diele.HLK
-  room: Flur
-10/2/27:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.EG.Flur.KNX.Diele.Präsenz
-  room: Flur
-10/2/28:
-  dpt: '9.004'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.EG.Flur.KNX.Diele.Helligkeit
-  room: Flur
-10/2/29:
-  dpt: '1.024'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.EG.Flur.KNX.Diele.Tag/Nacht
-  room: Flur
-10/2/3:
-  dpt: '5.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.EG.Flur.KNX.Eingang.Dimmen
-  room: Flur
-10/2/30:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.EG.Flur.KNX.Diele.Slave
-  room: Flur
-10/2/42:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.EG.Flur.KNX.Garderobe.Ein/Aus
-  room: Flur
-10/2/46:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.EG.Flur.KNX.Garderobe.HLK
-  room: Flur
-10/2/47:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.EG.Flur.KNX.Garderobe.Präsenz
-  room: Flur
-10/2/48:
-  dpt: '9.004'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.EG.Flur.KNX.Garderobe.Helligkeit
-  room: Flur
-10/2/49:
-  dpt: '1.024'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.EG.Flur.KNX.Garderobe.Tag/Nacht
-  room: Flur
-10/2/5:
-  dpt: '1.011'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.EG.Flur.KNX.Eingang.Schaltschwelle-Status
-  room: Flur
-10/2/50:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.EG.Flur.KNX.Garderobe.Slave
-  room: Flur
-10/2/6:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.EG.Flur.KNX.Eingang.HLK
-  room: Flur
-10/2/60:
-  dpt: '1.003'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.EG.Flur.EMA.Sperren
-  room: Flur
-10/2/61:
-  dpt: '1.011'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.EG.Flur.EMA.Sperren-Status
-  room: Flur
-10/2/62:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.EG.Flur.EMA.Ein/Aus
-  room: Flur
-10/2/66:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.EG.Flur.EMA.HLK
-  room: Flur
-10/2/67:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.EG.Flur.EMA.Präsenz
-  room: Flur
-10/2/69:
-  dpt: '1.024'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.EG.Flur.EMA.Tag/Nacht
-  room: Flur
-10/2/7:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.EG.Flur.KNX.Eingang.Präsenz
-  room: Flur
-10/2/8:
-  dpt: '9.004'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.EG.Flur.KNX.Eingang.Helligkeit
-  room: Flur
-10/2/80:
-  dpt: '1.003'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.EG.Gäste-WC.KNX.Sperren
-  room: Gäste-WC
-10/2/81:
-  dpt: '1.011'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.EG.Gäste-WC.KNX.Sperren-Status
-  room: Gäste-WC
-10/2/82:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.EG.Gäste-WC.KNX.Ein/Aus
-  room: Gäste-WC
-10/2/83:
-  dpt: '5.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.EG.Gäste-WC.KNX.Dimmen
-  room: Gäste-WC
-10/2/85:
-  dpt: '1.011'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.EG.Gäste-WC.KNX.Schaltschwelle-Status
-  room: Gäste-WC
-10/2/86:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.EG.Gäste-WC.KNX.HLK
-  room: Gäste-WC
-10/2/87:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.EG.Gäste-WC.KNX.Präsenz
-  room: Gäste-WC
-10/2/88:
-  dpt: '9.004'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.EG.Gäste-WC.KNX.Helligkeit
-  room: Gäste-WC
-10/2/89:
-  dpt: '1.024'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.EG.Gäste-WC.KNX.Tag/Nacht
-  room: Gäste-WC
-10/2/9:
-  dpt: '1.024'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.EG.Flur.KNX.Eingang.Tag/Nacht
-  room: Flur
-10/2/90:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.EG.Gäste-WC.KNX.Slave
-  room: Gäste-WC
-10/3/10:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Flur.KNX.Treppe.Slave
-  room: Flur
-10/3/100:
-  dpt: '1.003'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Badezimmer-Kinder.KNX.Sperren
-  room: Badezimmer-Kinder
-10/3/101:
-  dpt: '1.011'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Badezimmer-Kinder.KNX.Sperren-Status
-  room: Badezimmer-Kinder
-10/3/102:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Badezimmer-Kinder.KNX.Ein/Aus
-  room: Badezimmer-Kinder
-10/3/103:
-  dpt: '5.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Badezimmer-Kinder.KNX.Dimmen
-  room: Badezimmer-Kinder
-10/3/105:
-  dpt: '1.011'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Badezimmer-Kinder.KNX.Schaltschwelle-Status
-  room: Badezimmer-Kinder
-10/3/106:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Badezimmer-Kinder.KNX.HLK
-  room: Badezimmer-Kinder
-10/3/107:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Badezimmer-Kinder.KNX.Präsenz
-  room: Badezimmer-Kinder
-10/3/108:
-  dpt: '9.004'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Badezimmer-Kinder.KNX.Helligkeit
-  room: Badezimmer-Kinder
-10/3/109:
-  dpt: '1.024'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Badezimmer-Kinder.KNX.Tag/Nacht
-  room: Badezimmer-Kinder
-10/3/110:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Badezimmer-Kinder.KNX.Slave
-  room: Badezimmer-Kinder
-10/3/160:
-  dpt: '1.003'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Schlafzimmer-Eltern.KNX.Sperren
-  room: Schlafzimmer-Eltern
-10/3/161:
-  dpt: '1.011'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Schlafzimmer-Eltern.KNX..Sperren-Status
-  room: Schlafzimmer-Eltern
-10/3/162:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Schlafzimmer-Eltern.KNX.Ein/Aus
-  room: Schlafzimmer-Eltern
-10/3/163:
-  dpt: '5.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Schlafzimmer-Eltern.KNX.Dimmen
-  room: Schlafzimmer-Eltern
-10/3/165:
-  dpt: '1.011'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Schlafzimmer-Eltern.KNX.Schaltschwelle-Status
-  room: Schlafzimmer-Eltern
-10/3/166:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Schlafzimmer-Eltern.KNX.HLK
-  room: Schlafzimmer-Eltern
-10/3/167:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Schlafzimmer-Eltern.KNX.Präsenz
-  room: Schlafzimmer-Eltern
-10/3/168:
-  dpt: '9.004'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Schlafzimmer-Eltern.KNX.Helligkeit
-  room: Schlafzimmer-Eltern
-10/3/169:
-  dpt: '1.024'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Schlafzimmer-Eltern.KNX.Tag/Nacht
-  room: Schlafzimmer-Eltern
-10/3/170:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Schlafzimmer-Eltern.KNX.Slave
-  room: Schlafzimmer-Eltern
-10/3/180:
-  dpt: '1.003'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Begehbarer-Schrank.KNX.Sperren
-  room: Begehbarer-Schrank
-10/3/181:
-  dpt: '1.011'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Begehbarer-Schrank.KNX.Sperren-Status
-  room: Begehbarer-Schrank
-10/3/182:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Begehbarer-Schrank.KNX.Ein/Aus
-  room: Begehbarer-Schrank
-10/3/183:
-  dpt: '5.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Begehbarer-Schrank.KNX.Dimmen
-  room: Begehbarer-Schrank
-10/3/185:
-  dpt: '1.011'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Begehbarer-Schrank.KNX.Schaltschwelle-Status
-  room: Begehbarer-Schrank
-10/3/186:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Begehbarer-Schrank.KNX.HLK
-  room: Begehbarer-Schrank
-10/3/187:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Begehbarer-Schrank.KNX.Präsenz
-  room: Begehbarer-Schrank
-10/3/188:
-  dpt: '9.004'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Begehbarer-Schrank.KNX.Helligkeit
-  room: Begehbarer-Schrank
-10/3/189:
-  dpt: '1.024'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Begehbarer-Schrank.KNX.Tag/Nacht
-  room: Begehbarer-Schrank
-10/3/190:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Begehbarer-Schrank.KNX.Slave
-  room: Begehbarer-Schrank
-10/3/2:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Flur.KNX.Treppe.Ein/Aus
-  room: Flur
-10/3/20:
-  dpt: '1.003'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Flur.KNX.Gang.Sperren
-  room: Flur
-10/3/200:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Badezimmer-Eltern.KNX.Sperren
-  room: Badezimmer-Eltern
-10/3/201:
-  dpt: '1.011'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Badezimmer-Eltern.KNX.Sperren-Status
-  room: Badezimmer-Eltern
-10/3/202:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Badezimmer-Eltern.KNX.Ein/Aus
-  room: Badezimmer-Eltern
-10/3/203:
-  dpt: '5.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Badezimmer-Eltern.KNX.Dimmen
-  room: Badezimmer-Eltern
-10/3/205:
-  dpt: '1.011'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Badezimmer-Eltern.KNX.Schaltschwelle-Status
-  room: Badezimmer-Eltern
-10/3/206:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Badezimmer-Eltern.KNX.HLK
-  room: Badezimmer-Eltern
-10/3/207:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Badezimmer-Eltern.KNX.Präsenz
-  room: Badezimmer-Eltern
-10/3/208:
-  dpt: '9.004'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Badezimmer-Eltern.KNX.Helligkeit
-  room: Badezimmer-Eltern
-10/3/209:
-  dpt: '1.024'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Badezimmer-Eltern.KNX.Tag/Nacht
-  room: Badezimmer-Eltern
-10/3/21:
-  dpt: '1.011'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Flur.KNX.Gang.Sperren-Status
-  room: Flur
-10/3/210:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Badezimmer-Eltern.KNX.Slave
-  room: Badezimmer-Eltern
-10/3/22:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Flur.KNX.Gang.Ein/Aus
-  room: Flur
-10/3/23:
-  dpt: '5.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Flur.KNX.Gang.Dimmen
-  room: Flur
-10/3/25:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Flur.KNX.Gang.Schaltschwelle-Status
-  room: Flur
-10/3/26:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Flur.KNX.Gang.HLK
-  room: Flur
-10/3/27:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Flur.KNX.Gang.Präsenz
-  room: Flur
-10/3/28:
-  dpt: '9.004'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Flur.KNX.Gang.Helligkeit
-  room: Flur
-10/3/29:
-  dpt: '1.024'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Flur.KNX.Gang.Tag/Nacht
-  room: Flur
-10/3/30:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Flur.KNX.Gang.Slave
-  room: Flur
-10/3/40:
-  dpt: '1.003'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Flur.EMA.Treppe.Sperren
-  room: Flur
-10/3/41:
-  dpt: '1.011'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Flur.EMA.Treppe.Sperren-Status
-  room: Flur
-10/3/42:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Flur.EMA.Treppe.Ein/Aus
-  room: Flur
-10/3/46:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Flur.EMA.Treppe.HLK
-  room: Flur
-10/3/47:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Flur.EMA.Treppe.Präsenz
-  room: Flur
-10/3/49:
-  dpt: '1.024'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Flur.EMA.Treppe.Tag/Nacht
-  room: Flur
-10/3/6:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Flur.KNX.Treppe.HLK
-  room: Flur
-10/3/60:
-  dpt: '1.003'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Flur.EMA.Gang.Sperren
-  room: Flur
-10/3/61:
-  dpt: '1.011'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Flur.EMA.Gang.Sperren-Status
-  room: Flur
-10/3/62:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Flur.EMA.Gang.Ein/Aus
-  room: Flur
-10/3/66:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Flur.EMA.Gang.HLK
-  room: Flur
-10/3/67:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Flur.EMA.Gang.Präsenz
-  room: Flur
-10/3/69:
-  dpt: '1.024'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Flur.EMA.Gang.Tag/Nacht
-  room: Flur
-10/3/7:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Flur.KNX.Treppe.Präsenz
-  room: Flur
-10/3/8:
-  dpt: '9.004'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Flur.KNX.Treppe.Helligkeit
-  room: Flur
-10/3/9:
-  dpt: '1.024'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.OG.Flur.KNX.Treppe.Tag/Nacht
-  room: Flur
-10/4/0:
-  dpt: '1.003'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.DG.KNX.Sperren
-  room: KNX
-10/4/1:
-  dpt: '1.011'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.DG.KNX.Sperren-Status
-  room: KNX
-10/4/10:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.DG.KNX.Slave
-  room: KNX
-10/4/2:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.DG.KNX.Ein/Aus
-  room: KNX
-10/4/3:
-  dpt: '5.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.DG.KNX.Dimmen
-  room: KNX
-10/4/4:
-  dpt: '9.004'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.DG.KNX.Schaltschwelle
-  room: KNX
-10/4/6:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.DG.KNX.HLK
-  room: KNX
-10/4/7:
-  dpt: '1.001'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.DG.KNX.Präsenz
-  room: KNX
-10/4/8:
-  dpt: '9.004'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.DG.KNX.Helligkeit
-  room: KNX
-10/4/9:
-  dpt: '1.024'
-  function: Bewegungsmelder
-  name: Bewegungsmelder.DG.KNX.Tag/Nacht
-  room: KNX
-11/0/100:
+10/0/100:
   dpt: '1.011'
   function: Sicherheit
   name: Sicherheit.Zentral.KG.Fenster/Tür.Offen-Status
-11/0/120:
+10/0/120:
   dpt: '1.011'
   function: Sicherheit
   name: Sicherheit.Zentral.EG.Fenster/Tür.Offen-Status
-11/0/140:
+10/0/140:
   dpt: '1.011'
   function: Sicherheit
   name: Sicherheit.Zentral.OG.Fenster/Tür.Offen-Status
-11/1/1:
+10/1/1:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.KG.Garage.Fenster.Geöffnet-Status
   room: Garage
-11/1/11:
+10/1/11:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.KG.Garage.Garagentor.Geöffnet-Status
   room: Garage
-11/1/21:
+10/1/21:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.KG.Technikraum.Fenster.Geöffnet-Status
   room: Technikraum
-11/1/31:
+10/1/31:
   dpt: '1.005'
   function: Sicherheit
   name: Sicherheit.KG.Technikraum.Gasmelder.Alarm
   room: Technikraum
-11/1/41:
+10/1/41:
   dpt: '1.005'
   function: Sicherheit
   name: Sicherheit.KG.Technikraum.CO-Melder.Alarm
   room: Technikraum
-11/1/51:
+10/1/51:
   dpt: '1.005'
   function: Sicherheit
   name: Sicherheit.KG.Technikraum.Wassermelder.Alarm
   room: Technikraum
-11/1/61:
+10/1/61:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.KG.Vorratsraum.Fenster.Geöffnet-Status
   room: Vorratsraum
-11/1/71:
+10/1/71:
   dpt: '1.005'
   function: Sicherheit
   name: Sicherheit.KG.Vorratsraum.Gasmelder.Alarm
   room: Vorratsraum
-11/1/81:
+10/1/81:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.KG.Hauswirtschaftsraum.Fenster.Geöffnet-Status
   room: Hauswirtschaftsraum
-11/1/91:
+10/1/91:
   dpt: '1.005'
   function: Sicherheit
   name: Sicherheit.KG.Hauswirtschaftsraum.Wassermelder.Alarm
   room: Hauswirtschaftsraum
-11/2/1:
+10/2/1:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Flur.Fenster.Geöffnet-Status
   room: Flur
-11/2/101:
+10/2/101:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Küche.Fenster.Links.Geöffnet-Status
   room: Küche
-11/2/102:
+10/2/102:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Küche.Fenster.Links.Stellung-Kipp-Status
   room: Küche
-11/2/103:
+10/2/103:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Küche.Fenster.Links.Stellung-Geöffnet-Status
   room: Küche
-11/2/11:
+10/2/11:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Flur.Tür.Geöffnet-Status
   room: Flur
-11/2/111:
+10/2/111:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Küche.Fenster.Mitte-Links.Geöffnet-Status
   room: Küche
-11/2/112:
+10/2/112:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Küche.Fenster.Mitte-Links.Stellung-Kipp-Status
   room: Küche
-11/2/113:
+10/2/113:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Küche.Fenster.Mitte-Links.Stellung-Geöffnet-Status
   room: Küche
-11/2/121:
+10/2/121:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Küche.Fenster.Mitte-Rechts.Geöffnet-Status
   room: Küche
-11/2/122:
+10/2/122:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Küche.Fenster.Mitte-Rechts.Stellung-Kipp-Status
   room: Küche
-11/2/123:
+10/2/123:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Küche.Fenster.Mitte-Rechts.Stellung-Geöffnet-Status
   room: Küche
-11/2/131:
+10/2/131:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Küche.Fenster.Rechts.Geöffnet-Status
   room: Küche
-11/2/132:
+10/2/132:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Küche.Fenster.Rechts.Stellung-Kipp-Status
   room: Küche
-11/2/133:
+10/2/133:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Küche.Fenster.Rechts.Stellung-Geöffnet-Status
   room: Küche
-11/2/141:
+10/2/141:
   dpt: '1.005'
   function: Sicherheit
   name: Sicherheit.EG.Küche.Wassermelder.Küchenzeile.Links.Alarm
   room: Küche
-11/2/151:
+10/2/151:
   dpt: '1.005'
   function: Sicherheit
   name: Sicherheit.EG.Küche.Wassermelder.Küchenzeile.Rechts.Alarm
   room: Küche
-11/2/161:
+10/2/161:
   dpt: '1.005'
   function: Sicherheit
   name: Sicherheit.EG.Küche.Wassermelder.Kücheninsel.Alarm
   room: Küche
-11/2/2:
+10/2/2:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Flur.Fenster.Stellung-Kipp-Status
   room: Flur
-11/2/21:
+10/2/21:
   dpt: '1.005'
   function: Sicherheit
   name: Sicherheit.EG.Flur.Wassermelder-Alarm
   room: Flur
-11/2/3:
+10/2/3:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Flur.Fenster.Stellung-Geöffnet-Status
   room: Flur
-11/2/31:
+10/2/31:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Gäste-WC.Fenster.Geöffnet-Status
-  room: Gäste-WC
-11/2/32:
+  room: Gäste WC
+10/2/32:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Gäste-WC.Fenster.Stellung-Kipp-Status
-  room: Gäste-WC
-11/2/33:
+  room: Gäste WC
+10/2/33:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Gäste-WC.Fenster.Stellung-Geöffnet-Status
-  room: Gäste-WC
-11/2/41:
+  room: Gäste WC
+10/2/41:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Büro.Fenster.Links.Geöffnet-Status
   room: Büro
-11/2/42:
+10/2/42:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Büro.Fenster.Links.Stellung-Kipp-Status
   room: Büro
-11/2/43:
+10/2/43:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Büro.Fenster.Links.Stellung-Geöffnet-Status
   room: Büro
-11/2/51:
+10/2/51:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Büro.Fenster.Mitte.Geöffnet-Status
   room: Büro
-11/2/52:
+10/2/52:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Büro.Fenster.Mitte.Stellung-Kipp-Status
   room: Büro
-11/2/53:
+10/2/53:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Büro.Fenster.Mitte.Stellung-Geöffnet-Status
   room: Büro
-11/2/61:
+10/2/61:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Büro.Fenster.Rechts.Geöffnet-Status
   room: Büro
-11/2/62:
+10/2/62:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Büro.Fenster.Rechts.Stellung-Kipp-Status
   room: Büro
-11/2/63:
+10/2/63:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Büro.Fenster.Rechts.Stellung-Geöffnet-Status
   room: Büro
-11/2/71:
+10/2/71:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Büro.Fenster.Seite.Geöffnet-Status
   room: Büro
-11/2/72:
+10/2/72:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Büro.Fenster.Seite.Stellung-Kipp-Status
   room: Büro
-11/2/73:
+10/2/73:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Büro.Fenster.Seite.Stellung-Geöffnet-Status
   room: Büro
-11/2/81:
+10/2/81:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Wohnzimmer.Fenster.Geöffnet-Status
   room: Wohnzimmer
-11/2/91:
+10/2/91:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Esszimmer.Fenster.Geöffnet-Status
   room: Esszimmer
-11/3/1:
+10/3/1:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.OG.Flur.Fenster.Treppe.Geöffnet-Status
   room: Flur
-11/3/11:
+10/3/11:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.OG.Flur.Fenster.Galerie.Geöffnet-Status
   room: Flur
-11/3/12:
+10/3/12:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.OG.Flur.Fenster.Galerie.Stellung-Kipp-Status
   room: Flur
-11/3/13:
+10/3/13:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.OG.Flur.Fenster.Galerie.Stellung-Geöffnet-Status
   room: Flur
-11/3/2:
+10/3/2:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.OG.Flur.Fenster.Treppe.Stellung-Kipp-Status
   room: Flur
-11/3/21:
+10/3/21:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.OG.Abstellraum.Fenster.Geöffnet-Status
   room: Abstellraum
-11/3/22:
+10/3/22:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.OG.Abstellraum.Fenster.Stellung-Kipp-Status
   room: Abstellraum
-11/3/23:
+10/3/23:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.OG.Abstellraum.Fenster.Stellung-Geöffnet-Status
   room: Abstellraum
-11/3/3:
+10/3/3:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.OG.Flur.Fenster.Treppe.Stellung-Geöffnet-Status
   room: Flur
-11/3/31:
+10/3/31:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.OG.Badezimmer-Kinder.Fenster.Geöffnet-Status
-  room: Badezimmer-Kinder
-11/3/32:
+  room: Badezimmer Kinder
+10/3/32:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.OG.Badezimmer-Kinder.Fenster.Stellung-Kipp-Status
-  room: Badezimmer-Kinder
-11/3/33:
+  room: Badezimmer Kinder
+10/3/33:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.OG.Badezimmer-Kinder.Fenster.Stellung-Geöffnet-Status
-  room: Badezimmer-Kinder
-11/3/41:
+  room: Badezimmer Kinder
+10/3/41:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.OG.Schlafzimmer-Gregory.Fenster.Geöffnet-Status
-  room: Schlafzimmer-Gregory
-11/3/51:
+  room: Schlafzimmer Gregory
+10/3/51:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.OG.Schlafzimmer-Luis.Fenster.Geöffnet-Status
-  room: Schlafzimmer-Luis
-11/3/61:
+  room: Schlafzimmer Luis
+10/3/61:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.OG.Schlafzimmer-Eltern.Fenster.Geöffnet-Status
-  room: Schlafzimmer-Eltern
-11/3/71:
+  room: Schlafzimmer Eltern
+10/3/71:
   dpt: '1.005'
   function: Sicherheit
   name: Sicherheit.OG.Schlafzimmer-Eltern.Wassermelder.Alarm
-  room: Schlafzimmer-Eltern
-11/3/81:
+  room: Schlafzimmer Eltern
+10/3/81:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.OG.Badezimmer-Eltern.Fenster.Geöffnet-Status
-  room: Badezimmer-Eltern
-11/3/82:
+  room: Badezimmer Eltern
+10/3/82:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.OG.Badezimmer-Eltern.Fenster.Stellung-Kipp-Status
-  room: Badezimmer-Eltern
-11/3/83:
+  room: Badezimmer Eltern
+10/3/83:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.OG.Badezimmer-Eltern.Fenster.Stellung-Geöffnet-Status
-  room: Badezimmer-Eltern
-13/0/200:
+  room: Badezimmer Eltern
+12/0/200:
   dpt: '5.010'
   function: Multimedia
   name: Multimedia.Zentral.Stream.Alexander.Voreinstellung
-13/0/201:
+12/0/201:
   dpt: '5.010'
   function: Multimedia
   name: Multimedia.Zentral.Stream.Alexander.Aktion
-13/0/202:
+12/0/202:
   dpt: '1.001'
   function: Multimedia
   name: Multimedia.Zentral.Stream.Alexander.Wiederholung
-13/0/203:
+12/0/203:
   dpt: '1.011'
   function: Multimedia
   name: Multimedia.Zentral.Stream.Alexander.Wiederholung-Status
-13/0/204:
+12/0/204:
   dpt: '1.001'
   function: Multimedia
   name: Multimedia.Zentral.Stream.Alexander.Shuffle
-13/0/205:
+12/0/205:
   dpt: '1.011'
   function: Multimedia
   name: Multimedia.Zentral.Stream.Alexander.Shuffle-Status
-13/0/210:
+12/0/210:
   dpt: '5.010'
   function: Multimedia
   name: Multimedia.Zentral.Stream.Vanessa.Voreinstellung
-13/0/211:
+12/0/211:
   dpt: '5.010'
   function: Multimedia
   name: Multimedia.Zentral.Stream.Vanessa.Aktion
-13/0/212:
+12/0/212:
   dpt: '1.001'
   function: Multimedia
   name: Multimedia.Zentral.Stream.Vanessa.Wiederholung
-13/0/213:
+12/0/213:
   dpt: '1.011'
   function: Multimedia
   name: Multimedia.Zentral.Stream.Vanessa.Wiederholung-Status
-13/0/214:
+12/0/214:
   dpt: '1.001'
   function: Multimedia
   name: Multimedia.Zentral.Stream.Vanessa.Shuffle
-13/0/215:
+12/0/215:
   dpt: '1.011'
   function: Multimedia
   name: Multimedia.Zentral.Stream.Vanessa.Shuffle-Status
-13/0/220:
+12/0/220:
   dpt: '5.010'
   function: Multimedia
   name: Multimedia.Zentral.Stream.Luis.Voreinstellung
-13/0/221:
+12/0/221:
   dpt: '5.010'
   function: Multimedia
   name: Multimedia.Zentral.Stream.Luis.Aktion
-13/0/222:
+12/0/222:
   dpt: '1.001'
   function: Multimedia
   name: Multimedia.Zentral.Stream.Luis.Wiederholung
-13/0/223:
+12/0/223:
   dpt: '1.011'
   function: Multimedia
   name: Multimedia.Zentral.Stream.Luis.Wiederholung-Status
-13/0/224:
+12/0/224:
   dpt: '1.001'
   function: Multimedia
   name: Multimedia.Zentral.Stream.Luis.Shuffle
-13/0/225:
+12/0/225:
   dpt: '1.011'
   function: Multimedia
   name: Multimedia.Zentral.Stream.Luis.Shuffle-Status
-13/0/230:
+12/0/230:
   dpt: '5.010'
   function: Multimedia
   name: Multimedia.Zentral.Stream.Gregory.Voreinstellung
-13/0/231:
+12/0/231:
   dpt: '5.010'
   function: Multimedia
   name: Multimedia.Zentral.Stream.Gregory.Aktion
-13/0/232:
+12/0/232:
   dpt: '1.001'
   function: Multimedia
   name: Multimedia.Zentral.Stream.Gregory.Wiederholung
-13/0/233:
+12/0/233:
   dpt: '1.011'
   function: Multimedia
   name: Multimedia.Zentral.Stream.Gregory.Wiederholung-Status
-13/0/234:
+12/0/234:
   dpt: '1.001'
   function: Multimedia
   name: Multimedia.Zentral.Stream.Gregory.Shuffle
-13/0/235:
+12/0/235:
   dpt: '1.011'
   function: Multimedia
   name: Multimedia.Zentral.Stream.Gregory.Shuffle-Status
-13/2/101:
+12/2/101:
   dpt: '1.001'
-  function: Multimedia
-  name: Multimedia.EG.Wohnzimmer.Sony-TV.Ein/Aus
+  function: Entertainment
+  name: Entertainment.EG.Wohnzimmer.Sony-TV.Ein/Aus
   room: Wohnzimmer
-13/2/102:
+12/2/102:
   dpt: '1.011'
-  function: Multimedia
-  name: Multimedia.EG.Wohnzimmer.Sony-TV.Ein/Aus-Status
+  function: Entertainment
+  name: Entertainment.EG.Wohnzimmer.Sony-TV.Ein/Aus-Status
   room: Wohnzimmer
-13/2/103:
+12/2/103:
   dpt: '1.001'
-  function: Multimedia
-  name: Multimedia.EG.Wohnzimmer.Sony-TV.Stummschalten
+  function: Entertainment
+  name: Entertainment.EG.Wohnzimmer.Sony-TV.Stummschalten
   room: Wohnzimmer
-13/2/104:
+12/2/104:
   dpt: '1.011'
-  function: Multimedia
-  name: Multimedia.EG.Wohnzimmer.Sony-TV.Stummschalten-Status
+  function: Entertainment
+  name: Entertainment.EG.Wohnzimmer.Sony-TV.Stummschalten-Status
   room: Wohnzimmer
-13/2/105:
+12/2/105:
   dpt: '5.001'
-  function: Multimedia
-  name: Multimedia.EG.Wohnzimmer.Sony-TV.Lautstärke
+  function: Entertainment
+  name: Entertainment.EG.Wohnzimmer.Sony-TV.Lautstärke
   room: Wohnzimmer
-13/2/106:
+12/2/106:
   dpt: '5.001'
-  function: Multimedia
-  name: Multimedia.EG.Wohnzimmer.Sony-TV.Lautstärke-Status
+  function: Entertainment
+  name: Entertainment.EG.Wohnzimmer.Sony-TV.Lautstärke-Status
   room: Wohnzimmer
-13/2/121:
+12/2/121:
   dpt: '1.001'
-  function: Multimedia
-  name: Multimedia.EG.Esszimmer.Shape.Ein/Aus
+  function: Entertainment
+  name: Entertainment.EG.Esszimmer.Shape.Ein/Aus
   room: Esszimmer
-13/2/122:
+12/2/122:
   dpt: '1.011'
-  function: Multimedia
-  name: Multimedia.EG.Esszimmer.Shape.Ein/Aus-Status
+  function: Entertainment
+  name: Entertainment.EG.Esszimmer.Shape.Ein/Aus-Status
   room: Esszimmer
-13/2/123:
+12/2/123:
   dpt: '1.001'
-  function: Multimedia
-  name: Multimedia.EG.Esszimmer.Shape.Stummschalten
+  function: Entertainment
+  name: Entertainment.EG.Esszimmer.Shape.Stummschalten
   room: Esszimmer
-13/2/124:
+12/2/124:
   dpt: '1.011'
-  function: Multimedia
-  name: Multimedia.EG.Esszimmer.Shape.Stummschalten-Status
+  function: Entertainment
+  name: Entertainment.EG.Esszimmer.Shape.Stummschalten-Status
   room: Esszimmer
-13/2/125:
+12/2/125:
   dpt: '5.001'
-  function: Multimedia
-  name: Multimedia.EG.Esszimmer.Shape.Lautstärke
+  function: Entertainment
+  name: Entertainment.EG.Esszimmer.Shape.Lautstärke
   room: Esszimmer
-13/2/126:
+12/2/126:
   dpt: '5.001'
-  function: Multimedia
-  name: Multimedia.EG.Esszimmer.Shape.Lautstärke-Status
+  function: Entertainment
+  name: Entertainment.EG.Esszimmer.Shape.Lautstärke-Status
   room: Esszimmer
-13/2/127:
+12/2/127:
   dpt: '5.010'
-  function: Multimedia
-  name: Multimedia.EG.Esszimmer.Shape.Quelle
+  function: Entertainment
+  name: Entertainment.EG.Esszimmer.Shape.Quelle
   room: Esszimmer
-13/2/128:
+12/2/128:
   dpt: '5.010'
-  function: Multimedia
-  name: Multimedia.EG.Esszimmer.Shape.Quelle-Status
+  function: Entertainment
+  name: Entertainment.EG.Esszimmer.Shape.Quelle-Status
   room: Esszimmer
-13/2/141:
+12/2/141:
   dpt: '1.001'
-  function: Multimedia
-  name: Multimedia.EG.Küche.Sonos.Ein/Aus
+  function: Entertainment
+  name: Entertainment.EG.Küche.Sonos.Ein/Aus
   room: Küche
-13/2/142:
+12/2/142:
   dpt: '1.011'
-  function: Multimedia
-  name: Multimedia.EG.Küche.Sonos.Ein/Aus-Status
+  function: Entertainment
+  name: Entertainment.EG.Küche.Sonos.Ein/Aus-Status
   room: Küche
-13/2/143:
+12/2/143:
   dpt: '1.001'
-  function: Multimedia
-  name: Multimedia.EG.Küche.Sonos.Stummschalten
+  function: Entertainment
+  name: Entertainment.EG.Küche.Sonos.Stummschalten
   room: Küche
-13/2/144:
+12/2/144:
   dpt: '1.011'
-  function: Multimedia
-  name: Multimedia.EG.Küche.Sonos.Stummschalten-Status
+  function: Entertainment
+  name: Entertainment.EG.Küche.Sonos.Stummschalten-Status
   room: Küche
-13/2/145:
+12/2/145:
   dpt: '5.001'
-  function: Multimedia
-  name: Multimedia.EG.Küche.Sonos.Lautstärke
+  function: Entertainment
+  name: Entertainment.EG.Küche.Sonos.Lautstärke
   room: Küche
-13/2/146:
+12/2/146:
   dpt: '5.001'
-  function: Multimedia
-  name: Multimedia.EG.Küche.Sonos.Lautstärke-Status
+  function: Entertainment
+  name: Entertainment.EG.Küche.Sonos.Lautstärke-Status
   room: Küche
-13/2/41:
+12/2/41:
   dpt: '1.001'
-  function: Multimedia
-  name: Multimedia.EG.Büro.Sonos.Ein/Aus
+  function: Entertainment
+  name: Entertainment.EG.Büro.Sonos.Ein/Aus
   room: Büro
-13/2/42:
+12/2/42:
   dpt: '1.011'
-  function: Multimedia
-  name: Multimedia.EG.Büro.Sonos.Ein/Aus-Status
+  function: Entertainment
+  name: Entertainment.EG.Büro.Sonos.Ein/Aus-Status
   room: Büro
-13/2/43:
+12/2/43:
   dpt: '1.001'
-  function: Multimedia
-  name: Multimedia.EG.Büro.Sonos.Stummschalten
+  function: Entertainment
+  name: Entertainment.EG.Büro.Sonos.Stummschalten
   room: Büro
-13/2/44:
+12/2/44:
   dpt: '1.011'
-  function: Multimedia
-  name: Multimedia.EG.Büro.Sonos.Stummschalten-Status
+  function: Entertainment
+  name: Entertainment.EG.Büro.Sonos.Stummschalten-Status
   room: Büro
-13/2/45:
+12/2/45:
   dpt: '5.001'
-  function: Multimedia
-  name: Multimedia.EG.Büro.Sonos.Lautstärke
+  function: Entertainment
+  name: Entertainment.EG.Büro.Sonos.Lautstärke
   room: Büro
-13/2/46:
+12/2/46:
   dpt: '5.001'
-  function: Multimedia
-  name: Multimedia.EG.Büro.Sonos.Lautstärke-Status
+  function: Entertainment
+  name: Entertainment.EG.Büro.Sonos.Lautstärke-Status
   room: Büro
-13/2/61:
+12/2/61:
   dpt: '1.001'
-  function: Multimedia
-  name: Multimedia.EG.Wohnzimmer.Aalto.Ein/Aus
+  function: Entertainment
+  name: Entertainment.EG.Wohnzimmer.Aalto.Ein/Aus
   room: Wohnzimmer
-13/2/62:
+12/2/62:
   dpt: '1.011'
-  function: Multimedia
-  name: Multimedia.EG.Wohnzimmer.Aalto.Ein/Aus-Status
+  function: Entertainment
+  name: Entertainment.EG.Wohnzimmer.Aalto.Ein/Aus-Status
   room: Wohnzimmer
-13/2/63:
+12/2/63:
   dpt: '1.001'
-  function: Multimedia
-  name: Multimedia.EG.Wohnzimmer.Aalto.Stummschalten
+  function: Entertainment
+  name: Entertainment.EG.Wohnzimmer.Aalto.Stummschalten
   room: Wohnzimmer
-13/2/64:
+12/2/64:
   dpt: '1.011'
-  function: Multimedia
-  name: Multimedia.EG.Wohnzimmer.Aalto.Stummschalten-Status
+  function: Entertainment
+  name: Entertainment.EG.Wohnzimmer.Aalto.Stummschalten-Status
   room: Wohnzimmer
-13/2/65:
+12/2/65:
   dpt: '5.001'
-  function: Multimedia
-  name: Multimedia.EG.Wohnzimmer.Aalto.Lautstärke
+  function: Entertainment
+  name: Entertainment.EG.Wohnzimmer.Aalto.Lautstärke
   room: Wohnzimmer
-13/2/66:
+12/2/66:
   dpt: '5.001'
-  function: Multimedia
-  name: Multimedia.EG.Wohnzimmer.Aalto.Lautstärke-Status
+  function: Entertainment
+  name: Entertainment.EG.Wohnzimmer.Aalto.Lautstärke-Status
   room: Wohnzimmer
-13/2/67:
+12/2/67:
   dpt: '5.010'
-  function: Multimedia
-  name: Multimedia.EG.Wohnzimmer.Aalto.Quelle
+  function: Entertainment
+  name: Entertainment.EG.Wohnzimmer.Aalto.Quelle
   room: Wohnzimmer
-13/2/68:
+12/2/68:
   dpt: '5.010'
-  function: Multimedia
-  name: Multimedia.EG.Wohnzimmer.Aalto.Quelle-Status
+  function: Entertainment
+  name: Entertainment.EG.Wohnzimmer.Aalto.Quelle-Status
   room: Wohnzimmer
-13/2/81:
+12/2/81:
   dpt: '1.001'
-  function: Multimedia
-  name: Multimedia.EG.Wohnzimmer.Asano.Ein/Aus
+  function: Entertainment
+  name: Entertainment.EG.Wohnzimmer.Asano.Ein/Aus
   room: Wohnzimmer
-13/2/82:
+12/2/82:
   dpt: '1.011'
-  function: Multimedia
-  name: Multimedia.EG.Wohnzimmer.Asano.Ein/Aus-Status
+  function: Entertainment
+  name: Entertainment.EG.Wohnzimmer.Asano.Ein/Aus-Status
   room: Wohnzimmer
-13/2/83:
+12/2/83:
   dpt: '1.001'
-  function: Multimedia
-  name: Multimedia.EG.Wohnzimmer.Asano.Stummschalten
+  function: Entertainment
+  name: Entertainment.EG.Wohnzimmer.Asano.Stummschalten
   room: Wohnzimmer
-13/2/84:
+12/2/84:
   dpt: '1.011'
-  function: Multimedia
-  name: Multimedia.EG.Wohnzimmer.Asano.Stummschalten-Status
+  function: Entertainment
+  name: Entertainment.EG.Wohnzimmer.Asano.Stummschalten-Status
   room: Wohnzimmer
-13/2/85:
+12/2/85:
   dpt: '5.001'
-  function: Multimedia
-  name: Multimedia.EG.Wohnzimmer.Asano.Lautstärke
+  function: Entertainment
+  name: Entertainment.EG.Wohnzimmer.Asano.Lautstärke
   room: Wohnzimmer
-13/2/86:
+12/2/86:
   dpt: '5.001'
-  function: Multimedia
-  name: Multimedia.EG.Wohnzimmer.Asano.Lautstärke-Status
+  function: Entertainment
+  name: Entertainment.EG.Wohnzimmer.Asano.Lautstärke-Status
   room: Wohnzimmer
-13/2/87:
+12/2/87:
   dpt: '5.010'
-  function: Multimedia
-  name: Multimedia.EG.Wohnzimmer.Asano.Quelle
+  function: Entertainment
+  name: Entertainment.EG.Wohnzimmer.Asano.Quelle
   room: Wohnzimmer
-13/2/88:
+12/2/88:
   dpt: '5.010'
-  function: Multimedia
-  name: Multimedia.EG.Wohnzimmer.Asano.Quelle-Status
+  function: Entertainment
+  name: Entertainment.EG.Wohnzimmer.Asano.Quelle-Status
   room: Wohnzimmer
-13/3/101:
+12/3/101:
   dpt: '1.001'
-  function: Multimedia
-  name: Multimedia.OG.Schlafzimmer-Eltern.Asano.Ein/Aus
-  room: Schlafzimmer-Eltern
-13/3/102:
+  function: Entertainment
+  name: Entertainment.OG.Schlafzimmer-Eltern.Asano.Ein/Aus
+  room: Schlafzimmer Eltern
+12/3/102:
   dpt: '1.011'
-  function: Multimedia
-  name: Multimedia.OG.Schlafzimmer-Eltern.Asano.Ein/Aus-Status
-  room: Schlafzimmer-Eltern
-13/3/103:
+  function: Entertainment
+  name: Entertainment.OG.Schlafzimmer-Eltern.Asano.Ein/Aus-Status
+  room: Schlafzimmer Eltern
+12/3/103:
   dpt: '1.001'
-  function: Multimedia
-  name: Multimedia.OG.Schlafzimmer-Eltern.Asano.Stummschalten
-  room: Schlafzimmer-Eltern
-13/3/104:
+  function: Entertainment
+  name: Entertainment.OG.Schlafzimmer-Eltern.Asano.Stummschalten
+  room: Schlafzimmer Eltern
+12/3/104:
   dpt: '1.011'
-  function: Multimedia
-  name: Multimedia.OG.Schlafzimmer-Eltern.Asano.Stummschalten-Status
-  room: Schlafzimmer-Eltern
-13/3/105:
+  function: Entertainment
+  name: Entertainment.OG.Schlafzimmer-Eltern.Asano.Stummschalten-Status
+  room: Schlafzimmer Eltern
+12/3/105:
   dpt: '5.001'
-  function: Multimedia
-  name: Multimedia.OG.Schlafzimmer-Eltern.Asano.Lautstärke
-  room: Schlafzimmer-Eltern
-13/3/106:
+  function: Entertainment
+  name: Entertainment.OG.Schlafzimmer-Eltern.Asano.Lautstärke
+  room: Schlafzimmer Eltern
+12/3/106:
   dpt: '5.001'
-  function: Multimedia
-  name: Multimedia.OG.Schlafzimmer-Eltern.Asano.Lautstärke-Status
-  room: Schlafzimmer-Eltern
-13/3/107:
+  function: Entertainment
+  name: Entertainment.OG.Schlafzimmer-Eltern.Asano.Lautstärke-Status
+  room: Schlafzimmer Eltern
+12/3/107:
   dpt: '5.010'
-  function: Multimedia
-  name: Multimedia.OG.Schlafzimmer-Eltern.Asano.Quelle
-  room: Schlafzimmer-Eltern
-13/3/108:
+  function: Entertainment
+  name: Entertainment.OG.Schlafzimmer-Eltern.Asano.Quelle
+  room: Schlafzimmer Eltern
+12/3/108:
   dpt: '5.010'
-  function: Multimedia
-  name: Multimedia.OG.Schlafzimmer-Eltern.Asano.Quelle-Status
-  room: Schlafzimmer-Eltern
-13/3/121:
+  function: Entertainment
+  name: Entertainment.OG.Schlafzimmer-Eltern.Asano.Quelle-Status
+  room: Schlafzimmer Eltern
+12/3/121:
   dpt: '1.001'
-  function: Multimedia
-  name: Multimedia.OG.Schlafzimmer-Eltern.Sony-TV.Ein/Aus
-  room: Schlafzimmer-Eltern
-13/3/122:
+  function: Entertainment
+  name: Entertainment.OG.Schlafzimmer-Eltern.Sony-TV.Ein/Aus
+  room: Schlafzimmer Eltern
+12/3/122:
   dpt: '1.011'
-  function: Multimedia
-  name: Multimedia.OG.Schlafzimmer-Eltern.Sony-TV.Ein/Aus-Status
-  room: Schlafzimmer-Eltern
-13/3/123:
+  function: Entertainment
+  name: Entertainment.OG.Schlafzimmer-Eltern.Sony-TV.Ein/Aus-Status
+  room: Schlafzimmer Eltern
+12/3/123:
   dpt: '1.001'
-  function: Multimedia
-  name: Multimedia.OG.Schlafzimmer-Eltern.Sony-TV.Stummschalten
-  room: Schlafzimmer-Eltern
-13/3/124:
+  function: Entertainment
+  name: Entertainment.OG.Schlafzimmer-Eltern.Sony-TV.Stummschalten
+  room: Schlafzimmer Eltern
+12/3/124:
   dpt: '1.011'
-  function: Multimedia
-  name: Multimedia.OG.Schlafzimmer-Eltern.Sony-TV.Stummschalten-Status
-  room: Schlafzimmer-Eltern
-13/3/125:
+  function: Entertainment
+  name: Entertainment.OG.Schlafzimmer-Eltern.Sony-TV.Stummschalten-Status
+  room: Schlafzimmer Eltern
+12/3/125:
   dpt: '5.001'
-  function: Multimedia
-  name: Multimedia.OG.Schlafzimmer-Eltern.Sony-TV.Lautstärke
-  room: Schlafzimmer-Eltern
-13/3/126:
+  function: Entertainment
+  name: Entertainment.OG.Schlafzimmer-Eltern.Sony-TV.Lautstärke
+  room: Schlafzimmer Eltern
+12/3/126:
   dpt: '5.001'
-  function: Multimedia
-  name: Multimedia.OG.Schlafzimmer-Eltern.Sony-TV.Lautstärke-Status
-  room: Schlafzimmer-Eltern
-13/3/141:
+  function: Entertainment
+  name: Entertainment.OG.Schlafzimmer-Eltern.Sony-TV.Lautstärke-Status
+  room: Schlafzimmer Eltern
+12/3/141:
   dpt: '1.001'
-  function: Multimedia
-  name: Multimedia.OG.Badezimmer-Eltern.Asano.Ein/Aus
-  room: Badezimmer-Eltern
-13/3/142:
+  function: Entertainment
+  name: Entertainment.OG.Badezimmer-Eltern.Asano.Ein/Aus
+  room: Badezimmer Eltern
+12/3/142:
   dpt: '1.011'
-  function: Multimedia
-  name: Multimedia.OG.Badezimmer-Eltern.Asano.Ein/Aus-Status
-  room: Badezimmer-Eltern
-13/3/143:
+  function: Entertainment
+  name: Entertainment.OG.Badezimmer-Eltern.Asano.Ein/Aus-Status
+  room: Badezimmer Eltern
+12/3/143:
   dpt: '1.001'
-  function: Multimedia
-  name: Multimedia.OG.Badezimmer-Eltern.Asano.Stummschalten
-  room: Badezimmer-Eltern
-13/3/144:
+  function: Entertainment
+  name: Entertainment.OG.Badezimmer-Eltern.Asano.Stummschalten
+  room: Badezimmer Eltern
+12/3/144:
   dpt: '1.011'
-  function: Multimedia
-  name: Multimedia.OG.Badezimmer-Eltern.Asano.Stummschalten-Status
-  room: Badezimmer-Eltern
-13/3/145:
+  function: Entertainment
+  name: Entertainment.OG.Badezimmer-Eltern.Asano.Stummschalten-Status
+  room: Badezimmer Eltern
+12/3/145:
   dpt: '5.001'
-  function: Multimedia
-  name: Multimedia.OG.Badezimmer-Eltern.Asano.Lautstärke
-  room: Badezimmer-Eltern
-13/3/146:
+  function: Entertainment
+  name: Entertainment.OG.Badezimmer-Eltern.Asano.Lautstärke
+  room: Badezimmer Eltern
+12/3/146:
   dpt: '5.001'
-  function: Multimedia
-  name: Multimedia.OG.Badezimmer-Eltern.Asano.Lautstärke-Status
-  room: Badezimmer-Eltern
-13/3/147:
+  function: Entertainment
+  name: Entertainment.OG.Badezimmer-Eltern.Asano.Lautstärke-Status
+  room: Badezimmer Eltern
+12/3/147:
   dpt: '5.010'
-  function: Multimedia
-  name: Multimedia.OG.Badezimmer-Eltern.Asano.Quelle
-  room: Badezimmer-Eltern
-13/3/148:
+  function: Entertainment
+  name: Entertainment.OG.Badezimmer-Eltern.Asano.Quelle
+  room: Badezimmer Eltern
+12/3/148:
   dpt: '5.010'
-  function: Multimedia
-  name: Multimedia.OG.Badezimmer-Eltern.Asano.Quelle-Status
-  room: Badezimmer-Eltern
-13/3/61:
+  function: Entertainment
+  name: Entertainment.OG.Badezimmer-Eltern.Asano.Quelle-Status
+  room: Badezimmer Eltern
+12/3/61:
   dpt: '1.001'
-  function: Multimedia
-  name: Multimedia.OG.Schlafzimmer-Gregory.Sonos.Ein/Aus
-  room: Schlafzimmer-Gregory
-13/3/62:
+  function: Entertainment
+  name: Entertainment.OG.Schlafzimmer-Gregory.Sonos.Ein/Aus
+  room: Schlafzimmer Gregory
+12/3/62:
   dpt: '1.011'
-  function: Multimedia
-  name: Multimedia.OG.Schlafzimmer-Gregory.Sonos.Ein/Aus-Status
-  room: Schlafzimmer-Gregory
-13/3/63:
+  function: Entertainment
+  name: Entertainment.OG.Schlafzimmer-Gregory.Sonos.Ein/Aus-Status
+  room: Schlafzimmer Gregory
+12/3/63:
   dpt: '1.001'
-  function: Multimedia
-  name: Multimedia.OG.Schlafzimmer-Gregory.Sonos.Stummschalten
-  room: Schlafzimmer-Gregory
-13/3/81:
+  function: Entertainment
+  name: Entertainment.OG.Schlafzimmer-Gregory.Sonos.Stummschalten
+  room: Schlafzimmer Gregory
+12/3/81:
   dpt: '1.001'
-  function: Multimedia
-  name: Multimedia.OG.Schlafzimmer-Luis.Sonos.Ein/Aus
-  room: Schlafzimmer-Luis
-13/3/82:
+  function: Entertainment
+  name: Entertainment.OG.Schlafzimmer-Luis.Sonos.Ein/Aus
+  room: Schlafzimmer Luis
+12/3/82:
   dpt: '1.011'
-  function: Multimedia
-  name: Multimedia.OG.Schlafzimmer-Luis.Sonos.Ein/Aus-Status
-  room: Schlafzimmer-Luis
-13/5/1:
+  function: Entertainment
+  name: Entertainment.OG.Schlafzimmer-Luis.Sonos.Ein/Aus-Status
+  room: Schlafzimmer Luis
+12/5/1:
   dpt: '1.001'
-  function: Multimedia
-  name: Multimedia.A.Terrasse.Asano.Ein/Aus
+  function: Entertainment
+  name: Entertainment.A.Terrasse.Asano.Ein/Aus
   room: Terrasse
-13/5/2:
+12/5/2:
   dpt: '1.011'
-  function: Multimedia
-  name: Multimedia.A.Terrasse.Asano.Ein/Aus-Status
+  function: Entertainment
+  name: Entertainment.A.Terrasse.Asano.Ein/Aus-Status
   room: Terrasse
-13/5/3:
+12/5/3:
   dpt: '1.001'
-  function: Multimedia
-  name: Multimedia.A.Terrasse.Asano.Stummschalten
+  function: Entertainment
+  name: Entertainment.A.Terrasse.Asano.Stummschalten
   room: Terrasse
-13/5/4:
+12/5/4:
   dpt: '1.011'
-  function: Multimedia
-  name: Multimedia.A.Terrasse.Asano.Stummschalten-Status
+  function: Entertainment
+  name: Entertainment.A.Terrasse.Asano.Stummschalten-Status
   room: Terrasse
-13/5/5:
+12/5/5:
   dpt: '5.001'
-  function: Multimedia
-  name: Multimedia.A.Terrasse.Asano.Lautstärke
+  function: Entertainment
+  name: Entertainment.A.Terrasse.Asano.Lautstärke
   room: Terrasse
-13/5/6:
+12/5/6:
   dpt: '5.001'
-  function: Multimedia
-  name: Multimedia.A.Terrasse.Asano.Lautstärke-Status
+  function: Entertainment
+  name: Entertainment.A.Terrasse.Asano.Lautstärke-Status
   room: Terrasse
-13/5/7:
+12/5/7:
   dpt: '5.010'
-  function: Multimedia
-  name: Multimedia.A.Terrasse.Asano.Quelle
+  function: Entertainment
+  name: Entertainment.A.Terrasse.Asano.Quelle
   room: Terrasse
-13/5/8:
+12/5/8:
   dpt: '5.010'
-  function: Multimedia
-  name: Multimedia.A.Terrasse.Asano.Quelle-Status
+  function: Entertainment
+  name: Entertainment.A.Terrasse.Asano.Quelle-Status
   room: Terrasse
-15/1/1:
+14/1/1:
+  description: 3 - Technikraum (K3) Sicherheitstechnik
   dpt: '1.011'
-  function: Sicherheitstechnik
+  function: Einbruchmeldeanlage
   name: Sicherheitstechnik.EMA.Status
-15/1/10:
+  room: Technikraum
+14/1/10:
+  description: 3 - Technikraum (K3) Sicherheitstechnik
   dpt: '1.011'
-  function: Sicherheitstechnik
+  function: Einbruchmeldeanlage
   name: Sicherheitstechnik.EMA.Störung.Akku
-15/1/11:
+  room: Technikraum
+14/1/11:
+  description: 3 - Technikraum (K3) Sicherheitstechnik
   dpt: '1.011'
-  function: Sicherheitstechnik
+  function: Einbruchmeldeanlage
   name: Sicherheitstechnik.EMA.Störung.Übertragungseinrichtung
-15/1/2:
+  room: Technikraum
+14/1/2:
+  description: 3 - Technikraum (K3) Sicherheitstechnik
   dpt: '1.015'
-  function: Sicherheitstechnik
+  function: Einbruchmeldeanlage
   name: Sicherheitstechnik.EMA.Neustart
-15/1/20:
+  room: Technikraum
+14/1/20:
+  description: 3 - Technikraum (K3) Sicherheitstechnik
   dpt: '1.001'
-  function: Sicherheitstechnik
+  function: Einbruchmeldeanlage
   name: Sicherheitstechnik.EMA.Sicherungsbereich.Haus.Unscharf
-15/1/21:
+  room: Technikraum
+14/1/21:
+  description: 3 - Technikraum (K3) Sicherheitstechnik
   dpt: '1.011'
-  function: Sicherheitstechnik
+  function: Einbruchmeldeanlage
   name: Sicherheitstechnik.EMA.Sicherungsbereich.Haus.Unscharf-Status
-15/1/22:
+  room: Technikraum
+14/1/22:
+  description: 3 - Technikraum (K3) Sicherheitstechnik
   dpt: '1.001'
-  function: Sicherheitstechnik
+  function: Einbruchmeldeanlage
   name: Sicherheitstechnik.EMA.Sicherungsbereich.Haus.Intern-Scharf
-15/1/23:
+  room: Technikraum
+14/1/23:
+  description: 3 - Technikraum (K3) Sicherheitstechnik
   dpt: '1.011'
-  function: Sicherheitstechnik
+  function: Einbruchmeldeanlage
   name: Sicherheitstechnik.EMA.Sicherungsbereich.Haus.Intern-Scharf-Status
-15/1/24:
+  room: Technikraum
+14/1/24:
+  description: 3 - Technikraum (K3) Sicherheitstechnik
   dpt: '1.011'
-  function: Sicherheitstechnik
+  function: Einbruchmeldeanlage
   name: Sicherheitstechnik.EMA.Sicherungsbereich.Haus.Intern-Scharf-Bereit
-15/1/25:
+  room: Technikraum
+14/1/25:
+  description: 3 - Technikraum (K3) Sicherheitstechnik
   dpt: '1.001'
-  function: Sicherheitstechnik
+  function: Einbruchmeldeanlage
   name: Sicherheitstechnik.EMA.Sicherungsbereich.Haus.Extern-Scharf
-15/1/26:
+  room: Technikraum
+14/1/26:
+  description: 3 - Technikraum (K3) Sicherheitstechnik
   dpt: '1.011'
-  function: Sicherheitstechnik
+  function: Einbruchmeldeanlage
   name: Sicherheitstechnik.EMA.Sicherungsbereich.Haus.Extern-Scharf-Status
-15/1/27:
+  room: Technikraum
+14/1/27:
+  description: 3 - Technikraum (K3) Sicherheitstechnik
   dpt: '1.011'
-  function: Sicherheitstechnik
+  function: Einbruchmeldeanlage
   name: Sicherheitstechnik.EMA.Sicherungsbereich.Haus.Extern-Scharf-Bereit
-15/1/28:
+  room: Technikraum
+14/1/28:
+  description: 3 - Technikraum (K3) Sicherheitstechnik
   dpt: '1.005'
-  function: Sicherheitstechnik
+  function: Einbruchmeldeanlage
   name: Sicherheitstechnik.EMA.Sicherungsbereich.Haus.Alarm
-15/1/29:
+  room: Technikraum
+14/1/29:
+  description: 3 - Technikraum (K3) Sicherheitstechnik
   dpt: '1.015'
-  function: Sicherheitstechnik
+  function: Einbruchmeldeanlage
   name: Sicherheitstechnik.EMA.Sicherungsbereich.Haus.Alarm-Zurücksetzen
-15/1/3:
+  room: Technikraum
+14/1/3:
+  description: 3 - Technikraum (K3) Sicherheitstechnik
   dpt: '1.007'
-  function: Sicherheitstechnik
+  function: Einbruchmeldeanlage
   name: Sicherheitstechnik.EMA.Zustände-Lesen
-15/1/30:
+  room: Technikraum
+14/1/30:
+  description: 3 - Technikraum (K3) Sicherheitstechnik
   dpt: '1.011'
-  function: Sicherheitstechnik
+  function: Einbruchmeldeanlage
   name: Sicherheitstechnik.EMA.Sicherungsbereich.Haus.Störung
-15/1/4:
+  room: Technikraum
+14/1/4:
+  description: 3 - Technikraum (K3) Sicherheitstechnik
   dpt: '1.007'
-  function: Sicherheitstechnik
+  function: Einbruchmeldeanlage
   name: Sicherheitstechnik.EMA.Zustände-Aktualisieren
-15/1/40:
+  room: Technikraum
+14/1/40:
+  description: 3 - Technikraum (K3) Sicherheitstechnik
   dpt: '1.003'
-  function: Sicherheitstechnik
+  function: Einbruchmeldeanlage
   name: Sicherheitstechnik.EMA.Meldebereich.Sabotage.Sperren
-15/1/41:
+  room: Technikraum
+14/1/41:
+  description: 3 - Technikraum (K3) Sicherheitstechnik
   dpt: '1.011'
-  function: Sicherheitstechnik
+  function: Einbruchmeldeanlage
   name: Sicherheitstechnik.EMA.Meldebereich.Sabotage.Sperren-Status
-15/1/42:
+  room: Technikraum
+14/1/42:
+  description: 3 - Technikraum (K3) Sicherheitstechnik
   dpt: '1.011'
-  function: Sicherheitstechnik
+  function: Einbruchmeldeanlage
   name: Sicherheitstechnik.EMA.Meldebereich.Sabotage.Status
-15/1/43:
+  room: Technikraum
+14/1/43:
+  description: 3 - Technikraum (K3) Sicherheitstechnik
   dpt: '1.003'
-  function: Sicherheitstechnik
+  function: Einbruchmeldeanlage
   name: Sicherheitstechnik.EMA.Meldebereich.IR-Melder.Sperren
-15/1/44:
+  room: Technikraum
+14/1/44:
+  description: 3 - Technikraum (K3) Sicherheitstechnik
   dpt: '1.011'
-  function: Sicherheitstechnik
+  function: Einbruchmeldeanlage
   name: Sicherheitstechnik.EMA.Meldebereich.IR-Melder.Sperren-Status
-15/1/45:
+  room: Technikraum
+14/1/45:
+  description: 3 - Technikraum (K3) Sicherheitstechnik
   dpt: '1.011'
-  function: Sicherheitstechnik
+  function: Einbruchmeldeanlage
   name: Sicherheitstechnik.EMA.Meldebereich.IR-Melder.Status
-15/1/46:
+  room: Technikraum
+14/1/46:
+  description: 3 - Technikraum (K3) Sicherheitstechnik
   dpt: '1.003'
-  function: Sicherheitstechnik
+  function: Einbruchmeldeanlage
   name: Sicherheitstechnik.EMA.Meldebereich.Fensterkontakt.Sperren
-15/1/47:
+  room: Technikraum
+14/1/47:
+  description: 3 - Technikraum (K3) Sicherheitstechnik
   dpt: '1.011'
-  function: Sicherheitstechnik
+  function: Einbruchmeldeanlage
   name: Sicherheitstechnik.EMA.Meldebereich.Fensterkontakt.Sperren-Status
-15/1/48:
+  room: Technikraum
+14/1/48:
+  description: 3 - Technikraum (K3) Sicherheitstechnik
   dpt: '1.011'
-  function: Sicherheitstechnik
+  function: Einbruchmeldeanlage
   name: Sicherheitstechnik.EMA.Meldebereich.Fensterkontakt.Status
-15/1/49:
+  room: Technikraum
+14/1/49:
+  description: 3 - Technikraum (K3) Sicherheitstechnik
   dpt: '1.003'
-  function: Sicherheitstechnik
+  function: Einbruchmeldeanlage
   name: Sicherheitstechnik.EMA.Meldebereich.Türkontakt.Sperren
-15/1/5:
+  room: Technikraum
+14/1/5:
+  description: 3 - Technikraum (K3) Sicherheitstechnik
   dpt: '1.011'
-  function: Sicherheitstechnik
+  function: Einbruchmeldeanlage
   name: Sicherheitstechnik.EMA.Sabotage.Deckelkontakt
-15/1/50:
+  room: Technikraum
+14/1/50:
+  description: 3 - Technikraum (K3) Sicherheitstechnik
   dpt: '1.011'
-  function: Sicherheitstechnik
+  function: Einbruchmeldeanlage
   name: Sicherheitstechnik.EMA.Meldebereich.Türkontakt.Sperren-Status
-15/1/51:
+  room: Technikraum
+14/1/51:
+  description: 3 - Technikraum (K3) Sicherheitstechnik
   dpt: '1.011'
-  function: Sicherheitstechnik
+  function: Einbruchmeldeanlage
   name: Sicherheitstechnik.EMA.Meldebereich.Türkontakt.Status
-15/1/6:
+  room: Technikraum
+14/1/6:
+  description: 3 - Technikraum (K3) Sicherheitstechnik
   dpt: '1.011'
-  function: Sicherheitstechnik
+  function: Einbruchmeldeanlage
   name: Sicherheitstechnik.EMA.Sabotage.Signalgeber.Leitungsüberwachung.ASG
-15/1/7:
+  room: Technikraum
+14/1/7:
+  description: 3 - Technikraum (K3) Sicherheitstechnik
   dpt: '1.011'
-  function: Sicherheitstechnik
+  function: Einbruchmeldeanlage
   name: Sicherheitstechnik.EMA.Sabotage.Signalgeber.Leitungsüberwachung.OSG
-15/1/8:
+  room: Technikraum
+14/1/8:
+  description: 3 - Technikraum (K3) Sicherheitstechnik
   dpt: '1.011'
-  function: Sicherheitstechnik
+  function: Einbruchmeldeanlage
   name: Sicherheitstechnik.EMA.Sabotage.Signalgeber.Wandabreißkontakt
-15/1/9:
+  room: Technikraum
+14/1/9:
+  description: 3 - Technikraum (K3) Sicherheitstechnik
   dpt: '1.011'
-  function: Sicherheitstechnik
+  function: Einbruchmeldeanlage
   name: Sicherheitstechnik.EMA.Störung.Strom
-15/3/1:
+  room: Technikraum
+14/3/1:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Fassade.Objekterkennung.Person
-15/3/10:
+  room: Fassade
+14/3/10:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Fassade.Aktivität.Linienüberschreitung
-15/3/11:
+  room: Fassade
+14/3/11:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Fassade.Geräusch.Gespräch
-15/3/12:
+  room: Fassade
+14/3/12:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Fassade.Geräusch.Sirene
-15/3/121:
+  room: Fassade
+14/3/121:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Esszimmer.Objekterkennung.Person
-15/3/122:
+  room: Terrasse
+14/3/122:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Esszimmer.Objekterkennung.Fahrzeug
-15/3/123:
+  room: Terrasse
+14/3/123:
   dpt: '5.010'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Esszimmer.Gesichtserkennung.Gesicht-Bekannt
-15/3/124:
+  room: Terrasse
+14/3/124:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Esszimmer.Gesichtserkennung.Gesicht-Unbekannt
-15/3/125:
+  room: Terrasse
+14/3/125:
   dpt: '5.010'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Esszimmer.Gesichtserkennung.Gesicht-Markiert
-15/3/126:
+  room: Terrasse
+14/3/126:
   dpt: '5.010'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Esszimmer.Nummerschilderkennnung.Fahrzeug-Bekannt
-15/3/127:
+  room: Terrasse
+14/3/127:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Esszimmer.Nummerschilderkennnung.Fahrzeug-Unbekannt
-15/3/128:
+  room: Terrasse
+14/3/128:
   dpt: '5.010'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Esszimmer.Nummerschilderkennnung.Fahrzeug-Markiert
-15/3/129:
+  room: Terrasse
+14/3/129:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Esszimmer.Aktivität.Bewegung
-15/3/13:
+  room: Terrasse
+14/3/13:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Fassade.Geräusch.Glasbruch
-15/3/130:
+  room: Fassade
+14/3/130:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Esszimmer.Aktivität.Linienüberschreitung
-15/3/131:
+  room: Terrasse
+14/3/131:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Esszimmer.Geräusch.Gespräch
-15/3/132:
+  room: Terrasse
+14/3/132:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Esszimmer.Geräusch.Sirene
-15/3/133:
+  room: Terrasse
+14/3/133:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Esszimmer.Geräusch.Glasbruch
-15/3/134:
+  room: Terrasse
+14/3/134:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Esszimmer.Geräusch.Einbruch
-15/3/14:
+  room: Terrasse
+14/3/14:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Fassade.Geräusch.Einbruch
-15/3/2:
+  room: Fassade
+14/3/2:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Fassade.Objekterkennung.Fahrzeug
-15/3/3:
+  room: Fassade
+14/3/3:
   dpt: '5.010'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Fassade.Gesichtserkennung.Gesicht-Bekannt
-15/3/4:
+  room: Fassade
+14/3/4:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Fassade.Gesichtserkennung.Gesicht-Unbekannt
-15/3/41:
+  room: Fassade
+14/3/41:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Eingang.Objekterkennung.Person
-15/3/42:
+  room: Eingang
+14/3/42:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Eingang.Objekterkennung.Fahrzeug
-15/3/43:
+  room: Eingang
+14/3/43:
   dpt: '5.010'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Eingang.Gesichtserkennung.Gesicht-Bekannt
-15/3/44:
+  room: Eingang
+14/3/44:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Eingang.Gesichtserkennung.Gesicht-Unbekannt
-15/3/45:
+  room: Eingang
+14/3/45:
   dpt: '5.010'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Eingang.Gesichtserkennung.Gesicht-Markiert
-15/3/46:
+  room: Eingang
+14/3/46:
   dpt: '5.010'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Eingang.Nummerschilderkennnung.Fahrzeug-Bekannt
-15/3/47:
+  room: Eingang
+14/3/47:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Eingang.Nummerschilderkennnung.Fahrzeug-Unbekannt
-15/3/48:
+  room: Eingang
+14/3/48:
   dpt: '5.010'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Eingang.Nummerschilderkennnung.Fahrzeug-Markiert
-15/3/49:
+  room: Eingang
+14/3/49:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Eingang.Aktivität.Bewegung
-15/3/5:
+  room: Eingang
+14/3/5:
   dpt: '5.010'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Fassade.Gesichtserkennung.Gesicht-Markiert
-15/3/50:
+  room: Fassade
+14/3/50:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Eingang.Aktivität.Linienüberschreitung
-15/3/51:
+  room: Eingang
+14/3/51:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Eingang.Geräusch.Gespräch
-15/3/52:
+  room: Eingang
+14/3/52:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Eingang.Geräusch.Sirene
-15/3/53:
+  room: Eingang
+14/3/53:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Eingang.Geräusch.Glasbruch
-15/3/54:
+  room: Eingang
+14/3/54:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Eingang.Geräusch.Einbruch
-15/3/6:
+  room: Eingang
+14/3/6:
   dpt: '5.010'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Fassade.Nummerschilderkennnung.Fahrzeug-Bekannt
-15/3/7:
+  room: Fassade
+14/3/7:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Fassade.Nummerschilderkennnung.Fahrzeug-Unbekannt
-15/3/8:
+  room: Fassade
+14/3/8:
   dpt: '5.010'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Fassade.Nummerschilderkennnung.Fahrzeug-Markiert
-15/3/81:
+  room: Fassade
+14/3/81:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Wohnzimmer.Objekterkennung.Person
-15/3/82:
+  room: Terrasse
+14/3/82:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Wohnzimmer.Objekterkennung.Fahrzeug
-15/3/83:
+  room: Terrasse
+14/3/83:
   dpt: '5.010'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Wohnzimmer.Gesichtserkennung.Gesicht-Bekannt
-15/3/84:
+  room: Terrasse
+14/3/84:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Wohnzimmer.Gesichtserkennung.Gesicht-Unbekannt
-15/3/85:
+  room: Terrasse
+14/3/85:
   dpt: '5.010'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Wohnzimmer.Gesichtserkennung.Gesicht-Markiert
-15/3/86:
+  room: Terrasse
+14/3/86:
   dpt: '5.010'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Wohnzimmer.Nummerschilderkennnung.Fahrzeug-Bekannt
-15/3/87:
+  room: Terrasse
+14/3/87:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Wohnzimmer.Nummerschilderkennnung.Fahrzeug-Unbekannt
-15/3/88:
+  room: Terrasse
+14/3/88:
   dpt: '5.010'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Wohnzimmer.Nummerschilderkennnung.Fahrzeug-Markiert
-15/3/89:
+  room: Terrasse
+14/3/89:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Wohnzimmer.Aktivität.Bewegung
-15/3/9:
+  room: Terrasse
+14/3/9:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Fassade.Aktivität.Bewegung
-15/3/90:
+  room: Fassade
+14/3/90:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Wohnzimmer.Aktivität.Linienüberschreitung
-15/3/91:
+  room: Terrasse
+14/3/91:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Wohnzimmer.Geräusch.Gespräch
-15/3/92:
+  room: Terrasse
+14/3/92:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Wohnzimmer.Geräusch.Sirene
-15/3/93:
+  room: Terrasse
+14/3/93:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Wohnzimmer.Geräusch.Glasbruch
-15/3/94:
+  room: Terrasse
+14/3/94:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Wohnzimmer.Geräusch.Einbruch
-16/1/0:
+  room: Terrasse
+15/1/0:
+  description: 2 - Garage (K2) Energiezähler
   dpt: '13.013'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Netzbezug.Zählerstand-Gesamt
-16/1/1:
+  room: Garage
+15/1/1:
+  description: 2 - Garage (K2) Energiezähler
   dpt: '13.013'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Netzbezug.Zählerstand-Tagtarif
-16/1/10:
+  room: Garage
+15/1/10:
+  description: 2 - Garage (K2) Energiezähler
   dpt: '13.013'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Einspeisung.Zählerstand-Tagtarif-2
-16/1/11:
+  room: Garage
+15/1/11:
+  description: 2 - Garage (K2) Energiezähler
   dpt: '13.013'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Einspeisung.Zählerstand-Nachttarif-1
-16/1/12:
+  room: Garage
+15/1/12:
+  description: 2 - Garage (K2) Energiezähler
   dpt: '13.013'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Einspeisung.Zählerstand-Nachttarif-2
-16/1/13:
+  room: Garage
+15/1/13:
+  description: 2 - Garage (K2) Energiezähler
   dpt: '14.056'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Einspeisung.Wirkleistung-Gesamt-1
-16/1/14:
+  room: Garage
+15/1/14:
+  description: 2 - Garage (K2) Energiezähler
   dpt: '14.056'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Einspeisung.Wirkleistung-Gesamt-2
-16/1/15:
+  room: Garage
+15/1/15:
+  description: 2 - Garage (K2) Energiezähler
   dpt: '14.056'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Einspeisung.Wirkleistung-L1
-16/1/16:
+  room: Garage
+15/1/16:
+  description: 2 - Garage (K2) Energiezähler
   dpt: '14.056'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Einspeisung.Wirkleistung-L2
-16/1/17:
+  room: Garage
+15/1/17:
+  description: 2 - Garage (K2) Energiezähler
   dpt: '14.056'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Einspeisung.Wirkleistung-L3
-16/1/18:
+  room: Garage
+15/1/18:
+  description: 2 - Garage (K2) Energiezähler
   dpt: '14.019'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Stromstärke-L1
-16/1/19:
+  room: Garage
+15/1/19:
+  description: 2 - Garage (K2) Energiezähler
   dpt: '14.019'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Stromstärke-L2
-16/1/2:
+  room: Garage
+15/1/2:
+  description: 2 - Garage (K2) Energiezähler
   dpt: '13.013'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Netzbezug.Zählerstand-Nachttarif
-16/1/20:
+  room: Garage
+15/1/20:
+  description: 2 - Garage (K2) Energiezähler
   dpt: '14.019'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Stromstärke-L3
-16/1/21:
+  room: Garage
+15/1/21:
+  description: 2 - Garage (K2) Energiezähler
   dpt: '14.027'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Spannung-L1
-16/1/22:
+  room: Garage
+15/1/22:
+  description: 2 - Garage (K2) Energiezähler
   dpt: '14.027'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Spannung-L2
-16/1/23:
+  room: Garage
+15/1/23:
+  description: 2 - Garage (K2) Energiezähler
   dpt: '14.027'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Spannung-L3
-16/1/24:
+  room: Garage
+15/1/24:
+  description: 2 - Garage (K2) Energiezähler
   dpt: '14.000'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Wirkleistung-Gesamt
-16/1/3:
+  room: Garage
+15/1/3:
+  description: 2 - Garage (K2) Energiezähler
   dpt: '14.056'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Netzbezug.Wirkleistung-Gesamt
-16/1/4:
+  room: Garage
+15/1/4:
+  description: 2 - Garage (K2) Energiezähler
   dpt: '14.056'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Netzbezug.Wirkleistung-L1
-16/1/40:
+  room: Garage
+15/1/40:
   dpt: '14.005'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Wasser.Zählerstand-Skala-1
-16/1/41:
+  room: Vorratsraum
+15/1/41:
   dpt: '14.005'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Wasser.Zählerstand-Skala-2
-16/1/42:
+  room: Vorratsraum
+15/1/42:
   dpt: '14.005'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Wasser.Stichwert-Skala-1
-16/1/43:
+  room: Vorratsraum
+15/1/43:
   dpt: '14.005'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Wasser.Stichwert-Skala-2
-16/1/44:
+  room: Vorratsraum
+15/1/44:
   dpt: '14.005'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Wasser.Verbrauchswert-Skala-1
-16/1/45:
+  room: Vorratsraum
+15/1/45:
   dpt: '14.005'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Wasser.Verbrauchswert-Skala-2
-16/1/46:
+  room: Vorratsraum
+15/1/46:
   dpt: '14.005'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Wasser.Durchfluss-Gesamt
-16/1/47:
+  room: Vorratsraum
+15/1/47:
   dpt: '14.005'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Wasser.Durchfluss-Skala-1
-16/1/48:
+  room: Vorratsraum
+15/1/48:
   dpt: '14.005'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Wasser.Durchfluss-Skala-2
-16/1/49:
+  room: Vorratsraum
+15/1/49:
   dpt: '1.005'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Wasser.Durchfluss-Skala-1-Alarm
-16/1/5:
+  room: Vorratsraum
+15/1/5:
+  description: 2 - Garage (K2) Energiezähler
   dpt: '14.056'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Netzbezug.Wirkleistung-L2
-16/1/50:
+  room: Garage
+15/1/50:
   dpt: '1.005'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Wasser.Durchfluss-Skala-2-Alarm
-16/1/51:
+  room: Vorratsraum
+15/1/51:
   dpt: '1.005'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Wasser.Durchfluss-Skala-1-Alarm-Erweitert
-16/1/52:
+  room: Vorratsraum
+15/1/52:
   dpt: '1.005'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Wasser.Durchfluss-Skala-2-Alarm-Erweitert
-16/1/53:
+  room: Vorratsraum
+15/1/53:
   dpt: '1.001'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Wasser.Skalenumschaltung
-16/1/54:
+  room: Vorratsraum
+15/1/54:
   dpt: '11.001'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Wasser.Letztes-Stichdatum
-16/1/55:
+  room: Vorratsraum
+15/1/55:
   dpt: '11.001'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Wasser.Nächstes-Stichdatum
-16/1/56:
+  room: Vorratsraum
+15/1/56:
   dpt: '7.001'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Wasser.Reset
-16/1/57:
+  room: Vorratsraum
+15/1/57:
   dpt: '10.001'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Wasser.Reset-Uhrzeit
-16/1/58:
+  room: Vorratsraum
+15/1/58:
   dpt: '11.001'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Wasser.Reset-Datum
-16/1/59:
+  room: Vorratsraum
+15/1/59:
   dpt: '16.000'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Wasser.Seriennummer
-16/1/6:
+  room: Vorratsraum
+15/1/6:
+  description: 2 - Garage (K2) Energiezähler
   dpt: '14.056'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Netzbezug.Wirkleistung-L3
-16/1/7:
+  room: Garage
+15/1/7:
+  description: 2 - Garage (K2) Energiezähler
   dpt: '13.013'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Einspeisung.Zählerstand-Gesamt-1
-16/1/8:
+  room: Garage
+15/1/8:
+  description: 2 - Garage (K2) Energiezähler
   dpt: '13.013'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Einspeisung.Zählerstand-Gesamt-2
-16/1/9:
+  room: Garage
+15/1/9:
+  description: 2 - Garage (K2) Energiezähler
   dpt: '13.013'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Einspeisung.Zählerstand-Tagtarif-1
-16/3/1:
+  room: Garage
+15/3/1:
+  description: 4 - Vorratsraum (K4) Wohnraumlüftung
   dpt: '5.010'
   function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Lüftermodi
-16/3/10:
+  room: Vorratsraum
+15/3/10:
+  description: 4 - Vorratsraum (K4) Wohnraumlüftung
   dpt: '1.011'
   function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Lüftermodus-Mittel-Status
-16/3/11:
+  room: Vorratsraum
+15/3/11:
+  description: 4 - Vorratsraum (K4) Wohnraumlüftung
   dpt: '1.001'
   function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Lüftermodus-Hoch
-16/3/12:
+  room: Vorratsraum
+15/3/12:
+  description: 4 - Vorratsraum (K4) Wohnraumlüftung
   dpt: '1.011'
   function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Lüftermodus-Hoch-Status
-16/3/2:
+  room: Vorratsraum
+15/3/2:
+  description: 4 - Vorratsraum (K4) Wohnraumlüftung
   dpt: '5.010'
   function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Lüftermodi-Status
-16/3/20:
+  room: Vorratsraum
+15/3/20:
+  description: 4 - Vorratsraum (K4) Wohnraumlüftung
   dpt: '1.002'
   function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Status
-16/3/21:
+  room: Vorratsraum
+15/3/21:
+  description: 4 - Vorratsraum (K4) Wohnraumlüftung
   dpt: '5.001'
   function: Versorgungstechnik
   name: Versorgungstechnik.KWL.ComfoConnect-Status
-16/3/22:
+  room: Vorratsraum
+15/3/22:
+  description: 4 - Vorratsraum (K4) Wohnraumlüftung
   dpt: '1.002'
   function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Wartungsmodus-Status
-16/3/23:
+  room: Vorratsraum
+15/3/23:
+  description: 4 - Vorratsraum (K4) Wohnraumlüftung
   dpt: '1.002'
   function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Filterwechsel-Status
-16/3/24:
+  room: Vorratsraum
+15/3/24:
+  description: 4 - Vorratsraum (K4) Wohnraumlüftung
   dpt: '7.007'
   function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Filter-Betriebsstunden
-16/3/25:
+  room: Vorratsraum
+15/3/25:
+  description: 4 - Vorratsraum (K4) Wohnraumlüftung
   dpt: '13.002'
   function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Luftstrom
-16/3/26:
+  room: Vorratsraum
+15/3/26:
+  description: 4 - Vorratsraum (K4) Wohnraumlüftung
   dpt: '9.001'
   function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Temperatur-Abluft
-16/3/27:
+  room: Vorratsraum
+15/3/27:
+  description: 4 - Vorratsraum (K4) Wohnraumlüftung
   dpt: '9.001'
   function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Temperatur-Fortluft
-16/3/28:
+  room: Vorratsraum
+15/3/28:
+  description: 4 - Vorratsraum (K4) Wohnraumlüftung
   dpt: '9.001'
   function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Temperatur-Außenluft
-16/3/29:
+  room: Vorratsraum
+15/3/29:
+  description: 4 - Vorratsraum (K4) Wohnraumlüftung
   dpt: '9.001'
   function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Temperatur-Zuluft
-16/3/3:
+  room: Vorratsraum
+15/3/3:
+  description: 4 - Vorratsraum (K4) Wohnraumlüftung
   dpt: '1.001'
   function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Lüftermodus-Auto
-16/3/30:
+  room: Vorratsraum
+15/3/30:
+  description: 4 - Vorratsraum (K4) Wohnraumlüftung
   dpt: '9.007'
   function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Luftfeuchtigkeit-Abluft
-16/3/31:
+  room: Vorratsraum
+15/3/31:
+  description: 4 - Vorratsraum (K4) Wohnraumlüftung
   dpt: '9.007'
   function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Luftfeuchtigkeit-Fortluft
-16/3/32:
+  room: Vorratsraum
+15/3/32:
+  description: 4 - Vorratsraum (K4) Wohnraumlüftung
   dpt: '9.007'
   function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Luftfeuchtigkeit-Außenluft
-16/3/33:
+  room: Vorratsraum
+15/3/33:
+  description: 4 - Vorratsraum (K4) Wohnraumlüftung
   dpt: '9.007'
   function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Luftfeuchtigkeit-Zuluft
-16/3/4:
+  room: Vorratsraum
+15/3/4:
+  description: 4 - Vorratsraum (K4) Wohnraumlüftung
   dpt: '1.011'
   function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Lüftermodus-Auto-Status
-16/3/5:
+  room: Vorratsraum
+15/3/5:
+  description: 4 - Vorratsraum (K4) Wohnraumlüftung
   dpt: '1.001'
   function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Lüftermodus-Away
-16/3/6:
+  room: Vorratsraum
+15/3/6:
+  description: 4 - Vorratsraum (K4) Wohnraumlüftung
   dpt: '1.011'
   function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Lüftermodus-Away-Status
-16/3/7:
+  room: Vorratsraum
+15/3/7:
+  description: 4 - Vorratsraum (K4) Wohnraumlüftung
   dpt: '1.001'
   function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Lüftermodus-Niedrig
-16/3/8:
+  room: Vorratsraum
+15/3/8:
+  description: 4 - Vorratsraum (K4) Wohnraumlüftung
   dpt: '1.011'
   function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Lüftermodus-Niedrig-Status
-16/3/9:
+  room: Vorratsraum
+15/3/9:
+  description: 4 - Vorratsraum (K4) Wohnraumlüftung
   dpt: '1.001'
   function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Lüftermodus-Mittel
-16/5/102:
+  room: Vorratsraum
+15/5/102:
   dpt: '1.011'
   function: Versorgungstechnik
   name: Versorgungstechnik.Bewässerung.Kreislauf-10.Ein/Aus-Status
-16/5/112:
+  room: Garten
+15/5/112:
   dpt: '1.011'
   function: Versorgungstechnik
   name: Versorgungstechnik.Bewässerung.Kreislauf-11.Ein/Aus-Status
-16/5/12:
+  room: Garten
+15/5/12:
   dpt: '1.011'
   function: Versorgungstechnik
   name: Versorgungstechnik.Bewässerung.Kreislauf-1.Ein/Aus-Status
-16/5/122:
+  room: Garten
+15/5/122:
   dpt: '1.011'
   function: Versorgungstechnik
   name: Versorgungstechnik.Bewässerung.Kreislauf-12.Ein/Aus-Status
-16/5/132:
+  room: Garten
+15/5/132:
   dpt: '1.011'
   function: Versorgungstechnik
   name: Versorgungstechnik.Bewässerung.Kreislauf-13.Ein/Aus-Status
-16/5/142:
+  room: Garten
+15/5/142:
   dpt: '1.011'
   function: Versorgungstechnik
   name: Versorgungstechnik.Bewässerung.Kreislauf-14.Ein/Aus-Status
-16/5/2:
+  room: Garten
+15/5/2:
   dpt: '1.011'
   function: Versorgungstechnik
   name: Versorgungstechnik.Bewässerung.Kreislauf-Master.Ein/Aus-Status
-16/5/22:
+  room: Garten
+15/5/22:
   dpt: '1.011'
   function: Versorgungstechnik
   name: Versorgungstechnik.Bewässerung.Kreislauf-2..Ein/Aus-Status
-16/5/32:
+  room: Garten
+15/5/32:
   dpt: '1.011'
   function: Versorgungstechnik
   name: Versorgungstechnik.Bewässerung.Kreislauf-3.Ein/Aus-Status
-16/5/42:
+  room: Garten
+15/5/42:
   dpt: '1.011'
   function: Versorgungstechnik
   name: Versorgungstechnik.Bewässerung.Kreislauf-4.Ein/Aus-Status
-16/5/52:
+  room: Garten
+15/5/52:
   dpt: '1.011'
   function: Versorgungstechnik
   name: Versorgungstechnik.Bewässerung.Kreislauf-5.Ein/Aus-Status
-16/5/62:
+  room: Garten
+15/5/62:
   dpt: '1.011'
   function: Versorgungstechnik
   name: Versorgungstechnik.Bewässerung.Kreislauf-6.Ein/Aus-Status
-16/5/72:
+  room: Garten
+15/5/72:
   dpt: '1.011'
   function: Versorgungstechnik
   name: Versorgungstechnik.Bewässerung.Kreislauf-7.Ein/Aus-Staus
-16/5/82:
+  room: Garten
+15/5/82:
   dpt: '1.011'
   function: Versorgungstechnik
   name: Versorgungstechnik.Bewässerung.Kreislauf-8.Ein/Aus-Status
-16/5/92:
+  room: Garten
+15/5/92:
   dpt: '1.011'
   function: Versorgungstechnik
   name: Versorgungstechnik.Bewässerung.Kreislauf-9.Ein/Aus-Status
-17/0/20:
+  room: Garten
+16/0/20:
   dpt: '1.011'
   function: Informationstechnik
   name: Informationstechnik.Container.Monitor-Status
-17/2/104:
+16/2/104:
   dpt: '1.011'
   function: Informationstechnik
   name: Informationstechnik.Container.Postgres.Monitor-Status
-17/2/109:
+16/2/109:
   dpt: '1.011'
   function: Informationstechnik
   name: Informationstechnik.Container.Prometheus.Monitor-Status
-17/2/114:
+16/2/114:
   dpt: '1.011'
   function: Informationstechnik
   name: Informationstechnik.Container.Redis.Monitor-Status
-17/2/119:
+16/2/119:
   dpt: '1.011'
   function: Informationstechnik
   name: Informationstechnik.Container.Telegraf.Monitor-Status
-17/2/124:
+16/2/124:
   dpt: '1.011'
   function: Informationstechnik
   name: Informationstechnik.Container.Traefik.Monitor-Status
-17/2/129:
+16/2/129:
   dpt: '1.011'
   function: Informationstechnik
   name: Informationstechnik.Container.Unifi-poller.Monitor-Status
-17/2/134:
+16/2/134:
   dpt: '1.011'
   function: Informationstechnik
   name: Informationstechnik.Container.Watchtower.Monitor-Status
-17/2/139:
+16/2/139:
   dpt: '1.011'
   function: Informationstechnik
   name: Informationstechnik.Container.Whoami.Monitor-Status
-17/2/14:
+16/2/14:
   dpt: '1.011'
   function: Informationstechnik
   name: Informationstechnik.Container.Authelia.Monitor-Status
-17/2/19:
+16/2/19:
   dpt: '1.011'
   function: Informationstechnik
   name: Informationstechnik.Container.Bivac.Monitor-Status
-17/2/24:
+16/2/24:
   dpt: '1.011'
   function: Informationstechnik
   name: Informationstechnik.Container.Blackbox-exporter.Monitor-Status
-17/2/29:
+16/2/29:
   dpt: '1.011'
   function: Informationstechnik
   name: Informationstechnik.Container.Cadvisor.Monitor-Status
-17/2/34:
+16/2/34:
   dpt: '1.011'
   function: Informationstechnik
   name: Informationstechnik.Container.Crowdsec.Monitor-Status
-17/2/39:
+16/2/39:
   dpt: '1.011'
   function: Informationstechnik
   name: Informationstechnik.Container.Fritz-exporter.Monitor-Status
-17/2/4:
+16/2/4:
   dpt: '1.011'
   function: Informationstechnik
   name: Informationstechnik.Container.Alertmanager.Monitor-Status
-17/2/44:
+16/2/44:
   dpt: '1.011'
   function: Informationstechnik
   name: Informationstechnik.Container.Gollum.Monitor-Status
-17/2/49:
+16/2/49:
   dpt: '1.011'
   function: Informationstechnik
   name: Informationstechnik.Container.Grafana.Monitor-Status
-17/2/54:
+16/2/54:
   dpt: '1.011'
   function: Informationstechnik
   name: Informationstechnik.Container.Guacamole.Monitor-Status
-17/2/59:
+16/2/59:
   dpt: '1.011'
   function: Informationstechnik
   name: Informationstechnik.Container.Guacd.Monitor-Status
-17/2/64:
+16/2/64:
   dpt: '1.011'
   function: Informationstechnik
   name: Informationstechnik.Container.Heimdall.Monitor-Status
-17/2/69:
+16/2/69:
   dpt: '1.011'
   function: Informationstechnik
   name: Informationstechnik.Container.Influx.Monitor-Status
-17/2/74:
+16/2/74:
   dpt: '1.011'
   function: Informationstechnik
   name: Informationstechnik.Container.Loki.Monitor-Status
-17/2/79:
+16/2/79:
   dpt: '1.011'
   function: Informationstechnik
   name: Informationstechnik.Container.Minio.Monitor-Status
-17/2/84:
+16/2/84:
   dpt: '1.011'
   function: Informationstechnik
   name: Informationstechnik.Container.Mosquitto.Monitor-Status
-17/2/89:
+16/2/89:
   dpt: '1.011'
   function: Informationstechnik
   name: Informationstechnik.Container.Node-exporter.Monitor-Status
-17/2/9:
+16/2/9:
   dpt: '1.011'
   function: Informationstechnik
   name: Informationstechnik.Container.Alloy.Monitor-Status
-17/2/94:
+16/2/94:
   dpt: '1.011'
   function: Informationstechnik
   name: Informationstechnik.Container.Node-red.Monitor-Status
-17/2/99:
+16/2/99:
   dpt: '1.011'
   function: Informationstechnik
   name: Informationstechnik.Container.Portainer.Monitor-Status
@@ -3136,42 +2312,17 @@
 2/1/100:
   dpt: '1.003'
   function: Schalten
-  name: Schalten.KG.Technikraum.K1-L1.Heizung.Sperren
+  name: Schalten.KG.Technikraum.Bewässerung.Regen.Sperren
   room: Technikraum
 2/1/101:
   dpt: '1.001'
   function: Schalten
-  name: Schalten.KG.Technikraum.K1-L1.Heizung.Ein/Aus
+  name: Schalten.KG.Technikraum.Bewässerung.Regen.Ein/Aus
   room: Technikraum
 2/1/102:
   dpt: '1.011'
   function: Schalten
-  name: Schalten.KG.Technikraum.K1-L1.Heizung.Ein/Aus-Status
-  room: Technikraum
-2/1/103:
-  dpt: '13.100'
-  function: Schalten
-  name: Schalten.KG.Technikraum.K1-L1.Heizung.Betriebsstunden
-  room: Technikraum
-2/1/104:
-  dpt: '1.003'
-  function: Schalten
-  name: Schalten.KG.Technikraum.K1-L1.Heizung.Betriebsstunden-Löschen
-  room: Technikraum
-2/1/105:
-  dpt: '13.013'
-  function: Schalten
-  name: Schalten.KG.Technikraum.K1-L1.Heizung.Kilowattstunde
-  room: Technikraum
-2/1/106:
-  dpt: '1.003'
-  function: Schalten
-  name: Schalten.KG.Technikraum.K1-L1.Heizung.Löschen-Kilowattstunde
-  room: Technikraum
-2/1/107:
-  dpt: '7.012'
-  function: Schalten
-  name: Schalten.KG.Technikraum.K1-L1.Heizung.Stromwert
+  name: Schalten.KG.Technikraum.Bewässerung.Regen.Ein/Aus-Status
   room: Technikraum
 2/1/11:
   dpt: '1.001'
@@ -3181,394 +2332,604 @@
 2/1/110:
   dpt: '1.003'
   function: Schalten
-  name: Schalten.KG.Technikraum.K1-L2.Heizung.Sperren
-  room: Technikraum
+  name: Schalten.KG.Vorratsraum.K1-L3.Entfeuchter.Sperren
+  room: Vorratsraum
 2/1/111:
   dpt: '1.001'
   function: Schalten
-  name: Schalten.KG.Technikraum.K1-L2.Heizung.Ein/Aus
-  room: Technikraum
+  name: Schalten.KG.Vorratsraum.K1-L3.Entfeuchter.Ein/Aus
+  room: Vorratsraum
 2/1/112:
   dpt: '1.011'
   function: Schalten
-  name: Schalten.KG.Technikraum.K1-L2.Heizung.Ein/Aus-Status
-  room: Technikraum
+  name: Schalten.KG.Vorratsraum.K1-L3.Entfeuchter.Ein/Aus-Status
+  room: Vorratsraum
 2/1/113:
   dpt: '13.100'
   function: Schalten
-  name: Schalten.KG.Technikraum.K1-L2.Heizung.Betriebsstunden
-  room: Technikraum
+  name: Schalten.KG.Vorratsraum.K1-L3.Entfeuchter.Betriebsstunden
+  room: Vorratsraum
 2/1/114:
   dpt: '1.003'
   function: Schalten
-  name: Schalten.KG.Technikraum.K1-L2.Heizung.Betriebsstunden-Löschen
-  room: Technikraum
+  name: Schalten.KG.Vorratsraum.K1-L3.Entfeuchter.Betriebsstunden-Löschen
+  room: Vorratsraum
 2/1/115:
   dpt: '13.013'
   function: Schalten
-  name: Schalten.KG.Technikraum.K1-L2.Heizung.Kilowattstunde
-  room: Technikraum
+  name: Schalten.KG.Vorratsraum.K1-L3.Entfeuchter.Kilowattstunde
+  room: Vorratsraum
 2/1/116:
   dpt: '1.003'
   function: Schalten
-  name: Schalten.KG.Technikraum.K1-L2.Heizung.Kilowattstunde-Löschen
-  room: Technikraum
+  name: Schalten.KG.Vorratsraum.K1-L3.Entfeuchter.Kilowattstunde-Löschen
+  room: Vorratsraum
 2/1/117:
   dpt: '7.012'
   function: Schalten
-  name: Schalten.KG.Technikraum.K1-L2.Heizung.Stromwert
-  room: Technikraum
+  name: Schalten.KG.Vorratsraum.K1-L3.Entfeuchter.Stromwert
+  room: Vorratsraum
 2/1/12:
   dpt: '1.011'
   function: Schalten
   name: Schalten.KG.Flur.K1-L2.Heizkörper.Ein/Aus-Status
   room: Flur
 2/1/120:
-  dpt: '1.003'
+  dpt: '1.001'
   function: Schalten
-  name: Schalten.KG.Technikraum.K2-L1.Netzwerkschrank.Sperren
-  room: Technikraum
+  name: Schalten.KG.Vorratsraum.K1-L2.Steckdose.Sperren
+  room: Vorratsraum
 2/1/121:
   dpt: '1.001'
   function: Schalten
-  name: Schalten.KG.Technikraum.K2-L1.Netzwerkschrank.Ein/Aus
-  room: Technikraum
+  name: Schalten.KG.Vorratsraum.K1-L2.Steckdose.Ein/Aus
+  room: Vorratsraum
 2/1/122:
   dpt: '1.011'
   function: Schalten
-  name: Schalten.KG.Technikraum.K2-L1.Netzwerkschrank.Ein/Aus-Status
-  room: Technikraum
-2/1/123:
-  dpt: '13.100'
-  function: Schalten
-  name: Schalten.KG.Technikraum.K2-L1.Netzwerkschrank.Betriebsstunden
-  room: Technikraum
-2/1/124:
-  dpt: '1.003'
-  function: Schalten
-  name: Schalten.KG.Technikraum.K2-L1.Netzwerkschrank.Betriebsstunden-Löschen
-  room: Technikraum
-2/1/125:
-  dpt: '13.013'
-  function: Schalten
-  name: Schalten.KG.Technikraum.K2-L1.Netzwerkschrank.Kilowattstunde
-  room: Technikraum
-2/1/126:
-  dpt: '1.003'
-  function: Schalten
-  name: Schalten.KG.Technikraum.K2-L1.Netzwerkschrank.Kilowattstunde-Löschen
-  room: Technikraum
-2/1/127:
-  dpt: '7.012'
-  function: Schalten
-  name: Schalten.KG.Technikraum.K2-L1.Netzwerkschrank.Stromwert
-  room: Technikraum
+  name: Schalten.KG.Vorratsraum.K1-L2.Steckdose.Ein/Aus-Status
+  room: Vorratsraum
 2/1/130:
-  dpt: '1.003'
+  dpt: '1.001'
   function: Schalten
-  name: Schalten.KG.Technikraum.K2-L2.Netzwerkschrank.Sperren
-  room: Technikraum
+  name: Schalten.KG.Vorratsraum.K2-L1.Wasserstop.Sperren
+  room: Vorratsraum
 2/1/131:
   dpt: '1.001'
   function: Schalten
-  name: Schalten.KG.Technikraum.K2-L2.Netzwerkschrank.Ein/Aus
-  room: Technikraum
+  name: Schalten.KG.Vorratsraum.K2-L1.Wasserstop.Ein/Aus
+  room: Vorratsraum
 2/1/132:
   dpt: '1.011'
   function: Schalten
-  name: Schalten.KG.Technikraum.K2-L2.Netzwerkschrank.Ein/Aus-Status
-  room: Technikraum
-2/1/133:
-  dpt: '13.100'
-  function: Schalten
-  name: Schalten.KG.Technikraum.K2-L2.Netzwerkschrank.Betriebsstunden
-  room: Technikraum
-2/1/134:
-  dpt: '1.003'
-  function: Schalten
-  name: Schalten.KG.Technikraum.K2-L2.Netzwerkschrank.Betriebsstunden-Löschen
-  room: Technikraum
-2/1/135:
-  dpt: '13.013'
-  function: Schalten
-  name: Schalten.KG.Technikraum.K2-L2.Netzwerkschrank.Kilowattstunde
-  room: Technikraum
-2/1/136:
-  dpt: '1.003'
-  function: Schalten
-  name: Schalten.KG.Technikraum.K2-L2.Netzwerkschrank.Kilowattstunde-Löschen
-  room: Technikraum
-2/1/137:
-  dpt: '7.012'
-  function: Schalten
-  name: Schalten.KG.Technikraum.K2-L2.Netzwerkschrank.Stromwert
-  room: Technikraum
+  name: Schalten.KG.Vorratsraum.K2-L1.Wasserstop.Ein/Aus-Status
+  room: Vorratsraum
 2/1/140:
   dpt: '1.003'
   function: Schalten
-  name: Schalten.KG.Technikraum.K3-L3.Entfeuchter.Sperren
-  room: Technikraum
+  name: Schalten.KG.Vorratsraum.K3-L1.Lüftung.Sperren
+  room: Vorratsraum
 2/1/141:
   dpt: '1.001'
   function: Schalten
-  name: Schalten.KG.Technikraum.K3-L3.Entfeuchter.Ein/Aus
-  room: Technikraum
+  name: Schalten.KG.Vorratsraum.K3-L1.Lüftung.Ein/Aus
+  room: Vorratsraum
 2/1/142:
   dpt: '1.011'
   function: Schalten
-  name: Schalten.KG.Technikraum.K3-L3.Entfeuchter.Ein/Aus-Status
-  room: Technikraum
+  name: Schalten.KG.Vorratsraum.K3-L1.Lüftung.Ein/Aus-Status
+  room: Vorratsraum
 2/1/143:
   dpt: '13.100'
   function: Schalten
-  name: Schalten.KG.Technikraum.K3-L3.Entfeuchter.Betriebsstunden
-  room: Technikraum
+  name: Schalten.KG.Vorratsraum.K3-L1.Lüftung.Betriebsstunden
+  room: Vorratsraum
 2/1/144:
   dpt: '1.003'
   function: Schalten
-  name: Schalten.KG.Technikraum.K3-L3.Entfeuchter.Betriebsstunden-Löschen
-  room: Technikraum
+  name: Schalten.KG.Vorratsraum.K3-L1.Lüftung.Betriebsstunden-Löschen
+  room: Vorratsraum
 2/1/145:
   dpt: '13.013'
   function: Schalten
-  name: Schalten.KG.Technikraum.K3-L3.Entfeuchter.Kilowattstunde
-  room: Technikraum
+  name: Schalten.KG.Vorratsraum.K3-L1.Lüftung.Kilowattstunde
+  room: Vorratsraum
 2/1/146:
   dpt: '1.003'
   function: Schalten
-  name: Schalten.KG.Technikraum.K3-L3.Entfeuchter.Kilowattstunde-Löschen
-  room: Technikraum
+  name: Schalten.KG.Vorratsraum.K3-L1.Lüftung.Kilowattstunde-Löschen
+  room: Vorratsraum
 2/1/147:
   dpt: '7.012'
   function: Schalten
-  name: Schalten.KG.Technikraum.K3-L3.Entfeuchter.Stromwert
-  room: Technikraum
+  name: Schalten.KG.Vorratsraum.K3-L1.Lüftung.Stromwert
+  room: Vorratsraum
 2/1/150:
   dpt: '1.003'
   function: Schalten
-  name: Schalten.KG.Technikraum.Bewässerung.Regen.Sperren
-  room: Technikraum
+  name: Schalten.KG.Hauswirtschaftsraum.K1-L3.Entfeuchter.Sperren
+  room: Hauswirtschaftsraum
 2/1/151:
   dpt: '1.001'
   function: Schalten
-  name: Schalten.KG.Technikraum.Bewässerung.Regen.Ein/Aus
-  room: Technikraum
+  name: Schalten.KG.Hauswirtschaftsraum.K1-L3.Entfeuchter.Ein/Aus
+  room: Hauswirtschaftsraum
 2/1/152:
   dpt: '1.011'
   function: Schalten
-  name: Schalten.KG.Technikraum.Bewässerung.Regen.Ein/Aus-Status
-  room: Technikraum
+  name: Schalten.KG.Hauswirtschaftsraum.K1-L3.Entfeuchter.Ein/Aus-Status
+  room: Hauswirtschaftsraum
+2/1/153:
+  dpt: '13.100'
+  function: Schalten
+  name: Schalten.KG.Hauswirtschaftsraum.K1-L3.Entfeuchter.Betriebsstunden
+  room: Hauswirtschaftsraum
+2/1/154:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.KG.Hauswirtschaftsraum.K1-L3.Entfeuchter.Betriebsstunden-Löschen
+  room: Hauswirtschaftsraum
+2/1/155:
+  dpt: '13.013'
+  function: Schalten
+  name: Schalten.KG.Hauswirtschaftsraum.K1-L3.Entfeuchter.Kilowattstunde
+  room: Hauswirtschaftsraum
+2/1/156:
+  dpt: '1.010'
+  function: Schalten
+  name: Schalten.KG.hauswirtschaftsraum.K1-L3.Entfeuchter.Kilowattstunde-Löschen
+  room: Hauswirtschaftsraum
+2/1/157:
+  dpt: '7.012'
+  function: Schalten
+  name: Schalten.KG.Hauswirtschaftsraum.K1-L3.Entfeuchter.Stromwert
+  room: Hauswirtschaftsraum
+2/1/160:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.KG.Hauswirtschaftsraum.K1-L3.Heizkörper.Sperren
+  room: Hauswirtschaftsraum
+2/1/161:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.KG.Hauswirtschaftsraum.K1-L3.Heizkörper.Ein/Aus
+  room: Hauswirtschaftsraum
+2/1/162:
+  dpt: '1.011'
+  function: Schalten
+  name: Schalten.KG.Hauswirtschaftsraum.K1-L3.Heizkörper.Ein/Aus-Status
+  room: Hauswirtschaftsraum
+2/1/170:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.KG.Hauswirtschaftsraum.K2-L2.Fehrnseh.Sperren
+  room: Hauswirtschaftsraum
+2/1/171:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.KG.Hauswirtschaftsraum.K2-L2.Fehrnseh.Ein/Aus
+  room: Hauswirtschaftsraum
+2/1/172:
+  dpt: '1.011'
+  function: Schalten
+  name: Schalten.KG.Hauswirtschaftsraum.K2-L2.Fehrnseh.Ein/Aus-Status
+  room: Hauswirtschaftsraum
+2/1/180:
+  dpt: '1.003'
+  function: Schalten
+  name: Schalten.KG.Hauswirtschaftsraum.K3-L1.Trockner.Sperren
+  room: Hauswirtschaftsraum
+2/1/181:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.KG.Hauswirtschaftsraum.K3-L1.Trockner.Ein/Aus
+  room: Hauswirtschaftsraum
+2/1/182:
+  dpt: '1.011'
+  function: Schalten
+  name: Schalten.KG.Hauswirtschaftsraum.K3-L1.Trockner.Ein/Aus-Status
+  room: Hauswirtschaftsraum
+2/1/183:
+  dpt: '13.100'
+  function: Schalten
+  name: Schalten.KG.Hauswirtschaftsraum.K3-L1.Trockner.Betriebsstunden
+  room: Hauswirtschaftsraum
+2/1/184:
+  dpt: '1.003'
+  function: Schalten
+  name: Schalten.KG.Hauswirtschaftsraum.K3-L1.Trockner.Betriebsstunden-Löschen
+  room: Hauswirtschaftsraum
+2/1/185:
+  dpt: '13.013'
+  function: Schalten
+  name: Schalten.KG.Hauswirtschaftsraum.K3-L1.Trockner.Kilowattstunde
+  room: Hauswirtschaftsraum
+2/1/186:
+  dpt: '1.003'
+  function: Schalten
+  name: Schalten.KG.Hauswirtschaftsraum.K3-L1.Trockner.Kilowattstunde-Löschen
+  room: Hauswirtschaftsraum
+2/1/187:
+  dpt: '7.012'
+  function: Schalten
+  name: Schalten.KG.Hauswirtschaftsraum.K3-L1.Trockner.Stromwert
+  room: Hauswirtschaftsraum
+2/1/188:
+  dpt: '1.011'
+  function: Schalten
+  name: Schalten.KG.Hauswirtschaftsraum.K3-L1.Trockner.Status
+  room: Hauswirtschaftsraum
+2/1/190:
+  dpt: '1.003'
+  function: Schalten
+  name: Schalten.KG.Hauswirtschaftsraum.K4-L1.Waschmaschine.Sperren
+  room: Hauswirtschaftsraum
+2/1/191:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.KG.Hauswirtschaftsraum.K4-L1.Waschmaschine.Ein/Aus
+  room: Hauswirtschaftsraum
+2/1/192:
+  dpt: '1.011'
+  function: Schalten
+  name: Schalten.KG.Hauswirtschaftsraum.K4-L1.Waschmaschine.Ein/Aus-Status
+  room: Hauswirtschaftsraum
+2/1/193:
+  dpt: '13.100'
+  function: Schalten
+  name: Schalten.KG.Hauswirtschaftsraum.K4-L1.Waschmaschine.Betriebsstunden
+  room: Hauswirtschaftsraum
+2/1/194:
+  dpt: '1.003'
+  function: Schalten
+  name: Schalten.KG.Hauswirtschaftsraum.K4-L1.Waschmaschine.Betriebsstunden-Löschen
+  room: Hauswirtschaftsraum
+2/1/195:
+  dpt: '13.013'
+  function: Schalten
+  name: Schalten.KG.Hauswirtschaftsraum.K4-L1.Waschmaschine.Kilowattstunde
+  room: Hauswirtschaftsraum
+2/1/196:
+  dpt: '1.003'
+  function: Schalten
+  name: Schalten.KG.Hauswirtschaftsraum.K4-L1.Waschmaschine.Kilowattstunde-Löschen
+  room: Hauswirtschaftsraum
+2/1/197:
+  dpt: '7.012'
+  function: Schalten
+  name: Schalten.KG.Hauswirtschaftsraum.K4-L1.Waschmaschine.Stromwert
+  room: Hauswirtschaftsraum
+2/1/198:
+  dpt: '1.000'
+  function: Schalten
+  name: Schalten.KG.Hauswirtschaftsraum.K4-L1.Waschmaschine.Status
+  room: Hauswirtschaftsraum
 2/1/2:
   dpt: '1.011'
   function: Schalten
   name: Schalten.KG.Flur.K1-L1.Steckdose.Ein/Aus-Status
   room: Flur
-2/1/200:
-  dpt: '1.003'
-  function: Schalten
-  name: Schalten.KG.Vorratsraum.K1-L3.Entfeuchter.Sperren
-  room: Vorratsraum
-2/1/201:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.KG.Vorratsraum.K1-L3.Entfeuchter.Ein/Aus
-  room: Vorratsraum
-2/1/202:
-  dpt: '1.011'
-  function: Schalten
-  name: Schalten.KG.Vorratsraum.K1-L3.Entfeuchter.Ein/Aus-Status
-  room: Vorratsraum
-2/1/203:
-  dpt: '13.100'
-  function: Schalten
-  name: Schalten.KG.Vorratsraum.K1-L3.Entfeuchter.Betriebsstunden
-  room: Vorratsraum
-2/1/204:
-  dpt: '1.003'
-  function: Schalten
-  name: Schalten.KG.Vorratsraum.K1-L3.Entfeuchter.Betriebsstunden-Löschen
-  room: Vorratsraum
-2/1/205:
-  dpt: '13.013'
-  function: Schalten
-  name: Schalten.KG.Vorratsraum.K1-L3.Entfeuchter.Kilowattstunde
-  room: Vorratsraum
-2/1/206:
-  dpt: '1.003'
-  function: Schalten
-  name: Schalten.KG.Vorratsraum.K1-L3.Entfeuchter.Kilowattstunde-Löschen
-  room: Vorratsraum
-2/1/207:
-  dpt: '7.012'
-  function: Schalten
-  name: Schalten.KG.Vorratsraum.K1-L3.Entfeuchter.Stromwert
-  room: Vorratsraum
-2/1/210:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.KG.Vorratsraum.K1-L2.Steckdose.Sperren
-  room: Vorratsraum
-2/1/211:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.KG.Vorratsraum.K1-L2.Steckdose.Ein/Aus
-  room: Vorratsraum
-2/1/212:
-  dpt: '1.011'
-  function: Schalten
-  name: Schalten.KG.Vorratsraum.K1-L2.Steckdose.Ein/Aus-Status
-  room: Vorratsraum
-2/1/220:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.KG.Vorratsraum.K2-L1.Wasserstop.Sperren
-  room: Vorratsraum
-2/1/221:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.KG.Vorratsraum.K2-L1.Wasserstop.Ein/Aus
-  room: Vorratsraum
-2/1/222:
-  dpt: '1.011'
-  function: Schalten
-  name: Schalten.KG.Vorratsraum.K2-L1.Wasserstop.Ein/Aus-Status
-  room: Vorratsraum
-2/1/230:
-  dpt: '1.003'
-  function: Schalten
-  name: Schalten.KG.Vorratsraum.K3-L1.Lüftung.Sperren
-  room: Vorratsraum
-2/1/231:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.KG.Vorratsraum.K3-L1.Lüftung.Ein/Aus
-  room: Vorratsraum
-2/1/232:
-  dpt: '1.011'
-  function: Schalten
-  name: Schalten.KG.Vorratsraum.K3-L1.Lüftung.Ein/Aus-Status
-  room: Vorratsraum
-2/1/233:
-  dpt: '13.100'
-  function: Schalten
-  name: Schalten.KG.Vorratsraum.K3-L1.Lüftung.Betriebsstunden
-  room: Vorratsraum
-2/1/234:
-  dpt: '1.003'
-  function: Schalten
-  name: Schalten.KG.Vorratsraum.K3-L1.Lüftung.Betriebsstunden-Löschen
-  room: Vorratsraum
-2/1/235:
-  dpt: '13.013'
-  function: Schalten
-  name: Schalten.KG.Vorratsraum.K3-L1.Lüftung.Kilowattstunde
-  room: Vorratsraum
-2/1/236:
-  dpt: '1.003'
-  function: Schalten
-  name: Schalten.KG.Vorratsraum.K3-L1.Lüftung.Kilowattstunde-Löschen
-  room: Vorratsraum
-2/1/237:
-  dpt: '7.012'
-  function: Schalten
-  name: Schalten.KG.Vorratsraum.K3-L1.Lüftung.Stromwert
-  room: Vorratsraum
-2/1/50:
+2/1/20:
   dpt: '1.003'
   function: Schalten
   name: Schalten.KG.Garage.K1-L3.Entfeuchter.Sperren
   room: Garage
-2/1/51:
+2/1/21:
   dpt: '1.001'
   function: Schalten
   name: Schalten.KG.Garage.K1-L3.Entfeuchter.Ein/Aus
   room: Garage
-2/1/52:
+2/1/22:
   dpt: '1.011'
   function: Schalten
   name: Schalten.KG.Garage.K1-L3.Entfeuchter.Ein/Aus-Status
   room: Garage
-2/1/53:
+2/1/23:
   dpt: '13.100'
   function: Schalten
   name: Schalten.KG.Garage.K1-L3.Entfeuchter.Betriebsstunden
   room: Garage
-2/1/54:
+2/1/24:
   dpt: '1.003'
   function: Schalten
   name: Schalten.KG.Garage.K1-L3.Entfeuchter.Betriebsstunden-Löschen
   room: Garage
-2/1/55:
+2/1/25:
   dpt: '13.013'
   function: Schalten
   name: Schalten.KG.Garage.K1-L3.Entfeuchter.Kilowattstunde
   room: Garage
-2/1/56:
+2/1/26:
   dpt: '1.003'
   function: Schalten
   name: Schalten.KG.Garage.K1-L3.Entfeuchter.Kilowattstunde-Löschen
   room: Garage
-2/1/57:
+2/1/27:
   dpt: '7.012'
   function: Schalten
   name: Schalten.KG.Garage.K1-L3.Entfeuchter.Stromwert
   room: Garage
-2/1/60:
+2/1/30:
   dpt: '1.001'
   function: Schalten
   name: Schalten.KG.Garage.K2-L2.Steckdose.Sperren
   room: Garage
-2/1/61:
+2/1/31:
   dpt: '1.001'
   function: Schalten
   name: Schalten.KG.Garage.K2-L2.Steckdose.Ein/Aus
   room: Garage
-2/1/62:
+2/1/32:
   dpt: '1.011'
   function: Schalten
   name: Schalten.KG.Garage.K2-L2.Steckdose.Ein/Aus-Status
   room: Garage
-2/1/70:
+2/1/40:
   dpt: '1.001'
   function: Schalten
   name: Schalten.KG.Garage.K3-L1.Garagentor.Sperren
   room: Garage
-2/1/71:
+2/1/41:
   dpt: '1.001'
   function: Schalten
   name: Schalten.KG.Garage.K3-L1.Garagentor.Ein/Aus
   room: Garage
-2/1/72:
+2/1/42:
   dpt: '1.011'
   function: Schalten
   name: Schalten.KG.Garage.K3-L1.Garagentor.Ein/Aus-Status
   room: Garage
-2/2/100:
+2/1/50:
+  dpt: '1.003'
+  function: Schalten
+  name: Schalten.KG.Technikraum.K1-L1.Heizung.Sperren
+  room: Technikraum
+2/1/51:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.KG.Technikraum.K1-L1.Heizung.Ein/Aus
+  room: Technikraum
+2/1/52:
+  dpt: '1.011'
+  function: Schalten
+  name: Schalten.KG.Technikraum.K1-L1.Heizung.Ein/Aus-Status
+  room: Technikraum
+2/1/53:
+  dpt: '13.100'
+  function: Schalten
+  name: Schalten.KG.Technikraum.K1-L1.Heizung.Betriebsstunden
+  room: Technikraum
+2/1/54:
+  dpt: '1.003'
+  function: Schalten
+  name: Schalten.KG.Technikraum.K1-L1.Heizung.Betriebsstunden-Löschen
+  room: Technikraum
+2/1/55:
+  dpt: '13.013'
+  function: Schalten
+  name: Schalten.KG.Technikraum.K1-L1.Heizung.Kilowattstunde
+  room: Technikraum
+2/1/56:
+  dpt: '1.003'
+  function: Schalten
+  name: Schalten.KG.Technikraum.K1-L1.Heizung.Löschen-Kilowattstunde
+  room: Technikraum
+2/1/57:
+  dpt: '7.012'
+  function: Schalten
+  name: Schalten.KG.Technikraum.K1-L1.Heizung.Stromwert
+  room: Technikraum
+2/1/60:
+  dpt: '1.003'
+  function: Schalten
+  name: Schalten.KG.Technikraum.K1-L2.Heizung.Sperren
+  room: Technikraum
+2/1/61:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.KG.Technikraum.K1-L2.Heizung.Ein/Aus
+  room: Technikraum
+2/1/62:
+  dpt: '1.011'
+  function: Schalten
+  name: Schalten.KG.Technikraum.K1-L2.Heizung.Ein/Aus-Status
+  room: Technikraum
+2/1/63:
+  dpt: '13.100'
+  function: Schalten
+  name: Schalten.KG.Technikraum.K1-L2.Heizung.Betriebsstunden
+  room: Technikraum
+2/1/64:
+  dpt: '1.003'
+  function: Schalten
+  name: Schalten.KG.Technikraum.K1-L2.Heizung.Betriebsstunden-Löschen
+  room: Technikraum
+2/1/65:
+  dpt: '13.013'
+  function: Schalten
+  name: Schalten.KG.Technikraum.K1-L2.Heizung.Kilowattstunde
+  room: Technikraum
+2/1/66:
+  dpt: '1.003'
+  function: Schalten
+  name: Schalten.KG.Technikraum.K1-L2.Heizung.Kilowattstunde-Löschen
+  room: Technikraum
+2/1/67:
+  dpt: '7.012'
+  function: Schalten
+  name: Schalten.KG.Technikraum.K1-L2.Heizung.Stromwert
+  room: Technikraum
+2/1/70:
+  dpt: '1.003'
+  function: Schalten
+  name: Schalten.KG.Technikraum.K2-L1.Netzwerkschrank.Sperren
+  room: Technikraum
+2/1/71:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.KG.Technikraum.K2-L1.Netzwerkschrank.Ein/Aus
+  room: Technikraum
+2/1/72:
+  dpt: '1.011'
+  function: Schalten
+  name: Schalten.KG.Technikraum.K2-L1.Netzwerkschrank.Ein/Aus-Status
+  room: Technikraum
+2/1/73:
+  dpt: '13.100'
+  function: Schalten
+  name: Schalten.KG.Technikraum.K2-L1.Netzwerkschrank.Betriebsstunden
+  room: Technikraum
+2/1/74:
+  dpt: '1.003'
+  function: Schalten
+  name: Schalten.KG.Technikraum.K2-L1.Netzwerkschrank.Betriebsstunden-Löschen
+  room: Technikraum
+2/1/75:
+  dpt: '13.013'
+  function: Schalten
+  name: Schalten.KG.Technikraum.K2-L1.Netzwerkschrank.Kilowattstunde
+  room: Technikraum
+2/1/76:
+  dpt: '1.003'
+  function: Schalten
+  name: Schalten.KG.Technikraum.K2-L1.Netzwerkschrank.Kilowattstunde-Löschen
+  room: Technikraum
+2/1/77:
+  dpt: '7.012'
+  function: Schalten
+  name: Schalten.KG.Technikraum.K2-L1.Netzwerkschrank.Stromwert
+  room: Technikraum
+2/1/80:
+  dpt: '1.003'
+  function: Schalten
+  name: Schalten.KG.Technikraum.K2-L2.Netzwerkschrank.Sperren
+  room: Technikraum
+2/1/81:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.KG.Technikraum.K2-L2.Netzwerkschrank.Ein/Aus
+  room: Technikraum
+2/1/82:
+  dpt: '1.011'
+  function: Schalten
+  name: Schalten.KG.Technikraum.K2-L2.Netzwerkschrank.Ein/Aus-Status
+  room: Technikraum
+2/1/83:
+  dpt: '13.100'
+  function: Schalten
+  name: Schalten.KG.Technikraum.K2-L2.Netzwerkschrank.Betriebsstunden
+  room: Technikraum
+2/1/84:
+  dpt: '1.003'
+  function: Schalten
+  name: Schalten.KG.Technikraum.K2-L2.Netzwerkschrank.Betriebsstunden-Löschen
+  room: Technikraum
+2/1/85:
+  dpt: '13.013'
+  function: Schalten
+  name: Schalten.KG.Technikraum.K2-L2.Netzwerkschrank.Kilowattstunde
+  room: Technikraum
+2/1/86:
+  dpt: '1.003'
+  function: Schalten
+  name: Schalten.KG.Technikraum.K2-L2.Netzwerkschrank.Kilowattstunde-Löschen
+  room: Technikraum
+2/1/87:
+  dpt: '7.012'
+  function: Schalten
+  name: Schalten.KG.Technikraum.K2-L2.Netzwerkschrank.Stromwert
+  room: Technikraum
+2/1/90:
+  dpt: '1.003'
+  function: Schalten
+  name: Schalten.KG.Technikraum.K3-L3.Entfeuchter.Sperren
+  room: Technikraum
+2/1/91:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.KG.Technikraum.K3-L3.Entfeuchter.Ein/Aus
+  room: Technikraum
+2/1/92:
+  dpt: '1.011'
+  function: Schalten
+  name: Schalten.KG.Technikraum.K3-L3.Entfeuchter.Ein/Aus-Status
+  room: Technikraum
+2/1/93:
+  dpt: '13.100'
+  function: Schalten
+  name: Schalten.KG.Technikraum.K3-L3.Entfeuchter.Betriebsstunden
+  room: Technikraum
+2/1/94:
+  dpt: '1.003'
+  function: Schalten
+  name: Schalten.KG.Technikraum.K3-L3.Entfeuchter.Betriebsstunden-Löschen
+  room: Technikraum
+2/1/95:
+  dpt: '13.013'
+  function: Schalten
+  name: Schalten.KG.Technikraum.K3-L3.Entfeuchter.Kilowattstunde
+  room: Technikraum
+2/1/96:
+  dpt: '1.003'
+  function: Schalten
+  name: Schalten.KG.Technikraum.K3-L3.Entfeuchter.Kilowattstunde-Löschen
+  room: Technikraum
+2/1/97:
+  dpt: '7.012'
+  function: Schalten
+  name: Schalten.KG.Technikraum.K3-L3.Entfeuchter.Stromwert
+  room: Technikraum
+2/2/0:
   dpt: '1.001'
   function: Schalten
   name: Schalten.EG.Büro.K1-L2.Steckdose.Sperren
   room: Büro
-2/2/101:
+2/2/1:
   dpt: '1.001'
   function: Schalten
   name: Schalten.EG.Büro.K1-L2.Steckdose.Ein/Aus
   room: Büro
-2/2/102:
-  dpt: '1.011'
-  function: Schalten
-  name: Schalten.EG.Büro.K1-L2.Steckdose.Ein/Aus-Status
-  room: Büro
-2/2/110:
+2/2/10:
   dpt: '1.001'
   function: Schalten
   name: Schalten.EG.Büro.K2-L2.Schreibtisch.Sperren
   room: Büro
-2/2/111:
+2/2/100:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.EG.Küche.K1-L3.Steckdose.Sperren
+  room: Küche
+2/2/101:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.EG.Küche.K1-L3.Steckdose.Ein/Aus
+  room: Küche
+2/2/102:
+  dpt: '1.011'
+  function: Schalten
+  name: Schalten.EG.Küche.K1-L3.Steckdose.Ein/Aus-Status
+  room: Küche
+2/2/11:
   dpt: '1.001'
   function: Schalten
   name: Schalten.EG.Büro.K2-L2.Schreibtisch.Ein/Aus
   room: Büro
+2/2/110:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.EG.Küche.K2-L1.Steckdose.Sperren
+  room: Küche
+2/2/111:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.EG.Küche.K2-L1.Steckdose.Ein/Aus
+  room: Küche
 2/2/112:
+  dpt: '1.011'
+  function: Schalten
+  name: Schalten.EG.Küche.K2-L1.Steckdose.Ein/Aus-Status
+  room: Küche
+2/2/12:
   dpt: '1.011'
   function: Schalten
   name: Schalten.EG.Büro.K2-L2.Schreibtisch.Ein/Aus-Status
@@ -3576,268 +2937,813 @@
 2/2/120:
   dpt: '1.001'
   function: Schalten
+  name: Schalten.EG.Küche.K2-L2.Steckdose.Sperren
+  room: Küche
+2/2/121:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.EG.Küche.K2-L2.Steckdose.Ein/Aus
+  room: Küche
+2/2/122:
+  dpt: '1.011'
+  function: Schalten
+  name: Schalten.EG.Küche.K2-L2.Steckdose.Ein/Aus-Status
+  room: Küche
+2/2/130:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.EG.Küche.K3-L3.Kücheninsel.Sperren
+  room: Küche
+2/2/131:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.EG.Küche.K3-L3.Kücheninsel.Ein/Aus
+  room: Küche
+2/2/132:
+  dpt: '1.011'
+  function: Schalten
+  name: Schalten.EG.Küche.K3-L3.Kücheninsel.Ein/Aus-Status
+  room: Küche
+2/2/140:
+  dpt: '1.003'
+  function: Schalten
+  name: Schalten.EG.Küche.K4-L1.Geschirrspüler.Sperren
+  room: Küche
+2/2/141:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.EG.Küche.K4-L1.Geschirrspüler.Ein/Aus
+  room: Küche
+2/2/142:
+  dpt: '1.011'
+  function: Schalten
+  name: Schalten.EG.Küche.K4-L1.Geschirrspüler.Ein/Aus-Status
+  room: Küche
+2/2/143:
+  dpt: '13.100'
+  function: Schalten
+  name: Schalten.EG.Küche.K4-L1.Geschirrspüler.Betriebsstunden
+  room: Küche
+2/2/144:
+  dpt: '1.003'
+  function: Schalten
+  name: 'Schalten.EG.Küche.K4-L1.Geschirrspüler.Betriebsstunden-Löschen '
+  room: Küche
+2/2/145:
+  dpt: '13.013'
+  function: Schalten
+  name: Schalten.EG.Küche.K4-L1.Geschirrspüler.Kilowattstunde
+  room: Küche
+2/2/146:
+  dpt: '1.003'
+  function: Schalten
+  name: Schalten.EG.Küche.K4-L1.Geschirrspüler.Kilowattstunde-Löschen
+  room: Küche
+2/2/147:
+  dpt: '7.012'
+  function: Schalten
+  name: Schalten.EG.Küche.K4-L1.Geschirrspüler.Stromwert
+  room: Küche
+2/2/150:
+  dpt: '1.003'
+  function: Schalten
+  name: Schalten.EG.Küche.K5-L1.Haubenlüfter.Sperren
+  room: Küche
+2/2/151:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.EG.Küche.K5-L1.Haubenlüfter.Ein/Aus
+  room: Küche
+2/2/152:
+  dpt: '1.011'
+  function: Schalten
+  name: Schalten.EG.Küche.K5-L1.Haubenlüfter.Ein/Aus-Status
+  room: Küche
+2/2/153:
+  dpt: '13.100'
+  function: Schalten
+  name: Schalten.EG.Küche.K5-L1.Haubenlüfter.Betriebsstunden
+  room: Küche
+2/2/154:
+  dpt: '1.003'
+  function: Schalten
+  name: Schalten.EG.Küche.K5-L1.Haubenlüfter.Betriebsstunden-Löschen
+  room: Küche
+2/2/155:
+  dpt: '13.013'
+  function: Schalten
+  name: Schalten.EG.Küche.K5-L1.Haubenlüfter.Kilowattstunde
+  room: Küche
+2/2/156:
+  dpt: '1.003'
+  function: Schalten
+  name: Schalten.EG.Küche.K5-L1.Haubenlüfter.Kilowattstunde-Löschen
+  room: Küche
+2/2/157:
+  dpt: '7.012'
+  function: Schalten
+  name: Schalten.EG.Küche.K5-L1.Haubenlüfter.Stromwert
+  room: Küche
+2/2/160:
+  dpt: '1.003'
+  function: Schalten
+  name: Schalten.EG.Küche.K7-L1.Kühlschrank.Sperren
+  room: Küche
+2/2/161:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.EG.Küche.K7-L1.Kühlschrank.Ein/Aus
+  room: Küche
+2/2/162:
+  dpt: '1.011'
+  function: Schalten
+  name: Schalten.EG.Küche.K7-L1.Kühlschrank.Ein/Aus-Status
+  room: Küche
+2/2/163:
+  dpt: '13.100'
+  function: Schalten
+  name: Schalten.EG.Küche.K7-L1.Kühlschrank.Betriebsstunden
+  room: Küche
+2/2/164:
+  dpt: '1.003'
+  function: Schalten
+  name: Schalten.EG.Küche.K7-L1.Kühlschrank.Betriebsstunden-Löschen
+  room: Küche
+2/2/165:
+  dpt: '13.013'
+  function: Schalten
+  name: Schalten.EG.Küche.K7-L1.Kühlschrank.Kilowattstunde
+  room: Küche
+2/2/166:
+  dpt: '1.003'
+  function: Schalten
+  name: Schalten.EG.Küche.K7-L1.Kühlschrank.Kilowattstunde-Löschen
+  room: Küche
+2/2/167:
+  dpt: '7.012'
+  function: Schalten
+  name: Schalten.EG.Küche.K7-L1.Kühlschrank.Stromwert
+  room: Küche
+2/2/170:
+  dpt: '1.003'
+  function: Schalten
+  name: Schalten.EG.Küche.K9-L1.Backofen.Sperren
+  room: Küche
+2/2/171:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.EG.Küche.K9-L1.Backofen.Ein/Aus
+  room: Küche
+2/2/172:
+  dpt: '1.011'
+  function: Schalten
+  name: Schalten.EG.Küche.K9-L1.Backofen.Ein/Aus-Status
+  room: Küche
+2/2/173:
+  dpt: '13.100'
+  function: Schalten
+  name: Schalten.EG.Küche.K9-L1.Backofen.Betriebsstunden
+  room: Küche
+2/2/174:
+  dpt: '1.003'
+  function: Schalten
+  name: Schalten.EG.Küche.K9-L1.Backofen.Betriebsstunden-Löschen
+  room: Küche
+2/2/175:
+  dpt: '13.013'
+  function: Schalten
+  name: Schalten.EG.Küche.K9-L1.Backofen.Kilowattstunde
+  room: Küche
+2/2/176:
+  dpt: '1.003'
+  function: Schalten
+  name: Schalten.EG.Küche.K9-L1.Backofen.Kilowattstunde-Löschen
+  room: Küche
+2/2/177:
+  dpt: '7.012'
+  function: Schalten
+  name: Schalten.EG.Küche.K9-L1.Backofen.Stromwert
+  room: Küche
+2/2/180:
+  dpt: '1.003'
+  function: Schalten
+  name: Schalten.EG.Küche.K10-L1.Tellerwärmer.Sperren
+  room: Küche
+2/2/181:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.EG.Küche.K10-L1.Tellerwärmer.Ein/Aus
+  room: Küche
+2/2/182:
+  dpt: '1.011'
+  function: Schalten
+  name: Schalten.EG.Küche.K10-L1.Tellerwärmer.Ein/Aus-Status
+  room: Küche
+2/2/183:
+  dpt: '13.100'
+  function: Schalten
+  name: Schalten.EG.Küche.K10-L1.Tellerwärmer.Betriebsstunden
+  room: Küche
+2/2/184:
+  dpt: '1.003'
+  function: Schalten
+  name: Schalten.EG.Küche.K10-L1.Tellerwärmer.Betriebsstunden-Löschen
+  room: Küche
+2/2/185:
+  dpt: '13.013'
+  function: Schalten
+  name: Schalten.EG.Küche.K10-L1.Tellerwärmer.Kilowattstunde
+  room: Küche
+2/2/186:
+  dpt: '1.003'
+  function: Schalten
+  name: Schalten.EG.Küche.K10-L1.Tellerwärmer.Kilowattstunde-Löschen
+  room: Küche
+2/2/187:
+  dpt: '7.012'
+  function: Schalten
+  name: Schalten.EG.Küche.K10-L1.Tellerwärmer.Stromwert
+  room: Küche
+2/2/190:
+  dpt: '1.003'
+  function: Schalten
+  name: Schalten.EG.Küche.K12-L1.Mikrowelle.Sperren
+  room: Küche
+2/2/191:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.EG.Küche.K12-L1.Mikrowelle.Ein/Aus
+  room: Küche
+2/2/192:
+  dpt: '1.011'
+  function: Schalten
+  name: Schalten.EG.Küche.K12-L1.Mikrowelle.Ein/Aus-Status
+  room: Küche
+2/2/193:
+  dpt: '13.100'
+  function: Schalten
+  name: Schalten.EG.Küche.K12-L1.Mikrowelle.Betriebsstunden
+  room: Küche
+2/2/194:
+  dpt: '1.003'
+  function: Schalten
+  name: Schalten.EG.Küche.K12-L1.Mikrowelle.Betriebsstunden-Löschen
+  room: Küche
+2/2/195:
+  dpt: '13.013'
+  function: Schalten
+  name: Schalten.EG.Küche.K12-L1.Mikrowelle.Kilowattstunde
+  room: Küche
+2/2/196:
+  dpt: '1.003'
+  function: Schalten
+  name: Schalten.EG.Küche.K12-L1.Mikrowelle.Kilowattstunde-Löschen
+  room: Küche
+2/2/197:
+  dpt: '7.012'
+  function: Schalten
+  name: Schalten.EG.Küche.K12-L1.Mikrowelle.Stromwert
+  room: Küche
+2/2/2:
+  dpt: '1.011'
+  function: Schalten
+  name: Schalten.EG.Büro.K1-L2.Steckdose.Ein/Aus-Status
+  room: Büro
+2/2/20:
+  dpt: '1.001'
+  function: Schalten
   name: Schalten.EG.Büro.K2-L3.Schreibtisch.Sperren
   room: Büro
-2/2/121:
+2/2/200:
+  dpt: '1.003'
+  function: Schalten
+  name: Schalten.EG.Küche.K13-L1.Kaffeemaschine.Sperren
+  room: Küche
+2/2/201:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.EG.Küche.K13-L1.Kaffeemaschine.Ein/Aus
+  room: Küche
+2/2/202:
+  dpt: '1.011'
+  function: Schalten
+  name: Schalten.EG.Küche.K13-L1.Kaffeemaschine.Ein/Aus-Status
+  room: Küche
+2/2/203:
+  dpt: '13.100'
+  function: Schalten
+  name: Schalten.EG.Küche.K13-L1.Kaffeemaschine.Betriebsstunden
+  room: Küche
+2/2/204:
+  dpt: '1.003'
+  function: Schalten
+  name: Schalten.EG.Küche.K13-L1.Kaffeemaschine.Betriebsstunden-Löschen
+  room: Küche
+2/2/205:
+  dpt: '13.013'
+  function: Schalten
+  name: Schalten.EG.Küche.K13-L1.Kaffeemaschine.Kilowattstunde
+  room: Küche
+2/2/206:
+  dpt: '1.003'
+  function: Schalten
+  name: Schalten.EG.Küche.K13-L1.Kaffeemaschine.Kilowattstunde-Löschen
+  room: Küche
+2/2/207:
+  dpt: '7.012'
+  function: Schalten
+  name: Schalten.EG.Küche.K13-L1.Kaffeemaschine.Stromwert
+  room: Küche
+2/2/21:
   dpt: '1.001'
   function: Schalten
   name: Schalten.EG.Büro.K2-L3.Schreibtisch.Ein/Aus
   room: Büro
-2/2/122:
+2/2/210:
+  dpt: '1.003'
+  function: Schalten
+  name: Schalten.EG.Küche.K14-L1.Dampfgarer.Sperren
+  room: Küche
+2/2/211:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.EG.Küche.K14-L1.Dampfgarer.Ein/Aus
+  room: Küche
+2/2/212:
+  dpt: '1.011'
+  function: Schalten
+  name: Schalten.EG.Küche.K14-L1.Dampfgarer.Ein/Aus-Status
+  room: Küche
+2/2/213:
+  dpt: '13.100'
+  function: Schalten
+  name: Schalten.EG.Küche.K14-L1.Dampfgarer.Betriebsstunden
+  room: Küche
+2/2/214:
+  dpt: '1.003'
+  function: Schalten
+  name: Schalten.EG.Küche.K14-L1.Dampfgarer.Betriebsstunden-Löschen
+  room: Küche
+2/2/215:
+  dpt: '13.013'
+  function: Schalten
+  name: Schalten.EG.Küche.K14-L1.Dampfgarer.Kilowattstunde
+  room: Küche
+2/2/216:
+  dpt: '1.003'
+  function: Schalten
+  name: Schalten.EG.Küche.K14-L1.Dampfgarer.Kilowattstunde-Löschen
+  room: Küche
+2/2/217:
+  dpt: '7.012'
+  function: Schalten
+  name: Schalten.EG.Küche.K14-L1.Dampfgarer.Stromwert
+  room: Küche
+2/2/22:
   dpt: '1.011'
   function: Schalten
   name: Schalten.EG.Büro.K2-L3.Schreibtisch.Ein/Aus-Status
   room: Büro
-2/2/150:
+2/2/220:
+  dpt: '1.003'
+  function: Schalten
+  name: Schalten.EG.Küche.K15-L1.Gefrierschrank.Sperren
+  room: Küche
+2/2/221:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.EG.Küche.K15-L1.Gefrierschrank.Ein/Aus
+  room: Küche
+2/2/222:
+  dpt: '1.011'
+  function: Schalten
+  name: Schalten.EG.Küche.K15-L1.Gefrierschrank.Ein/Aus-Status
+  room: Küche
+2/2/223:
+  dpt: '13.100'
+  function: Schalten
+  name: Schalten.EG.Küche.K15-L1.Gefrierschrank.Betriebsstunden
+  room: Küche
+2/2/224:
+  dpt: '1.003'
+  function: Schalten
+  name: Schalten.EG.Küche.K15-L1.Gefrierschrank.Betriebsstunden-Löschen
+  room: Küche
+2/2/225:
+  dpt: '13.013'
+  function: Schalten
+  name: Schalten.EG.Küche.K15-L1.Gefrierschrank.Kilowattstunde
+  room: Küche
+2/2/226:
+  dpt: '1.003'
+  function: Schalten
+  name: Schalten.EG.Küche.K15-L1.Gefrierschrank.Kilowattstunde-Löschen
+  room: Küche
+2/2/227:
+  dpt: '7.012'
+  function: Schalten
+  name: Schalten.EG.Küche.K15-L1.Gefrierschrank.Stromwert
+  room: Küche
+2/2/30:
   dpt: '1.001'
   function: Schalten
   name: Schalten.EG.Wohnzimmer.K1-L2.Steckdose.Sperren
   room: Wohnzimmer
-2/2/151:
+2/2/31:
   dpt: '1.001'
   function: Schalten
   name: Schalten.EG.Wohnzimmer.K1-L2.Steckdose.Ein/Aus
   room: Wohnzimmer
-2/2/152:
+2/2/32:
   dpt: '1.011'
   function: Schalten
   name: Schalten.EG.Wohnzimmer.K1-L2.Steckdose.Ein/Aus-Status
   room: Wohnzimmer
-2/2/160:
+2/2/40:
   dpt: '1.001'
   function: Schalten
   name: Schalten.EG.Wohnzimmer.K2-L2.Steckdose.Sperren
   room: Wohnzimmer
-2/2/161:
+2/2/41:
   dpt: '1.001'
   function: Schalten
   name: Schalten.EG.Wohnzimmer.K2-L2.Steckdose.Ein/Aus
   room: Wohnzimmer
-2/2/162:
+2/2/42:
   dpt: '1.011'
   function: Schalten
   name: Schalten.EG.Wohnzimmer.K2-L2.Steckdose.Ein/Aus-Status
   room: Wohnzimmer
-2/2/170:
+2/2/50:
   dpt: '1.001'
   function: Schalten
   name: Schalten.EG.Wohnzimmer.K3-L1.Fernseh.Sperren
   room: Wohnzimmer
-2/2/171:
+2/2/51:
   dpt: '1.001'
   function: Schalten
   name: Schalten.EG.Wohnzimmer.K3-L1.Fernseh.Ein/Aus
   room: Wohnzimmer
-2/2/172:
+2/2/52:
   dpt: '1.011'
   function: Schalten
   name: Schalten.EG.Wohnzimmer.K3-L1.Fernseh.Ein/Aus-Status
   room: Wohnzimmer
-2/2/180:
+2/2/60:
   dpt: '1.001'
   function: Schalten
   name: Schalten.EG.Wohnzimmer.K3-L2.Fernseh.Sperren
   room: Wohnzimmer
-2/2/181:
+2/2/61:
   dpt: '1.001'
   function: Schalten
   name: Schalten.EG.Wohnzimmer.K3-L2.Fernseh.Ein/Aus
   room: Wohnzimmer
-2/2/182:
+2/2/62:
   dpt: '1.011'
   function: Schalten
   name: Schalten.EG.Wohnzimmer.K3-L2.Fernseh.Ein/Aus-Status
   room: Wohnzimmer
-2/2/190:
+2/2/70:
   dpt: '1.001'
   function: Schalten
   name: Schalten.EG.Wohnzimmer.K3-L3.Fernseh.Sperren
   room: Wohnzimmer
-2/2/191:
+2/2/71:
   dpt: '1.001'
   function: Schalten
   name: Schalten.EG.Wohnzimmer.K3-L3.Fernseh.Ein/Aus
   room: Wohnzimmer
-2/2/192:
+2/2/72:
   dpt: '1.011'
   function: Schalten
   name: Schalten.EG.Wohnzimmer.K3-L3.Fernseh.Ein/Aus-Status
   room: Wohnzimmer
-2/2/200:
+2/2/80:
   dpt: '1.003'
   function: Schalten
   name: Schalten.EG.Wohnzimmer.K4-L1.Ofen.Sperren
   room: Wohnzimmer
-2/2/201:
+2/2/81:
   dpt: '1.001'
   function: Schalten
   name: Schalten.EG.Wohnzimmer.K4-L1.Ofen.Ein/Aus
   room: Wohnzimmer
-2/2/202:
+2/2/82:
   dpt: '1.011'
   function: Schalten
   name: Schalten.EG.Wohnzimmer.K4-L1.Ofen.Ein/Aus-Status
   room: Wohnzimmer
-2/2/203:
+2/2/83:
   dpt: '13.100'
   function: Schalten
   name: Schalten.EG.Wohnzimmer.K4-L1.Ofen.Betriebsstunden
   room: Wohnzimmer
-2/2/204:
+2/2/84:
   dpt: '1.003'
   function: Schalten
   name: Schalten.EG.Wohnzimmer.K4-L1.Ofen.Betriebsstunden-Löschen
   room: Wohnzimmer
-2/2/205:
+2/2/85:
   dpt: '13.013'
   function: Schalten
   name: Schalten.EG.Wohnzimmer.K4-L1.Ofen.Kilowattstunde
   room: Wohnzimmer
-2/2/206:
+2/2/86:
   dpt: '1.003'
   function: Schalten
   name: Schalten.EG.Wohnzimmer.K4-L1.Ofen.Kilowattstunde-Löschen
   room: Wohnzimmer
-2/2/207:
+2/2/87:
   dpt: '7.012'
   function: Schalten
   name: Schalten.EG.Wohnzimmer.K4-L1.Ofen.Stromwert
   room: Wohnzimmer
-2/3/100:
+2/2/90:
   dpt: '1.001'
   function: Schalten
-  name: Schalten.OG.Badezimmer-Kinder.K1-L2.Schrank.Sperren
-  room: Badezimmer-Kinder
-2/3/101:
+  name: Schalten.EG.Esszimmer.K2-L3.Steckdose.Sperren
+  room: Esszimmer
+2/2/91:
   dpt: '1.001'
   function: Schalten
-  name: Schalten.OG.Badezimmer-Kinder.K1-L2.Schrank.Ein/Aus
-  room: Badezimmer-Kinder
-2/3/102:
+  name: Schalten.EG.Esszimmer.K2-L3.Steckdose.Ein/Aus
+  room: Esszimmer
+2/2/92:
   dpt: '1.011'
   function: Schalten
-  name: Schalten.OG.Badezimmer-Kinder.K1-L2.Schrank.Ein/Aus-Status
-  room: Badezimmer-Kinder
-2/3/110:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.OG.Badezimmer-Kinder.K1-L3.Schrank.Sperren
-  room: Badezimmer-Kinder
-2/3/111:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.OG.Badezimmer-Kinder.K1-L3.Schrank.Ein/Aus
-  room: Badezimmer-Kinder
-2/3/112:
-  dpt: '1.011'
-  function: Schalten
-  name: Schalten.OG.Badezimmer-Kinder.K1-L3.Schrank.Ein/Aus-Status
-  room: Badezimmer-Kinder
-2/3/120:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.OG.Badezimmer-Kinder.K2-L3.Heizkörper.Sperren
-  room: Badezimmer-Kinder
-2/3/121:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.OG.Badezimmer-Kinder.K2-L3.Heizkörper.Ein/Aus
-  room: Badezimmer-Kinder
-2/3/122:
-  dpt: '1.011'
-  function: Schalten
-  name: Schalten.OG.Badezimmer-Kinder.K2-L3.Heizkörper.Ein/Aus-Status
-  room: Badezimmer-Kinder
-2/3/150:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.OG.Schlafzimmer-Gregory.K1-L1.Steckdose.Sperren
-  room: Schlafzimmer-Gregory
-2/3/151:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.OG.Schlafzimmer-Gregory.K1-L1.Steckdose.Ein/Aus
-  room: Schlafzimmer-Gregory
-2/3/152:
-  dpt: '1.011'
-  function: Schalten
-  name: Schalten.OG.Schlafzimmer-Gregory.K1-L1.Steckdose.Ein/Aus-Status
-  room: Schlafzimmer-Gregory
-2/3/160:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.OG.Schlafzimmer-Gregory.K2-L2.Steckdose.Sperren
-  room: Schlafzimmer-Gregory
-2/3/161:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.OG.Schlafzimmer-Gregory.K2-L2.Steckdose.Ein/Aus
-  room: Schlafzimmer-Gregory
-2/3/162:
-  dpt: '1.011'
-  function: Schalten
-  name: Schalten.OG.Schlafzimmer-Gregory.K2-L2.Steckdose.Ein/Aus-Status
-  room: Schlafzimmer-Gregory
-2/3/50:
+  name: Schalten.EG.Esszimmer.K2-L3.Steckdose.Ein/Aus-Status
+  room: Esszimmer
+2/3/0:
   dpt: '1.001'
   function: Schalten
   name: Schalten.OG.Abstellraum.K1-L1.Steckdose.Sperren
   room: Abstellraum
-2/3/51:
+2/3/1:
   dpt: '1.001'
   function: Schalten
   name: Schalten.OG.Abstellraum.K1-L1.Steckdose.Ein/Aus
   room: Abstellraum
-2/3/52:
-  dpt: '1.011'
-  function: Schalten
-  name: Schalten.OG.Abstellraum.K1-L1.Steckdose.Ein/Aus-Status
-  room: Abstellraum
-2/3/60:
+2/3/10:
   dpt: '1.001'
   function: Schalten
   name: Schalten.OG.Abstellraum.K2-L1.Steckdose.Sperren
   room: Abstellraum
-2/3/61:
+2/3/100:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.OG.Schlafzimmer-Eltern.K2-L1.Bett.Sperren
+  room: Schlafzimmer Eltern
+2/3/101:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.OG.Schlafzimmer-Eltern.K2-L1.Bett.Ein/Aus
+  room: Schlafzimmer Eltern
+2/3/102:
+  dpt: '1.011'
+  function: Schalten
+  name: Schalten.OG.Schlafzimmer-Eltern.K2-L1.Bett.Ein/Aus-Status
+  room: Schlafzimmer Eltern
+2/3/11:
   dpt: '1.001'
   function: Schalten
   name: Schalten.OG.Abstellraum.K2-L1.Steckdose.Ein/Aus
   room: Abstellraum
-2/3/62:
+2/3/110:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.OG.Schlafzimmer-Eltern.K2-L2.Bett.Sperren
+  room: Schlafzimmer Eltern
+2/3/111:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.OG.Schlafzimmer-Eltern.K2-L2.Bett.Ein/Aus
+  room: Schlafzimmer Eltern
+2/3/112:
+  dpt: '1.011'
+  function: Schalten
+  name: Schalten.OG.Schlafzimmer-Eltern.K2-L2.Bett.Ein/Aus-Status
+  room: Schlafzimmer Eltern
+2/3/12:
   dpt: '1.011'
   function: Schalten
   name: Schalten.OG.Abstellraum.K2-L1.Steckdose.Ein/Aus-Status
   room: Abstellraum
+2/3/120:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.OG.Schlafzimmer-Eltern.K2-L3.Bett.Sperren
+  room: Schlafzimmer Eltern
+2/3/121:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.OG.Schlafzimmer-Eltern.K2-L3.Bett.Ein/Aus
+  room: Schlafzimmer Eltern
+2/3/122:
+  dpt: '1.011'
+  function: Schalten
+  name: Schalten.OG.Schlafzimmer-Eltern.K2-L3.Bett.Ein/Aus-Status
+  room: Schlafzimmer Eltern
+2/3/130:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.OG.Badezimmer-Eltern.K1-L2.Schrank.Sperren
+  room: Badezimmer Eltern
+2/3/131:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.OG.Badezimmer-Eltern.K1-L2.Schrank.Ein/Aus
+  room: Badezimmer Eltern
+2/3/132:
+  dpt: '1.011'
+  function: Schalten
+  name: Schalten.OG.Badezimmer-Eltern.K1-L2.Schrank.Ein/Aus-Status
+  room: Badezimmer Eltern
+2/3/140:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.OG.Badezimmer-Eltern.K1-L3.Schrank.Sperren
+  room: Badezimmer Eltern
+2/3/141:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.OG.Badezimmer-Eltern.K1-L3.Schrank.Ein/Aus
+  room: Badezimmer Eltern
+2/3/142:
+  dpt: '1.011'
+  function: Schalten
+  name: Schalten.OG.Badezimmer-Eltern.K1-L3.Schrank.Ein/Aus-Status
+  room: Badezimmer Eltern
+2/3/150:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.OG.Badezimmer-Eltern.K2-L3.Heizkörper.Sperren
+  room: Badezimmer Eltern
+2/3/151:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.OG.Badezimmer-Eltern.K2-L3.Heizkörper.Ein/Aus
+  room: Badezimmer Eltern
+2/3/152:
+  dpt: '1.011'
+  function: Schalten
+  name: Schalten.OG.Badezimmer-Eltern.K2-L3.Heizkörper.Ein/Aus-Status
+  room: Badezimmer Eltern
+2/3/2:
+  dpt: '1.011'
+  function: Schalten
+  name: Schalten.OG.Abstellraum.K1-L1.Steckdose.Ein/Aus-Status
+  room: Abstellraum
+2/3/20:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.OG.Badezimmer-Kinder.K1-L2.Schrank.Sperren
+  room: Badezimmer Kinder
+2/3/21:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.OG.Badezimmer-Kinder.K1-L2.Schrank.Ein/Aus
+  room: Badezimmer Kinder
+2/3/22:
+  dpt: '1.011'
+  function: Schalten
+  name: Schalten.OG.Badezimmer-Kinder.K1-L2.Schrank.Ein/Aus-Status
+  room: Badezimmer Kinder
+2/3/30:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.OG.Badezimmer-Kinder.K1-L3.Schrank.Sperren
+  room: Badezimmer Kinder
+2/3/31:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.OG.Badezimmer-Kinder.K1-L3.Schrank.Ein/Aus
+  room: Badezimmer Kinder
+2/3/32:
+  dpt: '1.011'
+  function: Schalten
+  name: Schalten.OG.Badezimmer-Kinder.K1-L3.Schrank.Ein/Aus-Status
+  room: Badezimmer Kinder
+2/3/40:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.OG.Badezimmer-Kinder.K2-L3.Heizkörper.Sperren
+  room: Badezimmer Kinder
+2/3/41:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.OG.Badezimmer-Kinder.K2-L3.Heizkörper.Ein/Aus
+  room: Badezimmer Kinder
+2/3/42:
+  dpt: '1.011'
+  function: Schalten
+  name: Schalten.OG.Badezimmer-Kinder.K2-L3.Heizkörper.Ein/Aus-Status
+  room: Badezimmer Kinder
+2/3/50:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.OG.Schlafzimmer-Gregory.K1-L1.Steckdose.Sperren
+  room: Schlafzimmer Gregory
+2/3/51:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.OG.Schlafzimmer-Gregory.K1-L1.Steckdose.Ein/Aus
+  room: Schlafzimmer Gregory
+2/3/52:
+  dpt: '1.011'
+  function: Schalten
+  name: Schalten.OG.Schlafzimmer-Gregory.K1-L1.Steckdose.Ein/Aus-Status
+  room: Schlafzimmer Gregory
+2/3/60:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.OG.Schlafzimmer-Gregory.K2-L2.Steckdose.Sperren
+  room: Schlafzimmer Gregory
+2/3/61:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.OG.Schlafzimmer-Gregory.K2-L2.Steckdose.Ein/Aus
+  room: Schlafzimmer Gregory
+2/3/62:
+  dpt: '1.011'
+  function: Schalten
+  name: Schalten.OG.Schlafzimmer-Gregory.K2-L2.Steckdose.Ein/Aus-Status
+  room: Schlafzimmer Gregory
+2/3/70:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.OG.Schlafzimmer-Luis.K1-L1.Steckdose.Sperren
+  room: Schlafzimmer Luis
+2/3/71:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.OG.Schlafzimmer-Luis.K1-L1.Steckdose.Ein/Aus
+  room: Schlafzimmer Luis
+2/3/72:
+  dpt: '1.011'
+  function: Schalten
+  name: Schalten.OG.Schlafzimmer-Luis.K1-L1.Steckdose.Ein/Aus-Status
+  room: Schlafzimmer Luis
+2/3/80:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.OG.Schlafzimmer-Luis.K2-L1.Steckdose.Sperren
+  room: Schlafzimmer Luis
+2/3/81:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.OG.Schlafzimmer-Luis.K2-L1.Steckdose.Ein/Aus
+  room: Schlafzimmer Luis
+2/3/82:
+  dpt: '1.011'
+  function: Schalten
+  name: Schalten.OG.Schlafzimmer-Luis.K2-L1.Steckdose.Ein/Aus-Status
+  room: Schlafzimmer Luis
+2/3/90:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.OG.Schlafzimmer-Eltern.K1-L1.Steckdose.Sperren
+  room: Schlafzimmer Eltern
+2/3/91:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.OG.Schlafzimmer-Eltern.K1-L1.Steckdose.Ein/Aus
+  room: Schlafzimmer Eltern
+2/3/92:
+  dpt: '1.011'
+  function: Schalten
+  name: Schalten.OG.Schlafzimmer-Eltern.K1-L1.Steckdose.Ein/Aus-Status
+  room: Schlafzimmer Eltern
 2/4/0:
   dpt: '1.001'
   function: Schalten
   name: Schalten.DG.Speicher.K1-L1.Steckdose.Sperren
-  room: Speicher
+  room: Speicher (S)
 2/4/1:
   dpt: '1.001'
   function: Schalten
   name: Schalten.DG.Speicher.K1-L1.Steckdose.Ein/Aus
-  room: Speicher
+  room: Speicher (S)
 2/4/10:
   dpt: '1.001'
   function: Schalten
   name: Schalten.DG.Speicher.K1-L2.Steckdose.Sperren
-  room: Speicher
+  room: Speicher (S)
 2/4/11:
   dpt: '1.001'
   function: Schalten
   name: Schalten.DG.Speicher.K1-L2.Steckdose.Ein/Aus
-  room: Speicher
+  room: Speicher (S)
 2/4/12:
   dpt: '1.011'
   function: Schalten
   name: Schalten.DG.Speicher.K1-L2.Steckdose.Ein/Aus-Status
-  room: Speicher
+  room: Speicher (S)
 2/4/2:
   dpt: '1.011'
   function: Schalten
   name: Schalten.DG.Speicher.K1-L1.Steckdose.Ein/Aus-Status
-  room: Speicher
+  room: Speicher (S)
 2/5/0:
   dpt: '1.001'
   function: Schalten
@@ -3848,7068 +3754,7423 @@
   function: Schalten
   name: Schalten.A.Fassade.K1-L1.Steckdose.Ein/Aus
   room: Fassade
-2/5/100:
+2/5/10:
   dpt: '1.001'
   function: Schalten
   name: Schalten.A.Terrasse.K1-L1.Steckdose.Sperren
   room: Terrasse
+2/5/100:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.A.Garten.K2-L3.Steckdose.Sperren
+  room: Garten
 2/5/101:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.A.Garten.K2-L3.Steckdose.Ein/Aus
+  room: Garten
+2/5/102:
+  dpt: '1.011'
+  function: Schalten
+  name: Schalten.A.Garten.K2-L3.Steckdose.Ein/Aus-Status
+  room: Garten
+2/5/11:
   dpt: '1.001'
   function: Schalten
   name: Schalten.A.Terrasse.K1-L1.Steckdose.Ein/Aus
   room: Terrasse
-2/5/102:
+2/5/110:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.A.Garten.K3-L1.Steckdose.Sperren
+  room: Garten
+2/5/111:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.A.Garten.K3-L1.Steckdose.Ein/Aus
+  room: Garten
+2/5/112:
+  dpt: '1.011'
+  function: Schalten
+  name: Schalten.A.Garten.K3-L1.Steckdose.Ein/Aus-Status
+  room: Garten
+2/5/12:
   dpt: '1.011'
   function: Schalten
   name: Schalten.A.Terrasse.K1-L1.Steckdose.Ein/Aus-Status
   room: Terrasse
-2/5/110:
+2/5/120:
   dpt: '1.001'
   function: Schalten
-  name: Schalten.A.Terrasse.K1-L2.Steckdose.Sperren
-  room: Terrasse
-2/5/111:
+  name: Schalten.A.Garten.K3-L2.Steckdose.Sperren
+  room: Garten
+2/5/121:
   dpt: '1.001'
   function: Schalten
-  name: Schalten.A.Terrasse.K1-L2.Steckdose.Ein/Aus
-  room: Terrasse
-2/5/112:
+  name: Schalten.A.Garten.K3-L2.Steckdose.Ein/Aus
+  room: Garten
+2/5/122:
   dpt: '1.011'
   function: Schalten
-  name: Schalten.A.Terrasse.K1-L2.Steckdose.Ein/Aus-Status
-  room: Terrasse
+  name: Schalten.A.Garten.K3-L2.Steckdose.Ein/Aus-Status
+  room: Garten
+2/5/130:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.A.Garten.K3-L3.Steckdose.Sperren
+  room: Garten
+2/5/131:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.A.Garten.K3-L3.Steckdose.Ein/Aus
+  room: Garten
+2/5/132:
+  dpt: '1.011'
+  function: Schalten
+  name: Schalten.A.Garten.K3-L3.Steckdose.Ein/Aus-Status
+  room: Garten
+2/5/140:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.A.Garten.K3-L4.Steckdose.Sperren
+  room: Garten
+2/5/141:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.A.Garten.K3-L4.Steckdose.Ein/Aus
+  room: Garten
+2/5/142:
+  dpt: '1.011'
+  function: Schalten
+  name: Schalten.A.Garten.K3-L4.Steckdose.Ein/Aus-Status
+  room: Garten
 2/5/150:
   dpt: '1.001'
   function: Schalten
-  name: Schalten.A.Balkon.K1-L1.Steckdose.Sperren
-  room: Balkon
+  name: Schalten.A.Garten.K3-L5.Steckdose.Sperren
+  room: Garten
 2/5/151:
   dpt: '1.001'
   function: Schalten
-  name: Schalten.A.Balkon.K1-L1.Steckdose.Ein/Aus
-  room: Balkon
+  name: Schalten.A.Garten.K3-L5.Steckdose.Ein/Aus
+  room: Garten
 2/5/152:
   dpt: '1.011'
   function: Schalten
-  name: Schalten.A.Balkon.K1-L1.Steckdose.Ein/Aus-Status
-  room: Balkon
-2/5/160:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.A.Balkon.K1-L2.Steckdose.Sperren
-  room: Balkon
-2/5/161:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.A.Balkon.K1-L2.Steckdose.Ein/Aus
-  room: Balkon
-2/5/162:
-  dpt: '1.011'
-  function: Schalten
-  name: Schalten.A.Balkon.K1-L2.Steckdose.Ein/Aus-Status
-  room: Balkon
+  name: Schalten.A.Garten.K3-L5.Steckdose.Ein/Aus-Status
+  room: Garten
 2/5/2:
   dpt: '1.011'
   function: Schalten
   name: Schalten.A.Fassade.K1-L1.Steckdose.Ein/Aus-Status
   room: Fassade
-3/1/0:
-  dpt: '1.003'
-  function: Schalten
-  name: Schalten.KG.Hauswirtschaftsraum.K1-L3.Entfeuchter.Sperren
-  room: Hauswirtschaftsraum
-3/1/1:
+2/5/20:
   dpt: '1.001'
   function: Schalten
-  name: Schalten.KG.Hauswirtschaftsraum.K1-L3.Entfeuchter.Ein/Aus
-  room: Hauswirtschaftsraum
-3/1/10:
+  name: Schalten.A.Terrasse.K1-L2.Steckdose.Sperren
+  room: Terrasse
+2/5/21:
   dpt: '1.001'
   function: Schalten
-  name: Schalten.KG.Hauswirtschaftsraum.K1-L3.Heizkörper.Sperren
-  room: Hauswirtschaftsraum
-3/1/11:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.KG.Hauswirtschaftsraum.K1-L3.Heizkörper.Ein/Aus
-  room: Hauswirtschaftsraum
-3/1/12:
+  name: Schalten.A.Terrasse.K1-L2.Steckdose.Ein/Aus
+  room: Terrasse
+2/5/22:
   dpt: '1.011'
   function: Schalten
-  name: Schalten.KG.Hauswirtschaftsraum.K1-L3.Heizkörper.Ein/Aus-Status
-  room: Hauswirtschaftsraum
-3/1/13:
+  name: Schalten.A.Terrasse.K1-L2.Steckdose.Ein/Aus-Status
+  room: Terrasse
+2/5/30:
   dpt: '1.001'
   function: Schalten
-  name: Schalten.KG.Hauswirtschaftsraum.K2-L2.Fehrnseh.Sperren
-  room: Hauswirtschaftsraum
-3/1/14:
+  name: Schalten.A.Balkon.K1-L1.Steckdose.Sperren
+  room: Balkon
+2/5/31:
   dpt: '1.001'
   function: Schalten
-  name: Schalten.KG.Hauswirtschaftsraum.K2-L2.Fehrnseh.Ein/Aus
-  room: Hauswirtschaftsraum
-3/1/15:
+  name: Schalten.A.Balkon.K1-L1.Steckdose.Ein/Aus
+  room: Balkon
+2/5/32:
   dpt: '1.011'
   function: Schalten
-  name: Schalten.KG.Hauswirtschaftsraum.K2-L2.Fehrnseh.Ein/Aus-Status
-  room: Hauswirtschaftsraum
-3/1/2:
+  name: Schalten.A.Balkon.K1-L1.Steckdose.Ein/Aus-Status
+  room: Balkon
+2/5/40:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.A.Balkon.K1-L2.Steckdose.Sperren
+  room: Balkon
+2/5/41:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.A.Balkon.K1-L2.Steckdose.Ein/Aus
+  room: Balkon
+2/5/42:
   dpt: '1.011'
   function: Schalten
-  name: Schalten.KG.Hauswirtschaftsraum.K1-L3.Entfeuchter.Ein/Aus-Status
-  room: Hauswirtschaftsraum
-3/1/20:
-  dpt: '1.003'
-  function: Schalten
-  name: Schalten.KG.Hauswirtschaftsraum.K3-L1.Trockner.Sperren
-  room: Hauswirtschaftsraum
-3/1/21:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.KG.Hauswirtschaftsraum.K3-L1.Trockner.Ein/Aus
-  room: Hauswirtschaftsraum
-3/1/22:
-  dpt: '1.011'
-  function: Schalten
-  name: Schalten.KG.Hauswirtschaftsraum.K3-L1.Trockner.Ein/Aus-Status
-  room: Hauswirtschaftsraum
-3/1/23:
-  dpt: '13.100'
-  function: Schalten
-  name: Schalten.KG.Hauswirtschaftsraum.K3-L1.Trockner.Betriebsstunden
-  room: Hauswirtschaftsraum
-3/1/24:
-  dpt: '1.003'
-  function: Schalten
-  name: Schalten.KG.Hauswirtschaftsraum.K3-L1.Trockner.Betriebsstunden-Löschen
-  room: Hauswirtschaftsraum
-3/1/25:
-  dpt: '13.013'
-  function: Schalten
-  name: Schalten.KG.Hauswirtschaftsraum.K3-L1.Trockner.Kilowattstunde
-  room: Hauswirtschaftsraum
-3/1/26:
-  dpt: '1.003'
-  function: Schalten
-  name: Schalten.KG.Hauswirtschaftsraum.K3-L1.Trockner.Kilowattstunde-Löschen
-  room: Hauswirtschaftsraum
-3/1/27:
-  dpt: '7.012'
-  function: Schalten
-  name: Schalten.KG.Hauswirtschaftsraum.K3-L1.Trockner.Stromwert
-  room: Hauswirtschaftsraum
-3/1/28:
-  dpt: '1.011'
-  function: Schalten
-  name: Schalten.KG.Hauswirtschaftsraum.K3-L1.Trockner.Status
-  room: Hauswirtschaftsraum
-3/1/3:
-  dpt: '13.100'
-  function: Schalten
-  name: Schalten.KG.Hauswirtschaftsraum.K1-L3.Entfeuchter.Betriebsstunden
-  room: Hauswirtschaftsraum
-3/1/30:
-  dpt: '1.003'
-  function: Schalten
-  name: Schalten.KG.Hauswirtschaftsraum.K4-L1.Waschmaschine.Sperren
-  room: Hauswirtschaftsraum
-3/1/31:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.KG.Hauswirtschaftsraum.K4-L1.Waschmaschine.Ein/Aus
-  room: Hauswirtschaftsraum
-3/1/32:
-  dpt: '1.011'
-  function: Schalten
-  name: Schalten.KG.Hauswirtschaftsraum.K4-L1.Waschmaschine.Ein/Aus-Status
-  room: Hauswirtschaftsraum
-3/1/33:
-  dpt: '13.100'
-  function: Schalten
-  name: Schalten.KG.Hauswirtschaftsraum.K4-L1.Waschmaschine.Betriebsstunden
-  room: Hauswirtschaftsraum
-3/1/34:
-  dpt: '1.003'
-  function: Schalten
-  name: Schalten.KG.Hauswirtschaftsraum.K4-L1.Waschmaschine.Betriebsstunden-Löschen
-  room: Hauswirtschaftsraum
-3/1/35:
-  dpt: '13.013'
-  function: Schalten
-  name: Schalten.KG.Hauswirtschaftsraum.K4-L1.Waschmaschine.Kilowattstunde
-  room: Hauswirtschaftsraum
-3/1/36:
-  dpt: '1.003'
-  function: Schalten
-  name: Schalten.KG.Hauswirtschaftsraum.K4-L1.Waschmaschine.Kilowattstunde-Löschen
-  room: Hauswirtschaftsraum
-3/1/37:
-  dpt: '7.012'
-  function: Schalten
-  name: Schalten.KG.Hauswirtschaftsraum.K4-L1.Waschmaschine.Stromwert
-  room: Hauswirtschaftsraum
-3/1/38:
-  dpt: '1.000'
-  function: Schalten
-  name: Schalten.KG.Hauswirtschaftsraum.K4-L1.Waschmaschine.Status
-  room: Hauswirtschaftsraum
-3/1/4:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.KG.Hauswirtschaftsraum.K1-L3.Entfeuchter.Betriebsstunden-Löschen
-  room: Hauswirtschaftsraum
-3/1/5:
-  dpt: '13.013'
-  function: Schalten
-  name: Schalten.KG.Hauswirtschaftsraum.K1-L3.Entfeuchter.Kilowattstunde
-  room: Hauswirtschaftsraum
-3/1/6:
-  dpt: '1.010'
-  function: Schalten
-  name: Schalten.KG.hauswirtschaftsraum.K1-L3.Entfeuchter.Kilowattstunde-Löschen
-  room: hauswirtschaftsraum
-3/1/7:
-  dpt: '7.012'
-  function: Schalten
-  name: Schalten.KG.Hauswirtschaftsraum.K1-L3.Entfeuchter.Stromwert
-  room: Hauswirtschaftsraum
-3/2/0:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.EG.Esszimmer.K2-L3.Steckdose.Sperren
-  room: Esszimmer
-3/2/1:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.EG.Esszimmer.K2-L3.Steckdose.Ein/Aus
-  room: Esszimmer
-3/2/100:
-  dpt: '1.003'
-  function: Schalten
-  name: Schalten.EG.Küche.K5-L1.Haubenlüfter.Sperren
-  room: Küche
-3/2/101:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.EG.Küche.K5-L1.Haubenlüfter.Ein/Aus
-  room: Küche
-3/2/102:
-  dpt: '1.011'
-  function: Schalten
-  name: Schalten.EG.Küche.K5-L1.Haubenlüfter.Ein/Aus-Status
-  room: Küche
-3/2/103:
-  dpt: '13.100'
-  function: Schalten
-  name: Schalten.EG.Küche.K5-L1.Haubenlüfter.Betriebsstunden
-  room: Küche
-3/2/104:
-  dpt: '1.003'
-  function: Schalten
-  name: Schalten.EG.Küche.K5-L1.Haubenlüfter.Betriebsstunden-Löschen
-  room: Küche
-3/2/105:
-  dpt: '13.013'
-  function: Schalten
-  name: Schalten.EG.Küche.K5-L1.Haubenlüfter.Kilowattstunde
-  room: Küche
-3/2/106:
-  dpt: '1.003'
-  function: Schalten
-  name: Schalten.EG.Küche.K5-L1.Haubenlüfter.Kilowattstunde-Löschen
-  room: Küche
-3/2/107:
-  dpt: '7.012'
-  function: Schalten
-  name: Schalten.EG.Küche.K5-L1.Haubenlüfter.Stromwert
-  room: Küche
-3/2/110:
-  dpt: '1.003'
-  function: Schalten
-  name: Schalten.EG.Küche.K7-L1.Kühlschrank.Sperren
-  room: Küche
-3/2/111:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.EG.Küche.K7-L1.Kühlschrank.Ein/Aus
-  room: Küche
-3/2/112:
-  dpt: '1.011'
-  function: Schalten
-  name: Schalten.EG.Küche.K7-L1.Kühlschrank.Ein/Aus-Status
-  room: Küche
-3/2/113:
-  dpt: '13.100'
-  function: Schalten
-  name: Schalten.EG.Küche.K7-L1.Kühlschrank.Betriebsstunden
-  room: Küche
-3/2/114:
-  dpt: '1.003'
-  function: Schalten
-  name: Schalten.EG.Küche.K7-L1.Kühlschrank.Betriebsstunden-Löschen
-  room: Küche
-3/2/115:
-  dpt: '13.013'
-  function: Schalten
-  name: Schalten.EG.Küche.K7-L1.Kühlschrank.Kilowattstunde
-  room: Küche
-3/2/116:
-  dpt: '1.003'
-  function: Schalten
-  name: Schalten.EG.Küche.K7-L1.Kühlschrank.Kilowattstunde-Löschen
-  room: Küche
-3/2/117:
-  dpt: '7.012'
-  function: Schalten
-  name: Schalten.EG.Küche.K7-L1.Kühlschrank.Stromwert
-  room: Küche
-3/2/120:
-  dpt: '1.003'
-  function: Schalten
-  name: Schalten.EG.Küche.K9-L1.Backofen.Sperren
-  room: Küche
-3/2/121:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.EG.Küche.K9-L1.Backofen.Ein/Aus
-  room: Küche
-3/2/122:
-  dpt: '1.011'
-  function: Schalten
-  name: Schalten.EG.Küche.K9-L1.Backofen.Ein/Aus-Status
-  room: Küche
-3/2/123:
-  dpt: '13.100'
-  function: Schalten
-  name: Schalten.EG.Küche.K9-L1.Backofen.Betriebsstunden
-  room: Küche
-3/2/124:
-  dpt: '1.003'
-  function: Schalten
-  name: Schalten.EG.Küche.K9-L1.Backofen.Betriebsstunden-Löschen
-  room: Küche
-3/2/125:
-  dpt: '13.013'
-  function: Schalten
-  name: Schalten.EG.Küche.K9-L1.Backofen.Kilowattstunde
-  room: Küche
-3/2/126:
-  dpt: '1.003'
-  function: Schalten
-  name: Schalten.EG.Küche.K9-L1.Backofen.Kilowattstunde-Löschen
-  room: Küche
-3/2/127:
-  dpt: '7.012'
-  function: Schalten
-  name: Schalten.EG.Küche.K9-L1.Backofen.Stromwert
-  room: Küche
-3/2/130:
-  dpt: '1.003'
-  function: Schalten
-  name: Schalten.EG.Küche.K10-L1.Tellerwärmer.Sperren
-  room: Küche
-3/2/131:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.EG.Küche.K10-L1.Tellerwärmer.Ein/Aus
-  room: Küche
-3/2/132:
-  dpt: '1.011'
-  function: Schalten
-  name: Schalten.EG.Küche.K10-L1.Tellerwärmer.Ein/Aus-Status
-  room: Küche
-3/2/133:
-  dpt: '13.100'
-  function: Schalten
-  name: Schalten.EG.Küche.K10-L1.Tellerwärmer.Betriebsstunden
-  room: Küche
-3/2/134:
-  dpt: '1.003'
-  function: Schalten
-  name: Schalten.EG.Küche.K10-L1.Tellerwärmer.Betriebsstunden-Löschen
-  room: Küche
-3/2/135:
-  dpt: '13.013'
-  function: Schalten
-  name: Schalten.EG.Küche.K10-L1.Tellerwärmer.Kilowattstunde
-  room: Küche
-3/2/136:
-  dpt: '1.003'
-  function: Schalten
-  name: Schalten.EG.Küche.K10-L1.Tellerwärmer.Kilowattstunde-Löschen
-  room: Küche
-3/2/137:
-  dpt: '7.012'
-  function: Schalten
-  name: Schalten.EG.Küche.K10-L1.Tellerwärmer.Stromwert
-  room: Küche
-3/2/140:
-  dpt: '1.003'
-  function: Schalten
-  name: Schalten.EG.Küche.K12-L1.Mikrowelle.Sperren
-  room: Küche
-3/2/141:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.EG.Küche.K12-L1.Mikrowelle.Ein/Aus
-  room: Küche
-3/2/142:
-  dpt: '1.011'
-  function: Schalten
-  name: Schalten.EG.Küche.K12-L1.Mikrowelle.Ein/Aus-Status
-  room: Küche
-3/2/143:
-  dpt: '13.100'
-  function: Schalten
-  name: Schalten.EG.Küche.K12-L1.Mikrowelle.Betriebsstunden
-  room: Küche
-3/2/144:
-  dpt: '1.003'
-  function: Schalten
-  name: Schalten.EG.Küche.K12-L1.Mikrowelle.Betriebsstunden-Löschen
-  room: Küche
-3/2/145:
-  dpt: '13.013'
-  function: Schalten
-  name: Schalten.EG.Küche.K12-L1.Mikrowelle.Kilowattstunde
-  room: Küche
-3/2/146:
-  dpt: '1.003'
-  function: Schalten
-  name: Schalten.EG.Küche.K12-L1.Mikrowelle.Kilowattstunde-Löschen
-  room: Küche
-3/2/147:
-  dpt: '7.012'
-  function: Schalten
-  name: Schalten.EG.Küche.K12-L1.Mikrowelle.Stromwert
-  room: Küche
-3/2/150:
-  dpt: '1.003'
-  function: Schalten
-  name: Schalten.EG.Küche.K13-L1.Kaffeemaschine.Sperren
-  room: Küche
-3/2/151:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.EG.Küche.K13-L1.Kaffeemaschine.Ein/Aus
-  room: Küche
-3/2/152:
-  dpt: '1.011'
-  function: Schalten
-  name: Schalten.EG.Küche.K13-L1.Kaffeemaschine.Ein/Aus-Status
-  room: Küche
-3/2/153:
-  dpt: '13.100'
-  function: Schalten
-  name: Schalten.EG.Küche.K13-L1.Kaffeemaschine.Betriebsstunden
-  room: Küche
-3/2/154:
-  dpt: '1.003'
-  function: Schalten
-  name: Schalten.EG.Küche.K13-L1.Kaffeemaschine.Betriebsstunden-Löschen
-  room: Küche
-3/2/155:
-  dpt: '13.013'
-  function: Schalten
-  name: Schalten.EG.Küche.K13-L1.Kaffeemaschine.Kilowattstunde
-  room: Küche
-3/2/156:
-  dpt: '1.003'
-  function: Schalten
-  name: Schalten.EG.Küche.K13-L1.Kaffeemaschine.Kilowattstunde-Löschen
-  room: Küche
-3/2/157:
-  dpt: '7.012'
-  function: Schalten
-  name: Schalten.EG.Küche.K13-L1.Kaffeemaschine.Stromwert
-  room: Küche
-3/2/160:
-  dpt: '1.003'
-  function: Schalten
-  name: Schalten.EG.Küche.K14-L1.Dampfgarer.Sperren
-  room: Küche
-3/2/161:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.EG.Küche.K14-L1.Dampfgarer.Ein/Aus
-  room: Küche
-3/2/162:
-  dpt: '1.011'
-  function: Schalten
-  name: Schalten.EG.Küche.K14-L1.Dampfgarer.Ein/Aus-Status
-  room: Küche
-3/2/163:
-  dpt: '13.100'
-  function: Schalten
-  name: Schalten.EG.Küche.K14-L1.Dampfgarer.Betriebsstunden
-  room: Küche
-3/2/164:
-  dpt: '1.003'
-  function: Schalten
-  name: Schalten.EG.Küche.K14-L1.Dampfgarer.Betriebsstunden-Löschen
-  room: Küche
-3/2/165:
-  dpt: '13.013'
-  function: Schalten
-  name: Schalten.EG.Küche.K14-L1.Dampfgarer.Kilowattstunde
-  room: Küche
-3/2/166:
-  dpt: '1.003'
-  function: Schalten
-  name: Schalten.EG.Küche.K14-L1.Dampfgarer.Kilowattstunde-Löschen
-  room: Küche
-3/2/167:
-  dpt: '7.012'
-  function: Schalten
-  name: Schalten.EG.Küche.K14-L1.Dampfgarer.Stromwert
-  room: Küche
-3/2/170:
-  dpt: '1.003'
-  function: Schalten
-  name: Schalten.EG.Küche.K15-L1.Gefrierschrank.Sperren
-  room: Küche
-3/2/171:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.EG.Küche.K15-L1.Gefrierschrank.Ein/Aus
-  room: Küche
-3/2/172:
-  dpt: '1.011'
-  function: Schalten
-  name: Schalten.EG.Küche.K15-L1.Gefrierschrank.Ein/Aus-Status
-  room: Küche
-3/2/173:
-  dpt: '13.100'
-  function: Schalten
-  name: Schalten.EG.Küche.K15-L1.Gefrierschrank.Betriebsstunden
-  room: Küche
-3/2/174:
-  dpt: '1.003'
-  function: Schalten
-  name: Schalten.EG.Küche.K15-L1.Gefrierschrank.Betriebsstunden-Löschen
-  room: Küche
-3/2/175:
-  dpt: '13.013'
-  function: Schalten
-  name: Schalten.EG.Küche.K15-L1.Gefrierschrank.Kilowattstunde
-  room: Küche
-3/2/176:
-  dpt: '1.003'
-  function: Schalten
-  name: Schalten.EG.Küche.K15-L1.Gefrierschrank.Kilowattstunde-Löschen
-  room: Küche
-3/2/177:
-  dpt: '7.012'
-  function: Schalten
-  name: Schalten.EG.Küche.K15-L1.Gefrierschrank.Stromwert
-  room: Küche
-3/2/2:
-  dpt: '1.011'
-  function: Schalten
-  name: Schalten.EG.Esszimmer.K2-L3.Steckdose.Ein/Aus-Status
-  room: Esszimmer
-3/2/50:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.EG.Küche.K1-L3.Steckdose.Sperren
-  room: Küche
-3/2/51:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.EG.Küche.K1-L3.Steckdose.Ein/Aus
-  room: Küche
-3/2/52:
-  dpt: '1.011'
-  function: Schalten
-  name: Schalten.EG.Küche.K1-L3.Steckdose.Ein/Aus-Status
-  room: Küche
-3/2/60:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.EG.Küche.K2-L1.Steckdose.Sperren
-  room: Küche
-3/2/61:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.EG.Küche.K2-L1.Steckdose.Ein/Aus
-  room: Küche
-3/2/62:
-  dpt: '1.011'
-  function: Schalten
-  name: Schalten.EG.Küche.K2-L1.Steckdose.Ein/Aus-Status
-  room: Küche
-3/2/70:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.EG.Küche.K2-L2.Steckdose.Sperren
-  room: Küche
-3/2/71:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.EG.Küche.K2-L2.Steckdose.Ein/Aus
-  room: Küche
-3/2/72:
-  dpt: '1.011'
-  function: Schalten
-  name: Schalten.EG.Küche.K2-L2.Steckdose.Ein/Aus-Status
-  room: Küche
-3/2/80:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.EG.Küche.K3-L3.Kücheninsel.Sperren
-  room: Küche
-3/2/81:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.EG.Küche.K3-L3.Kücheninsel.Ein/Aus
-  room: Küche
-3/2/82:
-  dpt: '1.011'
-  function: Schalten
-  name: Schalten.EG.Küche.K3-L3.Kücheninsel.Ein/Aus-Status
-  room: Küche
-3/2/90:
-  dpt: '1.003'
-  function: Schalten
-  name: Schalten.EG.Küche.K4-L1.Geschirrspüler.Sperren
-  room: Küche
-3/2/91:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.EG.Küche.K4-L1.Geschirrspüler.Ein/Aus
-  room: Küche
-3/2/92:
-  dpt: '1.011'
-  function: Schalten
-  name: Schalten.EG.Küche.K4-L1.Geschirrspüler.Ein/Aus-Status
-  room: Küche
-3/2/93:
-  dpt: '13.100'
-  function: Schalten
-  name: Schalten.EG.Küche.K4-L1.Geschirrspüler.Betriebsstunden
-  room: Küche
-3/2/94:
-  dpt: '1.003'
-  function: Schalten
-  name: 'Schalten.EG.Küche.K4-L1.Geschirrspüler.Betriebsstunden-Löschen '
-  room: Küche
-3/2/95:
-  dpt: '13.013'
-  function: Schalten
-  name: Schalten.EG.Küche.K4-L1.Geschirrspüler.Kilowattstunde
-  room: Küche
-3/2/96:
-  dpt: '1.003'
-  function: Schalten
-  name: Schalten.EG.Küche.K4-L1.Geschirrspüler.Kilowattstunde-Löschen
-  room: Küche
-3/2/97:
-  dpt: '7.012'
-  function: Schalten
-  name: Schalten.EG.Küche.K4-L1.Geschirrspüler.Stromwert
-  room: Küche
-3/3/0:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.OG.Schlafzimmer-Luis.K1-L1.Steckdose.Sperren
-  room: Schlafzimmer-Luis
-3/3/1:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.OG.Schlafzimmer-Luis.K1-L1.Steckdose.Ein/Aus
-  room: Schlafzimmer-Luis
-3/3/10:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.OG.Schlafzimmer-Luis.K2-L1.Steckdose.Sperren
-  room: Schlafzimmer-Luis
-3/3/11:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.OG.Schlafzimmer-Luis.K2-L1.Steckdose.Ein/Aus
-  room: Schlafzimmer-Luis
-3/3/12:
-  dpt: '1.011'
-  function: Schalten
-  name: Schalten.OG.Schlafzimmer-Luis.K2-L1.Steckdose.Ein/Aus-Status
-  room: Schlafzimmer-Luis
-3/3/150:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.OG.Badezimmer-Eltern.K1-L2.Schrank.Sperren
-  room: Badezimmer-Eltern
-3/3/151:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.OG.Badezimmer-Eltern.K1-L2.Schrank.Ein/Aus
-  room: Badezimmer-Eltern
-3/3/152:
-  dpt: '1.011'
-  function: Schalten
-  name: Schalten.OG.Badezimmer-Eltern.K1-L2.Schrank.Ein/Aus-Status
-  room: Badezimmer-Eltern
-3/3/160:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.OG.Badezimmer-Eltern.K1-L3.Schrank.Sperren
-  room: Badezimmer-Eltern
-3/3/161:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.OG.Badezimmer-Eltern.K1-L3.Schrank.Ein/Aus
-  room: Badezimmer-Eltern
-3/3/162:
-  dpt: '1.011'
-  function: Schalten
-  name: Schalten.OG.Badezimmer-Eltern.K1-L3.Schrank.Ein/Aus-Status
-  room: Badezimmer-Eltern
-3/3/170:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.OG.Badezimmer-Eltern.K2-L3.Heizkörper.Sperren
-  room: Badezimmer-Eltern
-3/3/171:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.OG.Badezimmer-Eltern.K2-L3.Heizkörper.Ein/Aus
-  room: Badezimmer-Eltern
-3/3/172:
-  dpt: '1.011'
-  function: Schalten
-  name: Schalten.OG.Badezimmer-Eltern.K2-L3.Heizkörper.Ein/Aus-Status
-  room: Badezimmer-Eltern
-3/3/2:
-  dpt: '1.011'
-  function: Schalten
-  name: Schalten.OG.Schlafzimmer-Luis.K1-L1.Steckdose.Ein/Aus-Status
-  room: Schlafzimmer-Luis
-3/3/50:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.OG.Schlafzimmer-Eltern.K1-L1.Steckdose.Sperren
-  room: Schlafzimmer-Eltern
-3/3/51:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.OG.Schlafzimmer-Eltern.K1-L1.Steckdose.Ein/Aus
-  room: Schlafzimmer-Eltern
-3/3/52:
-  dpt: '1.011'
-  function: Schalten
-  name: Schalten.OG.Schlafzimmer-Eltern.K1-L1.Steckdose.Ein/Aus-Status
-  room: Schlafzimmer-Eltern
-3/3/60:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.OG.Schlafzimmer-Eltern.K2-L1.Bett.Sperren
-  room: Schlafzimmer-Eltern
-3/3/61:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.OG.Schlafzimmer-Eltern.K2-L1.Bett.Ein/Aus
-  room: Schlafzimmer-Eltern
-3/3/62:
-  dpt: '1.011'
-  function: Schalten
-  name: Schalten.OG.Schlafzimmer-Eltern.K2-L1.Bett.Ein/Aus-Status
-  room: Schlafzimmer-Eltern
-3/3/70:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.OG.Schlafzimmer-Eltern.K2-L2.Bett.Sperren
-  room: Schlafzimmer-Eltern
-3/3/71:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.OG.Schlafzimmer-Eltern.K2-L2.Bett.Ein/Aus
-  room: Schlafzimmer-Eltern
-3/3/72:
-  dpt: '1.011'
-  function: Schalten
-  name: Schalten.OG.Schlafzimmer-Eltern.K2-L2.Bett.Ein/Aus-Status
-  room: Schlafzimmer-Eltern
-3/3/80:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.OG.Schlafzimmer-Eltern.K2-L3.Bett.Sperren
-  room: Schlafzimmer-Eltern
-3/3/81:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.OG.Schlafzimmer-Eltern.K2-L3.Bett.Ein/Aus
-  room: Schlafzimmer-Eltern
-3/3/82:
-  dpt: '1.011'
-  function: Schalten
-  name: Schalten.OG.Schlafzimmer-Eltern.K2-L3.Bett.Ein/Aus-Status
-  room: Schlafzimmer-Eltern
-3/5/0:
+  name: Schalten.A.Balkon.K1-L2.Steckdose.Ein/Aus-Status
+  room: Balkon
+2/5/50:
   dpt: '1.001'
   function: Schalten
   name: Schalten.A.Garten.K1-L1.Steckdose.Sperren
   room: Garten
-3/5/1:
+2/5/51:
   dpt: '1.001'
   function: Schalten
   name: Schalten.A.Garten.K1-L1.Steckdose.Ein/Aus
   room: Garten
-3/5/10:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.A.Garten.K1-L2.Steckdose.Sperren
-  room: Garten
-3/5/100:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.A.Garten.K3-L5.Steckdose.Sperren
-  room: Garten
-3/5/101:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.A.Garten.K3-L5.Steckdose.Ein/Aus
-  room: Garten
-3/5/102:
-  dpt: '1.011'
-  function: Schalten
-  name: Schalten.A.Garten.K3-L5.Steckdose.Ein/Aus-Status
-  room: Garten
-3/5/11:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.A.Garten.K1-L2.Steckdose.Ein/Aus
-  room: Garten
-3/5/12:
-  dpt: '1.011'
-  function: Schalten
-  name: Schalten.A.Garten.K1-L2.Steckdose.Ein/Aus-Status
-  room: Garten
-3/5/2:
+2/5/52:
   dpt: '1.011'
   function: Schalten
   name: Schalten.A.Garten.K1-L1.Steckdose.Ein/Aus-Status
   room: Garten
-3/5/20:
+2/5/60:
   dpt: '1.001'
   function: Schalten
   name: Schalten.A.Garten.K1-L2.Steckdose.Sperren
   room: Garten
-3/5/21:
+2/5/61:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.A.Garten.K1-L2.Steckdose.Ein/Aus
+  room: Garten
+2/5/62:
+  dpt: '1.011'
+  function: Schalten
+  name: Schalten.A.Garten.K1-L2.Steckdose.Ein/Aus-Status
+  room: Garten
+2/5/70:
+  dpt: '1.001'
+  function: Schalten
+  name: Schalten.A.Garten.K1-L3.Steckdose.Sperren
+  room: Garten
+2/5/71:
   dpt: '1.001'
   function: Schalten
   name: Schalten.A.Garten.K1-L3.Steckdose.Ein/Aus
   room: Garten
-3/5/22:
+2/5/72:
   dpt: '1.011'
   function: Schalten
   name: Schalten.A.Garten.K1-L3.Steckdose.Ein/Aus-Status
   room: Garten
-3/5/30:
+2/5/80:
   dpt: '1.001'
   function: Schalten
   name: Schalten.A.Garten.K2-L1.Steckdose.Sperren
   room: Garten
-3/5/31:
+2/5/81:
   dpt: '1.001'
   function: Schalten
   name: Schalten.A.Garten.K2-L1.Steckdose.Ein/Aus
   room: Garten
-3/5/32:
+2/5/82:
   dpt: '1.011'
   function: Schalten
   name: Schalten.A.Garten.K2-L1.Steckdose.Ein/Aus-Status
   room: Garten
-3/5/40:
+2/5/90:
   dpt: '1.001'
   function: Schalten
   name: Schalten.A.Garten.K2-L2.Steckdose.Sperren
   room: Garten
-3/5/41:
+2/5/91:
   dpt: '1.001'
   function: Schalten
   name: Schalten.A.Garten.K2-L2.Steckdose.Ein/Aus
   room: Garten
-3/5/42:
+2/5/92:
   dpt: '1.011'
   function: Schalten
   name: Schalten.A.Garten.K2-L2.Steckdose.Ein/Aus-Status
   room: Garten
-3/5/50:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.A.Garten.K2-L3.Steckdose.Sperren
-  room: Garten
-3/5/51:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.A.Garten.K2-L3.Steckdose.Ein/Aus
-  room: Garten
-3/5/52:
-  dpt: '1.011'
-  function: Schalten
-  name: Schalten.A.Garten.K2-L3.Steckdose.Ein/Aus-Status
-  room: Garten
-3/5/60:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.A.Garten.K3-L1.Steckdose.Sperren
-  room: Garten
-3/5/61:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.A.Garten.K3-L1.Steckdose.Ein/Aus
-  room: Garten
-3/5/62:
-  dpt: '1.011'
-  function: Schalten
-  name: Schalten.A.Garten.K3-L1.Steckdose.Ein/Aus-Status
-  room: Garten
-3/5/70:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.A.Garten.K3-L2.Steckdose.Sperren
-  room: Garten
-3/5/71:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.A.Garten.K3-L2.Steckdose.Ein/Aus
-  room: Garten
-3/5/72:
-  dpt: '1.011'
-  function: Schalten
-  name: Schalten.A.Garten.K3-L2.Steckdose.Ein/Aus-Status
-  room: Garten
-3/5/80:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.A.Garten.K3-L3.Steckdose.Sperren
-  room: Garten
-3/5/81:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.A.Garten.K3-L3.Steckdose.Ein/Aus
-  room: Garten
-3/5/82:
-  dpt: '1.011'
-  function: Schalten
-  name: Schalten.A.Garten.K3-L3.Steckdose.Ein/Aus-Status
-  room: Garten
-3/5/90:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.A.Garten.K3-L4.Steckdose.Sperren
-  room: Garten
-3/5/91:
-  dpt: '1.001'
-  function: Schalten
-  name: Schalten.A.Garten.K3-L4.Steckdose.Ein/Aus
-  room: Garten
-3/5/92:
-  dpt: '1.011'
-  function: Schalten
-  name: Schalten.A.Garten.K3-L4.Steckdose.Ein/Aus-Status
-  room: Garten
-4/0/0:
+3/0/0:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.KG.Flur.Ein/Aus
-4/0/1:
+3/0/1:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.KG.Flur.Ein/Aus-Status
-4/0/10:
+3/0/10:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.EG.Flur.Ein/Aus
-4/0/100:
+3/0/100:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.KG.Ein/Aus
-4/0/101:
+3/0/101:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.KG.Ein/Aus-Status
-4/0/11:
+3/0/11:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.EG.Flur.Ein/Aus-Status
-4/0/12:
+3/0/12:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.EG.Gäste-WC.Ein/Aus
-4/0/120:
+3/0/120:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.EG.Ein/Aus
-4/0/121:
+3/0/121:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.EG.Ein/Aus-Status
-4/0/13:
+3/0/13:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.EG.Gäste-WC.Ein/Aus-Status
-4/0/14:
+3/0/14:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.EG.Büro.Ein/Aus
-4/0/140:
+3/0/140:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.OG.Ein/Aus
-4/0/141:
+3/0/141:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.OG.Ein/Aus-Status
-4/0/15:
+3/0/15:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.EG.Büro.Ein/Aus-Status
-4/0/16:
+3/0/16:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.EG.Wohnzimmer.Ein/Aus
-4/0/160:
+3/0/160:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.DG.Ein/Aus
-4/0/161:
+3/0/161:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.DG.Ein/Aus-Status
-4/0/17:
+3/0/17:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.EG.Wohnzimmer.Ein/Aus-Status
-4/0/18:
+3/0/18:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.EG.Esszimmer.Ein/Aus
-4/0/180:
+3/0/180:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.A.Ein/Aus
-4/0/181:
+3/0/181:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.A.Ein/Aus-Status
-4/0/19:
+3/0/19:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.EG.Esszimmer.Ein/Aus-Status
-4/0/2:
+3/0/2:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.KG.Garage.Ein/Aus
-4/0/20:
+3/0/20:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.EG.Küche.Ein/Aus
-4/0/200:
+3/0/200:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.Ein/Aus
-4/0/201:
+3/0/201:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.Ein/Aus-Status
-4/0/21:
+3/0/21:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.EG.Küche.Ein/Aus-Status
-4/0/22:
+3/0/22:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.OG.Flur.Ein/Aus
-4/0/23:
+3/0/23:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.OG.Flur.Ein/Aus-Status
-4/0/24:
+3/0/24:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.OG.Abstellraum.Ein/Aus
-4/0/25:
+3/0/25:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.OG.Abstellraum.Ein/Aus-Status
-4/0/26:
+3/0/26:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.OG.Badezimmer-Kinder.Ein/Aus
-4/0/27:
+3/0/27:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.OG.Badezimmer-Kinder.Ein/Aus-Status
-4/0/28:
+3/0/28:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.OG.Schlafzimmer-Gregory.Ein/Aus
-4/0/29:
+3/0/29:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.OG.Schlafzimmer-Gregory.Ein/Aus-Status
-4/0/3:
+3/0/3:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.KG.Garage.Ein/Aus-Status
-4/0/30:
+3/0/30:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.OG.Schlafzimmer-Luis.Ein/Aus
-4/0/31:
+3/0/31:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.OG.Schlafzimmer-Luis.Ein/Aus-Status
-4/0/32:
+3/0/32:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.OG.Schlafzimmer-Eltern.Ein/Aus
-4/0/33:
+3/0/33:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.OG.Schlafzimmer-Eltern.Ein/Aus-Status
-4/0/34:
+3/0/34:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.OG.Begehbarer-Schrank.Ein/Aus
-4/0/35:
+3/0/35:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.OG.Begehbarer-Schrank.Ein/Aus-Status
-4/0/36:
+3/0/36:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.OG.Badezimmer-Eltern.Ein/Aus
-4/0/37:
+3/0/37:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.OG.Badezimmer-Eltern.Ein/Aus-Status
-4/0/38:
+3/0/38:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.DG.Speicher.Ein/Aus
-4/0/39:
+3/0/39:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.DG.Speicher.Ein/Aus-Status
-4/0/4:
+3/0/4:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.KG.Technikraum.Ein/Aus
-4/0/40:
-  dpt: '1.001'
-  function: Beleuchtung
-  name: Beleuchtung.Zentral.A.Eingang.Ein/Aus
-4/0/41:
-  dpt: '1.011'
-  function: Beleuchtung
-  name: Beleuchtung.Zentral.A.Eingang.Ein/Aus-Status
-4/0/42:
+3/0/40:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.A.Fassade.Ein/Aus
-4/0/43:
+3/0/41:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.A.Fassade.Ein/Aus-Status
-4/0/44:
+3/0/42:
+  dpt: '1.001'
+  function: Beleuchtung
+  name: Beleuchtung.Zentral.A.Eingang.Ein/Aus
+3/0/43:
+  dpt: '1.011'
+  function: Beleuchtung
+  name: Beleuchtung.Zentral.A.Eingang.Ein/Aus-Status
+3/0/44:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.A.Terrasse.Ein/Aus
-4/0/45:
+3/0/45:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.A.Terrasse.Ein/Aus-Status
-4/0/46:
+3/0/46:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.A.Balkon.Ein/Aus
-4/0/47:
+3/0/47:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.A.Balkon.Ein/Aus-Status
-4/0/48:
+3/0/48:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.A.Garten.Ein/Aus
-4/0/49:
+3/0/49:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.A.Garten.Ein/Aus-Status
-4/0/5:
+3/0/5:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.KG.Technikraum.Ein/Aus-Status
-4/0/50:
+3/0/50:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.A.Dach.Ein/Aus
-4/0/51:
+3/0/51:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.A.Dach.Ein/Aus-Status
-4/0/6:
+3/0/6:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.KG.Vorratsraum.Ein/Aus
-4/0/7:
+3/0/7:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.KG.Vorratsraum.Ein/Aus-Status
-4/0/8:
+3/0/8:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.KG.Hauswirtschaftsraum.Ein/Aus
-4/0/9:
+3/0/9:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.KG.Hauswirtschaftsraum.Ein/Aus-Status
-4/1/0:
+3/1/0:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.KG.Flur.Track.Sperren
   room: Flur
-4/1/1:
+3/1/1:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.KG.Flur.Track.Ein/Aus
   room: Flur
-4/1/10:
+3/1/10:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.KG.Flur.Indirekt.Sperren
   room: Flur
-4/1/100:
-  dpt: '1.003'
-  function: Beleuchtung
-  name: Beleuchtung.KG.Technikraum.Deckenleuchte.Sperren
-  room: Technikraum
-4/1/101:
-  dpt: '1.001'
-  function: Beleuchtung
-  name: Beleuchtung.KG.Technikraum.Deckenleuchte.Ein/Aus
-  room: Technikraum
-4/1/102:
-  dpt: '1.011'
-  function: Beleuchtung
-  name: Beleuchtung.KG.Technikraum.Deckenleuchte.Ein/Aus-Status
-  room: Technikraum
-4/1/103:
-  dpt: '3.007'
-  function: Beleuchtung
-  name: Beleuchtung.KG.Technikraum.Deckenleuchte.Dimmen-Relativ
-  room: Technikraum
-4/1/104:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.KG.Technikraum.Deckenleuchte.Dimmen-Absolut
-  room: Technikraum
-4/1/105:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.KG.Technikraum.Deckenleuchte.Dimmen-Status
-  room: Technikraum
-4/1/11:
+3/1/11:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.KG.Flur.Indirekt.Ein/Aus
   room: Flur
-4/1/12:
+3/1/12:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.KG.Flur.Indirekt.Ein/Aus-Status
   room: Flur
-4/1/13:
+3/1/13:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.KG.Flur.Indirekt.Dimmen-Relativ
   room: Flur
-4/1/14:
+3/1/14:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.KG.Flur.Indirekt.Dimmen-Absolut
   room: Flur
-4/1/15:
+3/1/15:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.KG.Flur.Indirekt.Dimmen-Status
   room: Flur
-4/1/150:
-  dpt: '1.003'
-  function: Beleuchtung
-  name: Beleuchtung.KG.Vorratsraum.Deckenleuchte.Sperren
-  room: Vorratsraum
-4/1/151:
-  dpt: '1.001'
-  function: Beleuchtung
-  name: Beleuchtung.KG.Vorratsraum.Deckenleuchte.Ein/Aus
-  room: Vorratsraum
-4/1/152:
-  dpt: '1.011'
-  function: Beleuchtung
-  name: Beleuchtung.KG.Vorratsraum.Deckenleuchte.Ein/Aus-Status
-  room: Vorratsraum
-4/1/153:
-  dpt: '3.007'
-  function: Beleuchtung
-  name: Beleuchtung.KG.Vorratsraum.Deckenleuchte.Dimmen-Relativ
-  room: Vorratsraum
-4/1/154:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.KG.Vorratsraum.Deckenleuchte.Dimmen-Absolut
-  room: Vorratsraum
-4/1/155:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.KG.Vorratsraum.Deckenleuchte.Dimmen-Status
-  room: Vorratsraum
-4/1/2:
+3/1/2:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.KG.Flur.Track.Ein/Aus-Status
   room: Flur
-4/1/20:
+3/1/20:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.KG.Flur.Bodenleuchte.Sperren
   room: Flur
-4/1/21:
+3/1/21:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.KG.Flur.Bodenleuchte.Ein/Aus
   room: Flur
-4/1/22:
+3/1/22:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.KG.Flur.Bodenleuchte.Ein/Aus-Status
   room: Flur
-4/1/23:
+3/1/23:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.KG.Flur.Bodenleuchte.Dimmen-Relativ
   room: Flur
-4/1/24:
+3/1/24:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.KG.Flur.Bodenleuchte.Dimmen-Absolut
   room: Flur
-4/1/25:
+3/1/25:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.KG.Flur.Bodenleuchte.Dimmen-Status
   room: Flur
-4/1/3:
+3/1/3:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.KG.Flur.Track.Dimmen-Relativ
   room: Flur
-4/1/4:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.KG.Flur.Track.Dimmen-Absolut
-  room: Flur
-4/1/5:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.KG.Flur.Track.Dimmen-Status
-  room: Flur
-4/1/50:
+3/1/30:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.KG.Garage.Deckenleuchte.Links.Sperren
   room: Garage
-4/1/51:
+3/1/31:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.KG.Garage.Deckenleuchte.Links.Ein/Aus
   room: Garage
-4/1/52:
+3/1/32:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.KG.Garage.Deckenleuchte.Links.Ein/Aus-Status
   room: Garage
-4/1/53:
+3/1/33:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.KG.Garage.Deckenleuchte.Links.Dimmen-Relativ
   room: Garage
-4/1/54:
+3/1/34:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.KG.Garage.Deckenleuchte.Links.Dimmen-Absolut
   room: Garage
-4/1/55:
+3/1/35:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.KG.Garage.Deckenleuchte.Links.Dimmen-Status
   room: Garage
-4/1/60:
+3/1/4:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.KG.Flur.Track.Dimmen-Absolut
+  room: Flur
+3/1/40:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.KG.Garage.Deckenleuchte.Rechts.Sperren
   room: Garage
-4/1/61:
+3/1/41:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.KG.Garage.Deckenleuchte.Rechts.Ein/Aus
   room: Garage
-4/1/62:
+3/1/42:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.KG.Garage.Deckenleuchte.Rechts.Ein/Aus-Status
   room: Garage
-4/1/63:
+3/1/43:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.KG.Garage.Deckenleuchte.Rechts.Dimmen-Relativ
   room: Garage
-4/1/64:
+3/1/44:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.KG.Garage.Deckenleuchte.Rechts.Dimmen-Absolut
   room: Garage
-4/1/65:
+3/1/45:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.KG.Garage.Deckenleuchte.Rechts.Dimmen-Status
   room: Garage
-4/2/0:
+3/1/5:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.KG.Flur.Track.Dimmen-Status
+  room: Flur
+3/1/50:
   dpt: '1.003'
   function: Beleuchtung
-  name: Beleuchtung.EG.Flur.Downlight.Diele.Sperren
-  room: Flur
-4/2/1:
+  name: Beleuchtung.KG.Technikraum.Deckenleuchte.Sperren
+  room: Technikraum
+3/1/51:
   dpt: '1.001'
   function: Beleuchtung
-  name: Beleuchtung.EG.Flur.Downlight.Diele.Ein/Aus
-  room: Flur
-4/2/10:
+  name: Beleuchtung.KG.Technikraum.Deckenleuchte.Ein/Aus
+  room: Technikraum
+3/1/52:
+  dpt: '1.011'
+  function: Beleuchtung
+  name: Beleuchtung.KG.Technikraum.Deckenleuchte.Ein/Aus-Status
+  room: Technikraum
+3/1/53:
+  dpt: '3.007'
+  function: Beleuchtung
+  name: Beleuchtung.KG.Technikraum.Deckenleuchte.Dimmen-Relativ
+  room: Technikraum
+3/1/54:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.KG.Technikraum.Deckenleuchte.Dimmen-Absolut
+  room: Technikraum
+3/1/55:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.KG.Technikraum.Deckenleuchte.Dimmen-Status
+  room: Technikraum
+3/1/60:
   dpt: '1.003'
   function: Beleuchtung
-  name: Beleuchtung.EG.Flur.Downlight.Garderobe.Sperren
-  room: Flur
-4/2/100:
-  dpt: '1.003'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Büro.Spots.Sperren
-  room: Büro
-4/2/101:
+  name: Beleuchtung.KG.Vorratsraum.Deckenleuchte.Sperren
+  room: Vorratsraum
+3/1/61:
   dpt: '1.001'
   function: Beleuchtung
-  name: Beleuchtung.EG.Büro.Spots.Ein/Aus
-  room: Büro
-4/2/102:
+  name: Beleuchtung.KG.Vorratsraum.Deckenleuchte.Ein/Aus
+  room: Vorratsraum
+3/1/62:
   dpt: '1.011'
   function: Beleuchtung
-  name: Beleuchtung.EG.Büro.Spots.Ein/Aus-Status
-  room: Büro
-4/2/103:
+  name: Beleuchtung.KG.Vorratsraum.Deckenleuchte.Ein/Aus-Status
+  room: Vorratsraum
+3/1/63:
   dpt: '3.007'
   function: Beleuchtung
-  name: Beleuchtung.EG.Büro.Spots.Dimmen-Relativ
-  room: Büro
-4/2/104:
+  name: Beleuchtung.KG.Vorratsraum.Deckenleuchte.Dimmen-Relativ
+  room: Vorratsraum
+3/1/64:
   dpt: '5.001'
   function: Beleuchtung
-  name: Beleuchtung.EG.Büro.Spots.Dimmen-Absolut
-  room: Büro
-4/2/105:
+  name: Beleuchtung.KG.Vorratsraum.Deckenleuchte.Dimmen-Absolut
+  room: Vorratsraum
+3/1/65:
   dpt: '5.001'
   function: Beleuchtung
-  name: Beleuchtung.EG.Büro.Spots.Dimmen-Status
-  room: Büro
-4/2/11:
-  dpt: '1.001'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Flur.Downlight.Garderobe.Ein/Aus
-  room: Flur
-4/2/110:
-  dpt: '1.003'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Büro.Stripe.Sperren
-  room: Büro
-4/2/111:
-  dpt: '1.001'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Büro.Stripe.Ein/Aus
-  room: Büro
-4/2/112:
-  dpt: '1.011'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Büro.Stripe.Ein/Aus-Status
-  room: Büro
-4/2/113:
-  dpt: '3.007'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Büro.Stripe.Dimmen-Relativ
-  room: Büro
-4/2/114:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Büro.Stripe.Dimmen-Absolut
-  room: Büro
-4/2/115:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Büro.Stripe.Dimmen-Status
-  room: Büro
-4/2/12:
-  dpt: '1.011'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Flur.Downlight.Garderobe.Ein/Aus-Status
-  room: Flur
-4/2/13:
-  dpt: '3.007'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Flur.Downlight.Garderobe.Dimmen-Relativ
-  room: Flur
-4/2/14:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Flur.Downlight.Garderobe.Dimmen-Absolut
-  room: Flur
-4/2/15:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Flur.Downlight.Garderobe.Dimmen-Status
-  room: Flur
-4/2/150:
-  dpt: '1.003'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Wohnzimmer.Downlight.Sperren
-  room: Wohnzimmer
-4/2/151:
-  dpt: '1.001'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Wohnzimmer.Downlight.Ein/Aus
-  room: Wohnzimmer
-4/2/152:
-  dpt: '1.011'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Wohnzimmer.Downlight.Ein/Aus-Status
-  room: Wohnzimmer
-4/2/153:
-  dpt: '3.007'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Wohnzimmer.Downlight.Dimmen-Relativ
-  room: Wohnzimmer
-4/2/154:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Wohnzimmer.Downlight.Dimmen-Absolut
-  room: Wohnzimmer
-4/2/155:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Wohnzimmer.Downlight.Dimmen-Status
-  room: Wohnzimmer
-4/2/160:
-  dpt: '1.003'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Wohnzimmer.Spots.Links.Sperren
-  room: Wohnzimmer
-4/2/161:
-  dpt: '1.001'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Wohnzimmer.Spots.Links.Ein/Aus
-  room: Wohnzimmer
-4/2/162:
-  dpt: '1.011'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Wohnzimmer.Spots.Links.Ein/Aus-Status
-  room: Wohnzimmer
-4/2/163:
-  dpt: '3.007'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Wohnzimmer.Spots.Links.Dimmen-Relativ
-  room: Wohnzimmer
-4/2/164:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Wohnzimmer.Spots.Links.Dimmen-Absolut
-  room: Wohnzimmer
-4/2/165:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Wohnzimmer.Spots.Links.Dimmen-Status
-  room: Wohnzimmer
-4/2/170:
-  dpt: '1.003'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Wohnzimmer.Stripe.Links.Sperren
-  room: Wohnzimmer
-4/2/171:
-  dpt: '1.001'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Wohnzimmer.Stripe.Links.Ein/Aus
-  room: Wohnzimmer
-4/2/172:
-  dpt: '1.011'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Wohnzimmer.Stripe.Links.Ein/Aus-Status
-  room: Wohnzimmer
-4/2/173:
-  dpt: '3.007'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Wohnzimmer.Stripe.Links.Dimmen-Relativ
-  room: Wohnzimmer
-4/2/174:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Wohnzimmer.Stripe.Links.Dimmen-Absolut
-  room: Wohnzimmer
-4/2/175:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Wohnzimmer.Stripe.Links.Dimmen-Status
-  room: Wohnzimmer
-4/2/180:
-  dpt: '1.003'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Wohnzimmer.Spots.Rechts.Sperren
-  room: Wohnzimmer
-4/2/181:
-  dpt: '1.001'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Wohnzimmer.Spots.Rechts.Ein/Aus
-  room: Wohnzimmer
-4/2/182:
-  dpt: '1.011'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Wohnzimmer.Spots.Rechts.Ein/Aus-Status
-  room: Wohnzimmer
-4/2/183:
-  dpt: '3.007'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Wohnzimmer.Spots.Rechts.Dimmen-Relativ
-  room: Wohnzimmer
-4/2/184:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Wohnzimmer.Spots.Rechts.Dimmen-Absolut
-  room: Wohnzimmer
-4/2/185:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Wohnzimmer.Spots.Rechts.Dimmen-Status
-  room: Wohnzimmer
-4/2/190:
-  dpt: '1.003'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Wohnzimmer.Stripe.Rechts.Sperren
-  room: Wohnzimmer
-4/2/191:
-  dpt: '1.001'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Wohnzimmer.Stripe.Rechts.Ein/Aus
-  room: Wohnzimmer
-4/2/192:
-  dpt: '1.011'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Wohnzimmer.Stripe.Rechts.Ein/Aus-Status
-  room: Wohnzimmer
-4/2/193:
-  dpt: '3.007'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Wohnzimmer.Stripe.Rechts.Dimmen-Relativ
-  room: Wohnzimmer
-4/2/194:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Wohnzimmer.Stripe.Rechts.Dimmen-Absolut
-  room: Wohnzimmer
-4/2/195:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Wohnzimmer.Stripe.Rechts.Dimmen-Status
-  room: Wohnzimmer
-4/2/2:
-  dpt: '1.011'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Flur.Downlight.Diele.Ein/Aus-Status
-  room: Flur
-4/2/20:
-  dpt: '1.003'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Flur.Bodenleuchte.Sperren
-  room: Flur
-4/2/200:
-  dpt: '1.003'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Wohnzimmer.Indirekt.Links.Sperren
-  room: Wohnzimmer
-4/2/201:
-  dpt: '1.001'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Wohnzimmer.Indirekt.Links.Ein/Aus
-  room: Wohnzimmer
-4/2/202:
-  dpt: '1.011'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Wohnzimmer.Indirekt.Links.Ein/Aus-Status
-  room: Wohnzimmer
-4/2/203:
-  dpt: '3.007'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Wohnzimmer.Indirekt.Links.Dimmen-Relativ
-  room: Wohnzimmer
-4/2/204:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Wohnzimmer.Indirekt.Links.Dimmen-Absolut
-  room: Wohnzimmer
-4/2/205:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Wohnzimmer.Indirekt.Links.Dimmen-Status
-  room: Wohnzimmer
-4/2/21:
-  dpt: '1.001'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Flur.Bodenleuchte.Ein/Aus
-  room: Flur
-4/2/210:
-  dpt: '1.003'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Wohnzimmer.Indirekt.Rechts.Sperren
-  room: Wohnzimmer
-4/2/211:
-  dpt: '1.001'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Wohnzimmer.Indirekt.Rechts.Ein/Aus
-  room: Wohnzimmer
-4/2/212:
-  dpt: '1.011'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Wohnzimmer.Indirekt.Rechts.Ein/Aus-Status
-  room: Wohnzimmer
-4/2/213:
-  dpt: '3.007'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Wohnzimmer.Indirekt.Rechts.Dimmen-Relativ
-  room: Wohnzimmer
-4/2/214:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Wohnzimmer.Indirekt.Rechts.Dimmen-Absolut
-  room: Wohnzimmer
-4/2/215:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Wohnzimmer.Indirekt.Rechts.Dimmen-Status
-  room: Wohnzimmer
-4/2/22:
-  dpt: '1.011'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Flur.Bodenleuchte.Ein/Aus-Status
-  room: Flur
-4/2/23:
-  dpt: '3.007'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Flur.Bodenleuchte.Dimmen-Relativ
-  room: Flur
-4/2/24:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Flur.Bodenleuchte.Dimmen-Absolut
-  room: Flur
-4/2/25:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Flur.Bodenleuchte.Dimmen-Status
-  room: Flur
-4/2/3:
-  dpt: '3.007'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Flur.Downlight.Diele.Dimmen-Relativ
-  room: Flur
-4/2/30:
-  dpt: '1.003'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Flur.Indirekt.Sperren
-  room: Flur
-4/2/31:
-  dpt: '1.001'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Flur.Indirekt.Ein/Aus
-  room: Flur
-4/2/32:
-  dpt: '1.011'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Flur.Indirekt.Ein/Aus-Status
-  room: Flur
-4/2/33:
-  dpt: '3.007'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Flur.Indirekt.Dimmen-Relativ
-  room: Flur
-4/2/34:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Flur.Indirekt.Dimmen-Absolut
-  room: Flur
-4/2/35:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Flur.Indirekt.Dimmen-Status
-  room: Flur
-4/2/4:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Flur.Downlight.Diele.Dimmen-Absolut
-  room: Flur
-4/2/5:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Flur.Downlight.Diele.Dimmen-Status
-  room: Flur
-4/2/50:
-  dpt: '1.003'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Gäste-WC.Pendelleuchte.Sperren
-  room: Gäste-WC
-4/2/51:
-  dpt: '1.001'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Gäste-WC.Pendelleuchte.Ein/Aus
-  room: Gäste-WC
-4/2/52:
-  dpt: '1.011'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Gäste-WC.Pendelleuchte.Ein/Aus-Status
-  room: Gäste-WC
-4/2/53:
-  dpt: '3.007'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Gäste-WC.Pendelleuchte.Dimmen-Relativ
-  room: Gäste-WC
-4/2/54:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Gäste-WC.Pendelleuchte.Dimmen-Absolut
-  room: Gäste-WC
-4/2/55:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Gäste-WC.Pendelleuchte.Dimmen-Status
-  room: Gäste-WC
-4/2/60:
-  dpt: '1.003'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Gäste-WC.Indirekt.Sperren
-  room: Gäste-WC
-4/2/61:
-  dpt: '1.001'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Gäste-WC.Indirekt.Ein/Aus
-  room: Gäste-WC
-4/2/62:
-  dpt: '1.011'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Gäste-WC.Indirekt.Ein/Aus-Status
-  room: Gäste-WC
-4/2/63:
-  dpt: '3.007'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Gäste-WC.Indirekt.Dimmen-Relativ
-  room: Gäste-WC
-4/2/64:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Gäste-WC.Indirekt.Dimmen-Absolut
-  room: Gäste-WC
-4/2/65:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Gäste-WC.Indirekt.Dimmen-Status
-  room: Gäste-WC
-4/3/0:
-  dpt: '1.003'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Flur.Pendelleuchte.Sperren
-  room: Flur
-4/3/1:
-  dpt: '1.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Flur.Pendelleuchte.Ein/Aus
-  room: Flur
-4/3/10:
-  dpt: '1.003'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Flur.Downlight.Treppe.Sperren
-  room: Flur
-4/3/100:
-  dpt: '1.003'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Kinder.Downlight.WC.Sperren
-  room: Badezimmer-Kinder
-4/3/101:
-  dpt: '1.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Kinder.Downlight.WC.Ein/Aus
-  room: Badezimmer-Kinder
-4/3/102:
-  dpt: '1.011'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Kinder.Downlight.WC.Ein/Aus-Status
-  room: Badezimmer-Kinder
-4/3/103:
-  dpt: '3.007'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Kinder.Downlight.WC.Dimmen-Relativ
-  room: Badezimmer-Kinder
-4/3/104:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Kinder.Downlight.WC.Dimmen-Absolut
-  room: Badezimmer-Kinder
-4/3/105:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Kinder.Downlight.WC.Dimmen-Status
-  room: Badezimmer-Kinder
-4/3/11:
-  dpt: '1.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Flur.Downlight.Treppe.Ein/Aus
-  room: Flur
-4/3/110:
-  dpt: '1.003'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Kinder.Downlight.Becken.Sperren
-  room: Badezimmer-Kinder
-4/3/111:
-  dpt: '1.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Kinder.Downlight.Becken.Ein/Aus
-  room: Badezimmer-Kinder
-4/3/112:
-  dpt: '1.011'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Kinder.Downlight.Becken.Ein/Aus-Status
-  room: Badezimmer-Kinder
-4/3/113:
-  dpt: '3.007'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Kinder.Downlight.Becken.Dimmen-Relativ
-  room: Badezimmer-Kinder
-4/3/114:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Kinder.Downlight.Becken.Dimmen-Absolut
-  room: Badezimmer-Kinder
-4/3/115:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Kinder.Downlight.Becken.Dimmen-Status
-  room: Badezimmer-Kinder
-4/3/12:
-  dpt: '1.011'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Flur.Downlight.Treppe.Ein/Aus-Status
-  room: Flur
-4/3/120:
-  dpt: '1.003'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Kinder.Indirekt.Sperren
-  room: Badezimmer-Kinder
-4/3/121:
-  dpt: '1.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Kinder.Indirekt.Ein/Aus
-  room: Badezimmer-Kinder
-4/3/122:
-  dpt: '1.011'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Kinder.Indirekt.Ein/Aus-Status
-  room: Badezimmer-Kinder
-4/3/123:
-  dpt: '3.007'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Kinder.Indirekt.Dimmen-Relativ
-  room: Badezimmer-Kinder
-4/3/124:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Kinder.Indirekt.Dimmen-Absolut
-  room: Badezimmer-Kinder
-4/3/125:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Kinder.Indirekt.Dimmen-Status
-  room: Badezimmer-Kinder
-4/3/13:
-  dpt: '3.007'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Flur.Downlight.Treppe.Dimmen-Relativ
-  room: Flur
-4/3/130:
-  dpt: '1.003'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Kinder.Spiegel.Sperren
-  room: Badezimmer-Kinder
-4/3/131:
-  dpt: '1.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Kinder.Spiegel.Ein/Aus
-  room: Badezimmer-Kinder
-4/3/132:
-  dpt: '1.011'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Kinder.Spiegel.Ein/Aus-Status
-  room: Badezimmer-Kinder
-4/3/133:
-  dpt: '3.007'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Kinder.Spiegel.Dimmen-Relativ
-  room: Badezimmer-Kinder
-4/3/134:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Kinder.Spiegel.Dimmen-Absolut
-  room: Badezimmer-Kinder
-4/3/135:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Kinder.Spiegel.Dimmen-Status
-  room: Badezimmer-Kinder
-4/3/136:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Kinder.Spiegel.Farbwert
-  room: Badezimmer-Kinder
-4/3/137:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Kinder.Spiegel.Farbwert-Status
-  room: Badezimmer-Kinder
-4/3/138:
-  dpt: '7.600'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Kinder.Spiegel.Farbtemperatur
-  room: Badezimmer-Kinder
-4/3/139:
-  dpt: '7.600'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Kinder.Spiegel.Farbtemperatur-Status
-  room: Badezimmer-Kinder
-4/3/14:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Flur.Downlight.Treppe.Dimmen-Absolut
-  room: Flur
-4/3/15:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Flur.Downlight.Treppe.Dimmen-Status
-  room: Flur
-4/3/150:
-  dpt: '1.003'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Schlafzimmer-Gregory.Downlight.Sperren
-  room: Schlafzimmer-Gregory
-4/3/151:
-  dpt: '1.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Schlafzimmer-Gregory.Downlight.Ein/Aus
-  room: Schlafzimmer-Gregory
-4/3/152:
-  dpt: '1.011'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Schlafzimmer-Gregory.Downlight.Ein/Aus-Status
-  room: Schlafzimmer-Gregory
-4/3/153:
-  dpt: '3.007'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Schlafzimmer-Gregory.Downlight.Dimmen-Relativ
-  room: Schlafzimmer-Gregory
-4/3/154:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Schlafzimmer-Gregory.Downlight.Dimmen-Absolut
-  room: Schlafzimmer-Gregory
-4/3/155:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Schlafzimmer-Gregory.Downlight.Dimmen-Status
-  room: Schlafzimmer-Gregory
-4/3/160:
-  dpt: '1.003'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Schlafzimmer-Gregory.Stripe.Sperren
-  room: Schlafzimmer-Gregory
-4/3/161:
-  dpt: '1.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Schlafzimmer-Gregory.Stripe.Ein/Aus
-  room: Schlafzimmer-Gregory
-4/3/162:
-  dpt: '1.011'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Schlafzimmer-Gregory.Stripe.Ein/Aus-Status
-  room: Schlafzimmer-Gregory
-4/3/163:
-  dpt: '3.007'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Schlafzimmer-Gregory.Stripe.Dimmen-Relativ
-  room: Schlafzimmer-Gregory
-4/3/164:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Schlafzimmer-Gregory.Stripe.Dimmen-Absolut
-  room: Schlafzimmer-Gregory
-4/3/165:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Schlafzimmer-Gregory.Stripe.Dimmen-Status
-  room: Schlafzimmer-Gregory
-4/3/166:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Schlafzimmer-Gregory.Stripe.Farbwert
-  room: Schlafzimmer-Gregory
-4/3/167:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Schlafzimmer-Gregory.Stripe.Farbwert-Status
-  room: Schlafzimmer-Gregory
-4/3/168:
-  dpt: '7.600'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Schlafzimmer-Gregory.Stripe.Farbtemparatur
-  room: Schlafzimmer-Gregory
-4/3/169:
-  dpt: '7.600'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Schlafzimmer-Gregory.Stripe.Farbtemparatur-Status
-  room: Schlafzimmer-Gregory
-4/3/170:
-  dpt: '232.600'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Schlafzimmer-Gregory.Stripe.Farbsteuerung
-  room: Schlafzimmer-Gregory
-4/3/171:
-  dpt: '232.600'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Schlafzimmer-Gregory.Stripe.Farbsteuerung-Status
-  room: Schlafzimmer-Gregory
-4/3/2:
-  dpt: '1.011'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Flur.Pendelleuchte.Ein/Aus-Status
-  room: Flur
-4/3/20:
-  dpt: '1.003'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Flur.Downlight.Galerie.Sperren
-  room: Flur
-4/3/21:
-  dpt: '1.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Flur.Downlight.Galerie.Ein/Aus
-  room: Flur
-4/3/22:
-  dpt: '1.011'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Flur.Downlight.Galerie.Ein/Aus-Status
-  room: Flur
-4/3/23:
-  dpt: '3.007'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Flur.Downlight.Galerie.Dimmen-Relativ
-  room: Flur
-4/3/24:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Flur.Downlight.Galerie.Dimmen-Absolut
-  room: Flur
-4/3/25:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Flur.Downlight.Galerie.Dimmen-Status
-  room: Flur
-4/3/3:
-  dpt: '3.007'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Flur.Pendelleuchte.Dimmen-Relativ
-  room: Flur
-4/3/30:
-  dpt: '1.003'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Flur.Downlight.Gang.Sperren
-  room: Flur
-4/3/31:
-  dpt: '1.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Flur.Downlight.Gang.Ein/Aus
-  room: Flur
-4/3/32:
-  dpt: '1.011'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Flur.Downlight.Gang.Ein/Aus-Status
-  room: Flur
-4/3/33:
-  dpt: '3.007'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Flur.Downlight.Gang.Dimmen-Relativ
-  room: Flur
-4/3/34:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Flur.Downlight.Gang.Dimmen-Absolut
-  room: Flur
-4/3/35:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Flur.Downlight.Gang.Dimmen-Status
-  room: Flur
-4/3/4:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Flur.Pendelleuchte.Dimmen-Absolut
-  room: Flur
-4/3/40:
-  dpt: '1.003'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Flur.Bodenleuchte.Sperren
-  room: Flur
-4/3/41:
-  dpt: '1.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Flur.Bodenleuchte.Ein/Aus
-  room: Flur
-4/3/42:
-  dpt: '1.011'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Flur.Bodenleuchte.Ein/Aus-Status
-  room: Flur
-4/3/43:
-  dpt: '3.007'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Flur.Bodenleuchte.Dimmen-Relativ
-  room: Flur
-4/3/44:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Flur.Bodenleuchte.Dimmen-Absolut
-  room: Flur
-4/3/45:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Flur.Bodenleuchte.Dimmen-Status
-  room: Flur
-4/3/5:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Flur.Pendelleuchte.Dimmen-Status
-  room: Flur
-4/3/50:
-  dpt: '1.003'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Abstellraum.Downlight.Sperren
-  room: Abstellraum
-4/3/51:
-  dpt: '1.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Abstellraum.Downlight.Ein/Aus
-  room: Abstellraum
-4/3/52:
-  dpt: '1.011'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Abstellraum.Downlight.Ein/Aus-Status
-  room: Abstellraum
-4/3/53:
-  dpt: '3.007'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Abstellraum.Downlight.Dimmen-Relativ
-  room: Abstellraum
-4/3/54:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Abstellraum.Downlight.Dimmen-Absolut
-  room: Abstellraum
-4/3/55:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Abstellraum.Downlight.Dimmen-Status
-  room: Abstellraum
-4/4/0:
-  dpt: '1.003'
-  function: Beleuchtung
-  name: Beleuchtung.DG.Speicher.Deckenleuchte.Sperren
-  room: Speicher
-4/4/1:
-  dpt: '1.001'
-  function: Beleuchtung
-  name: Beleuchtung.DG.Speicher.Deckenleuchte.Ein/Aus
-  room: Speicher
-4/4/2:
-  dpt: '1.011'
-  function: Beleuchtung
-  name: Beleuchtung.DG.Speicher.Deckenleuchte.Ein/Aus-Status
-  room: Speicher
-4/4/3:
-  dpt: '3.007'
-  function: Beleuchtung
-  name: Beleuchtung.DG.Speicher.Deckenleuchte.Dimmen-Relativ
-  room: Speicher
-4/4/4:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.DG.Speicher.Deckenleuchte.Dimmen-Absolut
-  room: Speicher
-4/4/5:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.DG.Speicher.Deckenleuchte.Dimmen-Status
-  room: Speicher
-4/5/0:
-  dpt: '1.003'
-  function: Beleuchtung
-  name: Beleuchtung.A.Fassade.Front.Sperren
-  room: Fassade
-4/5/1:
-  dpt: '1.001'
-  function: Beleuchtung
-  name: Beleuchtung.A.Fassade.Front.Ein/Aus
-  room: Fassade
-4/5/100:
-  dpt: '1.003'
-  function: Beleuchtung
-  name: Beleuchtung.A.Terrasse.Spots.Sperren
-  room: Terrasse
-4/5/101:
-  dpt: '1.001'
-  function: Beleuchtung
-  name: Beleuchtung.A.Terrasse.Spots.Ein/Aus
-  room: Terrasse
-4/5/102:
-  dpt: '1.011'
-  function: Beleuchtung
-  name: Beleuchtung.A.Terrasse.Spots.Ein/Aus-Status
-  room: Terrasse
-4/5/103:
-  dpt: '3.007'
-  function: Beleuchtung
-  name: Beleuchtung.A.Terrasse.Spots.Dimmen-Relativ
-  room: Terrasse
-4/5/104:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.A.Terrasse.Spots.Dimmen-Absolut
-  room: Terrasse
-4/5/105:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.A.Terrasse.Spots.Dimmen-Status
-  room: Terrasse
-4/5/110:
-  dpt: '1.003'
-  function: Beleuchtung
-  name: Beleuchtung.A.Terrasse.Stripe.Sperren
-  room: Terrasse
-4/5/111:
-  dpt: '1.001'
-  function: Beleuchtung
-  name: Beleuchtung.A.Terrasse.Stripe.Ein/Aus
-  room: Terrasse
-4/5/112:
-  dpt: '1.011'
-  function: Beleuchtung
-  name: Beleuchtung.A.Terrasse.Stripe.Ein/Aus-Status
-  room: Terrasse
-4/5/113:
-  dpt: '3.007'
-  function: Beleuchtung
-  name: Beleuchtung.A.Terrasse.Stripe.Dimmen-Relativ
-  room: Terrasse
-4/5/114:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.A.Terrasse.Stripe.Dimmen-Absolut
-  room: Terrasse
-4/5/115:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.A.Terrasse.Stripe.Dimmen-Status
-  room: Terrasse
-4/5/150:
-  dpt: '1.003'
-  function: Beleuchtung
-  name: Beleuchtung.A.Balkon.Spots.Sperren
-  room: Balkon
-4/5/151:
-  dpt: '1.001'
-  function: Beleuchtung
-  name: Beleuchtung.A.Balkon.Spots.Ein/Aus
-  room: Balkon
-4/5/152:
-  dpt: '1.011'
-  function: Beleuchtung
-  name: Beleuchtung.A.Balkon.Spots.Ein/Aus-Status
-  room: Balkon
-4/5/153:
-  dpt: '3.007'
-  function: Beleuchtung
-  name: Beleuchtung.A.Balkon.Spots.Dimmen-Relativ
-  room: Balkon
-4/5/154:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.A.Balkon.Spots.Dimmen-Absolut
-  room: Balkon
-4/5/155:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.A.Balkon.Spots.Dimmen-Status
-  room: Balkon
-4/5/2:
-  dpt: '1.011'
-  function: Beleuchtung
-  name: Beleuchtung.A.Fassade.Front.Ein/Aus-Status
-  room: Fassade
-4/5/3:
-  dpt: '3.007'
-  function: Beleuchtung
-  name: Beleuchtung.A.Fassade.Front.Dimmen-Relativ
-  room: Fassade
-4/5/4:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.A.Fassade.Front.Dimmen-Absolut
-  room: Fassade
-4/5/5:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.A.Fassade.Front.Dimmen-Status
-  room: Fassade
-4/5/50:
-  dpt: '1.003'
-  function: Beleuchtung
-  name: Beleuchtung.A.Eingang.Briefkasten.Sperren
-  room: Eingang
-4/5/51:
-  dpt: '1.001'
-  function: Beleuchtung
-  name: Beleuchtung.A.Eingang.Briefkasten.Ein/Aus
-  room: Eingang
-4/5/52:
-  dpt: '1.011'
-  function: Beleuchtung
-  name: Beleuchtung.A.Eingang.Briefkasten.Ein/Aus-Status
-  room: Eingang
-4/5/53:
-  dpt: '3.007'
-  function: Beleuchtung
-  name: Beleuchtung.A.Eingang.Briefkasten.Dimmen-Relativ
-  room: Eingang
-4/5/54:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.A.Eingang.Briefkasten.Dimmen-Absolut
-  room: Eingang
-4/5/55:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.A.Eingang.Briefkasten.Dimmen-Status
-  room: Eingang
-5/1/0:
+  name: Beleuchtung.KG.Vorratsraum.Deckenleuchte.Dimmen-Status
+  room: Vorratsraum
+3/1/70:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.KG.Hauswirtschaftsraum.Deckenleuchte.Sperren
   room: Hauswirtschaftsraum
-5/1/1:
+3/1/71:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.KG.Hauswirtschaftsraum.Deckenleuchte.Ein/Aus
   room: Hauswirtschaftsraum
-5/1/2:
+3/1/72:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.KG.Hauswirtschaftsraum.Deckenleuchte.Ein/Aus-Status
   room: Hauswirtschaftsraum
-5/1/3:
+3/1/73:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.KG.Hauswirtschaftsraum.Deckenleuchte.Dimmen-Relativ
   room: Hauswirtschaftsraum
-5/1/4:
+3/1/74:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.KG.Hauswirtschaftsraum.Deckenleuchte.Dimmen-Absolut
   room: Hauswirtschaftsraum
-5/1/5:
+3/1/75:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.KG.Hauswirtschaftsraum.Deckenleuchte.Dimmen-Status
   room: Hauswirtschaftsraum
-5/2/0:
+3/2/0:
+  dpt: '1.003'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Flur.Downlight.Diele.Sperren
+  room: Flur
+3/2/1:
+  dpt: '1.001'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Flur.Downlight.Diele.Ein/Aus
+  room: Flur
+3/2/10:
+  dpt: '1.003'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Flur.Downlight.Garderobe.Sperren
+  room: Flur
+3/2/100:
+  dpt: '1.003'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Wohnzimmer.Stripe.Links.Sperren
+  room: Wohnzimmer
+3/2/101:
+  dpt: '1.001'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Wohnzimmer.Stripe.Links.Ein/Aus
+  room: Wohnzimmer
+3/2/102:
+  dpt: '1.011'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Wohnzimmer.Stripe.Links.Ein/Aus-Status
+  room: Wohnzimmer
+3/2/103:
+  dpt: '3.007'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Wohnzimmer.Stripe.Links.Dimmen-Relativ
+  room: Wohnzimmer
+3/2/104:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Wohnzimmer.Stripe.Links.Dimmen-Absolut
+  room: Wohnzimmer
+3/2/105:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Wohnzimmer.Stripe.Links.Dimmen-Status
+  room: Wohnzimmer
+3/2/11:
+  dpt: '1.001'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Flur.Downlight.Garderobe.Ein/Aus
+  room: Flur
+3/2/110:
+  dpt: '1.003'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Wohnzimmer.Spots.Rechts.Sperren
+  room: Wohnzimmer
+3/2/111:
+  dpt: '1.001'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Wohnzimmer.Spots.Rechts.Ein/Aus
+  room: Wohnzimmer
+3/2/112:
+  dpt: '1.011'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Wohnzimmer.Spots.Rechts.Ein/Aus-Status
+  room: Wohnzimmer
+3/2/113:
+  dpt: '3.007'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Wohnzimmer.Spots.Rechts.Dimmen-Relativ
+  room: Wohnzimmer
+3/2/114:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Wohnzimmer.Spots.Rechts.Dimmen-Absolut
+  room: Wohnzimmer
+3/2/115:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Wohnzimmer.Spots.Rechts.Dimmen-Status
+  room: Wohnzimmer
+3/2/12:
+  dpt: '1.011'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Flur.Downlight.Garderobe.Ein/Aus-Status
+  room: Flur
+3/2/120:
+  dpt: '1.003'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Wohnzimmer.Stripe.Rechts.Sperren
+  room: Wohnzimmer
+3/2/121:
+  dpt: '1.001'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Wohnzimmer.Stripe.Rechts.Ein/Aus
+  room: Wohnzimmer
+3/2/122:
+  dpt: '1.011'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Wohnzimmer.Stripe.Rechts.Ein/Aus-Status
+  room: Wohnzimmer
+3/2/123:
+  dpt: '3.007'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Wohnzimmer.Stripe.Rechts.Dimmen-Relativ
+  room: Wohnzimmer
+3/2/124:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Wohnzimmer.Stripe.Rechts.Dimmen-Absolut
+  room: Wohnzimmer
+3/2/125:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Wohnzimmer.Stripe.Rechts.Dimmen-Status
+  room: Wohnzimmer
+3/2/13:
+  dpt: '3.007'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Flur.Downlight.Garderobe.Dimmen-Relativ
+  room: Flur
+3/2/130:
+  dpt: '1.003'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Wohnzimmer.Indirekt.Links.Sperren
+  room: Wohnzimmer
+3/2/131:
+  dpt: '1.001'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Wohnzimmer.Indirekt.Links.Ein/Aus
+  room: Wohnzimmer
+3/2/132:
+  dpt: '1.011'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Wohnzimmer.Indirekt.Links.Ein/Aus-Status
+  room: Wohnzimmer
+3/2/133:
+  dpt: '3.007'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Wohnzimmer.Indirekt.Links.Dimmen-Relativ
+  room: Wohnzimmer
+3/2/134:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Wohnzimmer.Indirekt.Links.Dimmen-Absolut
+  room: Wohnzimmer
+3/2/135:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Wohnzimmer.Indirekt.Links.Dimmen-Status
+  room: Wohnzimmer
+3/2/14:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Flur.Downlight.Garderobe.Dimmen-Absolut
+  room: Flur
+3/2/140:
+  dpt: '1.003'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Wohnzimmer.Indirekt.Rechts.Sperren
+  room: Wohnzimmer
+3/2/141:
+  dpt: '1.001'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Wohnzimmer.Indirekt.Rechts.Ein/Aus
+  room: Wohnzimmer
+3/2/142:
+  dpt: '1.011'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Wohnzimmer.Indirekt.Rechts.Ein/Aus-Status
+  room: Wohnzimmer
+3/2/143:
+  dpt: '3.007'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Wohnzimmer.Indirekt.Rechts.Dimmen-Relativ
+  room: Wohnzimmer
+3/2/144:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Wohnzimmer.Indirekt.Rechts.Dimmen-Absolut
+  room: Wohnzimmer
+3/2/145:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Wohnzimmer.Indirekt.Rechts.Dimmen-Status
+  room: Wohnzimmer
+3/2/15:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Flur.Downlight.Garderobe.Dimmen-Status
+  room: Flur
+3/2/150:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.EG.Esszimmer.Pendelleuchte.Sperren
   room: Esszimmer
-5/2/1:
+3/2/151:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Esszimmer.Pendelleuchte.Ein/Aus
   room: Esszimmer
-5/2/10:
-  dpt: '1.003'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Esszimmer.Indirekt.Sperren
-  room: Esszimmer
-5/2/100:
-  dpt: '1.003'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Küche.Küchenzeile.Sperren
-  room: Küche
-5/2/101:
-  dpt: '1.001'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Küche.Küchenzeile.Ein/Aus
-  room: Küche
-5/2/102:
-  dpt: '1.011'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Küche.Küchenzeile.Ein/Aus-Status
-  room: Küche
-5/2/103:
-  dpt: '3.007'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Küche.Küchenzeile.Dimmen-Relativ
-  room: Küche
-5/2/104:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Küche.Küchenzeile.Dimmen-Absolut
-  room: Küche
-5/2/105:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Küche.Küchenzeile.Dimmen-Status
-  room: Küche
-5/2/106:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Küche.Küchenzeile.Farbwert
-  room: Küche
-5/2/107:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Küche.Küchenzeile.Farbwert-Status
-  room: Küche
-5/2/108:
-  dpt: '7.600'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Küche.Küchenzeile.Farbtemparatur
-  room: Küche
-5/2/109:
-  dpt: '7.600'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Küche.Küchenzeile.Farbtemparatur-Status
-  room: Küche
-5/2/11:
-  dpt: '1.001'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Esszimmer.Indirekt.Ein/Aus
-  room: Esszimmer
-5/2/12:
-  dpt: '1.011'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Esszimmer.Indirekt.Ein/Aus-Status
-  room: Esszimmer
-5/2/13:
-  dpt: '3.007'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Esszimmer.Indirekt.Dimmen-Relativ
-  room: Esszimmer
-5/2/14:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Esszimmer.Indirekt.Dimmen-Absolut
-  room: Esszimmer
-5/2/15:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.EG.Esszimmer.Indirekt.Dimmen-Status
-  room: Esszimmer
-5/2/2:
+3/2/152:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.EG.Esszimmer.Pendelleuchte.Ein/Aus-Status
   room: Esszimmer
-5/2/3:
+3/2/153:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.EG.Esszimmer.Pendelleuchte.Dimmen-Relativ
   room: Esszimmer
-5/2/4:
+3/2/154:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Esszimmer.Pendelleuchte.Dimmen-Absolut
   room: Esszimmer
-5/2/5:
+3/2/155:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Esszimmer.Pendelleuchte.Dimmen-Status
   room: Esszimmer
-5/2/50:
+3/2/160:
+  dpt: '1.003'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Esszimmer.Indirekt.Sperren
+  room: Esszimmer
+3/2/161:
+  dpt: '1.001'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Esszimmer.Indirekt.Ein/Aus
+  room: Esszimmer
+3/2/162:
+  dpt: '1.011'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Esszimmer.Indirekt.Ein/Aus-Status
+  room: Esszimmer
+3/2/163:
+  dpt: '3.007'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Esszimmer.Indirekt.Dimmen-Relativ
+  room: Esszimmer
+3/2/164:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Esszimmer.Indirekt.Dimmen-Absolut
+  room: Esszimmer
+3/2/165:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Esszimmer.Indirekt.Dimmen-Status
+  room: Esszimmer
+3/2/170:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Track.Sperren
   room: Küche
-5/2/51:
+3/2/171:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Track.Ein/Aus
   room: Küche
-5/2/52:
+3/2/172:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Track.Ein/Aus-Status
   room: Küche
-5/2/53:
+3/2/173:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Track.Dimmen-Relativ
   room: Küche
-5/2/54:
+3/2/174:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Track.Dimmen-Absolut
   room: Küche
-5/2/55:
+3/2/175:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Track.Dimmen-Status
   room: Küche
-5/2/60:
+3/2/180:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Pendelleuchte.Groß.Sperren
   room: Küche
-5/2/61:
+3/2/181:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Pendelleuchte.Groß.Ein/Aus
   room: Küche
-5/2/62:
+3/2/182:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Pendelleuchte.Groß.Ein/Aus-Status
   room: Küche
-5/2/63:
+3/2/183:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Pendelleuchte.Groß.Dimmen-Relativ
   room: Küche
-5/2/64:
+3/2/184:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Pendelleuchte.Groß.Dimmen-Absolut
   room: Küche
-5/2/65:
+3/2/185:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Pendelleuchte.Groß.Dimmen-Status
   room: Küche
-5/2/70:
+3/2/190:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Pendelleuchte.Klein.Sperren
   room: Küche
-5/2/71:
+3/2/191:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Pendelleuchte.Klein.Ein/Aus
   room: Küche
-5/2/72:
+3/2/192:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Pendelleuchte.Klein.Ein/Aus-Status
   room: Küche
-5/2/73:
+3/2/193:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Pendelleuchte.Klein.Dimmen-Relativ
   room: Küche
-5/2/74:
+3/2/194:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Pendelleuchte.Klein.Dimmen-Absolut
   room: Küche
-5/2/75:
+3/2/195:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Pendelleuchte.Klein.Dimmen-Status
   room: Küche
-5/2/80:
+3/2/2:
+  dpt: '1.011'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Flur.Downlight.Diele.Ein/Aus-Status
+  room: Flur
+3/2/20:
+  dpt: '1.003'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Flur.Bodenleuchte.Sperren
+  room: Flur
+3/2/200:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Indirekt.Sperren
   room: Küche
-5/2/81:
+3/2/201:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Indirekt.Ein/Aus
   room: Küche
-5/2/82:
+3/2/202:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Indirekt.Ein/Aus-Status
   room: Küche
-5/2/83:
+3/2/203:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Indirekt.Dimmen-Relativ
   room: Küche
-5/2/84:
+3/2/204:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Indirekt.Dimmen-Absolut
   room: Küche
-5/2/85:
+3/2/205:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Indirekt.Dimmen-Status
   room: Küche
-5/2/90:
+3/2/21:
+  dpt: '1.001'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Flur.Bodenleuchte.Ein/Aus
+  room: Flur
+3/2/210:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Kücheninsel.Sperren
   room: Küche
-5/2/91:
+3/2/211:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Kücheninsel.Ein/Aus
   room: Küche
-5/2/92:
+3/2/212:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Kücheninsel.Ein/Aus-Status
   room: Küche
-5/2/93:
+3/2/213:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Kücheninsel.Dimmen-Relativ
   room: Küche
-5/2/94:
+3/2/214:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Kücheninsel.Dimmen-Absolut
   room: Küche
-5/2/95:
+3/2/215:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Kücheninsel.Dimmen-Status
   room: Küche
-5/2/96:
+3/2/216:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Kücheninsel.Farbwert
   room: Küche
-5/2/97:
+3/2/217:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Kücheninsel.Farbwert-Status
   room: Küche
-5/2/98:
+3/2/218:
   dpt: '7.600'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Kücheninsel.Farbtemparatur
   room: Küche
-5/2/99:
+3/2/219:
   dpt: '7.600'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Kücheninsel.Farbtemparatur-Status
   room: Küche
-5/3/0:
+3/2/22:
+  dpt: '1.011'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Flur.Bodenleuchte.Ein/Aus-Status
+  room: Flur
+3/2/220:
+  dpt: '1.003'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Küche.Küchenzeile.Sperren
+  room: Küche
+3/2/221:
+  dpt: '1.001'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Küche.Küchenzeile.Ein/Aus
+  room: Küche
+3/2/222:
+  dpt: '1.011'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Küche.Küchenzeile.Ein/Aus-Status
+  room: Küche
+3/2/223:
+  dpt: '3.007'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Küche.Küchenzeile.Dimmen-Relativ
+  room: Küche
+3/2/224:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Küche.Küchenzeile.Dimmen-Absolut
+  room: Küche
+3/2/225:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Küche.Küchenzeile.Dimmen-Status
+  room: Küche
+3/2/226:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Küche.Küchenzeile.Farbwert
+  room: Küche
+3/2/227:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Küche.Küchenzeile.Farbwert-Status
+  room: Küche
+3/2/228:
+  dpt: '7.600'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Küche.Küchenzeile.Farbtemparatur
+  room: Küche
+3/2/229:
+  dpt: '7.600'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Küche.Küchenzeile.Farbtemparatur-Status
+  room: Küche
+3/2/23:
+  dpt: '3.007'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Flur.Bodenleuchte.Dimmen-Relativ
+  room: Flur
+3/2/24:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Flur.Bodenleuchte.Dimmen-Absolut
+  room: Flur
+3/2/25:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Flur.Bodenleuchte.Dimmen-Status
+  room: Flur
+3/2/3:
+  dpt: '3.007'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Flur.Downlight.Diele.Dimmen-Relativ
+  room: Flur
+3/2/30:
+  dpt: '1.003'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Flur.Indirekt.Sperren
+  room: Flur
+3/2/31:
+  dpt: '1.001'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Flur.Indirekt.Ein/Aus
+  room: Flur
+3/2/32:
+  dpt: '1.011'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Flur.Indirekt.Ein/Aus-Status
+  room: Flur
+3/2/33:
+  dpt: '3.007'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Flur.Indirekt.Dimmen-Relativ
+  room: Flur
+3/2/34:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Flur.Indirekt.Dimmen-Absolut
+  room: Flur
+3/2/35:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Flur.Indirekt.Dimmen-Status
+  room: Flur
+3/2/4:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Flur.Downlight.Diele.Dimmen-Absolut
+  room: Flur
+3/2/40:
+  dpt: '1.003'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Gäste-WC.Pendelleuchte.Sperren
+  room: Gäste WC
+3/2/41:
+  dpt: '1.001'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Gäste-WC.Pendelleuchte.Ein/Aus
+  room: Gäste WC
+3/2/42:
+  dpt: '1.011'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Gäste-WC.Pendelleuchte.Ein/Aus-Status
+  room: Gäste WC
+3/2/43:
+  dpt: '3.007'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Gäste-WC.Pendelleuchte.Dimmen-Relativ
+  room: Gäste WC
+3/2/44:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Gäste-WC.Pendelleuchte.Dimmen-Absolut
+  room: Gäste WC
+3/2/45:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Gäste-WC.Pendelleuchte.Dimmen-Status
+  room: Gäste WC
+3/2/5:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Flur.Downlight.Diele.Dimmen-Status
+  room: Flur
+3/2/50:
+  dpt: '1.003'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Gäste-WC.Indirekt.Sperren
+  room: Gäste WC
+3/2/51:
+  dpt: '1.001'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Gäste-WC.Indirekt.Ein/Aus
+  room: Gäste WC
+3/2/52:
+  dpt: '1.011'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Gäste-WC.Indirekt.Ein/Aus-Status
+  room: Gäste WC
+3/2/53:
+  dpt: '3.007'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Gäste-WC.Indirekt.Dimmen-Relativ
+  room: Gäste WC
+3/2/54:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Gäste-WC.Indirekt.Dimmen-Absolut
+  room: Gäste WC
+3/2/55:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Gäste-WC.Indirekt.Dimmen-Status
+  room: Gäste WC
+3/2/60:
+  dpt: '1.003'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Büro.Spots.Sperren
+  room: Büro
+3/2/61:
+  dpt: '1.001'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Büro.Spots.Ein/Aus
+  room: Büro
+3/2/62:
+  dpt: '1.011'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Büro.Spots.Ein/Aus-Status
+  room: Büro
+3/2/63:
+  dpt: '3.007'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Büro.Spots.Dimmen-Relativ
+  room: Büro
+3/2/64:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Büro.Spots.Dimmen-Absolut
+  room: Büro
+3/2/65:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Büro.Spots.Dimmen-Status
+  room: Büro
+3/2/70:
+  dpt: '1.003'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Büro.Stripe.Sperren
+  room: Büro
+3/2/71:
+  dpt: '1.001'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Büro.Stripe.Ein/Aus
+  room: Büro
+3/2/72:
+  dpt: '1.011'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Büro.Stripe.Ein/Aus-Status
+  room: Büro
+3/2/73:
+  dpt: '3.007'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Büro.Stripe.Dimmen-Relativ
+  room: Büro
+3/2/74:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Büro.Stripe.Dimmen-Absolut
+  room: Büro
+3/2/75:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Büro.Stripe.Dimmen-Status
+  room: Büro
+3/2/80:
+  dpt: '1.003'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Wohnzimmer.Downlight.Sperren
+  room: Wohnzimmer
+3/2/81:
+  dpt: '1.001'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Wohnzimmer.Downlight.Ein/Aus
+  room: Wohnzimmer
+3/2/82:
+  dpt: '1.011'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Wohnzimmer.Downlight.Ein/Aus-Status
+  room: Wohnzimmer
+3/2/83:
+  dpt: '3.007'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Wohnzimmer.Downlight.Dimmen-Relativ
+  room: Wohnzimmer
+3/2/84:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Wohnzimmer.Downlight.Dimmen-Absolut
+  room: Wohnzimmer
+3/2/85:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Wohnzimmer.Downlight.Dimmen-Status
+  room: Wohnzimmer
+3/2/90:
+  dpt: '1.003'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Wohnzimmer.Spots.Links.Sperren
+  room: Wohnzimmer
+3/2/91:
+  dpt: '1.001'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Wohnzimmer.Spots.Links.Ein/Aus
+  room: Wohnzimmer
+3/2/92:
+  dpt: '1.011'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Wohnzimmer.Spots.Links.Ein/Aus-Status
+  room: Wohnzimmer
+3/2/93:
+  dpt: '3.007'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Wohnzimmer.Spots.Links.Dimmen-Relativ
+  room: Wohnzimmer
+3/2/94:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Wohnzimmer.Spots.Links.Dimmen-Absolut
+  room: Wohnzimmer
+3/2/95:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Wohnzimmer.Spots.Links.Dimmen-Status
+  room: Wohnzimmer
+3/3/0:
+  dpt: '1.003'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Flur.Pendelleuchte.Sperren
+  room: Flur
+3/3/1:
+  dpt: '1.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Flur.Pendelleuchte.Ein/Aus
+  room: Flur
+3/3/10:
+  dpt: '1.003'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Flur.Downlight.Treppe.Sperren
+  room: Flur
+3/3/100:
+  dpt: '1.003'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Schlafzimmer-Gregory.Downlight.Sperren
+  room: Schlafzimmer Gregory
+3/3/101:
+  dpt: '1.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Schlafzimmer-Gregory.Downlight.Ein/Aus
+  room: Schlafzimmer Gregory
+3/3/102:
+  dpt: '1.011'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Schlafzimmer-Gregory.Downlight.Ein/Aus-Status
+  room: Schlafzimmer Gregory
+3/3/103:
+  dpt: '3.007'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Schlafzimmer-Gregory.Downlight.Dimmen-Relativ
+  room: Schlafzimmer Gregory
+3/3/104:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Schlafzimmer-Gregory.Downlight.Dimmen-Absolut
+  room: Schlafzimmer Gregory
+3/3/105:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Schlafzimmer-Gregory.Downlight.Dimmen-Status
+  room: Schlafzimmer Gregory
+3/3/11:
+  dpt: '1.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Flur.Downlight.Treppe.Ein/Aus
+  room: Flur
+3/3/110:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Luis.Downlight.Sperren
-  room: Schlafzimmer-Luis
-5/3/1:
+  room: Schlafzimmer Luis
+3/3/111:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Luis.Downlight.Ein/Aus
-  room: Schlafzimmer-Luis
-5/3/10:
-  dpt: '1.003'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Schlafzimmer-Luis.Stripe.Sperren
-  room: Schlafzimmer-Luis
-5/3/100:
-  dpt: '1.003'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Begehbarer-Schrank.Deckenleuchte.Sperren
-  room: Begehbarer-Schrank
-5/3/101:
-  dpt: '1.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Begehbarer-Schrank.Deckenleuchte.Ein/Aus
-  room: Begehbarer-Schrank
-5/3/102:
-  dpt: '1.011'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Begehbarer-Schrank.Deckenleuchte.Ein/Aus-Status
-  room: Begehbarer-Schrank
-5/3/103:
-  dpt: '3.007'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Begehbarer-Schrank.Deckenleuchte.Dimmen-Relativ
-  room: Begehbarer-Schrank
-5/3/104:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Begehbarer-Schrank.Deckenleuchte.Dimmen-Absolut
-  room: Begehbarer-Schrank
-5/3/105:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Begehbarer-Schrank.Deckenleuchte.Dimmen-Status
-  room: Begehbarer-Schrank
-5/3/11:
-  dpt: '1.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Schlafzimmer-Luis.Stripe.Ein/Aus
-  room: Schlafzimmer-Luis
-5/3/12:
-  dpt: '1.011'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Schlafzimmer-Luis.Stripe.Ein/Aus-Status
-  room: Schlafzimmer-Luis
-5/3/13:
-  dpt: '3.007'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Schlafzimmer-Luis.Stripe.Dimmen-Relativ
-  room: Schlafzimmer-Luis
-5/3/14:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Schlafzimmer-Luis.Stripe.Dimmen-Absolut
-  room: Schlafzimmer-Luis
-5/3/15:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Schlafzimmer-Luis.Stripe.Dimmen-Status
-  room: Schlafzimmer-Luis
-5/3/150:
-  dpt: '1.003'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Eltern.Downlight.WC.Sperren
-  room: Badezimmer-Eltern
-5/3/151:
-  dpt: '1.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Eltern.Downlight.WC.Ein/Aus
-  room: Badezimmer-Eltern
-5/3/152:
-  dpt: '1.011'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Eltern.Downlight.WC.Ein/Aus-Status
-  room: Badezimmer-Eltern
-5/3/153:
-  dpt: '3.007'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Eltern.Downlight.WC.Dimmen-Relativ
-  room: Badezimmer-Eltern
-5/3/154:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Eltern.Downlight.WC.Dimmen-Absolut
-  room: Badezimmer-Eltern
-5/3/155:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Eltern.Downlight.WC.Dimmen-Status
-  room: Badezimmer-Eltern
-5/3/16:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Schlafzimmer-Luis.Stripe.Farbwert
-  room: Schlafzimmer-Luis
-5/3/160:
-  dpt: '1.003'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Eltern.Downlight.Becken.Sperren
-  room: Badezimmer-Eltern
-5/3/161:
-  dpt: '1.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Eltern.Downlight.Becken.Ein/Aus
-  room: Badezimmer-Eltern
-5/3/162:
-  dpt: '1.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Eltern.Downlight.Becken.Ein/Aus-Status
-  room: Badezimmer-Eltern
-5/3/163:
-  dpt: '3.007'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Eltern.Downlight.Becken.Dimmen-Relativ
-  room: Badezimmer-Eltern
-5/3/164:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Eltern.Downlight.Becken.Dimmen-Absolut
-  room: Badezimmer-Eltern
-5/3/165:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Eltern.Downlight.Becken.Dimmen-Status
-  room: Badezimmer-Eltern
-5/3/17:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Schlafzimmer-Luis.Stripe.Farbwert-Status
-  room: Schlafzimmer-Luis
-5/3/170:
-  dpt: '1.003'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Eltern.Indirekt.WC.Sperren
-  room: Badezimmer-Eltern
-5/3/171:
-  dpt: '1.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Eltern.Indirekt.WC.Ein/Aus
-  room: Badezimmer-Eltern
-5/3/172:
-  dpt: '1.011'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Eltern.Indirekt.WC.Ein/Aus-Status
-  room: Badezimmer-Eltern
-5/3/173:
-  dpt: '3.007'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Eltern.Indirekt.WC.Dimmen-Relativ
-  room: Badezimmer-Eltern
-5/3/174:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Eltern.Indirekt.WC.Dimmen-Absolut
-  room: Badezimmer-Eltern
-5/3/175:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Eltern.Indirekt.WC.Dimmen-Status
-  room: Badezimmer-Eltern
-5/3/18:
-  dpt: '7.600'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Schlafzimmer-Luis.Stripe.Farbtemparatur
-  room: Schlafzimmer-Luis
-5/3/180:
-  dpt: '1.003'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Eltern.Indirekt.Schrank.Sperren
-  room: Badezimmer-Eltern
-5/3/181:
-  dpt: '1.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Eltern.Indirekt.Schrank.Ein/Aus
-  room: Badezimmer-Eltern
-5/3/182:
-  dpt: '1.011'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Eltern.Indirekt.Schrank.Ein/Aus-Status
-  room: Badezimmer-Eltern
-5/3/183:
-  dpt: '3.007'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Eltern.Indirekt.Schrank.Dimmen-Relativ
-  room: Badezimmer-Eltern
-5/3/184:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Eltern.Indirekt.Schrank.Dimmen-Absolut
-  room: Badezimmer-Eltern
-5/3/185:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Eltern.Indirekt.Schrank.Dimmen-Status
-  room: Badezimmer-Eltern
-5/3/19:
-  dpt: '7.600'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Schlafzimmer-Luis.Stripe.Farbtemparatur-Status
-  room: Schlafzimmer-Luis
-5/3/190:
-  dpt: '1.003'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Eltern.RGB.Sperren
-  room: Badezimmer-Eltern
-5/3/191:
-  dpt: '1.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Eltern.RGB.Ein/Aus
-  room: Badezimmer-Eltern
-5/3/192:
-  dpt: '1.011'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Eltern.RGB.Ein/Aus-Status
-  room: Badezimmer-Eltern
-5/3/193:
-  dpt: '3.007'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Eltern.RGB.Dimmen-Relativ
-  room: Badezimmer-Eltern
-5/3/194:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Eltern.RGB.Dimmen-Absolut
-  room: Badezimmer-Eltern
-5/3/195:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Eltern.RGB.Dimmen-Status
-  room: Badezimmer-Eltern
-5/3/196:
-  dpt: '232.600'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Eltern.RGB.Farbsteuerung
-  room: Badezimmer-Eltern
-5/3/197:
-  dpt: '232.600'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Eltern.RGB.Farbsteuerung-Status
-  room: Badezimmer-Eltern
-5/3/2:
+  room: Schlafzimmer Luis
+3/3/112:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Luis.Downlight.Ein/Aus-Status
-  room: Schlafzimmer-Luis
-5/3/20:
-  dpt: '232.600'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Schlafzimmer-Luis.Stripe.Farbsteuerung
-  room: Schlafzimmer-Luis
-5/3/200:
-  dpt: '1.003'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Eltern.Spiegel.Sperren
-  room: Badezimmer-Eltern
-5/3/201:
-  dpt: '1.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Eltern.Spiegel.Ein/Aus
-  room: Badezimmer-Eltern
-5/3/202:
-  dpt: '1.011'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Eltern.Spiegel.Ein/Aus-Status
-  room: Badezimmer-Eltern
-5/3/203:
-  dpt: '3.007'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Eltern.Spiegel.Dimmen-Relativ
-  room: Badezimmer-Eltern
-5/3/204:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Eltern.Spiegel.Dimmen-Absolut
-  room: Badezimmer-Eltern
-5/3/205:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Eltern.Spiegel.Dimmen-Status
-  room: Badezimmer-Eltern
-5/3/206:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Eltern.Spiegel.Farbwert
-  room: Badezimmer-Eltern
-5/3/207:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Eltern.Spiegel.Farbwert-Status
-  room: Badezimmer-Eltern
-5/3/208:
-  dpt: '7.600'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Eltern.Spiegel.Farbtemparatur
-  room: Badezimmer-Eltern
-5/3/209:
-  dpt: '7.600'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Eltern.Spiegel.Farbtemparatur-Status
-  room: Badezimmer-Eltern
-5/3/21:
-  dpt: '232.600'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Schlafzimmer-Luis.Stripe.Farbsteuerung-Status
-  room: Schlafzimmer-Luis
-5/3/210:
-  dpt: '1.003'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Eltern.Schminkspiegel.Sperren
-  room: Badezimmer-Eltern
-5/3/211:
-  dpt: '1.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Eltern.Schminkspiegel.Ein/Aus
-  room: Badezimmer-Eltern
-5/3/212:
-  dpt: '1.011'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Eltern.Schminkspiegel.Ein/Aus-Status
-  room: Badezimmer-Eltern
-5/3/213:
-  dpt: '3.007'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Eltern.Schminkspiegel.Dimmen-Relativ
-  room: Badezimmer-Eltern
-5/3/214:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Eltern.Schminkspiegel.Dimmen-Absolut
-  room: Badezimmer-Eltern
-5/3/215:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Eltern.Schminkspiegel.Dimmen-Status
-  room: Badezimmer-Eltern
-5/3/216:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Eltern.Schminkspiegel.Farbwert
-  room: Badezimmer-Eltern
-5/3/217:
-  dpt: '5.001'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Eltern.Schminkspiegel.Farbwert-Status
-  room: Badezimmer-Eltern
-5/3/218:
-  dpt: '7.600'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Eltern.Schminkspiegel.Farbtemperatur
-  room: Badezimmer-Eltern
-5/3/219:
-  dpt: '7.600'
-  function: Beleuchtung
-  name: Beleuchtung.OG.Badezimmer-Eltern.Schminkspiegel.Farbtemperatur-Status
-  room: Badezimmer-Eltern
-5/3/3:
+  room: Schlafzimmer Luis
+3/3/113:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Luis.Downlight.Dimmen-Relativ
-  room: Schlafzimmer-Luis
-5/3/4:
+  room: Schlafzimmer Luis
+3/3/114:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Luis.Downlight.Dimmen-Absolut
-  room: Schlafzimmer-Luis
-5/3/5:
+  room: Schlafzimmer Luis
+3/3/115:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Luis.Downlight.Dimmen-Status
-  room: Schlafzimmer-Luis
-5/3/50:
+  room: Schlafzimmer Luis
+3/3/12:
+  dpt: '1.011'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Flur.Downlight.Treppe.Ein/Aus-Status
+  room: Flur
+3/3/120:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Downlight.Sperren
-  room: Schlafzimmer-Eltern
-5/3/51:
+  room: Schlafzimmer Eltern
+3/3/121:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Downlight.Ein/Aus
-  room: Schlafzimmer-Eltern
-5/3/52:
+  room: Schlafzimmer Eltern
+3/3/122:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Downlight.Ein/Aus-Status
-  room: Schlafzimmer-Eltern
-5/3/53:
+  room: Schlafzimmer Eltern
+3/3/123:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Downlight.Dimmen-Relativ
-  room: Schlafzimmer-Eltern
-5/3/54:
+  room: Schlafzimmer Eltern
+3/3/124:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Downlight.Dimmen-Absolut
-  room: Schlafzimmer-Eltern
-5/3/55:
+  room: Schlafzimmer Eltern
+3/3/125:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Downlight.Dimmen-Status
-  room: Schlafzimmer-Eltern
-5/3/60:
+  room: Schlafzimmer Eltern
+3/3/13:
+  dpt: '3.007'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Flur.Downlight.Treppe.Dimmen-Relativ
+  room: Flur
+3/3/130:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Leselicht.Links.Sperren
-  room: Schlafzimmer-Eltern
-5/3/61:
+  room: Schlafzimmer Eltern
+3/3/131:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Leselicht.Links.Ein/Aus
-  room: Schlafzimmer-Eltern
-5/3/62:
+  room: Schlafzimmer Eltern
+3/3/132:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Leselicht.Links.Ein/Aus-Status
-  room: Schlafzimmer-Eltern
-5/3/63:
+  room: Schlafzimmer Eltern
+3/3/133:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Leselicht.Links.Dimmen-Relativ
-  room: Schlafzimmer-Eltern
-5/3/64:
+  room: Schlafzimmer Eltern
+3/3/134:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Leselicht.Links.Dimmen-Absolut
-  room: Schlafzimmer-Eltern
-5/3/65:
+  room: Schlafzimmer Eltern
+3/3/135:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Leselicht.Links.Dimmen-Status
-  room: Schlafzimmer-Eltern
-5/3/70:
+  room: Schlafzimmer Eltern
+3/3/14:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Flur.Downlight.Treppe.Dimmen-Absolut
+  room: Flur
+3/3/140:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Leselicht.Rechts.Sperren
-  room: Schlafzimmer-Eltern
-5/3/71:
+  room: Schlafzimmer Eltern
+3/3/141:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Leselicht.Rechts.Ein/Aus
-  room: Schlafzimmer-Eltern
-5/3/72:
+  room: Schlafzimmer Eltern
+3/3/142:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Leselicht.Rechts.Ein/Aus-Status
-  room: Schlafzimmer-Eltern
-5/3/73:
+  room: Schlafzimmer Eltern
+3/3/143:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Leselicht.Rechts.Dimmen-Relativ
-  room: Schlafzimmer-Eltern
-5/3/74:
+  room: Schlafzimmer Eltern
+3/3/144:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Leselicht.Rechts.Dimmen-Absolut
-  room: Schlafzimmer-Eltern
-5/3/75:
+  room: Schlafzimmer Eltern
+3/3/145:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Leselicht.Rechts.Dimmen-Status
-  room: Schlafzimmer-Eltern
-5/3/80:
+  room: Schlafzimmer Eltern
+3/3/15:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Flur.Downlight.Treppe.Dimmen-Status
+  room: Flur
+3/3/150:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Indirekt.TV.Sperren
-  room: Schlafzimmer-Eltern
-5/3/81:
+  room: Schlafzimmer Eltern
+3/3/151:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Indirekt.TV.Ein/Aus
-  room: Schlafzimmer-Eltern
-5/3/82:
+  room: Schlafzimmer Eltern
+3/3/152:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Indirekt.TV.Ein/Aus-Status
-  room: Schlafzimmer-Eltern
-5/3/83:
+  room: Schlafzimmer Eltern
+3/3/153:
   dpt: '3.007'
   function: Beleuchtung
-  name: Beleuchtung.OG.Schlafzimmer-Eltern.TV.Indirekt.Dimmen-Relativ
-  room: Schlafzimmer-Eltern
-5/3/84:
+  name: Beleuchtung.OG.Schlafzimmer-Eltern.Indirekt.TV.Dimmen-Relativ
+  room: Schlafzimmer Eltern
+3/3/154:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Indirekt.TV.Dimmen-Absolut
-  room: Schlafzimmer-Eltern
-5/3/85:
+  room: Schlafzimmer Eltern
+3/3/155:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Indirekt.TV.Dimmen-Status
-  room: Schlafzimmer-Eltern
-5/3/90:
+  room: Schlafzimmer Eltern
+3/3/160:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Indirekt.Bett.Sperren
-  room: Schlafzimmer-Eltern
-5/3/91:
+  room: Schlafzimmer Eltern
+3/3/161:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Indirekt.Bett.Ein/Aus
-  room: Schlafzimmer-Eltern
-5/3/92:
+  room: Schlafzimmer Eltern
+3/3/162:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Indirekt.Bett.Ein/Aus-Status
-  room: Schlafzimmer-Eltern
-5/3/93:
+  room: Schlafzimmer Eltern
+3/3/163:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Indirekt.Bett.Dimmen-Relativ
-  room: Schlafzimmer-Eltern
-5/3/94:
+  room: Schlafzimmer Eltern
+3/3/164:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Indirekt.Bett.Dimmen-Absolut
-  room: Schlafzimmer-Eltern
-5/3/95:
+  room: Schlafzimmer Eltern
+3/3/165:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Indirekt.Bett.Dimmen-Status
-  room: Schlafzimmer-Eltern
-5/5/0:
+  room: Schlafzimmer Eltern
+3/3/170:
+  dpt: '1.003'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Begehbarer-Schrank.Deckenleuchte.Sperren
+  room: Begehbarer Schrank
+3/3/171:
+  dpt: '1.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Begehbarer-Schrank.Deckenleuchte.Ein/Aus
+  room: Begehbarer Schrank
+3/3/172:
+  dpt: '1.011'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Begehbarer-Schrank.Deckenleuchte.Ein/Aus-Status
+  room: Begehbarer Schrank
+3/3/173:
+  dpt: '3.007'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Begehbarer-Schrank.Deckenleuchte.Dimmen-Relativ
+  room: Begehbarer Schrank
+3/3/174:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Begehbarer-Schrank.Deckenleuchte.Dimmen-Absolut
+  room: Begehbarer Schrank
+3/3/175:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Begehbarer-Schrank.Deckenleuchte.Dimmen-Status
+  room: Begehbarer Schrank
+3/3/180:
+  dpt: '1.003'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Eltern.Downlight.WC.Sperren
+  room: Badezimmer Eltern
+3/3/181:
+  dpt: '1.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Eltern.Downlight.WC.Ein/Aus
+  room: Badezimmer Eltern
+3/3/182:
+  dpt: '1.011'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Eltern.Downlight.WC.Ein/Aus-Status
+  room: Badezimmer Eltern
+3/3/183:
+  dpt: '3.007'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Eltern.Downlight.WC.Dimmen-Relativ
+  room: Badezimmer Eltern
+3/3/184:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Eltern.Downlight.WC.Dimmen-Absolut
+  room: Badezimmer Eltern
+3/3/185:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Eltern.Downlight.WC.Dimmen-Status
+  room: Badezimmer Eltern
+3/3/190:
+  dpt: '1.003'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Eltern.Downlight.Becken.Sperren
+  room: Badezimmer Eltern
+3/3/191:
+  dpt: '1.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Eltern.Downlight.Becken.Ein/Aus
+  room: Badezimmer Eltern
+3/3/192:
+  dpt: '1.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Eltern.Downlight.Becken.Ein/Aus-Status
+  room: Badezimmer Eltern
+3/3/193:
+  dpt: '3.007'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Eltern.Downlight.Becken.Dimmen-Relativ
+  room: Badezimmer Eltern
+3/3/194:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Eltern.Downlight.Becken.Dimmen-Absolut
+  room: Badezimmer Eltern
+3/3/195:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Eltern.Downlight.Becken.Dimmen-Status
+  room: Badezimmer Eltern
+3/3/2:
+  dpt: '1.011'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Flur.Pendelleuchte.Ein/Aus-Status
+  room: Flur
+3/3/20:
+  dpt: '1.003'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Flur.Downlight.Galerie.Sperren
+  room: Flur
+3/3/200:
+  dpt: '1.003'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Eltern.Indirekt.WC.Sperren
+  room: Badezimmer Eltern
+3/3/201:
+  dpt: '1.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Eltern.Indirekt.WC.Ein/Aus
+  room: Badezimmer Eltern
+3/3/202:
+  dpt: '1.011'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Eltern.Indirekt.WC.Ein/Aus-Status
+  room: Badezimmer Eltern
+3/3/203:
+  dpt: '3.007'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Eltern.Indirekt.WC.Dimmen-Relativ
+  room: Badezimmer Eltern
+3/3/204:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Eltern.Indirekt.WC.Dimmen-Absolut
+  room: Badezimmer Eltern
+3/3/205:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Eltern.Indirekt.WC.Dimmen-Status
+  room: Badezimmer Eltern
+3/3/21:
+  dpt: '1.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Flur.Downlight.Galerie.Ein/Aus
+  room: Flur
+3/3/210:
+  dpt: '1.003'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Eltern.Indirekt.Schrank.Sperren
+  room: Badezimmer Eltern
+3/3/211:
+  dpt: '1.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Eltern.Indirekt.Schrank.Ein/Aus
+  room: Badezimmer Eltern
+3/3/212:
+  dpt: '1.011'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Eltern.Indirekt.Schrank.Ein/Aus-Status
+  room: Badezimmer Eltern
+3/3/213:
+  dpt: '3.007'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Eltern.Indirekt.Schrank.Dimmen-Relativ
+  room: Badezimmer Eltern
+3/3/214:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Eltern.Indirekt.Schrank.Dimmen-Absolut
+  room: Badezimmer Eltern
+3/3/215:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Eltern.Indirekt.Schrank.Dimmen-Status
+  room: Badezimmer Eltern
+3/3/22:
+  dpt: '1.011'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Flur.Downlight.Galerie.Ein/Aus-Status
+  room: Flur
+3/3/220:
+  dpt: '1.003'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Eltern.RGB.Sperren
+  room: Badezimmer Eltern
+3/3/221:
+  dpt: '1.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Eltern.RGB.Ein/Aus
+  room: Badezimmer Eltern
+3/3/222:
+  dpt: '1.011'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Eltern.RGB.Ein/Aus-Status
+  room: Badezimmer Eltern
+3/3/223:
+  dpt: '3.007'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Eltern.RGB.Dimmen-Relativ
+  room: Badezimmer Eltern
+3/3/224:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Eltern.RGB.Dimmen-Absolut
+  room: Badezimmer Eltern
+3/3/225:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Eltern.RGB.Dimmen-Status
+  room: Badezimmer Eltern
+3/3/226:
+  dpt: '232.600'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Eltern.RGB.Farbsteuerung
+  room: Badezimmer Eltern
+3/3/227:
+  dpt: '232.600'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Eltern.RGB.Farbsteuerung-Status
+  room: Badezimmer Eltern
+3/3/23:
+  dpt: '3.007'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Flur.Downlight.Galerie.Dimmen-Relativ
+  room: Flur
+3/3/230:
+  dpt: '1.003'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Eltern.Spiegel.Sperren
+  room: Badezimmer Eltern
+3/3/231:
+  dpt: '1.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Eltern.Spiegel.Ein/Aus
+  room: Badezimmer Eltern
+3/3/232:
+  dpt: '1.011'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Eltern.Spiegel.Ein/Aus-Status
+  room: Badezimmer Eltern
+3/3/233:
+  dpt: '3.007'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Eltern.Spiegel.Dimmen-Relativ
+  room: Badezimmer Eltern
+3/3/234:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Eltern.Spiegel.Dimmen-Absolut
+  room: Badezimmer Eltern
+3/3/235:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Eltern.Spiegel.Dimmen-Status
+  room: Badezimmer Eltern
+3/3/236:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Eltern.Spiegel.Farbwert
+  room: Badezimmer Eltern
+3/3/237:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Eltern.Spiegel.Farbwert-Status
+  room: Badezimmer Eltern
+3/3/238:
+  dpt: '7.600'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Eltern.Spiegel.Farbtemparatur
+  room: Badezimmer Eltern
+3/3/239:
+  dpt: '7.600'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Eltern.Spiegel.Farbtemparatur-Status
+  room: Badezimmer Eltern
+3/3/24:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Flur.Downlight.Galerie.Dimmen-Absolut
+  room: Flur
+3/3/240:
+  dpt: '1.003'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Eltern.Schminkspiegel.Sperren
+  room: Badezimmer Eltern
+3/3/241:
+  dpt: '1.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Eltern.Schminkspiegel.Ein/Aus
+  room: Badezimmer Eltern
+3/3/242:
+  dpt: '1.011'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Eltern.Schminkspiegel.Ein/Aus-Status
+  room: Badezimmer Eltern
+3/3/243:
+  dpt: '3.007'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Eltern.Schminkspiegel.Dimmen-Relativ
+  room: Badezimmer Eltern
+3/3/244:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Eltern.Schminkspiegel.Dimmen-Absolut
+  room: Badezimmer Eltern
+3/3/245:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Eltern.Schminkspiegel.Dimmen-Status
+  room: Badezimmer Eltern
+3/3/246:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Eltern.Schminkspiegel.Farbwert
+  room: Badezimmer Eltern
+3/3/247:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Eltern.Schminkspiegel.Farbwert-Status
+  room: Badezimmer Eltern
+3/3/248:
+  dpt: '7.600'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Eltern.Schminkspiegel.Farbtemperatur
+  room: Badezimmer Eltern
+3/3/249:
+  dpt: '7.600'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Eltern.Schminkspiegel.Farbtemperatur-Status
+  room: Badezimmer Eltern
+3/3/25:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Flur.Downlight.Galerie.Dimmen-Status
+  room: Flur
+3/3/3:
+  dpt: '3.007'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Flur.Pendelleuchte.Dimmen-Relativ
+  room: Flur
+3/3/30:
+  dpt: '1.003'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Flur.Downlight.Gang.Sperren
+  room: Flur
+3/3/31:
+  dpt: '1.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Flur.Downlight.Gang.Ein/Aus
+  room: Flur
+3/3/32:
+  dpt: '1.011'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Flur.Downlight.Gang.Ein/Aus-Status
+  room: Flur
+3/3/33:
+  dpt: '3.007'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Flur.Downlight.Gang.Dimmen-Relativ
+  room: Flur
+3/3/34:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Flur.Downlight.Gang.Dimmen-Absolut
+  room: Flur
+3/3/35:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Flur.Downlight.Gang.Dimmen-Status
+  room: Flur
+3/3/4:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Flur.Pendelleuchte.Dimmen-Absolut
+  room: Flur
+3/3/40:
+  dpt: '1.003'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Flur.Bodenleuchte.Sperren
+  room: Flur
+3/3/41:
+  dpt: '1.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Flur.Bodenleuchte.Ein/Aus
+  room: Flur
+3/3/42:
+  dpt: '1.011'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Flur.Bodenleuchte.Ein/Aus-Status
+  room: Flur
+3/3/43:
+  dpt: '3.007'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Flur.Bodenleuchte.Dimmen-Relativ
+  room: Flur
+3/3/44:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Flur.Bodenleuchte.Dimmen-Absolut
+  room: Flur
+3/3/45:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Flur.Bodenleuchte.Dimmen-Status
+  room: Flur
+3/3/5:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Flur.Pendelleuchte.Dimmen-Status
+  room: Flur
+3/3/50:
+  dpt: '1.003'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Abstellraum.Downlight.Sperren
+  room: Abstellraum
+3/3/51:
+  dpt: '1.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Abstellraum.Downlight.Ein/Aus
+  room: Abstellraum
+3/3/52:
+  dpt: '1.011'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Abstellraum.Downlight.Ein/Aus-Status
+  room: Abstellraum
+3/3/53:
+  dpt: '3.007'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Abstellraum.Downlight.Dimmen-Relativ
+  room: Abstellraum
+3/3/54:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Abstellraum.Downlight.Dimmen-Absolut
+  room: Abstellraum
+3/3/55:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Abstellraum.Downlight.Dimmen-Status
+  room: Abstellraum
+3/3/60:
+  dpt: '1.003'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Kinder.Downlight.WC.Sperren
+  room: Badezimmer Kinder
+3/3/61:
+  dpt: '1.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Kinder.Downlight.WC.Ein/Aus
+  room: Badezimmer Kinder
+3/3/62:
+  dpt: '1.011'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Kinder.Downlight.WC.Ein/Aus-Status
+  room: Badezimmer Kinder
+3/3/63:
+  dpt: '3.007'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Kinder.Downlight.WC.Dimmen-Relativ
+  room: Badezimmer Kinder
+3/3/64:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Kinder.Downlight.WC.Dimmen-Absolut
+  room: Badezimmer Kinder
+3/3/65:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Kinder.Downlight.WC.Dimmen-Status
+  room: Badezimmer Kinder
+3/3/70:
+  dpt: '1.003'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Kinder.Downlight.Becken.Sperren
+  room: Badezimmer Kinder
+3/3/71:
+  dpt: '1.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Kinder.Downlight.Becken.Ein/Aus
+  room: Badezimmer Kinder
+3/3/72:
+  dpt: '1.011'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Kinder.Downlight.Becken.Ein/Aus-Status
+  room: Badezimmer Kinder
+3/3/73:
+  dpt: '3.007'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Kinder.Downlight.Becken.Dimmen-Relativ
+  room: Badezimmer Kinder
+3/3/74:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Kinder.Downlight.Becken.Dimmen-Absolut
+  room: Badezimmer Kinder
+3/3/75:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Kinder.Downlight.Becken.Dimmen-Status
+  room: Badezimmer Kinder
+3/3/80:
+  dpt: '1.003'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Kinder.Indirekt.Sperren
+  room: Badezimmer Kinder
+3/3/81:
+  dpt: '1.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Kinder.Indirekt.Ein/Aus
+  room: Badezimmer Kinder
+3/3/82:
+  dpt: '1.011'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Kinder.Indirekt.Ein/Aus-Status
+  room: Badezimmer Kinder
+3/3/83:
+  dpt: '3.007'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Kinder.Indirekt.Dimmen-Relativ
+  room: Badezimmer Kinder
+3/3/84:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Kinder.Indirekt.Dimmen-Absolut
+  room: Badezimmer Kinder
+3/3/85:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Kinder.Indirekt.Dimmen-Status
+  room: Badezimmer Kinder
+3/3/90:
+  dpt: '1.003'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Kinder.Spiegel.Sperren
+  room: Badezimmer Kinder
+3/3/91:
+  dpt: '1.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Kinder.Spiegel.Ein/Aus
+  room: Badezimmer Kinder
+3/3/92:
+  dpt: '1.011'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Kinder.Spiegel.Ein/Aus-Status
+  room: Badezimmer Kinder
+3/3/93:
+  dpt: '3.007'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Kinder.Spiegel.Dimmen-Relativ
+  room: Badezimmer Kinder
+3/3/94:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Kinder.Spiegel.Dimmen-Absolut
+  room: Badezimmer Kinder
+3/3/95:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Kinder.Spiegel.Dimmen-Status
+  room: Badezimmer Kinder
+3/3/96:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Kinder.Spiegel.Farbwert
+  room: Badezimmer Kinder
+3/3/97:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Kinder.Spiegel.Farbwert-Status
+  room: Badezimmer Kinder
+3/3/98:
+  dpt: '7.600'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Kinder.Spiegel.Farbtemperatur
+  room: Badezimmer Kinder
+3/3/99:
+  dpt: '7.600'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Badezimmer-Kinder.Spiegel.Farbtemperatur-Status
+  room: Badezimmer Kinder
+3/4/0:
+  dpt: '1.003'
+  function: Beleuchtung
+  name: Beleuchtung.DG.Speicher.Deckenleuchte.Sperren
+  room: Speicher (S)
+3/4/1:
+  dpt: '1.001'
+  function: Beleuchtung
+  name: Beleuchtung.DG.Speicher.Deckenleuchte.Ein/Aus
+  room: Speicher (S)
+3/4/2:
+  dpt: '1.011'
+  function: Beleuchtung
+  name: Beleuchtung.DG.Speicher.Deckenleuchte.Ein/Aus-Status
+  room: Speicher (S)
+3/4/3:
+  dpt: '3.007'
+  function: Beleuchtung
+  name: Beleuchtung.DG.Speicher.Deckenleuchte.Dimmen-Relativ
+  room: Speicher (S)
+3/4/4:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.DG.Speicher.Deckenleuchte.Dimmen-Absolut
+  room: Speicher (S)
+3/4/5:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.DG.Speicher.Deckenleuchte.Dimmen-Status
+  room: Speicher (S)
+3/5/0:
+  dpt: '1.003'
+  function: Beleuchtung
+  name: Beleuchtung.A.Fassade.Front.Sperren
+  room: Fassade
+3/5/1:
+  dpt: '1.001'
+  function: Beleuchtung
+  name: Beleuchtung.A.Fassade.Front.Ein/Aus
+  room: Fassade
+3/5/10:
+  dpt: '1.003'
+  function: Beleuchtung
+  name: Beleuchtung.A.Eingang.Briefkasten.Sperren
+  room: Eingang
+3/5/11:
+  dpt: '1.001'
+  function: Beleuchtung
+  name: Beleuchtung.A.Eingang.Briefkasten.Ein/Aus
+  room: Eingang
+3/5/12:
+  dpt: '1.011'
+  function: Beleuchtung
+  name: Beleuchtung.A.Eingang.Briefkasten.Ein/Aus-Status
+  room: Eingang
+3/5/13:
+  dpt: '3.007'
+  function: Beleuchtung
+  name: Beleuchtung.A.Eingang.Briefkasten.Dimmen-Relativ
+  room: Eingang
+3/5/14:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.A.Eingang.Briefkasten.Dimmen-Absolut
+  room: Eingang
+3/5/15:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.A.Eingang.Briefkasten.Dimmen-Status
+  room: Eingang
+3/5/2:
+  dpt: '1.011'
+  function: Beleuchtung
+  name: Beleuchtung.A.Fassade.Front.Ein/Aus-Status
+  room: Fassade
+3/5/3:
+  dpt: '3.007'
+  function: Beleuchtung
+  name: Beleuchtung.A.Fassade.Front.Dimmen-Relativ
+  room: Fassade
+3/5/30:
+  dpt: '1.003'
+  function: Beleuchtung
+  name: Beleuchtung.A.Terrasse.Spots.Sperren
+  room: Terrasse
+3/5/31:
+  dpt: '1.001'
+  function: Beleuchtung
+  name: Beleuchtung.A.Terrasse.Spots.Ein/Aus
+  room: Terrasse
+3/5/32:
+  dpt: '1.011'
+  function: Beleuchtung
+  name: Beleuchtung.A.Terrasse.Spots.Ein/Aus-Status
+  room: Terrasse
+3/5/33:
+  dpt: '3.007'
+  function: Beleuchtung
+  name: Beleuchtung.A.Terrasse.Spots.Dimmen-Relativ
+  room: Terrasse
+3/5/34:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.A.Terrasse.Spots.Dimmen-Absolut
+  room: Terrasse
+3/5/35:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.A.Terrasse.Spots.Dimmen-Status
+  room: Terrasse
+3/5/4:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.A.Fassade.Front.Dimmen-Absolut
+  room: Fassade
+3/5/40:
+  dpt: '1.003'
+  function: Beleuchtung
+  name: Beleuchtung.A.Terrasse.Stripe.Sperren
+  room: Terrasse
+3/5/41:
+  dpt: '1.001'
+  function: Beleuchtung
+  name: Beleuchtung.A.Terrasse.Stripe.Ein/Aus
+  room: Terrasse
+3/5/42:
+  dpt: '1.011'
+  function: Beleuchtung
+  name: Beleuchtung.A.Terrasse.Stripe.Ein/Aus-Status
+  room: Terrasse
+3/5/43:
+  dpt: '3.007'
+  function: Beleuchtung
+  name: Beleuchtung.A.Terrasse.Stripe.Dimmen-Relativ
+  room: Terrasse
+3/5/44:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.A.Terrasse.Stripe.Dimmen-Absolut
+  room: Terrasse
+3/5/45:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.A.Terrasse.Stripe.Dimmen-Status
+  room: Terrasse
+3/5/5:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.A.Fassade.Front.Dimmen-Status
+  room: Fassade
+3/5/50:
+  dpt: '1.003'
+  function: Beleuchtung
+  name: Beleuchtung.A.Balkon.Spots.Sperren
+  room: Balkon
+3/5/51:
+  dpt: '1.001'
+  function: Beleuchtung
+  name: Beleuchtung.A.Balkon.Spots.Ein/Aus
+  room: Balkon
+3/5/52:
+  dpt: '1.011'
+  function: Beleuchtung
+  name: Beleuchtung.A.Balkon.Spots.Ein/Aus-Status
+  room: Balkon
+3/5/53:
+  dpt: '3.007'
+  function: Beleuchtung
+  name: Beleuchtung.A.Balkon.Spots.Dimmen-Relativ
+  room: Balkon
+3/5/54:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.A.Balkon.Spots.Dimmen-Absolut
+  room: Balkon
+3/5/55:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.A.Balkon.Spots.Dimmen-Status
+  room: Balkon
+3/5/60:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.A.Garten.Hochbeet.Poller.Sperren
   room: Garten
-5/5/1:
+3/5/61:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.A.Garten.Hochbeet.Poller.Ein/Aus
   room: Garten
-5/5/2:
+3/5/62:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.A.Garten.Hochbeet.Poller.Ein/Aus-Status
   room: Garten
-5/5/3:
+3/5/63:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.A.Garten.Hochbeet.Poller.Dimmen-Relativ
   room: Garten
-5/5/4:
+3/5/64:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.A.Garten.Hochbeet.Poller.Dimmen-Absolut
   room: Garten
-5/5/5:
+3/5/65:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.A.Garten.Hochbeet.Poller.Dimmen-Status
   room: Garten
-6/0/120:
+4/3/60:
+  dpt: '1.003'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Schlafzimmer-Gregory.Stripe.Sperren
+  room: Schlafzimmer Gregory
+4/3/61:
+  dpt: '1.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Schlafzimmer-Gregory.Stripe.Ein/Aus
+  room: Schlafzimmer Gregory
+4/3/62:
+  dpt: '1.011'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Schlafzimmer-Gregory.Stripe.Ein/Aus-Status
+  room: Schlafzimmer Gregory
+4/3/63:
+  dpt: '3.007'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Schlafzimmer-Gregory.Stripe.Dimmen-Relativ
+  room: Schlafzimmer Gregory
+4/3/64:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Schlafzimmer-Gregory.Stripe.Dimmen-Absolut
+  room: Schlafzimmer Gregory
+4/3/65:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Schlafzimmer-Gregory.Stripe.Dimmen-Status
+  room: Schlafzimmer Gregory
+4/3/66:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Schlafzimmer-Gregory.Stripe.Farbwert
+  room: Schlafzimmer Gregory
+4/3/67:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Schlafzimmer-Gregory.Stripe.Farbwert-Status
+  room: Schlafzimmer Gregory
+4/3/68:
+  dpt: '7.600'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Schlafzimmer-Gregory.Stripe.Farbtemparatur
+  room: Schlafzimmer Gregory
+4/3/69:
+  dpt: '7.600'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Schlafzimmer-Gregory.Stripe.Farbtemparatur-Status
+  room: Schlafzimmer Gregory
+4/3/70:
+  dpt: '232.600'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Schlafzimmer-Gregory.Stripe.Farbsteuerung
+  room: Schlafzimmer Gregory
+4/3/71:
+  dpt: '232.600'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Schlafzimmer-Gregory.Stripe.Farbsteuerung-Status
+  room: Schlafzimmer Gregory
+4/3/80:
+  dpt: '1.003'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Schlafzimmer-Luis.Stripe.Sperren
+  room: Schlafzimmer Luis
+4/3/81:
+  dpt: '1.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Schlafzimmer-Luis.Stripe.Ein/Aus
+  room: Schlafzimmer Luis
+4/3/82:
+  dpt: '1.011'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Schlafzimmer-Luis.Stripe.Ein/Aus-Status
+  room: Schlafzimmer Luis
+4/3/83:
+  dpt: '3.007'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Schlafzimmer-Luis.Stripe.Dimmen-Relativ
+  room: Schlafzimmer Luis
+4/3/84:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Schlafzimmer-Luis.Stripe.Dimmen-Absolut
+  room: Schlafzimmer Luis
+4/3/85:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Schlafzimmer-Luis.Stripe.Dimmen-Status
+  room: Schlafzimmer Luis
+4/3/86:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Schlafzimmer-Luis.Stripe.Farbwert
+  room: Schlafzimmer Luis
+4/3/87:
+  dpt: '5.001'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Schlafzimmer-Luis.Stripe.Farbwert-Status
+  room: Schlafzimmer Luis
+4/3/88:
+  dpt: '7.600'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Schlafzimmer-Luis.Stripe.Farbtemparatur
+  room: Schlafzimmer Luis
+4/3/89:
+  dpt: '7.600'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Schlafzimmer-Luis.Stripe.Farbtemparatur-Status
+  room: Schlafzimmer Luis
+4/3/90:
+  dpt: '232.600'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Schlafzimmer-Luis.Stripe.Farbsteuerung
+  room: Schlafzimmer Luis
+4/3/91:
+  dpt: '232.600'
+  function: Beleuchtung
+  name: Beleuchtung.OG.Schlafzimmer-Luis.Stripe.Farbsteuerung-Status
+  room: Schlafzimmer Luis
+5/0/120:
   dpt: '1.008'
   function: Beschattung
   name: Beschattung.Zentral.EG.Raffstore.Innen.Fahren
-6/0/121:
+5/0/121:
   dpt: '1.007'
   function: Beschattung
   name: Beschattung.Zentral.EG.Raffstore.Innen.Stoppen
-6/0/122:
+5/0/122:
   dpt: '1.008'
   function: Beschattung
   name: Beschattung.Zentral.EG.Raffstore.Außen.Fahren
-6/0/123:
+5/0/123:
   dpt: '1.007'
   function: Beschattung
   name: Beschattung.Zentral.EG.Raffstore.Außen.Stoppen
-6/0/140:
+5/0/140:
   dpt: '1.008'
   function: Beschattung
   name: Beschattung.Zentral.OG.Raffstore.Innen.Fahren
-6/0/141:
+5/0/141:
   dpt: '1.007'
   function: Beschattung
   name: Beschattung.Zentral.OG.Raffstore.Innen.Stoppen
-6/0/142:
+5/0/142:
   dpt: '1.008'
   function: Beschattung
   name: Beschattung.Zentral.OG.Raffstore.Außen.Fahren
-6/0/143:
+5/0/143:
   dpt: '1.007'
   function: Beschattung
   name: Beschattung.Zentral.OG.Raffstore.Außen.Stoppen
-6/0/144:
+5/0/144:
   dpt: '1.008'
   function: Beschattung
   name: Beschattung.Zentral.OG.Vorhang.Fahren
-6/0/145:
+5/0/145:
   dpt: '1.017'
   function: Beschattung
   name: Beschattung.Zentral.OG.Vorhang.Stoppen
-6/0/200:
+5/0/200:
   dpt: '1.001'
   function: Beschattung
   name: Beschattung.Zentral.Raffstore.Außen-1.Automatik.Sperren
-6/0/201:
+5/0/201:
   dpt: '1.008'
   function: Beschattung
   name: Beschattung.Zentral.Raffstore.Außen-1.Automatik.Fahren
-6/0/202:
+5/0/202:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.Zentral.Raffstore.Außen-1.Automatik.Position
-6/0/203:
+5/0/203:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.Zentral.Raffstore.Außen-1.Automatik.Rotation
-6/0/204:
+5/0/204:
   dpt: '9.004'
   function: Beschattung
   name: Beschattung.Zentral.Raffstore.Außen-1.Automatik.Helligkeitsschwelle
-6/0/205:
+5/0/205:
   dpt: '9.004'
   function: Beschattung
   name: Beschattung.Zentral.Raffstore.Außen-1.Automatik.Dämmerungsschwelle
-6/0/210:
+5/0/210:
   dpt: '1.001'
   function: Beschattung
   name: Beschattung.Zentral.Raffstore.Außen-2.Automatik.Sperren
-6/0/211:
+5/0/211:
   dpt: '1.008'
   function: Beschattung
   name: Beschattung.Zentral.Raffstore.Außen-2.Automatik.Fahren
-6/0/212:
+5/0/212:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.Zentral.Raffstore.Außen-2.Automatik.Position
-6/0/213:
+5/0/213:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.Zentral.Raffstore.Außen-2.Automatik.Rotation
-6/0/214:
+5/0/214:
   dpt: '9.004'
   function: Beschattung
   name: Beschattung.Zentral.Raffstore.Außen-2.Automatik.Helligkeitsschwelle
-6/0/215:
+5/0/215:
   dpt: '9.004'
   function: Beschattung
   name: Beschattung.Zentral.Raffstore.Außen-2.Automatik.Dämmerungsschwelle
-6/0/220:
+5/0/220:
   dpt: '1.001'
   function: Beschattung
   name: Beschattung.Zentral.Raffstore.Innen.Automatik.Sperren
-6/0/221:
+5/0/221:
   dpt: '1.008'
   function: Beschattung
   name: Beschattung.Zentral.Raffstore.Innen.Automatik.Fahren
-6/0/222:
+5/0/222:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.Zentral.Raffstore.Innen.Automatik.Position
-6/0/223:
+5/0/223:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.Zentral.Raffstore.Innen.Automatik.Rotation
-6/0/224:
+5/0/224:
   dpt: '9.004'
   function: Beschattung
   name: Beschattung.Zentral.Raffstore.Innen.Automatik.Helligkeitsschwelle
-6/0/225:
+5/0/225:
   dpt: '9.004'
   function: Beschattung
   name: Beschattung.Zentral.Raffstore.Innen.Automatik.Dämmerungsschwelle
-6/2/0:
+5/2/0:
   dpt: '1.003'
   function: Beschattung
   name: Beschattung.EG.Büro.Raffstore.Sperren
   room: Büro
-6/2/1:
+5/2/1:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.EG.Büro.Raffstore.Sperren-Status
   room: Büro
-6/2/10:
+5/2/10:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.EG.Büro.Raffstore.Geschlossen-Status
   room: Büro
-6/2/100:
+5/2/100:
   dpt: '1.003'
   function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Rechts.Sperren
   room: Küche
-6/2/101:
+5/2/101:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Rechts.Sperren-Status
   room: Küche
-6/2/102:
+5/2/102:
   dpt: '1.008'
   function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Rechts.Fahren
   room: Küche
-6/2/103:
+5/2/103:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Rechts.Fahren-Status
   room: Küche
-6/2/104:
+5/2/104:
   dpt: '1.007'
   function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Rechts.Stoppen
   room: Küche
-6/2/105:
+5/2/105:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Rechts.Position
   room: Küche
-6/2/106:
+5/2/106:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Rechts.Position-Status
   room: Küche
-6/2/107:
+5/2/107:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Rechts.Rotation
   room: Küche
-6/2/108:
+5/2/108:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Rechts.Rotation-Status
   room: Küche
-6/2/109:
+5/2/109:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Rechts.Geöffnet-Status
   room: Küche
-6/2/11:
+5/2/11:
   dpt: '1.010'
   function: Beschattung
   name: Beschattung.EG.Büro.Raffstore.Fahrzeit
   room: Büro
-6/2/110:
+5/2/110:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Rechts.Geschlossen-Status
   room: Küche
-6/2/111:
+5/2/111:
   dpt: '1.010'
   function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Rechts.Fahrzeit
   room: Küche
-6/2/2:
+5/2/2:
   dpt: '1.008'
   function: Beschattung
   name: Beschattung.EG.Büro.Raffstore.Fahren
   room: Büro
-6/2/20:
+5/2/20:
   dpt: '1.003'
   function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Links.Sperren
   room: Wohnzimmer
-6/2/21:
+5/2/21:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Links.Sperren-Status
   room: Wohnzimmer
-6/2/22:
+5/2/22:
   dpt: '1.008'
   function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Links.Fahren
   room: Wohnzimmer
-6/2/23:
+5/2/23:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Links.Fahren-Status
   room: Wohnzimmer
-6/2/24:
+5/2/24:
   dpt: '1.007'
   function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Links.Stoppen
   room: Wohnzimmer
-6/2/25:
+5/2/25:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Links.Position
   room: Wohnzimmer
-6/2/26:
+5/2/26:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Links.Position-Status
   room: Wohnzimmer
-6/2/27:
+5/2/27:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Links.Rotation
   room: Wohnzimmer
-6/2/28:
+5/2/28:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Links.Rotation-Status
   room: Wohnzimmer
-6/2/29:
+5/2/29:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Links.Geöffnet-Status
   room: Wohnzimmer
-6/2/3:
+5/2/3:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.EG.Büro.Raffstore.Fahren-Status
   room: Büro
-6/2/30:
+5/2/30:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Links.Geschlossen-Status
   room: Wohnzimmer
-6/2/31:
+5/2/31:
   dpt: '1.010'
   function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Links.Fahrzeit
   room: Wohnzimmer
-6/2/4:
+5/2/4:
   dpt: '1.007'
   function: Beschattung
   name: Beschattung.EG.Büro.Raffstore.Stoppen
   room: Büro
-6/2/40:
+5/2/40:
   dpt: '1.003'
   function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Rechts.Sperren
   room: Wohnzimmer
-6/2/41:
+5/2/41:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Rechts.Sperren-Status
   room: Wohnzimmer
-6/2/42:
+5/2/42:
   dpt: '1.008'
   function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Rechts.Fahren
   room: Wohnzimmer
-6/2/43:
+5/2/43:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Rechts.Fahren-Status
   room: Wohnzimmer
-6/2/44:
+5/2/44:
   dpt: '1.007'
   function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Rechts.Stoppen
   room: Wohnzimmer
-6/2/45:
+5/2/45:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Rechts.Position
   room: Wohnzimmer
-6/2/46:
+5/2/46:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Rechts.Position-Status
   room: Wohnzimmer
-6/2/47:
+5/2/47:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Rechts.Rotation
   room: Wohnzimmer
-6/2/48:
+5/2/48:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Rechts.Rotation-Status
   room: Wohnzimmer
-6/2/49:
+5/2/49:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Rechts.Geöffnet-Status
   room: Wohnzimmer
-6/2/5:
+5/2/5:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.EG.Büro.Raffstore.Position
   room: Büro
-6/2/50:
+5/2/50:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Rechts.Geschlossen-Status
   room: Wohnzimmer
-6/2/51:
+5/2/51:
   dpt: '1.010'
   function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Rechts.Fahrzeit
   room: Wohnzimmer
-6/2/6:
+5/2/6:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.EG.Büro.Raffstore.Position-Status
   room: Büro
-6/2/60:
+5/2/60:
   dpt: '1.003'
   function: Beschattung
   name: Beschattung.EG.Esszimmer.Raffstore.Sperren
   room: Esszimmer
-6/2/61:
+5/2/61:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.EG.Esszimmer.Raffstore.Sperren-Status
   room: Esszimmer
-6/2/62:
+5/2/62:
   dpt: '1.008'
   function: Beschattung
   name: Beschattung.EG.Esszimmer.Raffstore.Fahren
   room: Esszimmer
-6/2/63:
+5/2/63:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.EG.Esszimmer.Raffstore.Fahren-Status
   room: Esszimmer
-6/2/64:
+5/2/64:
   dpt: '1.007'
   function: Beschattung
   name: Beschattung.EG.Esszimmer.Raffstore.Stoppen
   room: Esszimmer
-6/2/65:
+5/2/65:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.EG.Esszimmer.Raffstore.Position
   room: Esszimmer
-6/2/66:
+5/2/66:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.EG.Esszimmer.Raffstore.Position-Status
   room: Esszimmer
-6/2/67:
+5/2/67:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.EG.Esszimmer.Raffstore.Rotation
   room: Esszimmer
-6/2/68:
+5/2/68:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.EG.Esszimmer.Raffstore.Rotation-Status
   room: Esszimmer
-6/2/69:
+5/2/69:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.EG.Esszimmer.Raffstore.Geöffnet-Status
   room: Esszimmer
-6/2/7:
+5/2/7:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.EG.Büro.Raffstore.Rotation
   room: Büro
-6/2/70:
+5/2/70:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.EG.Esszimmer.Raffstore.Geschlossen-Status
   room: Esszimmer
-6/2/71:
+5/2/71:
   dpt: '1.010'
   function: Beschattung
   name: Beschattung.EG.Esszimmer.Raffstore.Fahrzeit
   room: Esszimmer
-6/2/8:
+5/2/8:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.EG.Büro.Raffstore.Rotation-Status
   room: Büro
-6/2/80:
+5/2/80:
   dpt: '1.003'
   function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Links.Sperren
   room: Küche
-6/2/81:
+5/2/81:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Links.Sperren-Status
   room: Küche
-6/2/82:
+5/2/82:
   dpt: '1.008'
   function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Links.Fahren
   room: Küche
-6/2/83:
+5/2/83:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Links.Fahren-Status
   room: Küche
-6/2/84:
+5/2/84:
   dpt: '1.007'
   function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Links.Stoppen
   room: Küche
-6/2/85:
+5/2/85:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Links.Position
   room: Küche
-6/2/86:
+5/2/86:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Links.Position-Status
   room: Küche
-6/2/87:
+5/2/87:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Links.Rotation
   room: Küche
-6/2/88:
+5/2/88:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Links.Rotation-Status
   room: Küche
-6/2/89:
+5/2/89:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Links.Geöffnet-Status
   room: Küche
-6/2/9:
+5/2/9:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.EG.Büro.Raffstore.Geöffnet-Status
   room: Büro
-6/2/90:
+5/2/90:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Links.Geschlossen-Status
   room: Küche
-6/2/91:
+5/2/91:
   dpt: '1.010'
   function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Links.Fahrzeit
   room: Küche
-6/3/0:
+5/3/0:
   dpt: '1.003'
   function: Beschattung
   name: Beschattung.OG.Flur.Raffstore.Sperren
   room: Flur
-6/3/1:
+5/3/1:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Flur.Raffstore.Sperren-Status
   room: Flur
-6/3/10:
+5/3/10:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Flur.Raffstore.Geschlossen-Status
   room: Flur
-6/3/100:
+5/3/100:
   dpt: '1.003'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Raffstore.Sperren
-  room: Schlafzimmer-Luis
-6/3/101:
+  room: Schlafzimmer Luis
+5/3/101:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Raffstore.Sperren-Status
-  room: Schlafzimmer-Luis
-6/3/102:
+  room: Schlafzimmer Luis
+5/3/102:
   dpt: '1.008'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Raffstore.Fahren
-  room: Schlafzimmer-Luis
-6/3/103:
+  room: Schlafzimmer Luis
+5/3/103:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Raffstore.Fahren-Status
-  room: Schlafzimmer-Luis
-6/3/104:
+  room: Schlafzimmer Luis
+5/3/104:
   dpt: '1.007'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Raffstore.Stoppen
-  room: Schlafzimmer-Luis
-6/3/105:
+  room: Schlafzimmer Luis
+5/3/105:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Raffstore.Postion
-  room: Schlafzimmer-Luis
-6/3/106:
+  room: Schlafzimmer Luis
+5/3/106:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Raffstore.Position-Status
-  room: Schlafzimmer-Luis
-6/3/107:
+  room: Schlafzimmer Luis
+5/3/107:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Raffstore.Rotation
-  room: Schlafzimmer-Luis
-6/3/108:
+  room: Schlafzimmer Luis
+5/3/108:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Raffstore.Rotation-Status
-  room: Schlafzimmer-Luis
-6/3/109:
+  room: Schlafzimmer Luis
+5/3/109:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Raffstore.Geöffnet-Status
-  room: Schlafzimmer-Luis
-6/3/11:
+  room: Schlafzimmer Luis
+5/3/11:
   dpt: '1.010'
   function: Beschattung
   name: Beschattung.OG.Flur.Raffstore.Fahrzeit
   room: Flur
-6/3/110:
+5/3/110:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Raffstore.Geschlossen-Status
-  room: Schlafzimmer-Luis
-6/3/111:
+  room: Schlafzimmer Luis
+5/3/111:
   dpt: '1.010'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Raffstore.Fahrzeit
-  room: Schlafzimmer-Luis
-6/3/120:
+  room: Schlafzimmer Luis
+5/3/120:
   dpt: '1.003'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Vorhang.Sperren
-  room: Schlafzimmer-Luis
-6/3/121:
+  room: Schlafzimmer Luis
+5/3/121:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Vorhang.Sperren-Status
-  room: Schlafzimmer-Luis
-6/3/122:
+  room: Schlafzimmer Luis
+5/3/122:
   dpt: '1.008'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Vorhang.Fahren
-  room: Schlafzimmer-Luis
-6/3/123:
+  room: Schlafzimmer Luis
+5/3/123:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Vorhang.Fahren-Status
-  room: Schlafzimmer-Luis
-6/3/124:
+  room: Schlafzimmer Luis
+5/3/124:
   dpt: '1.017'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Vorhang.Stoppen
-  room: Schlafzimmer-Luis
-6/3/125:
+  room: Schlafzimmer Luis
+5/3/125:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Vorhang.Position
-  room: Schlafzimmer-Luis
-6/3/126:
+  room: Schlafzimmer Luis
+5/3/126:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Vorhang.Position-Status
-  room: Schlafzimmer-Luis
-6/3/129:
+  room: Schlafzimmer Luis
+5/3/129:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Vorhang.Geöffnet-Status
-  room: Schlafzimmer-Luis
-6/3/130:
+  room: Schlafzimmer Luis
+5/3/130:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Vorhang.Geschlossen-Status
-  room: Schlafzimmer-Luis
-6/3/131:
+  room: Schlafzimmer Luis
+5/3/131:
   dpt: '1.010'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Vorhang.Fahrzeit
-  room: Schlafzimmer-Luis
-6/3/140:
+  room: Schlafzimmer Luis
+5/3/140:
   dpt: '1.003'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Raffstore.Sperren
-  room: Schlafzimmer-Eltern
-6/3/141:
+  room: Schlafzimmer Eltern
+5/3/141:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Raffstore.Sperren-Status
-  room: Schlafzimmer-Eltern
-6/3/142:
+  room: Schlafzimmer Eltern
+5/3/142:
   dpt: '1.008'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Raffstore.Fahren
-  room: Schlafzimmer-Eltern
-6/3/143:
+  room: Schlafzimmer Eltern
+5/3/143:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Raffstore.Fahren-Status
-  room: Schlafzimmer-Eltern
-6/3/144:
+  room: Schlafzimmer Eltern
+5/3/144:
   dpt: '1.007'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Raffstore.Stoppen
-  room: Schlafzimmer-Eltern
-6/3/145:
+  room: Schlafzimmer Eltern
+5/3/145:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Raffstore.Position
-  room: Schlafzimmer-Eltern
-6/3/146:
+  room: Schlafzimmer Eltern
+5/3/146:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Raffstore.Position-Status
-  room: Schlafzimmer-Eltern
-6/3/147:
+  room: Schlafzimmer Eltern
+5/3/147:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Raffstore.Rotation
-  room: Schlafzimmer-Eltern
-6/3/148:
+  room: Schlafzimmer Eltern
+5/3/148:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Raffstore.Rotation-Status
-  room: Schlafzimmer-Eltern
-6/3/149:
+  room: Schlafzimmer Eltern
+5/3/149:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Raffstore.Geöffnet-Status
-  room: Schlafzimmer-Eltern
-6/3/150:
+  room: Schlafzimmer Eltern
+5/3/150:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Raffstore.Geschlossen-Status
-  room: Schlafzimmer-Eltern
-6/3/151:
+  room: Schlafzimmer Eltern
+5/3/151:
   dpt: '1.010'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Raffstore.Fahrzeit
-  room: Schlafzimmer-Eltern
-6/3/160:
+  room: Schlafzimmer Eltern
+5/3/160:
   dpt: '1.003'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Vorhang.Sperren
-  room: Schlafzimmer-Eltern
-6/3/161:
+  room: Schlafzimmer Eltern
+5/3/161:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Vorhang.Sperren-Status
-  room: Schlafzimmer-Eltern
-6/3/162:
+  room: Schlafzimmer Eltern
+5/3/162:
   dpt: '1.008'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Vorhang.Fahren
-  room: Schlafzimmer-Eltern
-6/3/163:
+  room: Schlafzimmer Eltern
+5/3/163:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Vorhang.Fahren-Status
-  room: Schlafzimmer-Eltern
-6/3/164:
+  room: Schlafzimmer Eltern
+5/3/164:
   dpt: '1.017'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Vorhang.Stoppen
-  room: Schlafzimmer-Eltern
-6/3/165:
+  room: Schlafzimmer Eltern
+5/3/165:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Vorhang.Position
-  room: Schlafzimmer-Eltern
-6/3/166:
+  room: Schlafzimmer Eltern
+5/3/166:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Vorhang.Position-Status
-  room: Schlafzimmer-Eltern
-6/3/169:
+  room: Schlafzimmer Eltern
+5/3/169:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Vorhang.Geöffnet-Status
-  room: Schlafzimmer-Eltern
-6/3/170:
+  room: Schlafzimmer Eltern
+5/3/170:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Vorhang.Geschlossen-Status
-  room: Schlafzimmer-Eltern
-6/3/171:
+  room: Schlafzimmer Eltern
+5/3/171:
   dpt: '1.010'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Vorhang.Fahrzeit
-  room: Schlafzimmer-Eltern
-6/3/180:
+  room: Schlafzimmer Eltern
+5/3/180:
   dpt: '1.003'
   function: Beschattung
   name: Beschattung.OG.Badezimmer-Eltern.Raffstore.Sperren
-  room: Badezimmer-Eltern
-6/3/181:
+  room: Badezimmer Eltern
+5/3/181:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Badezimmer-Eltern.Raffstore.Sperren-Status
-  room: Badezimmer-Eltern
-6/3/182:
+  room: Badezimmer Eltern
+5/3/182:
   dpt: '1.008'
   function: Beschattung
   name: Beschattung.OG.Badezimmer-Eltern.Raffstore.Fahren
-  room: Badezimmer-Eltern
-6/3/183:
+  room: Badezimmer Eltern
+5/3/183:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Badezimmer-Eltern.Raffstore.Fahren-Status
-  room: Badezimmer-Eltern
-6/3/184:
+  room: Badezimmer Eltern
+5/3/184:
   dpt: '1.007'
   function: Beschattung
   name: Beschattung.OG.Badezimmer-Eltern.Raffstore.Stoppen
-  room: Badezimmer-Eltern
-6/3/185:
+  room: Badezimmer Eltern
+5/3/185:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Badezimmer-Eltern.Raffstore.Position
-  room: Badezimmer-Eltern
-6/3/186:
+  room: Badezimmer Eltern
+5/3/186:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Badezimmer-Eltern.Raffstore.Position-Status
-  room: Badezimmer-Eltern
-6/3/187:
+  room: Badezimmer Eltern
+5/3/187:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Badezimmer-Eltern.Raffstore.Rotation
-  room: Badezimmer-Eltern
-6/3/188:
+  room: Badezimmer Eltern
+5/3/188:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Badezimmer-Eltern.Raffstore.Rotation-Status
-  room: Badezimmer-Eltern
-6/3/189:
+  room: Badezimmer Eltern
+5/3/189:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Badezimmer-Eltern.Raffstore.Geöffnet-Status
-  room: Badezimmer-Eltern
-6/3/190:
+  room: Badezimmer Eltern
+5/3/190:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Badezimmer-Eltern.Raffstore.Geschlossen-Status
-  room: Badezimmer-Eltern
-6/3/191:
+  room: Badezimmer Eltern
+5/3/191:
   dpt: '1.010'
   function: Beschattung
   name: Beschattung.OG.Badezimmer-Eltern.Raffstore.Fahrzeit
-  room: Badezimmer-Eltern
-6/3/2:
+  room: Badezimmer Eltern
+5/3/2:
   dpt: '1.008'
   function: Beschattung
   name: Beschattung.OG.Flur.Raffstore.Fahren
   room: Flur
-6/3/20:
+5/3/20:
   dpt: '1.003'
   function: Beschattung
   name: Beschattung.OG.Abstellraum.Raffstore.Sperren
   room: Abstellraum
-6/3/21:
+5/3/21:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Abstellraum.Raffstore.Sperren-Status
   room: Abstellraum
-6/3/22:
+5/3/22:
   dpt: '1.008'
   function: Beschattung
   name: Beschattung.OG.Abstellraum.Raffstore.Fahren
   room: Abstellraum
-6/3/23:
+5/3/23:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Abstellraum.Raffstore.Fahren-Status
   room: Abstellraum
-6/3/24:
+5/3/24:
   dpt: '1.007'
   function: Beschattung
   name: Beschattung.OG.Abstellraum.Raffstore.Stoppen
   room: Abstellraum
-6/3/25:
+5/3/25:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Abstellraum.Raffstore.Position
   room: Abstellraum
-6/3/26:
+5/3/26:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Abstellraum.Raffstore.Position-Status
   room: Abstellraum
-6/3/27:
+5/3/27:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Abstellraum.Raffstore.Rotation
   room: Abstellraum
-6/3/28:
+5/3/28:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Abstellraum.Raffstore.Rotation-Status
   room: Abstellraum
-6/3/29:
+5/3/29:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Abstellraum.Raffstore.Geöffnet-Status
   room: Abstellraum
-6/3/3:
+5/3/3:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Flur.Raffstore.Fahren-Status
   room: Flur
-6/3/30:
+5/3/30:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Abstellraum.Raffstore.Geschlossen-Status
   room: Abstellraum
-6/3/31:
+5/3/31:
   dpt: '1.010'
   function: Beschattung
   name: Beschattung.OG.Abstellraum.Raffstore.Fahrzeit
   room: Abstellraum
-6/3/4:
+5/3/4:
   dpt: '1.007'
   function: Beschattung
   name: Beschattung.OG.Flur.Raffstore.Stoppen
   room: Flur
-6/3/40:
+5/3/40:
   dpt: '1.003'
   function: Beschattung
   name: Beschattung.OG.Badezimmer-Kinder.Raffstore.Sperren
-  room: Badezimmer-Kinder
-6/3/41:
+  room: Badezimmer Kinder
+5/3/41:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Badezimmer-Kinder.Raffstore.Sperren-Status
-  room: Badezimmer-Kinder
-6/3/42:
+  room: Badezimmer Kinder
+5/3/42:
   dpt: '1.008'
   function: Beschattung
   name: Beschattung.OG.Badezimmer-Kinder.Raffstore.Fahren
-  room: Badezimmer-Kinder
-6/3/43:
+  room: Badezimmer Kinder
+5/3/43:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Badezimmer-Kinder.Raffstore.Fahren-Status
-  room: Badezimmer-Kinder
-6/3/44:
+  room: Badezimmer Kinder
+5/3/44:
   dpt: '1.007'
   function: Beschattung
   name: Beschattung.OG.Badezimmer-Kinder.Raffstore.Stoppen
-  room: Badezimmer-Kinder
-6/3/45:
+  room: Badezimmer Kinder
+5/3/45:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Badezimmer-Kinder.Raffstore.Postion
-  room: Badezimmer-Kinder
-6/3/46:
+  room: Badezimmer Kinder
+5/3/46:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Badezimmer-Kinder.Raffstore.Position-Status
-  room: Badezimmer-Kinder
-6/3/47:
+  room: Badezimmer Kinder
+5/3/47:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Badezimmer-Kinder.Raffstore.Rotation
-  room: Badezimmer-Kinder
-6/3/48:
+  room: Badezimmer Kinder
+5/3/48:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Badezimmer-Kinder.Raffstore.Rotation-Status
-  room: Badezimmer-Kinder
-6/3/49:
+  room: Badezimmer Kinder
+5/3/49:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Badezimmer-Kinder.Raffstore.Geöffnet-Status
-  room: Badezimmer-Kinder
-6/3/5:
+  room: Badezimmer Kinder
+5/3/5:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Flur.Raffstore.Position
   room: Flur
-6/3/50:
+5/3/50:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Badezimmer-Kinder.Raffstore.Geschlossen-Status
-  room: Badezimmer-Kinder
-6/3/51:
+  room: Badezimmer Kinder
+5/3/51:
   dpt: '1.010'
   function: Beschattung
   name: Beschattung.OG.Badezimmer-Kinder.Raffstore.Fahrzeit
-  room: Badezimmer-Kinder
-6/3/6:
+  room: Badezimmer Kinder
+5/3/6:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Flur.Raffstore.Position-Status
   room: Flur
-6/3/60:
+5/3/60:
   dpt: '1.003'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Raffstore.Sperren
-  room: Schlafzimmer-Gregory
-6/3/61:
+  room: Schlafzimmer Gregory
+5/3/61:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Raffstore.Sperren-Status
-  room: Schlafzimmer-Gregory
-6/3/62:
+  room: Schlafzimmer Gregory
+5/3/62:
   dpt: '1.008'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Raffstore.Fahren
-  room: Schlafzimmer-Gregory
-6/3/63:
+  room: Schlafzimmer Gregory
+5/3/63:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Raffstore.Fahren-Status
-  room: Schlafzimmer-Gregory
-6/3/64:
+  room: Schlafzimmer Gregory
+5/3/64:
   dpt: '1.007'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Raffstore.Stoppen
-  room: Schlafzimmer-Gregory
-6/3/65:
+  room: Schlafzimmer Gregory
+5/3/65:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Raffstore.Position
-  room: Schlafzimmer-Gregory
-6/3/66:
+  room: Schlafzimmer Gregory
+5/3/66:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Raffstore.Position-Status
-  room: Schlafzimmer-Gregory
-6/3/67:
+  room: Schlafzimmer Gregory
+5/3/67:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Raffstore.Rotation
-  room: Schlafzimmer-Gregory
-6/3/68:
+  room: Schlafzimmer Gregory
+5/3/68:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Raffstore.Rotation-Status
-  room: Schlafzimmer-Gregory
-6/3/69:
+  room: Schlafzimmer Gregory
+5/3/69:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Raffstore.Geöffnet-Status
-  room: Schlafzimmer-Gregory
-6/3/7:
+  room: Schlafzimmer Gregory
+5/3/7:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Flur.Raffstore.Rotation
   room: Flur
-6/3/70:
+5/3/70:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Raffstore.Geschlossen-Status
-  room: Schlafzimmer-Gregory
-6/3/71:
+  room: Schlafzimmer Gregory
+5/3/71:
   dpt: '1.010'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Raffstore.Fahrzeit
-  room: Schlafzimmer-Gregory
-6/3/8:
+  room: Schlafzimmer Gregory
+5/3/8:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Flur.Raffstore.Rotation-Status
   room: Flur
-6/3/80:
+5/3/80:
   dpt: '1.003'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Vorhang.Sperren
-  room: Schlafzimmer-Gregory
-6/3/81:
+  room: Schlafzimmer Gregory
+5/3/81:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Vorhang.Sperren-Status
-  room: Schlafzimmer-Gregory
-6/3/82:
+  room: Schlafzimmer Gregory
+5/3/82:
   dpt: '1.008'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Vorhang.Fahren
-  room: Schlafzimmer-Gregory
-6/3/83:
+  room: Schlafzimmer Gregory
+5/3/83:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Vorhang.Fahren-Status
-  room: Schlafzimmer-Gregory
-6/3/84:
+  room: Schlafzimmer Gregory
+5/3/84:
   dpt: '1.017'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Vorhang.Stoppen
-  room: Schlafzimmer-Gregory
-6/3/85:
+  room: Schlafzimmer Gregory
+5/3/85:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Vorhang.Position
-  room: Schlafzimmer-Gregory
-6/3/86:
+  room: Schlafzimmer Gregory
+5/3/86:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Vorhang.Position-Status
-  room: Schlafzimmer-Gregory
-6/3/89:
+  room: Schlafzimmer Gregory
+5/3/89:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Vorhang.Geöffnet-Status
-  room: Schlafzimmer-Gregory
-6/3/9:
+  room: Schlafzimmer Gregory
+5/3/9:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Flur.Raffstore.Geöffnet-Status
   room: Flur
-6/3/90:
+5/3/90:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Vorhang.Geschlossen-Status
-  room: Schlafzimmer-Gregory
-6/3/91:
+  room: Schlafzimmer Gregory
+5/3/91:
   dpt: '1.010'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Vorhang.Fahrzeit
-  room: Schlafzimmer-Gregory
-7/0/200:
+  room: Schlafzimmer Gregory
+6/0/200:
   dpt: '5.010'
   function: Raumklima
   name: Raumklima.Zentral.KWL.Lüftermodi
-7/0/201:
+6/0/201:
   dpt: '5.010'
   function: Raumklima
   name: Raumklima.Zentral.KWL.Lüftermodi-Status
-7/2/0:
+6/2/0:
   dpt: '1.003'
   function: Raumklima
   name: Raumklima.EG.Flur.FBH.Sperren
   room: Flur
-7/2/1:
+6/2/1:
   dpt: '5.001'
   function: Raumklima
   name: Raumklima.EG.Flur.FBH.Stellwert-Status
   room: Flur
-7/2/100:
+6/2/100:
   dpt: '1.003'
   function: Raumklima
   name: Raumklima.EG.Küche.FBH.Sperren
   room: Küche
-7/2/101:
+6/2/101:
   dpt: '5.001'
   function: Raumklima
   name: Raumklima.EG.Küche.FBH.Stellwert-Status
   room: Küche
-7/2/102:
+6/2/102:
   dpt: '9.001'
   function: Raumklima
   name: Raumklima.EG.Küche.FBH.Soll-Temperatur
   room: Küche
-7/2/103:
+6/2/103:
   dpt: '9.001'
   function: Raumklima
   name: Raumklima.EG.Küche.FBH.Soll-Temperatur-Status
   room: Küche
-7/2/104:
+6/2/104:
   dpt: '9.002'
   function: Raumklima
   name: Raumklima.EG.Küche.FBH.Sollwertverschiebung
   room: Küche
-7/2/105:
+6/2/105:
   dpt: '20.102'
   function: Raumklima
   name: Raumklima.EG.Küche.FBH.HVAC
   room: Küche
-7/2/106:
+6/2/106:
   dpt: '20.102'
   function: Raumklima
   name: Raumklima.EG.Küche.FBH.HVAC-Status
   room: Küche
-7/2/107:
+6/2/107:
   dpt: '1.011'
   function: Raumklima
   name: Raumklima.EG.Küche.FBH.Aktiv
   room: Küche
-7/2/108:
+6/2/108:
   dpt: '16.000'
   function: Raumklima
   name: Raumklima.EG.Küche.FBH.Diagnose
   room: Küche
-7/2/2:
+6/2/2:
   dpt: '9.001'
   function: Raumklima
   name: Raumklima.EG.Flur.FBH.Soll-Temperatur
   room: Flur
-7/2/20:
+6/2/20:
   dpt: '1.003'
   function: Raumklima
   name: Raumklima.EG.Gäste-WC.FBH.Sperren
-  room: Gäste-WC
-7/2/21:
+  room: Gäste WC
+6/2/21:
   dpt: '5.001'
   function: Raumklima
   name: Raumklima.EG.Gäste-WC.FBH.Stellwert-Status
-  room: Gäste-WC
-7/2/22:
+  room: Gäste WC
+6/2/22:
   dpt: '9.001'
   function: Raumklima
   name: Raumklima.EG.Gäste-WC.FBH.Soll-Temperatur
-  room: Gäste-WC
-7/2/23:
+  room: Gäste WC
+6/2/23:
   dpt: '9.001'
   function: Raumklima
   name: Raumklima.EG.Gäste-WC.FBH.Soll-Temperatur-Status
-  room: Gäste-WC
-7/2/24:
+  room: Gäste WC
+6/2/24:
   dpt: '9.002'
   function: Raumklima
   name: Raumklima.EG.Gäste-WC.FBH.Sollwertverschiebung
-  room: Gäste-WC
-7/2/25:
+  room: Gäste WC
+6/2/25:
   dpt: '20.102'
   function: Raumklima
   name: Raumklima.EG.Gäste-WC.HVAC
-  room: Gäste-WC
-7/2/26:
+  room: Gäste WC
+6/2/26:
   dpt: '20.102'
   function: Raumklima
   name: Raumklima.EG.Gäste-WC.HVAC-Status
-  room: Gäste-WC
-7/2/27:
+  room: Gäste WC
+6/2/27:
   dpt: '1.011'
   function: Raumklima
   name: Raumklima.EG.Gäste-WC.FBH.Aktiv
-  room: Gäste-WC
-7/2/28:
+  room: Gäste WC
+6/2/28:
   dpt: '16.000'
   function: Raumklima
   name: Raumklima.EG.Gäste-WC.FBH.Diagnose
-  room: Gäste-WC
-7/2/3:
+  room: Gäste WC
+6/2/3:
   dpt: '9.001'
   function: Raumklima
   name: Raumklima.EG.Flur.FBH.Soll-Temperatur-Status
   room: Flur
-7/2/4:
+6/2/4:
   dpt: '9.002'
   function: Raumklima
   name: Raumklima.EG.Flur.FBH.Sollwertverschiebung
   room: Flur
-7/2/40:
+6/2/40:
   dpt: '1.003'
   function: Raumklima
   name: Raumklima.EG.Büro.FBH.Sperren
   room: Büro
-7/2/41:
+6/2/41:
   dpt: '5.001'
   function: Raumklima
   name: Raumklima.EG.Büro.FBH.Stellwert-Status
   room: Büro
-7/2/42:
+6/2/42:
   dpt: '9.001'
   function: Raumklima
   name: Raumklima.EG.Büro.FBH.Soll-Temperatur
   room: Büro
-7/2/43:
+6/2/43:
   dpt: '9.001'
   function: Raumklima
   name: Raumklima.EG.Büro.FBH.Soll-Temperatur-Status
   room: Büro
-7/2/44:
+6/2/44:
   dpt: '9.002'
   function: Raumklima
   name: Raumklima.EG.Büro.FBH.Sollwertverschiebung
   room: Büro
-7/2/45:
+6/2/45:
   dpt: '20.102'
   function: Raumklima
   name: Raumklima.EG.Büro.FBH.HVAC
   room: Büro
-7/2/46:
+6/2/46:
   dpt: '20.102'
   function: Raumklima
   name: Raumklima.EG.Büro.FBH.HVAC-Status
   room: Büro
-7/2/47:
+6/2/47:
   dpt: '1.011'
   function: Raumklima
   name: Raumklima.EG.Büro.FBH.Aktiv
   room: Büro
-7/2/48:
+6/2/48:
   dpt: '16.000'
   function: Raumklima
   name: Raumklima.EG.Büro.FBH.Diagnose
   room: Büro
-7/2/5:
+6/2/5:
   dpt: '20.102'
   function: Raumklima
   name: Raumklima.EG.Flur.FBH.HVAC
   room: Flur
-7/2/6:
+6/2/6:
   dpt: '20.102'
   function: Raumklima
   name: Raumklima.EG.Flur.FBH.HVAC-Status
   room: Flur
-7/2/60:
+6/2/60:
   dpt: '1.003'
   function: Raumklima
   name: Raumklima.EG.Wohnzimmer.FBH.Sperren
   room: Wohnzimmer
-7/2/61:
+6/2/61:
   dpt: '5.001'
   function: Raumklima
   name: Raumklima.EG.Wohnzimmer.FBH.Stellwert-Status
   room: Wohnzimmer
-7/2/62:
+6/2/62:
   dpt: '9.001'
   function: Raumklima
   name: Raumklima.EG.Wohnzimmer.FBH.Soll-Temperatur
   room: Wohnzimmer
-7/2/63:
+6/2/63:
   dpt: '9.001'
   function: Raumklima
   name: Raumklima.EG.Wohnzimmer.FBH.Soll-Temperatur-Status
   room: Wohnzimmer
-7/2/64:
+6/2/64:
   dpt: '9.002'
   function: Raumklima
   name: Raumklima.EG.Wohnzimmer.FBH.Sollwertverschiebung
   room: Wohnzimmer
-7/2/65:
+6/2/65:
   dpt: '20.102'
   function: Raumklima
   name: Raumklima.EG.Wohnzimmer.FBH.HVAC
   room: Wohnzimmer
-7/2/66:
+6/2/66:
   dpt: '20.102'
   function: Raumklima
   name: Raumklima.EG.Wohnzimmer.FBH.HVAC-Status
   room: Wohnzimmer
-7/2/67:
+6/2/67:
   dpt: '1.011'
   function: Raumklima
   name: Raumklima.EG.Wohnzimmer.FBH.Aktiv
   room: Wohnzimmer
-7/2/68:
+6/2/68:
   dpt: '16.000'
   function: Raumklima
   name: Raumklima.EG.Wohnzimmer.FBH.Diagnose
   room: Wohnzimmer
-7/2/7:
+6/2/7:
   dpt: '1.011'
   function: Raumklima
   name: Raumklima.EG.Flur.FBH.Aktiv
   room: Flur
-7/2/8:
+6/2/8:
   dpt: '16.000'
   function: Raumklima
   name: Raumklima.EG.Flur.FBH.Diagnose
   room: Flur
-7/2/80:
+6/2/80:
   dpt: '1.003'
   function: Raumklima
-  name: Raumklima.EG.Esszimer.FBH.Sperren
-  room: Esszimer
-7/2/81:
+  name: Raumklima.EG.Esszimmer.FBH.Sperren
+  room: Esszimmer
+6/2/81:
   dpt: '5.001'
   function: Raumklima
-  name: Raumklima.EG.Esszimer.FBH.Stellwert-Status
-  room: Esszimer
-7/2/82:
+  name: Raumklima.EG.Esszimmer.FBH.Stellwert-Status
+  room: Esszimmer
+6/2/82:
   dpt: '9.001'
   function: Raumklima
-  name: Raumklima.EG.Esszimer.FBH.Soll-Temperatur
-  room: Esszimer
-7/2/83:
+  name: Raumklima.EG.Esszimmer.FBH.Soll-Temperatur
+  room: Esszimmer
+6/2/83:
   dpt: '9.001'
   function: Raumklima
-  name: Raumklima.EG.Esszimer.FBH.Soll-Temperatur-Status
-  room: Esszimer
-7/2/84:
+  name: Raumklima.EG.Esszimmer.FBH.Soll-Temperatur-Status
+  room: Esszimmer
+6/2/84:
   dpt: '9.002'
   function: Raumklima
-  name: Raumklima.EG.Esszimer.FBH.Sollwertverschiebung
-  room: Esszimer
-7/2/85:
+  name: Raumklima.EG.Esszimmer.FBH.Sollwertverschiebung
+  room: Esszimmer
+6/2/85:
   dpt: '20.102'
   function: Raumklima
-  name: Raumklima.EG.Esszimer.FBH.HVAC
-  room: Esszimer
-7/2/86:
+  name: Raumklima.EG.Esszimmer.FBH.HVAC
+  room: Esszimmer
+6/2/86:
   dpt: '20.102'
   function: Raumklima
-  name: Raumklima.EG.Esszimer.FBH.HVAC-Status
-  room: Esszimer
-7/2/87:
+  name: Raumklima.EG.Esszimmer.FBH.HVAC-Status
+  room: Esszimmer
+6/2/87:
   dpt: '1.011'
   function: Raumklima
-  name: Raumklima.EG.Esszimer.FBH.Aktiv
-  room: Esszimer
-7/2/88:
+  name: Raumklima.EG.Esszimmer.FBH.Aktiv
+  room: Esszimmer
+6/2/88:
   dpt: '16.000'
   function: Raumklima
-  name: Raumklima.EG.Esszimer.FBH.Diagnose
-  room: Esszimer
-7/3/0:
+  name: Raumklima.EG.Esszimmer.FBH.Diagnose
+  room: Esszimmer
+6/3/0:
   dpt: '1.003'
   function: Raumklima
   name: Raumklima.OG.Flur.FBH.Sperren
   room: Flur
-7/3/1:
+6/3/1:
   dpt: '5.001'
   function: Raumklima
   name: Raumklima.OG.Flur.FBH.Stellwert-Status
   room: Flur
-7/3/100:
+6/3/100:
   dpt: '1.003'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.FBH.Sperren
-  room: Schlafzimmer-Eltern
-7/3/101:
+  room: Schlafzimmer Eltern
+6/3/101:
   dpt: '5.001'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.FBH.Stellwert-Status
-  room: Schlafzimmer-Eltern
-7/3/102:
+  room: Schlafzimmer Eltern
+6/3/102:
   dpt: '9.001'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.FBH.Soll-Temperatur
-  room: Schlafzimmer-Eltern
-7/3/103:
+  room: Schlafzimmer Eltern
+6/3/103:
   dpt: '9.001'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.FBH.Soll-Temperatur-Status
-  room: Schlafzimmer-Eltern
-7/3/104:
+  room: Schlafzimmer Eltern
+6/3/104:
   dpt: '9.002'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.FBH.Sollwertverschiebung
-  room: Schlafzimmer-Eltern
-7/3/105:
+  room: Schlafzimmer Eltern
+6/3/105:
   dpt: '20.102'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.HVAC
-  room: Schlafzimmer-Eltern
-7/3/106:
+  room: Schlafzimmer Eltern
+6/3/106:
   dpt: '20.102'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.HVAC-Status
-  room: Schlafzimmer-Eltern
-7/3/107:
+  room: Schlafzimmer Eltern
+6/3/107:
   dpt: '1.011'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.Aktiv
-  room: Schlafzimmer-Eltern
-7/3/108:
+  room: Schlafzimmer Eltern
+6/3/108:
   dpt: '16.000'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.Diagnose
-  room: Schlafzimmer-Eltern
-7/3/120:
+  room: Schlafzimmer Eltern
+6/3/120:
   dpt: '1.003'
   function: Raumklima
   name: Raumklima.OG.Begehbarer-Schrank.FBH.Sperren
-  room: Begehbarer-Schrank
-7/3/121:
+  room: Begehbarer Schrank
+6/3/121:
   dpt: '5.001'
   function: Raumklima
   name: Raumklima.OG.Begehbarer-Schrank.FBH.Stellwert-Status
-  room: Begehbarer-Schrank
-7/3/122:
+  room: Begehbarer Schrank
+6/3/122:
   dpt: '9.001'
   function: Raumklima
   name: Raumklima.OG.Begehbarer-Schrank.FBH.Soll-Temperatur
-  room: Begehbarer-Schrank
-7/3/123:
+  room: Begehbarer Schrank
+6/3/123:
   dpt: '9.001'
   function: Raumklima
   name: Raumklima.OG.Begehbarer-Schrank.FBH.Soll-Temperatur-Status
-  room: Begehbarer-Schrank
-7/3/124:
+  room: Begehbarer Schrank
+6/3/124:
   dpt: '9.002'
   function: Raumklima
   name: Raumklima.OG.Begehbarer-Schrank.FBH.Sollwertverschiebung
-  room: Begehbarer-Schrank
-7/3/125:
+  room: Begehbarer Schrank
+6/3/125:
   dpt: '20.102'
   function: Raumklima
   name: Raumklima.OG.Begehbarer-Schrank.FBH.HVAC
-  room: Begehbarer-Schrank
-7/3/126:
+  room: Begehbarer Schrank
+6/3/126:
   dpt: '20.102'
   function: Raumklima
   name: Raumklima.OG.Begehbarer-Schrank.FBH.HVAC-Status
-  room: Begehbarer-Schrank
-7/3/127:
+  room: Begehbarer Schrank
+6/3/127:
   dpt: '1.011'
   function: Raumklima
   name: Raumklima.OG.Begehbarer-Schrank.FBH.Aktiv
-  room: Begehbarer-Schrank
-7/3/128:
+  room: Begehbarer Schrank
+6/3/128:
   dpt: '16.000'
   function: Raumklima
   name: Raumklima.OG.Begehbarer-Schrank.FBH.Diagnose
-  room: Begehbarer-Schrank
-7/3/140:
+  room: Begehbarer Schrank
+6/3/140:
   dpt: '1.003'
   function: Raumklima
   name: Raumklima.OG.Badezimmer-Eltern.FBH.Sperren
-  room: Badezimmer-Eltern
-7/3/141:
+  room: Badezimmer Eltern
+6/3/141:
   dpt: '5.001'
   function: Raumklima
   name: Raumklima.OG.Badezimmer-Eltern.FBH.Stellwert-Status
-  room: Badezimmer-Eltern
-7/3/142:
+  room: Badezimmer Eltern
+6/3/142:
   dpt: '9.001'
   function: Raumklima
   name: Raumklima.OG.Badezimmer-Eltern.FBH.Soll-Temperatur
-  room: Badezimmer-Eltern
-7/3/143:
+  room: Badezimmer Eltern
+6/3/143:
   dpt: '9.001'
   function: Raumklima
   name: Raumklima.OG.Badezimmer-Eltern.FBH.Soll-Temperatur-Status
-  room: Badezimmer-Eltern
-7/3/144:
+  room: Badezimmer Eltern
+6/3/144:
   dpt: '9.002'
   function: Raumklima
   name: Raumklima.OG.Badezimmer-Eltern.FBH.Sollwertverschiebung
-  room: Badezimmer-Eltern
-7/3/145:
+  room: Badezimmer Eltern
+6/3/145:
   dpt: '20.102'
   function: Raumklima
   name: Raumklima.OG.Badezimmer-Eltern.FBH.HVAC
-  room: Badezimmer-Eltern
-7/3/146:
+  room: Badezimmer Eltern
+6/3/146:
   dpt: '20.102'
   function: Raumklima
   name: Raumklima.OG.Badezimmer-Eltern.FBH.HVAC-Status
-  room: Badezimmer-Eltern
-7/3/147:
+  room: Badezimmer Eltern
+6/3/147:
   dpt: '1.011'
   function: Raumklima
   name: Raumklima.OG.Badezimmer-Eltern.FBH.Aktiv
-  room: Badezimmer-Eltern
-7/3/148:
+  room: Badezimmer Eltern
+6/3/148:
   dpt: '16.000'
   function: Raumklima
   name: Raumklima.OG.Badezimmer-Eltern.FBH.Diagnose
-  room: Badezimmer-Eltern
-7/3/2:
+  room: Badezimmer Eltern
+6/3/2:
   dpt: '9.001'
   function: Raumklima
   name: Raumklima.OG.Flur.FBH.Soll-Temperatur
   room: Flur
-7/3/20:
+6/3/20:
   dpt: '1.003'
   function: Raumklima
   name: Raumklima.OG.Abstellraum.FBH.Sperren
   room: Abstellraum
-7/3/21:
+6/3/21:
   dpt: '5.001'
   function: Raumklima
   name: Raumklima.OG.Abstellraum.FBH.Stellwert-Status
   room: Abstellraum
-7/3/22:
+6/3/22:
   dpt: '9.001'
   function: Raumklima
   name: Raumklima.OG.Abstellraum.FBH.Soll-Temperatur
   room: Abstellraum
-7/3/23:
+6/3/23:
   dpt: '9.001'
   function: Raumklima
   name: Raumklima.OG.Abstellraum.FBH.Soll-Temperatur-Status
   room: Abstellraum
-7/3/24:
+6/3/24:
   dpt: '9.002'
   function: Raumklima
   name: Raumklima.OG.Abstellraum.FBH.Sollwertverschiebung
   room: Abstellraum
-7/3/25:
+6/3/25:
   dpt: '20.102'
   function: Raumklima
   name: Raumklima.OG.Abstellraum.FBH.HVAC
   room: Abstellraum
-7/3/26:
+6/3/26:
   dpt: '20.102'
   function: Raumklima
   name: Raumklima.OG.Abstellraum.FBH.HVAC-Status
   room: Abstellraum
-7/3/27:
+6/3/27:
   dpt: '1.011'
   function: Raumklima
   name: Raumklima.OG.Abstellraum.FBH.Aktiv
   room: Abstellraum
-7/3/28:
+6/3/28:
   dpt: '16.000'
   function: Raumklima
   name: Raumklima.OG.Abstellraum.FBH.Diagnose
   room: Abstellraum
-7/3/3:
+6/3/3:
   dpt: '9.001'
   function: Raumklima
   name: Raumklima.OG.Flur.FBH.Soll-Temperatur-Status
   room: Flur
-7/3/4:
+6/3/4:
   dpt: '9.002'
   function: Raumklima
   name: Raumklima.OG.Flur.FBH.Sollwertverschiebung
   room: Flur
-7/3/40:
+6/3/40:
   dpt: '1.003'
   function: Raumklima
   name: Raumklima.OG.Badezimmer-Kinder.FBH.Sperren
-  room: Badezimmer-Kinder
-7/3/41:
+  room: Badezimmer Kinder
+6/3/41:
   dpt: '5.001'
   function: Raumklima
   name: Raumklima.OG.Badezimmer-Kinder.FBH.Stellwert-Status
-  room: Badezimmer-Kinder
-7/3/42:
+  room: Badezimmer Kinder
+6/3/42:
   dpt: '9.001'
   function: Raumklima
   name: Raumklima.OG.Badezimmer-Kinder.FBH.Soll-Temperatur
-  room: Badezimmer-Kinder
-7/3/43:
+  room: Badezimmer Kinder
+6/3/43:
   dpt: '9.001'
   function: Raumklima
   name: Raumklima.OG.Badezimmer-Kinder.FBH.Soll-Temperatur-Status
-  room: Badezimmer-Kinder
-7/3/44:
+  room: Badezimmer Kinder
+6/3/44:
   dpt: '9.002'
   function: Raumklima
   name: Raumklima.OG.Badezimmer-Kinder.FBH.Sollwertveränderung
-  room: Badezimmer-Kinder
-7/3/45:
+  room: Badezimmer Kinder
+6/3/45:
   dpt: '20.102'
   function: Raumklima
   name: Raumklima.OG.Badezimmer-Kinder.HVAC
-  room: Badezimmer-Kinder
-7/3/46:
+  room: Badezimmer Kinder
+6/3/46:
   dpt: '20.102'
   function: Raumklima
   name: Raumklima.OG.Badezimmer-Kinder.HVAC-Status
-  room: Badezimmer-Kinder
-7/3/47:
+  room: Badezimmer Kinder
+6/3/47:
   dpt: '1.011'
   function: Raumklima
   name: Raumklima.OG.Badezimmer-Kinder.Aktiv
-  room: Badezimmer-Kinder
-7/3/48:
+  room: Badezimmer Kinder
+6/3/48:
   dpt: '16.000'
   function: Raumklima
   name: Raumklima.OG.Badezimmer-Kinder.FBH.Diagnose
-  room: Badezimmer-Kinder
-7/3/5:
+  room: Badezimmer Kinder
+6/3/5:
   dpt: '20.102'
   function: Raumklima
   name: Raumklima.OG.Flur.FBH.HVAC
   room: Flur
-7/3/6:
+6/3/6:
   dpt: '20.102'
   function: Raumklima
   name: Raumklima.OG.Flur.FBH.HVAC-Status
   room: Flur
-7/3/60:
+6/3/60:
   dpt: '1.003'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Gregory.FBH.Sperren
-  room: Schlafzimmer-Gregory
-7/3/61:
+  room: Schlafzimmer Gregory
+6/3/61:
   dpt: '5.001'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Gregory.FBH.Stellwert-Status
-  room: Schlafzimmer-Gregory
-7/3/62:
+  room: Schlafzimmer Gregory
+6/3/62:
   dpt: '9.001'
   function: Raumklima
-  name: Raumklima.OG.Schlafzimmer-Gregory.FBH.Soll-Temperartur
-  room: Schlafzimmer-Gregory
-7/3/63:
+  name: Raumklima.OG.Schlafzimmer-Gregory.FBH.Soll-Temperatur
+  room: Schlafzimmer Gregory
+6/3/63:
   dpt: '9.001'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Gregory.FBH.Soll-Temperatur-Status
-  room: Schlafzimmer-Gregory
-7/3/64:
+  room: Schlafzimmer Gregory
+6/3/64:
   dpt: '9.002'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Gregory.FBH.Sollwertverschiebung
-  room: Schlafzimmer-Gregory
-7/3/65:
+  room: Schlafzimmer Gregory
+6/3/65:
   dpt: '20.102'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Gregory.HVAC
-  room: Schlafzimmer-Gregory
-7/3/66:
+  room: Schlafzimmer Gregory
+6/3/66:
   dpt: '20.102'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Gregory.HVAC-Status
-  room: Schlafzimmer-Gregory
-7/3/67:
+  room: Schlafzimmer Gregory
+6/3/67:
   dpt: '1.011'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Gregory.Aktiv
-  room: Schlafzimmer-Gregory
-7/3/68:
+  room: Schlafzimmer Gregory
+6/3/68:
   dpt: '16.000'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Gregory.Diagnose
-  room: Schlafzimmer-Gregory
-7/3/7:
+  room: Schlafzimmer Gregory
+6/3/7:
   dpt: '1.011'
   function: Raumklima
   name: Raumklima.OG.Flur.FBH.Aktiv
   room: Flur
-7/3/8:
+6/3/8:
   dpt: '16.000'
   function: Raumklima
   name: Raumklima.OG.Flur.FBH.Diagnose
   room: Flur
-7/3/80:
+6/3/80:
   dpt: '1.003'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Luis.FBH.Sperren
-  room: Schlafzimmer-Luis
-7/3/81:
+  room: Schlafzimmer Luis
+6/3/81:
   dpt: '5.001'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Luis.FBH.Stellwert-Status
-  room: Schlafzimmer-Luis
-7/3/82:
+  room: Schlafzimmer Luis
+6/3/82:
   dpt: '9.001'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Luis.FBH.Soll-Temperatur
-  room: Schlafzimmer-Luis
-7/3/83:
+  room: Schlafzimmer Luis
+6/3/83:
   dpt: '9.001'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Luis.FBH.Soll-Temperatur-Status
-  room: Schlafzimmer-Luis
-7/3/84:
+  room: Schlafzimmer Luis
+6/3/84:
   dpt: '9.002'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Luis.FBH.Sollwertverschiebung
-  room: Schlafzimmer-Luis
-7/3/85:
+  room: Schlafzimmer Luis
+6/3/85:
   dpt: '20.102'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Luis.FBH.HVAC
-  room: Schlafzimmer-Luis
-7/3/86:
+  room: Schlafzimmer Luis
+6/3/86:
   dpt: '20.102'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Luis.FBH.HVAC-Status
-  room: Schlafzimmer-Luis
-7/3/87:
+  room: Schlafzimmer Luis
+6/3/87:
   dpt: '1.011'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Luis.FBH.Aktiv
-  room: Schlafzimmer-Luis
-7/3/88:
+  room: Schlafzimmer Luis
+6/3/88:
   dpt: '16.000'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Luis.FBH.Diagnose
-  room: Schlafzimmer-Luis
-8/0/200:
+  room: Schlafzimmer Luis
+7/0/200:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.Zentral.Schalter.Sperren
-8/0/201:
+7/0/201:
   dpt: '5.010'
   function: Bedienelemente
   name: Bedienelemente.Zentral.Schalter.Farbe
-8/2/0:
+7/2/0:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.EG.Büro.Schalter.Sperren
   room: Büro
-8/2/1:
+7/2/1:
   dpt: '5.010'
   function: Bedienelemente
   name: Bedienelemente.EG.Büro.Schalter.Farbe
   room: Büro
-8/2/10:
+7/2/10:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.EG.Büro.Schalter.Multitouch-Kurz
   room: Büro
-8/2/16:
+7/2/16:
   dpt: '1.024'
   function: Bedienelemente
   name: Bedienelemente.EG.Büro.Schalter.Tag/Nacht
   room: Büro
-8/2/2:
+7/2/2:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.EG.Büro.Schalter.Sensor-1-Kurz
   room: Büro
-8/2/20:
+7/2/20:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.EG.Wohnzimmer.Schalter.Sperren
   room: Wohnzimmer
-8/2/21:
+7/2/21:
   dpt: '5.010'
   function: Bedienelemente
   name: Bedienelemente.EG.Wohnzimmer.Schalter.Farbe
   room: Wohnzimmer
-8/2/22:
+7/2/22:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.EG.Wohnzimmer.Schalter.Sensor-1-Kurz
   room: Wohnzimmer
-8/2/23:
+7/2/23:
   dpt: '3.007'
   function: Bedienelemente
   name: Bedienelemente.EG.Wohnzimmer.Schalter.Sensor-1-Lang
   room: Wohnzimmer
-8/2/24:
+7/2/24:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.EG.Wohnzimmer.Schalter.Sensor-2-Kurz
   room: Wohnzimmer
-8/2/25:
+7/2/25:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.EG.Wohnzimmer.Schalter.Sensor-2-Lang
   room: Wohnzimmer
-8/2/28:
+7/2/28:
   dpt: '1.009'
   function: Bedienelemente
   name: Bedienelemente.EG.Wohnzimmer.Schalter.Sensor-4-Kurz
   room: Wohnzimmer
-8/2/29:
+7/2/29:
   dpt: '1.009'
   function: Bedienelemente
   name: Bedienelemente.EG.Wohnzimmer.Schalter.Sensor-4-Lang
   room: Wohnzimmer
-8/2/3:
+7/2/3:
   dpt: '3.007'
   function: Bedienelemente
   name: Bedienelemente.EG.Büro.Schalter.Sensor-1-Lang
   room: Büro
-8/2/30:
+7/2/30:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.EG.Wohnzimmer.Schalter.Multitouch-Kurz
   room: Wohnzimmer
-8/2/36:
+7/2/36:
   dpt: '1.024'
   function: Bedienelemente
   name: Bedienelemente.EG.Wohnzimmer.Schalter.Tag/Nacht
   room: Wohnzimmer
-8/2/4:
+7/2/4:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.EG.Büro.Schalter.Sensor-2-Kurz
   room: Büro
-8/2/5:
+7/2/5:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.EG.Büro.Schalter.Sensor-2-Lang
   room: Büro
-8/2/8:
+7/2/8:
   dpt: '1.009'
   function: Bedienelemente
   name: Bedienelemente.EG.Büro.Schalter.Sensor-4-Kurz
   room: Büro
-8/2/9:
+7/2/9:
   dpt: '1.009'
   function: Bedienelemente
   name: Bedienelemente.EG.Büro.Schalter.Sensor-4-Lang
   room: Büro
-8/3/0:
+7/3/0:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Abstellraum.Schalter.Sperren
   room: Abstellraum
-8/3/1:
+7/3/1:
   dpt: '5.010'
   function: Bedienelemente
   name: Bedienelemente.OG.Abstellraum.Schalter.Farbe
   room: Abstellraum
-8/3/10:
+7/3/10:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Abstellraum.Schalter.Multitouch-Kurz
   room: Abstellraum
-8/3/100:
+7/3/100:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Bett-Links.Sperren
-  room: Schlafzimmer-Eltern
-8/3/101:
+  room: Schlafzimmer Eltern
+7/3/101:
   dpt: '5.010'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Bett-Links.Farbe
-  room: Schlafzimmer-Eltern
-8/3/102:
+  room: Schlafzimmer Eltern
+7/3/102:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Bett-Links.Sensor-1-Kurz
-  room: Schlafzimmer-Eltern
-8/3/103:
+  room: Schlafzimmer Eltern
+7/3/103:
   dpt: '3.007'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Bett-Links.Sensor-1-Lang
-  room: Schlafzimmer-Eltern
-8/3/104:
+  room: Schlafzimmer Eltern
+7/3/104:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Bett-Links.Sensor-2-Kurz
-  room: Schlafzimmer-Eltern
-8/3/105:
+  room: Schlafzimmer Eltern
+7/3/105:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Bett-Links.Sensor-2-Lang
-  room: Schlafzimmer-Eltern
-8/3/110:
+  room: Schlafzimmer Eltern
+7/3/110:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Bett-Links.Multitouch-Kurz
-  room: Schlafzimmer-Eltern
-8/3/111:
+  room: Schlafzimmer Eltern
+7/3/111:
   dpt: '1.008'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Bett-Links.Multitouch-Lang-1
-  room: Schlafzimmer-Eltern
-8/3/112:
+  room: Schlafzimmer Eltern
+7/3/112:
   dpt: '1.017'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Bett-Links.Multitouch-Lang-2
-  room: Schlafzimmer-Eltern
-8/3/116:
+  room: Schlafzimmer Eltern
+7/3/116:
   dpt: '1.024'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Bett-Links.Tag/Nacht
-  room: Schlafzimmer-Eltern
-8/3/120:
+  room: Schlafzimmer Eltern
+7/3/120:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Bett-Rechts.Sperren
-  room: Schlafzimmer-Eltern
-8/3/121:
+  room: Schlafzimmer Eltern
+7/3/121:
   dpt: '5.010'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Bett-Rechts.Farbe
-  room: Schlafzimmer-Eltern
-8/3/122:
+  room: Schlafzimmer Eltern
+7/3/122:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Bett-Rechts.Sensor-1-Kurz
-  room: Schlafzimmer-Eltern
-8/3/123:
+  room: Schlafzimmer Eltern
+7/3/123:
   dpt: '3.007'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Bett-Rechts.Sensor-1-Lang
-  room: Schlafzimmer-Eltern
-8/3/124:
+  room: Schlafzimmer Eltern
+7/3/124:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Bett-Rechts.Sensor-2-Kurz
-  room: Schlafzimmer-Eltern
-8/3/125:
+  room: Schlafzimmer Eltern
+7/3/125:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Bett-Rechts.Sensor-2-Lang
-  room: Schlafzimmer-Eltern
-8/3/130:
+  room: Schlafzimmer Eltern
+7/3/130:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Bett-Rechts.Multitouch-Kurz
-  room: Schlafzimmer-Eltern
-8/3/131:
+  room: Schlafzimmer Eltern
+7/3/131:
   dpt: '1.008'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Bett-Rechts.Multitouch-Lang-1
-  room: Schlafzimmer-Eltern
-8/3/132:
+  room: Schlafzimmer Eltern
+7/3/132:
   dpt: '1.017'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Bett-Rechts.Multitouch-Lang-2
-  room: Schlafzimmer-Eltern
-8/3/136:
+  room: Schlafzimmer Eltern
+7/3/136:
   dpt: '1.024'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Bett-Rechts.Tag/Nacht
-  room: Schlafzimmer-Eltern
-8/3/140:
+  room: Schlafzimmer Eltern
+7/3/140:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Eltern.Schalter.Sperren
-  room: Badezimmer-Eltern
-8/3/141:
+  room: Badezimmer Eltern
+7/3/141:
   dpt: '5.010'
   function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Eltern.Schalter.Farbe
-  room: Badezimmer-Eltern
-8/3/142:
+  room: Badezimmer Eltern
+7/3/142:
   dpt: '1.009'
   function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Eltern.Schalter.Sensor-1-Kurz
-  room: Badezimmer-Eltern
-8/3/143:
+  room: Badezimmer Eltern
+7/3/143:
   dpt: '3.007'
   function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Eltern.Schalter.Sensor-1-Lang
-  room: Badezimmer-Eltern
-8/3/144:
+  room: Badezimmer Eltern
+7/3/144:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Eltern.Schalter.Sensor-2-Kurz
-  room: Badezimmer-Eltern
-8/3/145:
+  room: Badezimmer Eltern
+7/3/145:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Eltern.Schalter.Sensor-2-Lang
-  room: Badezimmer-Eltern
-8/3/148:
+  room: Badezimmer Eltern
+7/3/148:
   dpt: '1.009'
   function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Eltern.Schalter.Sensor-4-Kurz
-  room: Badezimmer-Eltern
-8/3/149:
+  room: Badezimmer Eltern
+7/3/149:
   dpt: '1.009'
   function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Eltern.Schalter.Sensor-4-Lang
-  room: Badezimmer-Eltern
-8/3/150:
+  room: Badezimmer Eltern
+7/3/150:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Eltern.Schalter.Multitouch-Kurz
-  room: Badezimmer-Eltern
-8/3/153:
+  room: Badezimmer Eltern
+7/3/153:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Eltern.Schalter.Multitouch-RGB-Rot
-  room: Badezimmer-Eltern
-8/3/156:
+  room: Badezimmer Eltern
+7/3/156:
   dpt: '1.024'
   function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Eltern.Schalter.Tag/Nacht
-  room: Badezimmer-Eltern
-8/3/16:
+  room: Badezimmer Eltern
+7/3/16:
   dpt: '1.024'
   function: Bedienelemente
   name: Bedienelemente.OG.Abstellraum.Schalter.Tag/Nacht
   room: Abstellraum
-8/3/2:
+7/3/2:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Abstellraum.Schalter.Sensor-1-Kurz
   room: Abstellraum
-8/3/20:
+7/3/20:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Kinder.Schalter.Sperren
-  room: Badezimmer-Kinder
-8/3/21:
+  room: Badezimmer Kinder
+7/3/21:
   dpt: '5.010'
   function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Kinder.Schalter.Farbe
-  room: Badezimmer-Kinder
-8/3/22:
+  room: Badezimmer Kinder
+7/3/22:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Kinder.Schalter.Sensor-1-Kurz
-  room: Badezimmer-Kinder
-8/3/23:
+  room: Badezimmer Kinder
+7/3/23:
   dpt: '3.007'
   function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Kinder.Schalter.Sensor-1-Lang
-  room: Badezimmer-Kinder
-8/3/24:
+  room: Badezimmer Kinder
+7/3/24:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Kinder.Schalter.Sensor-2-Kurz
-  room: Badezimmer-Kinder
-8/3/25:
+  room: Badezimmer Kinder
+7/3/25:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Kinder.Schalter.Sensor-2-Lang
-  room: Badezimmer-Kinder
-8/3/28:
+  room: Badezimmer Kinder
+7/3/28:
   dpt: '1.009'
   function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Kinder.Schalter.Sensor-4-Kurz
-  room: Badezimmer-Kinder
-8/3/29:
+  room: Badezimmer Kinder
+7/3/29:
   dpt: '1.009'
   function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Kinder.Schalter.Sensor-4-Lang
-  room: Badezimmer-Kinder
-8/3/3:
+  room: Badezimmer Kinder
+7/3/3:
   dpt: '3.007'
   function: Bedienelemente
   name: Bedienelemente.OG.Abstellraum.Schalter.Sensor-1-Lang
   room: Abstellraum
-8/3/30:
+7/3/30:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Kinder.Schalter.Multitouch-Kurz
-  room: Badezimmer-Kinder
-8/3/36:
+  room: Badezimmer Kinder
+7/3/36:
   dpt: '1.024'
   function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Kinder.Schalter.Tag/Nacht
-  room: Badezimmer-Kinder
-8/3/4:
+  room: Badezimmer Kinder
+7/3/4:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Abstellraum.Schalter.Sensor-2-Kurz
   room: Abstellraum
-8/3/40:
+7/3/40:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Gregory.Schalter.Sperren
-  room: Schlafzimmer-Gregory
-8/3/41:
+  room: Schlafzimmer Gregory
+7/3/41:
   dpt: '5.010'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Gregory.Schalter.Farbe
-  room: Schlafzimmer-Gregory
-8/3/42:
+  room: Schlafzimmer Gregory
+7/3/42:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Gregory.Schalter.Sensor-1-Kurz
-  room: Schlafzimmer-Gregory
-8/3/43:
+  room: Schlafzimmer Gregory
+7/3/43:
   dpt: '3.007'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Gregory.Schalter.Sensor-1-Lang
-  room: Schlafzimmer-Gregory
-8/3/44:
+  room: Schlafzimmer Gregory
+7/3/44:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Gregory.Schalter.Sensor-2-Kurz
-  room: Schlafzimmer-Gregory
-8/3/45:
+  room: Schlafzimmer Gregory
+7/3/45:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Gregory.Schalter.Sensor-2-Lang
-  room: Schlafzimmer-Gregory
-8/3/48:
+  room: Schlafzimmer Gregory
+7/3/48:
   dpt: '1.009'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Gregory.Schalter.Sensor-4-Kurz
-  room: Schlafzimmer-Gregory
-8/3/49:
+  room: Schlafzimmer Gregory
+7/3/49:
   dpt: '1.009'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Gregory.Schalter.Sensor-4-Lang
-  room: Schlafzimmer-Gregory
-8/3/5:
+  room: Schlafzimmer Gregory
+7/3/5:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Abstellraum.Schalter.Sensor-2-Lang
   room: Abstellraum
-8/3/50:
+7/3/50:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Gregory.Schalter.Multitouch-Kurz
-  room: Schlafzimmer-Gregory
-8/3/51:
+  room: Schlafzimmer Gregory
+7/3/51:
   dpt: '1.008'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Gregory.Schalter.Multitouch-Lang-1
-  room: Schlafzimmer-Gregory
-8/3/52:
+  room: Schlafzimmer Gregory
+7/3/52:
   dpt: '1.017'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Gregory.Schalter.Multitouch-Lang-2
-  room: Schlafzimmer-Gregory
-8/3/56:
+  room: Schlafzimmer Gregory
+7/3/56:
   dpt: '1.024'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Gregory.Schalter.Tag/Nacht
-  room: Schlafzimmer-Gregory
-8/3/60:
+  room: Schlafzimmer Gregory
+7/3/60:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Luis.Schalter.Sperren
-  room: Schlafzimmer-Luis
-8/3/61:
+  room: Schlafzimmer Luis
+7/3/61:
   dpt: '5.005'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Luis.Schalter.Farbe
-  room: Schlafzimmer-Luis
-8/3/62:
+  room: Schlafzimmer Luis
+7/3/62:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Luis.Schalter.Sensor-1-Kurz
-  room: Schlafzimmer-Luis
-8/3/63:
+  room: Schlafzimmer Luis
+7/3/63:
   dpt: '3.007'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Luis.Schalter.Sensor-1-Lang
-  room: Schlafzimmer-Luis
-8/3/64:
+  room: Schlafzimmer Luis
+7/3/64:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Luis.Schalter.Sensor-2-Kurz
-  room: Schlafzimmer-Luis
-8/3/65:
+  room: Schlafzimmer Luis
+7/3/65:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Luis.Schalter.Sensor-2-Lang
-  room: Schlafzimmer-Luis
-8/3/68:
+  room: Schlafzimmer Luis
+7/3/68:
   dpt: '1.009'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Luis.Schalter.Sensor-4-Kurz
-  room: Schlafzimmer-Luis
-8/3/69:
+  room: Schlafzimmer Luis
+7/3/69:
   dpt: '1.009'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Luis.Schalter.Sensor-4-Lang
-  room: Schlafzimmer-Luis
-8/3/70:
+  room: Schlafzimmer Luis
+7/3/70:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Luis.Schalter.Multitouch-Kurz
-  room: Schlafzimmer-Luis
-8/3/71:
+  room: Schlafzimmer Luis
+7/3/71:
   dpt: '1.009'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Luis.Schalter.Multitouch-Lang-1
-  room: Schlafzimmer-Luis
-8/3/72:
+  room: Schlafzimmer Luis
+7/3/72:
   dpt: '1.009'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Luis.Schalter.Multitouch-Lang-2
-  room: Schlafzimmer-Luis
-8/3/76:
+  room: Schlafzimmer Luis
+7/3/76:
   dpt: '1.024'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Luis.Schalter.Tag/Nacht
-  room: Schlafzimmer-Luis
-8/3/8:
+  room: Schlafzimmer Luis
+7/3/8:
   dpt: '1.009'
   function: Bedienelemente
   name: Bedienelemente.OG.Abstellraum.Schalter.Sensor-4-Kurz
   room: Abstellraum
-8/3/80:
+7/3/80:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Sperren
-  room: Schlafzimmer-Eltern
-8/3/81:
+  room: Schlafzimmer Eltern
+7/3/81:
   dpt: '5.010'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Farbe
-  room: Schlafzimmer-Eltern
-8/3/82:
+  room: Schlafzimmer Eltern
+7/3/82:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Sensor-1-Kurz
-  room: Schlafzimmer-Eltern
-8/3/83:
+  room: Schlafzimmer Eltern
+7/3/83:
   dpt: '3.007'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Sensor-1-Lang
-  room: Schlafzimmer-Eltern
-8/3/84:
+  room: Schlafzimmer Eltern
+7/3/84:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Sensor-2-Kurz
-  room: Schlafzimmer-Eltern
-8/3/85:
+  room: Schlafzimmer Eltern
+7/3/85:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Sensor-2-Lang
-  room: Schlafzimmer-Eltern
-8/3/88:
+  room: Schlafzimmer Eltern
+7/3/88:
   dpt: '1.009'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Sensor-4-Kurz
-  room: Schlafzimmer-Eltern
-8/3/89:
+  room: Schlafzimmer Eltern
+7/3/89:
   dpt: '1.009'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Sensor-4-Lang
-  room: Schlafzimmer-Eltern
-8/3/9:
+  room: Schlafzimmer Eltern
+7/3/9:
   dpt: '1.009'
   function: Bedienelemente
   name: Bedienelemente.OG.Abstellraum.Schalter.Sensor-4-Lang
   room: Abstellraum
-8/3/90:
+7/3/90:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Multitouch-Kurz
-  room: Schlafzimmer-Eltern
-8/3/91:
+  room: Schlafzimmer Eltern
+7/3/91:
   dpt: '1.009'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Multitouch-Lang-1
-  room: Schlafzimmer-Eltern
-8/3/92:
+  room: Schlafzimmer Eltern
+7/3/92:
   dpt: '1.009'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Multitouch-Lang-2
-  room: Schlafzimmer-Eltern
-8/3/96:
+  room: Schlafzimmer Eltern
+7/3/96:
   dpt: '1.024'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Tag/Nacht
-  room: Schlafzimmer-Eltern
-9/0/180:
+  room: Schlafzimmer Eltern
+8/0/180:
   dpt: '9.004'
   function: Sensorik
   name: Sensorik.Zentral.A.Helligkeit-SO
-9/0/181:
+8/0/181:
   dpt: '9.004'
   function: Sensorik
   name: Sensorik.Zentral.A.Helligkeit-NW
-9/0/182:
+8/0/182:
   dpt: '9.004'
   function: Sensorik
   name: Sensorik.Zentral.A.Helligkeit-Alle
-9/0/183:
+8/0/183:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.Zentral.A.Temperatur-Alle
-9/1/100:
+8/1/100:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Vorratsraum.Sensor.VOC-Alarm-1
   room: Vorratsraum
-9/1/101:
+8/1/101:
   dpt: '9.008'
   function: Sensorik
   name: Sensorik.KG.Vorratsraum.Sensor.CO2
   room: Vorratsraum
-9/1/102:
+8/1/102:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Vorratsraum.Sensor.CO2-Alarm-1
   room: Vorratsraum
-9/1/103:
+8/1/103:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Vorratsraum.Sensor.CO2-Alarm-2
   room: Vorratsraum
-9/1/104:
+8/1/104:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Vorratsraum.Sensor.CO2-Alarm-3
   room: Vorratsraum
-9/1/105:
+8/1/105:
   dpt: '14.058'
   function: Sensorik
   name: Sensorik.KG.Vorratsraum.Sensor.Luftdruck-Relativ
   room: Vorratsraum
-9/1/106:
+8/1/106:
   dpt: '14.058'
   function: Sensorik
   name: Sensorik.KG.Vorratsraum.Sensor.Luftdruck-Absolut
   room: Vorratsraum
-9/1/107:
+8/1/107:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Vorratsraum.Sensor.Luftdruck-Alarm-1
   room: Vorratsraum
-9/1/121:
+8/1/121:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.KG.Hauswirtschaftsraum.Sensor.Temperatur
   room: Hauswirtschaftsraum
-9/1/122:
+8/1/122:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Hauswirtschaftsraum.Sensor.Temperatur-Alarm-1
   room: Hauswirtschaftsraum
-9/1/123:
+8/1/123:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Hauswirtschaftsraum.Sensor.Temperatur-Alarm-2
   room: Hauswirtschaftsraum
-9/1/124:
+8/1/124:
   dpt: '9.007'
   function: Sensorik
   name: Sensorik.KG.Hauswirtschaftsraum.Sensor.Luftfeuchtigkeit
   room: Hauswirtschaftsraum
-9/1/125:
+8/1/125:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Hauswirtschaftsraum.Sensor.Luftfeuchtigkeit-Alarm-1
   room: Hauswirtschaftsraum
-9/1/126:
+8/1/126:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Hauswirtschaftsraum.Sensor.Luftfeuchtigkeit-Alarm-2
   room: Hauswirtschaftsraum
-9/1/127:
+8/1/127:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.KG.Hauswirtschaftsraum.Sensor.Taupunkt
   room: Hauswirtschaftsraum
-9/1/128:
+8/1/128:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Hauswirtschaftsraum.Sensor.Taupunkt-Alarm-1
   room: Hauswirtschaftsraum
-9/1/129:
+8/1/129:
   dpt: '9.008'
   function: Sensorik
   name: Sensorik.KG.Hauswirtschaftsraum.Sensor.VOC
   room: Hauswirtschaftsraum
-9/1/130:
+8/1/130:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Hauswirtschaftsraum.Sensor.VOC-Alarm-1
   room: Hauswirtschaftsraum
-9/1/131:
+8/1/131:
   dpt: '9.008'
   function: Sensorik
   name: Sensorik.KG.Hauswirtschaftsraum.Sensor.CO2
   room: Hauswirtschaftsraum
-9/1/132:
+8/1/132:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Hauswirtschaftsraum.Sensor.CO2-Alarm-1
   room: Hauswirtschaftsraum
-9/1/133:
+8/1/133:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Hauswirtschaftsraum.Sensor.CO2-Alarm-2
   room: Hauswirtschaftsraum
-9/1/134:
+8/1/134:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Hauswirtschaftsraum.Sensor.CO2-Alarm-3
   room: Hauswirtschaftsraum
-9/1/135:
+8/1/135:
   dpt: '14.058'
   function: Sensorik
   name: Sensorik.KG.Hauswirtschaftsraum.Sensor.Luftdruck-Relativ
   room: Hauswirtschaftsraum
-9/1/136:
+8/1/136:
   dpt: '14.058'
   function: Sensorik
   name: Sensorik.KG.Hauswirtschaftsraum.Sensor.Luftdruck-Absolut
   room: Hauswirtschaftsraum
-9/1/137:
+8/1/137:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Hauswirtschaftsraum.Sensor.Luftdruck-Alarm-1
   room: Hauswirtschaftsraum
-9/1/20:
+8/1/20:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.KG.Flur.BWM.Decke.Temperatur
   room: Flur
-9/1/21:
+8/1/21:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.KG.Flur.BWM.Wand.Temperatur
   room: Flur
-9/1/31:
+8/1/31:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.KG.Garage.Sensor.Temperatur
   room: Garage
-9/1/32:
+8/1/32:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Garage.Sensor.Temperatur-Alarm-1
   room: Garage
-9/1/33:
+8/1/33:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Garage.Sensor.Temperatur-Alarm-2
   room: Garage
-9/1/34:
+8/1/34:
   dpt: '9.007'
   function: Sensorik
   name: Sensorik.KG.Garage.Sensor.Luftfeuchtigkeit
   room: Garage
-9/1/35:
+8/1/35:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Garage.Sensor.Luftfeuchtigkeit-Alarm-1
   room: Garage
-9/1/36:
+8/1/36:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Garage.Sensor.Luftfeuchtigkeit-Alarm-2
   room: Garage
-9/1/37:
+8/1/37:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.KG.Garage.Sensor.Taupunkt
   room: Garage
-9/1/38:
+8/1/38:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Garage.Sensor.Taupunkt-Alarm-1
   room: Garage
-9/1/39:
+8/1/39:
   dpt: '9.008'
   function: Sensorik
   name: Sensorik.KG.Garage.Sensor.VOC
   room: Garage
-9/1/40:
+8/1/40:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Garage.Sensor.VOC-Alarm-1
   room: Garage
-9/1/41:
+8/1/41:
   dpt: '9.008'
   function: Sensorik
   name: Sensorik.KG.Garage.Sensor.CO2
   room: Garage
-9/1/42:
+8/1/42:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Garage.Sensor.CO2-Alarm-1
   room: Garage
-9/1/43:
+8/1/43:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Garage.Sensor.CO2-Alarm-2
   room: Garage
-9/1/44:
+8/1/44:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Garage.Sensor.CO2-Alarm-3
   room: Garage
-9/1/45:
+8/1/45:
   dpt: '14.058'
   function: Sensorik
   name: Sensorik.KG.Garage.Sensor.Luftdruck-Relativ
   room: Garage
-9/1/46:
+8/1/46:
   dpt: '14.058'
   function: Sensorik
   name: Sensorik.KG.Garage.Sensor.Luftdruck-Absolut
   room: Garage
-9/1/47:
+8/1/47:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Garage.Sensor.Luftdruck-Alarm-1
   room: Garage
-9/1/61:
+8/1/61:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.KG.Technikraum.Sensor.Temperatur
   room: Technikraum
-9/1/62:
+8/1/62:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Technikraum.Sensor.Temperatur-Alarm-1
   room: Technikraum
-9/1/63:
+8/1/63:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Technikraum.Sensor.Temperatur-Alarm-2
   room: Technikraum
-9/1/64:
+8/1/64:
   dpt: '9.007'
   function: Sensorik
   name: Sensorik.KG.Technikraum.Sensor.Luftfeuchtigkeit
   room: Technikraum
-9/1/65:
+8/1/65:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Technikraum.Sensor.Luftfeuchtigkeit-Alarm-1
   room: Technikraum
-9/1/66:
+8/1/66:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Technikraum.Sensor.Luftfeuchtigkeit-Alarm-2
   room: Technikraum
-9/1/67:
+8/1/67:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.KG.Technikraum.Sensor.Taupunkt
   room: Technikraum
-9/1/68:
+8/1/68:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Technikraum.Sensor.Taupunkt-Alarm-1
   room: Technikraum
-9/1/69:
+8/1/69:
   dpt: '9.008'
   function: Sensorik
   name: Sensorik.KG.Technikraum.Sensor.VOC
   room: Technikraum
-9/1/70:
+8/1/70:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Technikraum.Sensor.VOC-Alarm-1
   room: Technikraum
-9/1/71:
+8/1/71:
   dpt: '9.008'
   function: Sensorik
   name: Sensorik.KG.Technikraum.Sensor.CO2
   room: Technikraum
-9/1/72:
+8/1/72:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Technikraum.Sensor.CO2-Alarm-1
   room: Technikraum
-9/1/73:
+8/1/73:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Technikraum.Sensor.CO2-Alarm-2
   room: Technikraum
-9/1/74:
+8/1/74:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Technikraum.Sensor.CO2-Alarm-3
   room: Technikraum
-9/1/75:
+8/1/75:
   dpt: '14.058'
   function: Sensorik
   name: Sensorik.KG.Technikraum.Sensor.Luftdruck-Relativ
   room: Technikraum
-9/1/76:
+8/1/76:
   dpt: '14.058'
   function: Sensorik
   name: Sensorik.KG.Technikraum.Sensor.Luftdruck-Absolut
   room: Technikraum
-9/1/77:
+8/1/77:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Technikraum.Sensor.Luftdruck-Alarm-1
   room: Technikraum
-9/1/91:
+8/1/91:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.KG.Vorratsraum.Sensor.Temperatur
   room: Vorratsraum
-9/1/92:
+8/1/92:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Vorratsraum.Sensor.Temperatur-Alarm-1
   room: Vorratsraum
-9/1/93:
+8/1/93:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Vorratsraum.Sensor.Temperatur-Alarm-2
   room: Vorratsraum
-9/1/94:
+8/1/94:
   dpt: '9.007'
   function: Sensorik
   name: Sensorik.KG.Vorratsraum.Sensor.Luftfeuchtigkeit
   room: Vorratsraum
-9/1/95:
+8/1/95:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Vorratsraum.Sensor.Luftfeuchtigkeit-Alarm-1
   room: Vorratsraum
-9/1/96:
+8/1/96:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Vorratsraum.Sensor.Luftfeuchtigkeit-Alarm-2
   room: Vorratsraum
-9/1/97:
+8/1/97:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.KG.Vorratsraum.Sensor.Taupunkt
   room: Vorratsraum
-9/1/98:
+8/1/98:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Vorratsraum.Sensor.Taupunkt-Alarm-1
   room: Vorratsraum
-9/1/99:
+8/1/99:
   dpt: '9.008'
   function: Sensorik
   name: Sensorik.KG.Vorratsraum.Sensor.VOC
   room: Vorratsraum
-9/2/101:
+8/2/101:
   dpt: '9.008'
   function: Sensorik
   name: Sensorik.EG.Wohnzimmer.Sensor.CO2
   room: Wohnzimmer
-9/2/102:
+8/2/102:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Wohnzimmer.Sensor.CO2-Alarm-1
   room: Wohnzimmer
-9/2/103:
+8/2/103:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Wohnzimmer.Sensor.CO2-Alarm-2
   room: Wohnzimmer
-9/2/104:
+8/2/104:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Wohnzimmer.Sensor.CO2-Alarm-3
   room: Wohnzimmer
-9/2/110:
+8/2/110:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.EG.Wohnzimmer.Schalter.Temperatur
   room: Wohnzimmer
-9/2/121:
+8/2/121:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.EG.Esszimmer.Sensor.Temperatur
   room: Esszimmer
-9/2/122:
+8/2/122:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Esszimmer.Sensor.Temperatur-Alarm-1
   room: Esszimmer
-9/2/123:
+8/2/123:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Esszimmer.Sensor.Temperatur-Alarm-2
   room: Esszimmer
-9/2/124:
+8/2/124:
   dpt: '9.007'
   function: Sensorik
   name: Sensorik.EG.Esszimmer.Sensor.Luftfeuchtigkeit
   room: Esszimmer
-9/2/125:
+8/2/125:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Esszimmer.Sensor.Luftfeuchtigkeit-Alarm-1
   room: Esszimmer
-9/2/126:
+8/2/126:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Esszimmer.Sensor.Luftfeuchtigkeit-Alarm-2
   room: Esszimmer
-9/2/127:
+8/2/127:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.EG.Esszimmer.Sensor.Taupunkt
   room: Esszimmer
-9/2/128:
+8/2/128:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Esszimmer.Sensor.Taupunkt-Alarm-1
   room: Esszimmer
-9/2/131:
+8/2/131:
   dpt: '9.008'
   function: Sensorik
   name: Sensorik.EG.Esszimmer.Sensor.CO2
   room: Esszimmer
-9/2/132:
+8/2/132:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Esszimmer.Sensor.CO2-Alarm-1
   room: Esszimmer
-9/2/133:
+8/2/133:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Esszimmer.Sensor.CO2-Alarm-2
   room: Esszimmer
-9/2/134:
+8/2/134:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Esszimmer.Sensor.CO2-Alarm-3
   room: Esszimmer
-9/2/151:
+8/2/151:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.EG.Küche.Sensor.Temperatur
   room: Küche
-9/2/152:
+8/2/152:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Küche.Sensor.Temperatur-Alarm-1
   room: Küche
-9/2/153:
+8/2/153:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Küche.Sensor.Temperatur-Alarm-2
   room: Küche
-9/2/154:
+8/2/154:
   dpt: '9.007'
   function: Sensorik
   name: Sensorik.EG.Küche.Sensor.Luftfeuchtigkeit
   room: Küche
-9/2/155:
+8/2/155:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Küche.Sensor.Luftfeuchtigkeit-Alarm-1
   room: Küche
-9/2/156:
+8/2/156:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Küche.Sensor.Luftfeuchtigkeit-Alarm-2
   room: Küche
-9/2/157:
+8/2/157:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.EG.Küche.Sensor.Taupunkt
   room: Küche
-9/2/158:
+8/2/158:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Küche.Sensor.Taupunkt-Alarm-1
   room: Küche
-9/2/161:
+8/2/161:
   dpt: '9.008'
   function: Sensorik
   name: Sensorik.EG.Küche.Sensor.CO2
   room: Küche
-9/2/162:
+8/2/162:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Küche.Sensor.CO2-Alarm-1
   room: Küche
-9/2/163:
+8/2/163:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Küche.Sensor.CO2-Alarm-2
   room: Küche
-9/2/164:
+8/2/164:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Küche.Sensor.CO2-Alarm-3
   room: Küche
-9/2/20:
+8/2/20:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.EG.Flur.BWM.Eingang.Temperatur
   room: Flur
-9/2/21:
+8/2/21:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.EG.Flur.BWM.Diele.Temperatur
   room: Flur
-9/2/22:
+8/2/22:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.EG.Flur.BWM.Garderobe.Temperatur
   room: Flur
-9/2/31:
+8/2/31:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.EG.Gäste-WC.Sensor.Temperatur
-  room: Gäste-WC
-9/2/32:
+  room: Gäste WC
+8/2/32:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Gäste-WC.Sensor.Temperatur-Alarm-1
-  room: Gäste-WC
-9/2/33:
+  room: Gäste WC
+8/2/33:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Gäste-WC.Sensor.Temperatur-Alarm-2
-  room: Gäste-WC
-9/2/34:
+  room: Gäste WC
+8/2/34:
   dpt: '9.007'
   function: Sensorik
   name: Sensorik.EG.Gäste-WC.Sensor.Luftfeuchtigkeit
-  room: Gäste-WC
-9/2/35:
+  room: Gäste WC
+8/2/35:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Gäste-WC.Sensor.Luftfeuchtigkeit-Alarm-1
-  room: Gäste-WC
-9/2/36:
+  room: Gäste WC
+8/2/36:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Gäste-WC.Sensor.Luftfeuchtigkeit-Alarm-2
-  room: Gäste-WC
-9/2/37:
+  room: Gäste WC
+8/2/37:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.EG.Gäste-WC.Sensor.Taupunkt
-  room: Gäste-WC
-9/2/38:
+  room: Gäste WC
+8/2/38:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Gäste-WC.Sensor.Taupunkt-Alarm-1
-  room: Gäste-WC
-9/2/41:
+  room: Gäste WC
+8/2/41:
   dpt: '9.008'
   function: Sensorik
   name: Sensorik.EG.Gäste-WC.Sensor.CO2
-  room: Gäste-WC
-9/2/42:
+  room: Gäste WC
+8/2/42:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Gäste-WC.Sensor.CO2-Alarm-1
-  room: Gäste-WC
-9/2/43:
+  room: Gäste WC
+8/2/43:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Gäste-WC.Sensor.CO2-Alarm-2
-  room: Gäste-WC
-9/2/44:
+  room: Gäste WC
+8/2/44:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Gäste-WC.Sensor.CO2-Alarm-3
-  room: Gäste-WC
-9/2/50:
+  room: Gäste WC
+8/2/50:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.EG.Gäste-WC.BWM.Temperatur
-  room: Gäste-WC
-9/2/61:
+  room: Gäste WC
+8/2/61:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.EG.Büro.Sensor.Temperatur
   room: Büro
-9/2/62:
+8/2/62:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Büro.Sensor.Temperatur-Alarm-1
   room: Büro
-9/2/63:
+8/2/63:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Büro.Sensor.Temperatur-Alarm-2
   room: Büro
-9/2/64:
+8/2/64:
   dpt: '9.007'
   function: Sensorik
   name: Sensorik.EG.Büro.Sensor.Luftfeuchtigkeit
   room: Büro
-9/2/65:
+8/2/65:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Büro.Sensor.Luftfeuchtigkeit-Alarm-1
   room: Büro
-9/2/66:
+8/2/66:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Büro.Sensor.Luftfeuchtigkeit-Alarm-2
   room: Büro
-9/2/67:
+8/2/67:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.EG.Büro.Sensor.Taupunkt
   room: Büro
-9/2/68:
+8/2/68:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Büro.Sensor.Taupunkt-Alarm-1
   room: Büro
-9/2/71:
+8/2/71:
   dpt: '9.008'
   function: Sensorik
   name: Sensorik.EG.Büro.Sensor.CO2
   room: Büro
-9/2/72:
+8/2/72:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Büro.Sensor.CO2-Alarm-1
   room: Büro
-9/2/73:
+8/2/73:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Büro.Sensor.CO2-Alarm-2
   room: Büro
-9/2/74:
+8/2/74:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Büro.Sensor.CO2-Alarm-3
   room: Büro
-9/2/80:
+8/2/80:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.EG.Büro.Schalter.Temperatur
   room: Büro
-9/2/91:
+8/2/91:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.EG.Wohnzimmer.Sensor.Temperatur
   room: Wohnzimmer
-9/2/92:
+8/2/92:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Wohnzimmer.Sensor.Temperatur-Alarm-1
   room: Wohnzimmer
-9/2/93:
+8/2/93:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Wohnzimmer.Sensor.Temperatur-Alarm-2
   room: Wohnzimmer
-9/2/94:
+8/2/94:
   dpt: '9.007'
   function: Sensorik
   name: Sensorik.EG.Wohnzimmer.Sensor.Luftfeuchtigkeit
   room: Wohnzimmer
-9/2/95:
+8/2/95:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Wohnzimmer.Sensor.Luftfeuchtigkeit-Alarm-1
   room: Wohnzimmer
-9/2/96:
+8/2/96:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Wohnzimmer.Sensor.Luftfeuchtigkeit-Alarm-2
   room: Wohnzimmer
-9/2/97:
+8/2/97:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.EG.Wohnzimmer.Sensor.Taupunkt
   room: Wohnzimmer
-9/2/98:
+8/2/98:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Wohnzimmer.Sensor.Taupunkt-Alarm-1
   room: Wohnzimmer
-9/3/100:
+8/3/100:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Gregory.Sensor.VOC-Alarm-1
-  room: Schlafzimmer-Gregory
-9/3/101:
+  room: Schlafzimmer Gregory
+8/3/101:
   dpt: '9.008'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Gregory.Sensor.CO2
-  room: Schlafzimmer-Gregory
-9/3/102:
+  room: Schlafzimmer Gregory
+8/3/102:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Gregory.Sensor.CO2-Alarm-1
-  room: Schlafzimmer-Gregory
-9/3/103:
+  room: Schlafzimmer Gregory
+8/3/103:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Gregory.Sensor.CO2-Alarm-2
-  room: Schlafzimmer-Gregory
-9/3/104:
+  room: Schlafzimmer Gregory
+8/3/104:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Gregory.Sensor.CO2-Alarm-3
-  room: Schlafzimmer-Gregory
-9/3/110:
+  room: Schlafzimmer Gregory
+8/3/110:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Gregory.Schalter.Temperatur
-  room: Schlafzimmer-Gregory
-9/3/121:
+  room: Schlafzimmer Gregory
+8/3/121:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Luis.Sensor.Temperatur
-  room: Schlafzimmer-Luis
-9/3/122:
+  room: Schlafzimmer Luis
+8/3/122:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Luis.Sensor.Temperatur-Alarm-1
-  room: Schlafzimmer-Luis
-9/3/123:
+  room: Schlafzimmer Luis
+8/3/123:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Luis.Sensor.Temperatur-Alarm-2
-  room: Schlafzimmer-Luis
-9/3/124:
+  room: Schlafzimmer Luis
+8/3/124:
   dpt: '9.007'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Luis.Sensor.Luftfeuchtigkeit
-  room: Schlafzimmer-Luis
-9/3/125:
+  room: Schlafzimmer Luis
+8/3/125:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Luis.Sensor.Luftfeuchtigkeit-Alarm-1
-  room: Schlafzimmer-Luis
-9/3/126:
+  room: Schlafzimmer Luis
+8/3/126:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Luis.Sensor.Luftfeuchtigkeit-Alarm-2
-  room: Schlafzimmer-Luis
-9/3/127:
+  room: Schlafzimmer Luis
+8/3/127:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Luis.Sensor.Taupunkt
-  room: Schlafzimmer-Luis
-9/3/128:
+  room: Schlafzimmer Luis
+8/3/128:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Luis.Sensor.Taupunkt-Alarm-1
-  room: Schlafzimmer-Luis
-9/3/130:
+  room: Schlafzimmer Luis
+8/3/130:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Luis.Sensor.VOC-Alarm-1
-  room: Schlafzimmer-Luis
-9/3/131:
+  room: Schlafzimmer Luis
+8/3/131:
   dpt: '9.008'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Luis.Sensor.CO2
-  room: Schlafzimmer-Luis
-9/3/132:
+  room: Schlafzimmer Luis
+8/3/132:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Luis.Sensor.CO2-Alarm-1
-  room: Schlafzimmer-Luis
-9/3/133:
+  room: Schlafzimmer Luis
+8/3/133:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Luis.Sensor.CO2-Alarm-2
-  room: Schlafzimmer-Luis
-9/3/134:
+  room: Schlafzimmer Luis
+8/3/134:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Luis.Sensor.CO2-Alarm-3
-  room: Schlafzimmer-Luis
-9/3/140:
+  room: Schlafzimmer Luis
+8/3/140:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Luis.Schalter.Temperatur
-  room: Schlafzimmer-Luis
-9/3/151:
+  room: Schlafzimmer Luis
+8/3/151:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Eltern.Sensor.Temperatur
-  room: Schlafzimmer-Eltern
-9/3/152:
+  room: Schlafzimmer Eltern
+8/3/152:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Eltern.Sensor.Temperatur-Alarm-1
-  room: Schlafzimmer-Eltern
-9/3/153:
+  room: Schlafzimmer Eltern
+8/3/153:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Eltern.Sensor.Temperatur-Alarm-2
-  room: Schlafzimmer-Eltern
-9/3/154:
+  room: Schlafzimmer Eltern
+8/3/154:
   dpt: '9.007'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Eltern.Sensor.Luftfeuchtigkeit
-  room: Schlafzimmer-Eltern
-9/3/155:
+  room: Schlafzimmer Eltern
+8/3/155:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Eltern.Sensor.Luftfeuchtigkeit-Alarm-1
-  room: Schlafzimmer-Eltern
-9/3/156:
+  room: Schlafzimmer Eltern
+8/3/156:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Eltern.Sensor.Luftfeuchtigkeit-Alarm-2
-  room: Schlafzimmer-Eltern
-9/3/157:
+  room: Schlafzimmer Eltern
+8/3/157:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Eltern.Sensor.Taupunkt
-  room: Schlafzimmer-Eltern
-9/3/158:
+  room: Schlafzimmer Eltern
+8/3/158:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Eltern.Sensor.Taupunkt-Alarm-1
-  room: Schlafzimmer-Eltern
-9/3/160:
+  room: Schlafzimmer Eltern
+8/3/160:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Eltern.Sensor.VOC-Alarm-1
-  room: Schlafzimmer-Eltern
-9/3/161:
+  room: Schlafzimmer Eltern
+8/3/161:
   dpt: '9.008'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Eltern.Sensor.CO2
-  room: Schlafzimmer-Eltern
-9/3/162:
+  room: Schlafzimmer Eltern
+8/3/162:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Eltern.Sensor.CO2-Alarm-1
-  room: Schlafzimmer-Eltern
-9/3/163:
+  room: Schlafzimmer Eltern
+8/3/163:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Eltern.Sensor.CO2-Alarm-2
-  room: Schlafzimmer-Eltern
-9/3/164:
+  room: Schlafzimmer Eltern
+8/3/164:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Eltern.Sensor.CO2-Alarm-3
-  room: Schlafzimmer-Eltern
-9/3/170:
+  room: Schlafzimmer Eltern
+8/3/170:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Eltern.Schalter.Temperatur
-  room: Schlafzimmer-Eltern
-9/3/171:
+  room: Schlafzimmer Eltern
+8/3/171:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Eltern.Schalter.Bett-Links.Temperatur
-  room: Schlafzimmer-Eltern
-9/3/172:
+  room: Schlafzimmer Eltern
+8/3/172:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Eltern.Schalter.Bett-Rechts.Temperatur
-  room: Schlafzimmer-Eltern
-9/3/173:
+  room: Schlafzimmer Eltern
+8/3/173:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Eltern.BWM.Temperatur
-  room: Schlafzimmer-Eltern
-9/3/183:
+  room: Schlafzimmer Eltern
+8/3/183:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.OG.Begehbarer-Schrank.Sensor.Temperatur-Alarm-2
-  room: Begehbarer-Schrank
-9/3/20:
+  room: Begehbarer Schrank
+8/3/20:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.OG.Flur.BWM.Treppe.Temperatur
   room: Flur
-9/3/200:
+8/3/200:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.OG.Begehbarer-Schrank.BWM.Temperatur
-  room: Begehbarer-Schrank
-9/3/21:
+  room: Begehbarer Schrank
+8/3/21:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.OG.Flur.BWM.Gang.Temperatur
   room: Flur
-9/3/211:
+8/3/211:
   dpt: '9.001'
   function: Sensorik
-  name: Sensorik.OG.Badezimmer-Eltern.Sensor.Temperartur
-  room: Badezimmer-Eltern
-9/3/212:
+  name: Sensorik.OG.Badezimmer-Eltern.Sensor.Temperatur
+  room: Badezimmer Eltern
+8/3/212:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Badezimmer-Eltern.Sensor.Temperatur-Alarm-1
-  room: Badezimmer-Eltern
-9/3/213:
+  room: Badezimmer Eltern
+8/3/213:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Badezimmer-Eltern.Sensor.Temperatur-Alarm-2
-  room: Badezimmer-Eltern
-9/3/214:
+  room: Badezimmer Eltern
+8/3/214:
   dpt: '9.007'
   function: Sensorik
   name: Sensorik.OG.Badezimmer-Eltern.Sensor.Luftfeuchtigkeit
-  room: Badezimmer-Eltern
-9/3/215:
+  room: Badezimmer Eltern
+8/3/215:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Badezimmer-Eltern.Sensor.Luftfeuchtigkeit-Alarm-1
-  room: Badezimmer-Eltern
-9/3/216:
+  room: Badezimmer Eltern
+8/3/216:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Badezimmer-Eltern.Sensor.Luftfeuchtigkeit-Alarm-2
-  room: Badezimmer-Eltern
-9/3/217:
+  room: Badezimmer Eltern
+8/3/217:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.OG.Badezimmer-Eltern.Sensor.Taupunkt
-  room: Badezimmer-Eltern
-9/3/218:
+  room: Badezimmer Eltern
+8/3/218:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Badezimmer-Eltern.Sensor.Taupunkt-Alarm-1
-  room: Badezimmer-Eltern
-9/3/220:
+  room: Badezimmer Eltern
+8/3/220:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Badezimmer-Eltern.Sensor.VOC-Alarm-1
-  room: Badezimmer-Eltern
-9/3/221:
+  room: Badezimmer Eltern
+8/3/221:
   dpt: '9.008'
   function: Sensorik
   name: Sensorik.OG.Badezimmer-Eltern.Sensor.CO2
-  room: Badezimmer-Eltern
-9/3/222:
+  room: Badezimmer Eltern
+8/3/222:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Badezimmer-Eltern.Sensor.CO2-Alarm-1
-  room: Badezimmer-Eltern
-9/3/223:
+  room: Badezimmer Eltern
+8/3/223:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Badezimmer-Eltern.Sensor.CO2-Alarm-2
-  room: Badezimmer-Eltern
-9/3/224:
+  room: Badezimmer Eltern
+8/3/224:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Badezimmer-Eltern.Sensor.CO2-Alarm-3
-  room: Badezimmer-Eltern
-9/3/230:
+  room: Badezimmer Eltern
+8/3/230:
   dpt: '9.001'
   function: Sensorik
-  name: Sensorik.OG.Badezimmer-Eltern.Schalter.Temperartur
-  room: Badezimmer-Eltern
-9/3/231:
+  name: Sensorik.OG.Badezimmer-Eltern.Schalter.Temperatur
+  room: Badezimmer Eltern
+8/3/231:
   dpt: '9.001'
   function: Sensorik
-  name: Sensorik.OG.Badezimmer-Eltern.BWM.Temperartur
-  room: Badezimmer-Eltern
-9/3/31:
+  name: Sensorik.OG.Badezimmer-Eltern.BWM.Temperatur
+  room: Badezimmer Eltern
+8/3/31:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.OG.Abstellraum.Sensor.Temperatur
   room: Abstellraum
-9/3/32:
+8/3/32:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Abstellraum.Sensor.Temperatur-Alarm-1
   room: Abstellraum
-9/3/33:
+8/3/33:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Abstellraum.Sensor.Temperatur-Alarm-2
   room: Abstellraum
-9/3/34:
+8/3/34:
   dpt: '9.007'
   function: Sensorik
   name: Sensorik.OG.Abstellraum.Sensor.Luftfeuchtigkeit
   room: Abstellraum
-9/3/35:
+8/3/35:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Abstellraum.Sensor.Luftfeuchtigkeit-Alarm-1
   room: Abstellraum
-9/3/36:
+8/3/36:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Abstellraum.Sensor.Luftfeuchtigkeit-Alarm-2
   room: Abstellraum
-9/3/37:
+8/3/37:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.OG.Abstellraum.Sensor.Taupunkt
   room: Abstellraum
-9/3/38:
+8/3/38:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Abstellraum.Sensor.Taupunkt-Alarm-1
   room: Abstellraum
-9/3/40:
+8/3/40:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Abstellraum.Sensor.VOC-Alarm-1
   room: Abstellraum
-9/3/41:
+8/3/41:
   dpt: '9.008'
   function: Sensorik
   name: Sensorik.OG.Abstellraum.Sensor.CO2
   room: Abstellraum
-9/3/42:
+8/3/42:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Abstellraum.Sensor.CO2-Alarm-1
   room: Abstellraum
-9/3/43:
+8/3/43:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Abstellraum.Sensor.CO2-Alarm-2
   room: Abstellraum
-9/3/44:
+8/3/44:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Abstellraum.Sensor.CO2-Alarm-3
   room: Abstellraum
-9/3/50:
+8/3/50:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.OG.Abstellraum.Schalter.Temperatur
   room: Abstellraum
-9/3/61:
+8/3/61:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.OG.Badezimmer-Kinder.Sensor.Temperatur
-  room: Badezimmer-Kinder
-9/3/62:
+  room: Badezimmer Kinder
+8/3/62:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Badezimmer-Kinder.Sensor.Temperatur-Alarm-1
-  room: Badezimmer-Kinder
-9/3/63:
+  room: Badezimmer Kinder
+8/3/63:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Badezimmer-Kinder.Sensor.Temperatur-Alarm-2
-  room: Badezimmer-Kinder
-9/3/64:
+  room: Badezimmer Kinder
+8/3/64:
   dpt: '9.007'
   function: Sensorik
   name: Sensorik.OG.Badezimmer-Kinder.Sensor.Luftfeuchtigkeit
-  room: Badezimmer-Kinder
-9/3/65:
+  room: Badezimmer Kinder
+8/3/65:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Badezimmer-Kinder.Sensor.Luftfeuchtigkeit-Alarm-1
-  room: Badezimmer-Kinder
-9/3/66:
+  room: Badezimmer Kinder
+8/3/66:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Badezimmer-Kinder.Sensor.Luftfeuchtigkeit-Alarm-2
-  room: Badezimmer-Kinder
-9/3/67:
+  room: Badezimmer Kinder
+8/3/67:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.OG.Badezimmer-Kinder.Sensor.Taupunkt
-  room: Badezimmer-Kinder
-9/3/68:
+  room: Badezimmer Kinder
+8/3/68:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Badezimmer-Kinder.Sensor.Taupunkt-Alarm-1
-  room: Badezimmer-Kinder
-9/3/70:
+  room: Badezimmer Kinder
+8/3/70:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Badezimmer-Kinder.Sensor.VOC-Alarm-1
-  room: Badezimmer-Kinder
-9/3/71:
+  room: Badezimmer Kinder
+8/3/71:
   dpt: '9.008'
   function: Sensorik
   name: Sensorik.OG.Badezimmer-Kinder.Sensor.CO2
-  room: Badezimmer-Kinder
-9/3/72:
+  room: Badezimmer Kinder
+8/3/72:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Badezimmer-Kinder.Sensor.CO2-Alarm-1
-  room: Badezimmer-Kinder
-9/3/73:
+  room: Badezimmer Kinder
+8/3/73:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Badezimmer-Kinder.Sensor.CO2-Alarm-2
-  room: Badezimmer-Kinder
-9/3/74:
+  room: Badezimmer Kinder
+8/3/74:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Badezimmer-Kinder.Sensor.CO2-Alarm-3
-  room: Badezimmer-Kinder
-9/3/80:
+  room: Badezimmer Kinder
+8/3/80:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.OG.Badezimmer-Kinder.Schalter.Temperatur
-  room: Badezimmer-Kinder
-9/3/81:
+  room: Badezimmer Kinder
+8/3/81:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.OG.Badezimmer-Kinder.BWM.Temperatur
-  room: Badezimmer-Kinder
-9/3/91:
+  room: Badezimmer Kinder
+8/3/91:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Gregory.Sensor.Temperatur
-  room: Schlafzimmer-Gregory
-9/3/92:
+  room: Schlafzimmer Gregory
+8/3/92:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Gregory.Sensor.Temperatur-Alarm-1
-  room: Schlafzimmer-Gregory
-9/3/93:
+  room: Schlafzimmer Gregory
+8/3/93:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Gregory.Sensor.Temperatur-Alarm-2
-  room: Schlafzimmer-Gregory
-9/3/94:
+  room: Schlafzimmer Gregory
+8/3/94:
   dpt: '9.007'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Gregory.Sensor.Luftfeuchtigkeit
-  room: Schlafzimmer-Gregory
-9/3/95:
+  room: Schlafzimmer Gregory
+8/3/95:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Gregory.Sensor.Luftfeuchtigkeit-Alarm-1
-  room: Schlafzimmer-Gregory
-9/3/96:
+  room: Schlafzimmer Gregory
+8/3/96:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Gregory.Sensor.Luftfeuchtigkeit-Alarm-2
-  room: Schlafzimmer-Gregory
-9/3/97:
+  room: Schlafzimmer Gregory
+8/3/97:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Gregory.Sensor.Taupunkt
-  room: Schlafzimmer-Gregory
-9/3/98:
+  room: Schlafzimmer Gregory
+8/3/98:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Gregory.Sensor.Taupunkt-Alarm-1
-  room: Schlafzimmer-Gregory
-9/4/1:
+  room: Schlafzimmer Gregory
+8/4/1:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.DG.Speicher.Sensor.Temperatur
-  room: Speicher
-9/4/10:
+  room: Speicher (S)
+8/4/10:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.DG.Speicher.Sensor.VOC-Alarm-1
-  room: Speicher
-9/4/11:
+  room: Speicher (S)
+8/4/11:
   dpt: '9.008'
   function: Sensorik
   name: Sensorik.DG.Speicher.Sensor.CO2
-  room: Speicher
-9/4/12:
+  room: Speicher (S)
+8/4/12:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.DG.Speicher.Sensor.CO2-Alarm-1
-  room: Speicher
-9/4/13:
+  room: Speicher (S)
+8/4/13:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.DG.Speicher.Sensor.CO2-Alarm-2
-  room: Speicher
-9/4/14:
+  room: Speicher (S)
+8/4/14:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.DG.Speicher.Sensor.CO2-Alarm-3
-  room: Speicher
-9/4/15:
+  room: Speicher (S)
+8/4/15:
   dpt: '14.058'
   function: Sensorik
   name: Sensorik.DG.Speicher.Sensor.Luftdruck-Relativ
-  room: Speicher
-9/4/16:
+  room: Speicher (S)
+8/4/16:
   dpt: '14.058'
   function: Sensorik
   name: Sensorik.DG.Speicher.Sensor.Luftdruck-Absolut
-  room: Speicher
-9/4/17:
+  room: Speicher (S)
+8/4/17:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.DG.Speicher.Sensor.Luftdruck-Alarm-1
-  room: Speicher
-9/4/2:
+  room: Speicher (S)
+8/4/2:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.DG.Speicher.Sensor.Temperatur-Alarm-1
-  room: Speicher
-9/4/3:
+  room: Speicher (S)
+8/4/3:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.DG.Speicher.Sensor.Temperatur-Alarm-2
-  room: Speicher
-9/4/4:
+  room: Speicher (S)
+8/4/4:
   dpt: '9.007'
   function: Sensorik
   name: Sensorik.DG.Speicher.Sensor.Luftfeuchtigkeit
-  room: Speicher
-9/4/5:
+  room: Speicher (S)
+8/4/5:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.DG.Speicher.Sensor.Luftfeuchtigkeit-Alarm-1
-  room: Speicher
-9/4/6:
+  room: Speicher (S)
+8/4/6:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.DG.Speicher.Sensor.Luftfeuchtigkeit-Alarm-2
-  room: Speicher
-9/4/7:
+  room: Speicher (S)
+8/4/7:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.DG.Speicher.Sensor.Taupunkt
-  room: Speicher
-9/4/8:
+  room: Speicher (S)
+8/4/8:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.DG.Speicher.Sensor.Taupunkt-Alarm-1
-  room: Speicher
-9/4/9:
+  room: Speicher (S)
+8/4/9:
   dpt: '9.008'
   function: Sensorik
   name: Sensorik.DG.Speicher.Sensor.VOC
-  room: Speicher
-9/5/1:
+  room: Speicher (S)
+8/5/1:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.A.Fassade.Außensensor.Temperatur
   room: Fassade
-9/5/10:
+8/5/10:
   dpt: '9.004'
   function: Sensorik
   name: Sensorik.A.Fassade.Außensensor.Helligkeit-Mitte
   room: Fassade
-9/5/101:
+8/5/101:
   dpt: '9.007'
   function: Sensorik
-  name: Sensorik.A.DachAußensensor.SO.Luftfeuchtigkeit
-  room: DachAußensensor
-9/5/102:
+  name: Sensorik.A.Dach.Außensensor.SO.Luftfeuchtigkeit
+  room: Dach
+8/5/102:
   dpt: '9.007'
   function: Sensorik
   name: Sensorik.A.Dach.Außensensor.SO.Luftfeuchtigkeit-Alle
   room: Dach
-9/5/103:
+8/5/103:
   dpt: '1.001'
   function: Sensorik
   name: Sensorik.A.Dach.Außensensor.SO.Luftfeuchtigkeit-Alarm-1
   room: Dach
-9/5/104:
+8/5/104:
   dpt: '1.001'
   function: Sensorik
   name: Sensorik.A.Dach.Außensensor.SO.Luftfeuchtigkeit-Alarm-2
   room: Dach
-9/5/105:
+8/5/105:
   dpt: '1.001'
   function: Sensorik
   name: Sensorik.A.Dach.Außensensor.SO.Luftfeuchtigkeit-Status
   room: Dach
-9/5/106:
+8/5/106:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.A.Dach.Außensensor.SO.Taupunkt
   room: Dach
-9/5/108:
+8/5/108:
   dpt: '14.058'
   function: Sensorik
   name: Sensorik.A.Dach.Außensensor.SO.Luftdruck-Relativ
   room: Dach
-9/5/109:
+8/5/109:
   dpt: '14.058'
   function: Sensorik
   name: Sensorik.A.Dach.Außensensor.SO.Luftdruck-Absolut
   room: Dach
-9/5/11:
+8/5/11:
   dpt: '9.004'
   function: Sensorik
   name: Sensorik.A.Fassade.Außensensor.Helligkeit-Rechts
   room: Fassade
-9/5/110:
+8/5/110:
   dpt: '1.001'
   function: Sensorik
   name: Sensorik.A.Dach.Außensensor.SO.Luftdruck-Alarm-1
   room: Dach
-9/5/111:
+8/5/111:
   dpt: '1.001'
   function: Sensorik
   name: Sensorik.A.Dach.Außensensor.SO.Luftdruck-Status
   room: Dach
-9/5/12:
+8/5/12:
   dpt: '9.004'
   function: Sensorik
   name: Sensorik.A.Fassade.Außensensor.Helligkeit-Alle
   room: Fassade
-9/5/121:
+8/5/121:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.A.Dach.Außensensor.NW.Temperatur
   room: Dach
-9/5/122:
+8/5/122:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.A.Dach.Außensensor.NW.Temperatur-Alle
   room: Dach
-9/5/123:
+8/5/123:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.A.Dach.Außensensor.NW.Temperatur-Alarm-1
   room: Dach
-9/5/124:
+8/5/124:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.A.Dach.Außensensor.NW.Temperatur-Alarm-2
   room: Dach
-9/5/125:
+8/5/125:
   dpt: '1.001'
   function: Sensorik
   name: Sensorik.A.Dach.Außensensor.NW.Temperatur-Status
   room: Dach
-9/5/129:
+8/5/129:
   dpt: '9.004'
   function: Sensorik
   name: Sensorik.A.Dach.Außensensor.NW.Helligkeit-Links
   room: Dach
-9/5/130:
+8/5/130:
   dpt: '9.004'
   function: Sensorik
   name: Sensorik.A.Dach.Außensensor.NW.Helligkeit-Mitte
   room: Dach
-9/5/131:
+8/5/131:
   dpt: '9.004'
   function: Sensorik
   name: Sensorik.A.Dach.Außensensor.NW.Helligkeit-Rechts
   room: Dach
-9/5/132:
+8/5/132:
   dpt: '9.004'
   function: Sensorik
   name: Sensorik.A.Dach.Außensensor.NW.Helligkeit-Alle
   room: Dach
-9/5/2:
+8/5/2:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.A.Fassade.Außensensor.Temperatur-Alle
   room: Fassade
-9/5/3:
+8/5/3:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.A.Fassade.Außensensor.Temperatur-Alarm-1
   room: Fassade
-9/5/4:
+8/5/4:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.A.Fassade.Außensensor.Temperatur-Alarm-2
   room: Fassade
-9/5/41:
+8/5/41:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.A.Dach.Wetterstation.Temperatur
   room: Dach
-9/5/43:
+8/5/43:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.A.Dach.Wetterstation.Temperatur-Alarm-1
   room: Dach
-9/5/44:
+8/5/44:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.A.Dach.Wetterstation.Temperatur-Alarm-2
   room: Dach
-9/5/45:
+8/5/45:
   dpt: '1.001'
   function: Sensorik
   name: Sensorik.A.Dach.Wetterstation.Temperatur-Status
   room: Dach
-9/5/46:
+8/5/46:
   dpt: '9.005'
   function: Sensorik
   name: Sensorik.A.Dach.Wetterstation.Windgeschwindigkeit
   room: Dach
-9/5/47:
+8/5/47:
   dpt: '1.001'
   function: Sensorik
   name: Sensorik.A.Dach.Wetterstation.Windgeschwindigkeit-Alarm-1
   room: Dach
-9/5/48:
+8/5/48:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.A.Dach.Wetterstation.Windgeschwindigkeit-Alarm-Erweitert-1
   room: Dach
-9/5/49:
+8/5/49:
   dpt: '9.004'
   function: Sensorik
   name: Sensorik.A.Dach.Wetterstation.Helligkeit-Links
   room: Dach
-9/5/5:
+8/5/5:
   dpt: '1.001'
   function: Sensorik
   name: Sensorik.A.Fassade.Außensensor.Temperatur-Status
   room: Fassade
-9/5/50:
+8/5/50:
   dpt: '9.004'
   function: Sensorik
   name: Sensorik.A.Dach.Wetterstation.Helligkeit-Mitte
   room: Dach
-9/5/51:
+8/5/51:
   dpt: '9.004'
   function: Sensorik
   name: Sensorik.A.Dach.Wetterstation.Helligkeit-Rechts
   room: Dach
-9/5/52:
+8/5/52:
   dpt: '9.004'
   function: Sensorik
   name: Sensorik.A.Dach.Wetterstation.Helligkeit-Alle
   room: Dach
-9/5/53:
+8/5/53:
   dpt: '1.001'
   function: Sensorik
   name: Sensorik.A.Dach.Wetterstation.Regen
   room: Dach
-9/5/54:
+8/5/54:
   dpt: '1.001'
   function: Sensorik
   name: Sensorik.A.Dach.Wetterstation.Regen-Alarm-1
   room: Dach
-9/5/55:
+8/5/55:
   dpt: '1.001'
   function: Sensorik
   name: Sensorik.A.Dach.Wetterstation.Frost
   room: Dach
-9/5/56:
+8/5/56:
   dpt: '1.001'
   function: Sensorik
   name: Sensorik.A.Dach.Wetterstation.Frost-Alarm-1
   room: Dach
-9/5/57:
+8/5/57:
   dpt: '14.007'
   function: Sensorik
   name: Sensorik.A.Dach.Wetterstation.Azimut
   room: Dach
-9/5/58:
+8/5/58:
   dpt: '14.007'
   function: Sensorik
   name: Sensorik.A.Dach.Wetterstation.Elevation
   room: Dach
-9/5/59:
+8/5/59:
   dpt: '14.007'
   function: Sensorik
   name: Sensorik.A.Dach.Wetterstation.GPS-Breitengrad
   room: Dach
-9/5/60:
+8/5/60:
   dpt: '14.007'
   function: Sensorik
   name: Sensorik.A.Dach.Wetterstation.GPS-Längengrad
   room: Dach
-9/5/81:
+8/5/81:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.A.Dach.Außensensor.SO.Temperatur
   room: Dach
-9/5/82:
+8/5/82:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.A.Dach.Außensensor.SO.Temperatur-Alle
   room: Dach
-9/5/83:
+8/5/83:
   dpt: '1.001'
   function: Sensorik
   name: Sensorik.A.Dach.Außensensor.SO.Temperatur-Alarm-1
   room: Dach
-9/5/84:
+8/5/84:
   dpt: '1.001'
   function: Sensorik
   name: Sensorik.A.Dach.Außensensor.SO.Temperatur-Alarm-2
   room: Dach
-9/5/85:
+8/5/85:
   dpt: '1.001'
   function: Sensorik
   name: Sensorik.A.Dach.Außensensor.SO.Temperatur-Status
   room: Dach
-9/5/9:
+8/5/9:
   dpt: '9.004'
   function: Sensorik
   name: Sensorik.A.Fassade.Außensensor.Helligkeit-Links
   room: Fassade
+9/1/0:
+  dpt: '1.003'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Flur.KNX.Decke.Sperren
+  room: Flur
+9/1/1:
+  dpt: '1.011'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Flur.KNX.Decke.Sperren-Status
+  room: Flur
+9/1/10:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Flur.KNX.Decke.Slave
+  room: Flur
+9/1/100:
+  dpt: '1.003'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Garage.EMA.Sperren
+  room: Garage
+9/1/101:
+  dpt: '1.011'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Garage.EMA.Sperren-Staus
+  room: Garage
+9/1/102:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Garage.EMA.Ein/Aus
+  room: Garage
+9/1/106:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Garage.EMA.HLK
+  room: Garage
+9/1/107:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Garage.EMA.Präsenz
+  room: Garage
+9/1/109:
+  dpt: '1.024'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Garage.EMA.Tag/Nacht
+  room: Garage
+9/1/120:
+  dpt: '1.003'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Technikraum.KNX.Sperren
+  room: Technikraum
+9/1/121:
+  dpt: '1.011'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Technikraum.KNX.Sperren-Status
+  room: Technikraum
+9/1/122:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Technikraum.KNX.Ein/Aus
+  room: Technikraum
+9/1/123:
+  dpt: '5.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Technikraum.KNX.Dimmen
+  room: Technikraum
+9/1/124:
+  dpt: '9.004'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Technikraum.KNX.Schaltschwelle
+  room: Technikraum
+9/1/126:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Technikraum.KNX.HLK
+  room: Technikraum
+9/1/127:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Technikraum.KNX.Präsenz
+  room: Technikraum
+9/1/128:
+  dpt: '9.004'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Technikraum.KNX.Helligkeit
+  room: Technikraum
+9/1/129:
+  dpt: '1.024'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Technikraum.KNX.Tag/Nacht
+  room: Technikraum
+9/1/130:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Technikraum.KNX.Slave
+  room: Technikraum
+9/1/140:
+  dpt: '1.003'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Vorratsraum.KNX.Sperren
+  room: Vorratsraum
+9/1/141:
+  dpt: '1.011'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Vorratsraum.KNX.Sperren-Status
+  room: Vorratsraum
+9/1/142:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Vorratsraum.KNX.Ein/Aus
+  room: Vorratsraum
+9/1/143:
+  dpt: '5.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Vorratsraum.KNX.Dimmen
+  room: Vorratsraum
+9/1/144:
+  dpt: '9.004'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Vorratsraum.KNX.Schaltschwelle
+  room: Vorratsraum
+9/1/146:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Vorratsraum.KNX.HLK
+  room: Vorratsraum
+9/1/147:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Vorratsraum.KNX.Präsenz
+  room: Vorratsraum
+9/1/148:
+  dpt: '9.004'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Vorratsraum.KNX.Helligkeit
+  room: Vorratsraum
+9/1/149:
+  dpt: '1.024'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Vorratsraum.KNX.Tag/Nacht
+  room: Vorratsraum
+9/1/150:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Vorratsraum.KNX.Slave
+  room: Vorratsraum
+9/1/160:
+  dpt: '1.003'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Hauswirtschaftsraum.KNX.Sperren
+  room: Hauswirtschaftsraum
+9/1/161:
+  dpt: '1.011'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Hauswirtschaftsraum.KNX.Sperren-Status
+  room: Hauswirtschaftsraum
+9/1/162:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Hauswirtschaftsraum.KNX.Ein/Aus
+  room: Hauswirtschaftsraum
+9/1/163:
+  dpt: '5.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Hauswirtschaftsraum.KNX.Dimmen
+  room: Hauswirtschaftsraum
+9/1/164:
+  dpt: '9.004'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Hauswirtschaftsraum.KNX.Schaltschwelle
+  room: Hauswirtschaftsraum
+9/1/166:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Hauswirtschaftsraum.KNX.HLK
+  room: Hauswirtschaftsraum
+9/1/167:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Hauswirtschaftsraum.KNX.Präsenz
+  room: Hauswirtschaftsraum
+9/1/168:
+  dpt: '9.004'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Hauswirtschaftsraum.KNX.Helligkeit
+  room: Hauswirtschaftsraum
+9/1/169:
+  dpt: '1.024'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Hauswirtschaftsraum.KNX.Tag/Nacht
+  room: Hauswirtschaftsraum
+9/1/170:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Hauswirtschaftsraum.KNX.Slave
+  room: Hauswirtschaftsraum
+9/1/2:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Flur.KNX.Decke.Ein/Aus
+  room: Flur
+9/1/20:
+  dpt: '1.003'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Flur.KNX.Wand.Sperren
+  room: Flur
+9/1/21:
+  dpt: '1.011'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Flur.KNX.Wand.Sperren-Status
+  room: Flur
+9/1/22:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Flur.KNX.Wand.Ein/Aus
+  room: Flur
+9/1/23:
+  dpt: '5.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Flur.KNX.Wand.Dimmen
+  room: Flur
+9/1/25:
+  dpt: '1.011'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Flur.KNX.Wand.Schaltschwelle-Status
+  room: Flur
+9/1/26:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Flur.KNX.Wand.HLK
+  room: Flur
+9/1/27:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Flur.KNX.Wand.Präsenz
+  room: Flur
+9/1/28:
+  dpt: '9.004'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Flur.KNX.Wand.Helligkeit
+  room: Flur
+9/1/29:
+  dpt: '1.024'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Flur.KNX.Wand.Tag/Nacht
+  room: Flur
+9/1/3:
+  dpt: '5.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Flur.KNX.Decke.Dimmen
+  room: Flur
+9/1/30:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Flur.KNX.Wand.Slave
+  room: Flur
+9/1/40:
+  dpt: '1.003'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Flur.EMA.Sperren
+  room: Flur
+9/1/41:
+  dpt: '1.011'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Flur.EMA.Sperren-Status
+  room: Flur
+9/1/42:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Flur.EMA.Ein/Aus
+  room: Flur
+9/1/46:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Flur.EMA.HLK
+  room: Flur
+9/1/47:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Flur.EMA.Präsenz
+  room: Flur
+9/1/49:
+  dpt: '1.024'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Flur.EMA.Tag/Nacht
+  room: Flur
+9/1/5:
+  dpt: '1.011'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Flur.KNX.Decke.Schaltschwelle-Status
+  room: Flur
+9/1/6:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Flur.KNX.Decke.HLK
+  room: Flur
+9/1/60:
+  dpt: '1.003'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Garage.KNX.Decke.Sperren
+  room: Garage
+9/1/61:
+  dpt: '1.011'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Garage.KNX.Decke.Sperren-Status
+  room: Garage
+9/1/62:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Garage.KNX.Decke.Ein/Aus
+  room: Garage
+9/1/63:
+  dpt: '5.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Garage.KNX.Decke.Dimmen
+  room: Garage
+9/1/64:
+  dpt: '9.004'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Garage.KNX.Decke.Schaltschwelle
+  room: Garage
+9/1/66:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Garage.KNX.Decke.HLK
+  room: Garage
+9/1/67:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Garage.KNX.Decke.Präsenz
+  room: Garage
+9/1/68:
+  dpt: '9.004'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Garage.KNX.Decke.Helligkeit
+  room: Garage
+9/1/69:
+  dpt: '1.024'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Garage.KNX.Decke.Tag/Nacht
+  room: Garage
+9/1/7:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Flur.KNX.Decke.Präsenz
+  room: Flur
+9/1/70:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Garage.KNX.Decke.Slave
+  room: Garage
+9/1/8:
+  dpt: '9.004'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Flur.KNX.Decke.Helligkeit
+  room: Flur
+9/1/82:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Garage.KNX.Wand.Ein/Aus
+  room: Garage
+9/1/83:
+  dpt: '5.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Garage.KNX.Wand.Dimmen
+  room: Garage
+9/1/86:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Garage.KNX.Wand.HLK
+  room: Garage
+9/1/87:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Garage.KNX.Wand.Präsenz
+  room: Garage
+9/1/88:
+  dpt: '9.004'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Garage.KNX.Wand.Helligkeit
+  room: Garage
+9/1/89:
+  dpt: '1.024'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Garage.KNX.Wand.Tag/Nacht
+  room: Garage
+9/1/9:
+  dpt: '1.024'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Flur.KNX.Decke.Tag/Nacht
+  room: Flur
+9/1/90:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.KG.Garage.KNX.Wand.Slave
+  room: Garage
+9/2/0:
+  dpt: '1.003'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.EG.Flur.KNX.Eingang.Sperren
+  room: Flur
+9/2/1:
+  dpt: '1.011'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.EG.Flur.KNX.Eingang.Sperren-Status
+  room: Flur
+9/2/10:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.EG.Flur.KNX.Eingang.Slave
+  room: Flur
+9/2/100:
+  dpt: '1.003'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.EG.Büro.EMA.Sperren
+  room: Büro
+9/2/101:
+  dpt: '1.011'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.EG.Büro.EMA.Sperren-Status
+  room: Büro
+9/2/102:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.EG.Büro.EMA.Ein/Aus
+  room: Büro
+9/2/106:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.EG.Büro.EMA.HLK
+  room: Büro
+9/2/107:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.EG.Büro.EMA.Präsenz
+  room: Büro
+9/2/109:
+  dpt: '1.024'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.EG.Büro.EMA.Tag/Nacht
+  room: Büro
+9/2/120:
+  dpt: '1.003'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.EG.Wohnzimmer.EMA.Sperren
+  room: Wohnzimmer
+9/2/121:
+  dpt: '1.011'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.EG.Wohnzimmer.EMA.Sperren-Status
+  room: Wohnzimmer
+9/2/122:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.EG.Wohnzimmer.EMA.Ein/Aus
+  room: Wohnzimmer
+9/2/126:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.EG.Wohnzimmer.EMA.HLK
+  room: Wohnzimmer
+9/2/127:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.EG.Wohnzimmer.EMA.Präsenz
+  room: Wohnzimmer
+9/2/129:
+  dpt: '1.024'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.EG.Wohnzimmer.EMA.Tag/Nacht
+  room: Wohnzimmer
+9/2/140:
+  dpt: '1.003'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.EG.Esszimmer.EMA.Sperren
+  room: Esszimmer
+9/2/141:
+  dpt: '1.011'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.EG.Esszimmer.EMA.Sperren-Status
+  room: Esszimmer
+9/2/142:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.EG.Esszimmer.EMA.Ein/Aus
+  room: Esszimmer
+9/2/146:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.EG.Esszimmer.EMA.HLK
+  room: Esszimmer
+9/2/147:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.EG.Esszimmer.EMA.Präsenz
+  room: Esszimmer
+9/2/149:
+  dpt: '1.024'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.EG.Esszimmer.EMA.Tag/Nacht
+  room: Esszimmer
+9/2/2:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.EG.Flur.KNX.Eingang.Ein/Aus
+  room: Flur
+9/2/20:
+  dpt: '1.003'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.EG.Flur.KNX.Diele.Sperren
+  room: Flur
+9/2/21:
+  dpt: '1.011'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.EG.Flur.KNX.Diele.Sperren-Status
+  room: Flur
+9/2/22:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.EG.Flur.KNX.Diele.Ein/Aus
+  room: Flur
+9/2/23:
+  dpt: '5.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.EG.Flur.KNX.Diele.Dimmen
+  room: Flur
+9/2/25:
+  dpt: '1.011'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.EG.Flur.KNX.Diele.Schaltschwelle-Status
+  room: Flur
+9/2/26:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.EG.Flur.KNX.Diele.HLK
+  room: Flur
+9/2/27:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.EG.Flur.KNX.Diele.Präsenz
+  room: Flur
+9/2/28:
+  dpt: '9.004'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.EG.Flur.KNX.Diele.Helligkeit
+  room: Flur
+9/2/29:
+  dpt: '1.024'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.EG.Flur.KNX.Diele.Tag/Nacht
+  room: Flur
+9/2/3:
+  dpt: '5.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.EG.Flur.KNX.Eingang.Dimmen
+  room: Flur
+9/2/30:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.EG.Flur.KNX.Diele.Slave
+  room: Flur
+9/2/42:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.EG.Flur.KNX.Garderobe.Ein/Aus
+  room: Flur
+9/2/46:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.EG.Flur.KNX.Garderobe.HLK
+  room: Flur
+9/2/47:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.EG.Flur.KNX.Garderobe.Präsenz
+  room: Flur
+9/2/48:
+  dpt: '9.004'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.EG.Flur.KNX.Garderobe.Helligkeit
+  room: Flur
+9/2/49:
+  dpt: '1.024'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.EG.Flur.KNX.Garderobe.Tag/Nacht
+  room: Flur
+9/2/5:
+  dpt: '1.011'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.EG.Flur.KNX.Eingang.Schaltschwelle-Status
+  room: Flur
+9/2/50:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.EG.Flur.KNX.Garderobe.Slave
+  room: Flur
+9/2/6:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.EG.Flur.KNX.Eingang.HLK
+  room: Flur
+9/2/60:
+  dpt: '1.003'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.EG.Flur.EMA.Sperren
+  room: Flur
+9/2/61:
+  dpt: '1.011'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.EG.Flur.EMA.Sperren-Status
+  room: Flur
+9/2/62:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.EG.Flur.EMA.Ein/Aus
+  room: Flur
+9/2/66:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.EG.Flur.EMA.HLK
+  room: Flur
+9/2/67:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.EG.Flur.EMA.Präsenz
+  room: Flur
+9/2/69:
+  dpt: '1.024'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.EG.Flur.EMA.Tag/Nacht
+  room: Flur
+9/2/7:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.EG.Flur.KNX.Eingang.Präsenz
+  room: Flur
+9/2/8:
+  dpt: '9.004'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.EG.Flur.KNX.Eingang.Helligkeit
+  room: Flur
+9/2/80:
+  dpt: '1.003'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.EG.Gäste-WC.KNX.Sperren
+  room: Gäste WC
+9/2/81:
+  dpt: '1.011'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.EG.Gäste-WC.KNX.Sperren-Status
+  room: Gäste WC
+9/2/82:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.EG.Gäste-WC.KNX.Ein/Aus
+  room: Gäste WC
+9/2/83:
+  dpt: '5.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.EG.Gäste-WC.KNX.Dimmen
+  room: Gäste WC
+9/2/85:
+  dpt: '1.011'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.EG.Gäste-WC.KNX.Schaltschwelle-Status
+  room: Gäste WC
+9/2/86:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.EG.Gäste-WC.KNX.HLK
+  room: Gäste WC
+9/2/87:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.EG.Gäste-WC.KNX.Präsenz
+  room: Gäste WC
+9/2/88:
+  dpt: '9.004'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.EG.Gäste-WC.KNX.Helligkeit
+  room: Gäste WC
+9/2/89:
+  dpt: '1.024'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.EG.Gäste-WC.KNX.Tag/Nacht
+  room: Gäste WC
+9/2/9:
+  dpt: '1.024'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.EG.Flur.KNX.Eingang.Tag/Nacht
+  room: Flur
+9/2/90:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.EG.Gäste-WC.KNX.Slave
+  room: Gäste WC
+9/3/10:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Flur.KNX.Treppe.Slave
+  room: Flur
+9/3/100:
+  dpt: '1.003'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Badezimmer-Kinder.KNX.Sperren
+  room: Badezimmer Kinder
+9/3/101:
+  dpt: '1.011'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Badezimmer-Kinder.KNX.Sperren-Status
+  room: Badezimmer Kinder
+9/3/102:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Badezimmer-Kinder.KNX.Ein/Aus
+  room: Badezimmer Kinder
+9/3/103:
+  dpt: '5.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Badezimmer-Kinder.KNX.Dimmen
+  room: Badezimmer Kinder
+9/3/105:
+  dpt: '1.011'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Badezimmer-Kinder.KNX.Schaltschwelle-Status
+  room: Badezimmer Kinder
+9/3/106:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Badezimmer-Kinder.KNX.HLK
+  room: Badezimmer Kinder
+9/3/107:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Badezimmer-Kinder.KNX.Präsenz
+  room: Badezimmer Kinder
+9/3/108:
+  dpt: '9.004'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Badezimmer-Kinder.KNX.Helligkeit
+  room: Badezimmer Kinder
+9/3/109:
+  dpt: '1.024'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Badezimmer-Kinder.KNX.Tag/Nacht
+  room: Badezimmer Kinder
+9/3/110:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Badezimmer-Kinder.KNX.Slave
+  room: Badezimmer Kinder
+9/3/160:
+  dpt: '1.003'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Schlafzimmer-Eltern.KNX.Sperren
+  room: Schlafzimmer Eltern
+9/3/161:
+  dpt: '1.011'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Schlafzimmer-Eltern.KNX..Sperren-Status
+  room: Schlafzimmer Eltern
+9/3/162:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Schlafzimmer-Eltern.KNX.Ein/Aus
+  room: Schlafzimmer Eltern
+9/3/163:
+  dpt: '5.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Schlafzimmer-Eltern.KNX.Dimmen
+  room: Schlafzimmer Eltern
+9/3/165:
+  dpt: '1.011'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Schlafzimmer-Eltern.KNX.Schaltschwelle-Status
+  room: Schlafzimmer Eltern
+9/3/166:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Schlafzimmer-Eltern.KNX.HLK
+  room: Schlafzimmer Eltern
+9/3/167:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Schlafzimmer-Eltern.KNX.Präsenz
+  room: Schlafzimmer Eltern
+9/3/168:
+  dpt: '9.004'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Schlafzimmer-Eltern.KNX.Helligkeit
+  room: Schlafzimmer Eltern
+9/3/169:
+  dpt: '1.024'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Schlafzimmer-Eltern.KNX.Tag/Nacht
+  room: Schlafzimmer Eltern
+9/3/170:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Schlafzimmer-Eltern.KNX.Slave
+  room: Schlafzimmer Eltern
+9/3/180:
+  dpt: '1.003'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Begehbarer-Schrank.KNX.Sperren
+  room: Begehbarer Schrank
+9/3/181:
+  dpt: '1.011'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Begehbarer-Schrank.KNX.Sperren-Status
+  room: Begehbarer Schrank
+9/3/182:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Begehbarer-Schrank.KNX.Ein/Aus
+  room: Begehbarer Schrank
+9/3/183:
+  dpt: '5.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Begehbarer-Schrank.KNX.Dimmen
+  room: Begehbarer Schrank
+9/3/185:
+  dpt: '1.011'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Begehbarer-Schrank.KNX.Schaltschwelle-Status
+  room: Begehbarer Schrank
+9/3/186:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Begehbarer-Schrank.KNX.HLK
+  room: Begehbarer Schrank
+9/3/187:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Begehbarer-Schrank.KNX.Präsenz
+  room: Begehbarer Schrank
+9/3/188:
+  dpt: '9.004'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Begehbarer-Schrank.KNX.Helligkeit
+  room: Begehbarer Schrank
+9/3/189:
+  dpt: '1.024'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Begehbarer-Schrank.KNX.Tag/Nacht
+  room: Begehbarer Schrank
+9/3/190:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Begehbarer-Schrank.KNX.Slave
+  room: Begehbarer Schrank
+9/3/2:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Flur.KNX.Treppe.Ein/Aus
+  room: Flur
+9/3/20:
+  dpt: '1.003'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Flur.KNX.Gang.Sperren
+  room: Flur
+9/3/200:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Badezimmer-Eltern.KNX.Sperren
+  room: Badezimmer Eltern
+9/3/201:
+  dpt: '1.011'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Badezimmer-Eltern.KNX.Sperren-Status
+  room: Badezimmer Eltern
+9/3/202:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Badezimmer-Eltern.KNX.Ein/Aus
+  room: Badezimmer Eltern
+9/3/203:
+  dpt: '5.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Badezimmer-Eltern.KNX.Dimmen
+  room: Badezimmer Eltern
+9/3/205:
+  dpt: '1.011'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Badezimmer-Eltern.KNX.Schaltschwelle-Status
+  room: Badezimmer Eltern
+9/3/206:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Badezimmer-Eltern.KNX.HLK
+  room: Badezimmer Eltern
+9/3/207:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Badezimmer-Eltern.KNX.Präsenz
+  room: Badezimmer Eltern
+9/3/208:
+  dpt: '9.004'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Badezimmer-Eltern.KNX.Helligkeit
+  room: Badezimmer Eltern
+9/3/209:
+  dpt: '1.024'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Badezimmer-Eltern.KNX.Tag/Nacht
+  room: Badezimmer Eltern
+9/3/21:
+  dpt: '1.011'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Flur.KNX.Gang.Sperren-Status
+  room: Flur
+9/3/210:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Badezimmer-Eltern.KNX.Slave
+  room: Badezimmer Eltern
+9/3/22:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Flur.KNX.Gang.Ein/Aus
+  room: Flur
+9/3/23:
+  dpt: '5.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Flur.KNX.Gang.Dimmen
+  room: Flur
+9/3/25:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Flur.KNX.Gang.Schaltschwelle-Status
+  room: Flur
+9/3/26:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Flur.KNX.Gang.HLK
+  room: Flur
+9/3/27:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Flur.KNX.Gang.Präsenz
+  room: Flur
+9/3/28:
+  dpt: '9.004'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Flur.KNX.Gang.Helligkeit
+  room: Flur
+9/3/29:
+  dpt: '1.024'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Flur.KNX.Gang.Tag/Nacht
+  room: Flur
+9/3/30:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Flur.KNX.Gang.Slave
+  room: Flur
+9/3/40:
+  dpt: '1.003'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Flur.EMA.Treppe.Sperren
+  room: Flur
+9/3/41:
+  dpt: '1.011'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Flur.EMA.Treppe.Sperren-Status
+  room: Flur
+9/3/42:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Flur.EMA.Treppe.Ein/Aus
+  room: Flur
+9/3/46:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Flur.EMA.Treppe.HLK
+  room: Flur
+9/3/47:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Flur.EMA.Treppe.Präsenz
+  room: Flur
+9/3/49:
+  dpt: '1.024'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Flur.EMA.Treppe.Tag/Nacht
+  room: Flur
+9/3/6:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Flur.KNX.Treppe.HLK
+  room: Flur
+9/3/60:
+  dpt: '1.003'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Flur.EMA.Gang.Sperren
+  room: Flur
+9/3/61:
+  dpt: '1.011'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Flur.EMA.Gang.Sperren-Status
+  room: Flur
+9/3/62:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Flur.EMA.Gang.Ein/Aus
+  room: Flur
+9/3/66:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Flur.EMA.Gang.HLK
+  room: Flur
+9/3/67:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Flur.EMA.Gang.Präsenz
+  room: Flur
+9/3/69:
+  dpt: '1.024'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Flur.EMA.Gang.Tag/Nacht
+  room: Flur
+9/3/7:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Flur.KNX.Treppe.Präsenz
+  room: Flur
+9/3/8:
+  dpt: '9.004'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Flur.KNX.Treppe.Helligkeit
+  room: Flur
+9/3/9:
+  dpt: '1.024'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.OG.Flur.KNX.Treppe.Tag/Nacht
+  room: Flur
+9/4/0:
+  dpt: '1.003'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.DG.KNX.Sperren
+  room: Speicher (S)
+9/4/1:
+  dpt: '1.011'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.DG.KNX.Sperren-Status
+  room: Speicher (S)
+9/4/10:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.DG.KNX.Slave
+  room: Speicher (S)
+9/4/2:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.DG.KNX.Ein/Aus
+  room: Speicher (S)
+9/4/3:
+  dpt: '5.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.DG.KNX.Dimmen
+  room: Speicher (S)
+9/4/4:
+  dpt: '9.004'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.DG.KNX.Schaltschwelle
+  room: Speicher (S)
+9/4/6:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.DG.KNX.HLK
+  room: Speicher (S)
+9/4/7:
+  dpt: '1.001'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.DG.KNX.Präsenz
+  room: Speicher (S)
+9/4/8:
+  dpt: '9.004'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.DG.KNX.Helligkeit
+  room: Speicher (S)
+9/4/9:
+  dpt: '1.024'
+  function: Bewegungsmelder
+  name: Bewegungsmelder.DG.KNX.Tag/Nacht
+  room: Speicher (S)


### PR DESCRIPTION
Re-export from ETS after large-scale GA address-space restructuring:

* hauptgruppen-shift: 1418 GAs shifted by main-1 (6→5, 7→6, …)
* funktions-rename: 77 Multimedia.* GAs moved from main 13 to main 12 as Entertainment.*
* building-hierarchie: room names switched from hyphen to space (Schlafzimmer-Eltern → Schlafzimmer Eltern); minor annotations like "Speicher (S)" added
* typo fixes: Esszimer → Esszimmer (9), Temperartur → Temperatur (4), DachAußensensor → Dach.Außensensor (1), Garten K1-L2 duplicate split into K1-L2 + K1-L3 (1)

All 2254 GAs are mappable old↔new — see migration/knx_ga_mapping.csv (throwaway, not committed). TSDB-side knx hypertable migration runs separately via psql once this lands.