### PR TITLE
fix(redpanda-connect): align NATS ack_wait with S3 batch window

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/streams/ems_esp.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/ems_esp.yaml
@@ -8,8 +8,8 @@ input:
     subject: ems-esp.>
     durable: redpanda-connect-ems-esp
     deliver: all
-    ack_wait: 30s
-    max_ack_pending: 2000
+    ack_wait: 20m
+    max_ack_pending: 5000
 
 pipeline:
   processors:

--- a/kubernetes/applications/redpanda-connect/base/streams/knx.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/knx.yaml
@@ -8,8 +8,8 @@ input:
     subject: knx.>
     durable: redpanda-connect-knx
     deliver: all
-    ack_wait: 30s
-    max_ack_pending: 2000
+    ack_wait: 20m
+    max_ack_pending: 5000
 
 pipeline:
   processors:

--- a/kubernetes/applications/redpanda-connect/base/streams/solaredge_inverter.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/solaredge_inverter.yaml
@@ -8,8 +8,8 @@ input:
     subject: "*.modbus.inverter"
     durable: redpanda-connect-solaredge-inverter
     deliver: all
-    ack_wait: 30s
-    max_ack_pending: 2000
+    ack_wait: 20m
+    max_ack_pending: 5000
 
 pipeline:
   processors:

--- a/kubernetes/applications/redpanda-connect/base/streams/solaredge_powerflow.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/solaredge_powerflow.yaml
@@ -8,8 +8,8 @@ input:
     subject: "*.powerflow"
     durable: redpanda-connect-solaredge-powerflow
     deliver: all
-    ack_wait: 30s
-    max_ack_pending: 2000
+    ack_wait: 20m
+    max_ack_pending: 5000
 
 pipeline:
   processors:

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_charge_manager.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_charge_manager.yaml
@@ -8,8 +8,8 @@ input:
     subject: warp.charge_manager.>
     durable: redpanda-connect-warp-charge-manager
     deliver: all
-    ack_wait: 30s
-    max_ack_pending: 2000
+    ack_wait: 20m
+    max_ack_pending: 5000
 
 pipeline:
   processors:

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_charge_tracker.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_charge_tracker.yaml
@@ -8,8 +8,8 @@ input:
     subject: warp.charge_tracker.>
     durable: redpanda-connect-warp-charge-tracker
     deliver: all
-    ack_wait: 30s
-    max_ack_pending: 2000
+    ack_wait: 20m
+    max_ack_pending: 5000
 
 pipeline:
   processors:

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_evse.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_evse.yaml
@@ -8,8 +8,8 @@ input:
     subject: warp.evse.>
     durable: redpanda-connect-warp-evse
     deliver: all
-    ack_wait: 30s
-    max_ack_pending: 2000
+    ack_wait: 20m
+    max_ack_pending: 5000
 
 pipeline:
   processors:

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_meter.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_meter.yaml
@@ -8,8 +8,8 @@ input:
     subject: warp.meters.>
     durable: redpanda-connect-warp-meter
     deliver: all
-    ack_wait: 30s
-    max_ack_pending: 2000
+    ack_wait: 20m
+    max_ack_pending: 5000
 
 pipeline:
   processors:

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_system.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_system.yaml
@@ -10,8 +10,8 @@ input:
           subject: warp.rtc.>
           durable: redpanda-connect-warp-system-rtc
           deliver: all
-          ack_wait: 30s
-          max_ack_pending: 2000
+          ack_wait: 20m
+          max_ack_pending: 5000
       - nats_jetstream:
           urls: ["nats://nats.nats.svc:4222"]
           auth:
@@ -21,8 +21,8 @@ input:
           subject: warp.esp32.>
           durable: redpanda-connect-warp-system-esp32
           deliver: all
-          ack_wait: 30s
-          max_ack_pending: 2000
+          ack_wait: 20m
+          max_ack_pending: 5000
       - nats_jetstream:
           urls: ["nats://nats.nats.svc:4222"]
           auth:
@@ -32,8 +32,8 @@ input:
           subject: warp.ntp.>
           durable: redpanda-connect-warp-system-ntp
           deliver: all
-          ack_wait: 30s
-          max_ack_pending: 2000
+          ack_wait: 20m
+          max_ack_pending: 5000
 
 pipeline:
   processors:


### PR DESCRIPTION
## Summary
- All 9 stream inputs were configured with `ack_wait: 30s` while the `aws_s3` output batches for 15 min. With `broker.pattern: fan_out` every NATS message stayed unacked until both `sql_raw` and `aws_s3` succeeded, causing each message to be redelivered ~30× before its S3 flush.
- Bump `ack_wait` to `20m` (just above the batch period) and `max_ack_pending` from 2000 to 5000 across all streams.

## Test plan
- [x] `kubectl exec nats-0 -- wget -qO- http://localhost:8222/jsz?consumers=true` shows `num_redelivered` no longer increasing rapidly after rollout
- [x] `ack_floor` keeps pace with `delivered_seq` (gap reflects only currently-buffered batches, not redelivered tail)
- [x] TSDB write rate unchanged; data still arrives via sql_raw output

🤖 Generated with [Claude Code](https://claude.com/claude-code)