### PR TITLE
refactor(infra): drop deprecated acl from pve user lifecycle

### DIFF
--- a/infrastructure/modules/00-pve-cluster-user/main.tf
+++ b/infrastructure/modules/00-pve-cluster-user/main.tf
@@ -30,10 +30,8 @@ resource "proxmox_virtual_environment_user" "this" {
   comment    = var.comment
 
   lifecycle {
-    ## Avoid perpetual diffs
-    ## acl: managed separately via proxmox_acl resource
-    ## password: can only be set with ticket (not API token) - ignore updates after creation
-    ignore_changes = [acl, password]
+    ## password can only be set with ticket (not API token) - ignore updates after creation
+    ignore_changes = [password]
   }
 }
 


### PR DESCRIPTION
## Summary
- ACLs for PVE users are managed via dedicated `proxmox_acl` resources since the earlier migration
- Inline `acl` blocks have been removed from state via `tofu state rm` + `tofu import` for all 5 users (alexander, homepage, omni, proxmate, ups_monitor)
- `lifecycle.ignore_changes` is reduced to `[password]` — the `acl` entry is no longer needed

Note: the bpg/proxmox v0.107.0 deprecation warning for the inline `acl` block still fires regardless — it's a provider-side bug where `Deprecated` is combined with `DefaultFunc`, so the warning triggers for every user instance whether or not `acl` is set. Tracked upstream in [bpg/terraform-provider-proxmox#2913](https://github.com/bpg/terraform-provider-proxmox/issues/2913) (with root-cause comment).

## Test plan
- [x] `tofu plan` reports `No changes` after re-import + lifecycle change
- [x] State of all 5 users contains no `acl` attribute (`tofu state show` verified for alexander)
- [x] pre-commit hooks pass (OpenTofu fmt, secrets, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)