### PR TITLE
fix(pbs): correct verify alert + daily verify + remove-vanished sync

### DIFF
--- a/infrastructure/templates/30-cloud-init/proxmox-backup-server/pbs-bootstrap.sh
+++ b/infrastructure/templates/30-cloud-init/proxmox-backup-server/pbs-bootstrap.sh
@@ -282,7 +282,7 @@ setup_verification() {
   info "Setting up verification job for ${datastore_name}..."
   proxmox-backup-manager verify-job create "${job_id}" \
     --store "${datastore_name}" \
-    --schedule "Sat 04:00" || die "Could not create verification job for ${datastore_name}."
+    --schedule "daily" || die "Could not create verification job for ${datastore_name}."
 
   success "Verification job for ${datastore_name} set up successfully."
 }
@@ -304,6 +304,7 @@ setup_sync() {
   proxmox-backup-manager sync-job create "${job_id}" \
     --remote-store "${DATASTORE_PRIMARY_NAME}" \
     --store "${DATASTORE_SECONDARY_NAME}" \
+    --remove-vanished true \
     --schedule "*-*-* 05:00" || die "Could not create sync job."
 
   success "Sync job for between primary and secondary datastores set up successfully."

--- a/kubernetes/applications/prometheus/base/prometheus-rule.yaml
+++ b/kubernetes/applications/prometheus/base/prometheus-rule.yaml
@@ -80,7 +80,9 @@ spec:
             description: "Last backup of VM {{ $labels.vm_name }} (id {{ $labels.vm_id }}) in datastore {{ $labels.datastore }} is older than 2 days."
 
         - alert: PbsLastVerifyFailed
-          expr: 'pbs_snapshot_vm_last_verify == 0'
+          # pbs-exporter values: 0 = not verified yet, 1 = ok, 2 = failed.
+          # Only alert on real failures, not on fresh snapshots awaiting the next verify run.
+          expr: 'pbs_snapshot_vm_last_verify == 2'
           for: 10m
           labels:
             severity: warning


### PR DESCRIPTION
## Summary
- Triggered by today's `PbsLastVerifyFailed` (vm/1100) + `PbsBackupStale` (vm/1001 on datastore-secondary) alerts. Both turned out to be alert/config issues, not real backup problems.
- `PbsLastVerifyFailed`: pbs-exporter encodes `pbs_snapshot_vm_last_verify` as `0`=not-verified-yet, `1`=ok, `2`=failed. The previous expr `== 0` fired for every fresh snapshot between the weekly verify runs. Changed to `== 2`.
- PBS bootstrap: verify-job schedule moved from `Sat 04:00` → `daily` so new snapshots are picked up within 24h. Sync job `pull-from-primary` now sets `--remove-vanished true` so groups pruned on primary don't accumulate as orphans on secondary (the vm/1001 leftover that fired today).

## Already done out-of-band on backup-01
- `verify-datastore-primary` + `verify-datastore-secondary` updated to `daily` schedule.
- `pull-from-primary` updated with `remove-vanished true`.
- Orphan vm/1001 group (12 snapshots, 2026-03-29 → 2026-05-01) removed from `datastore-secondary`; chunks will be reclaimed by next GC.

## Test plan
- [ ] After Argo sync, confirm `PbsLastVerifyFailed` resolves once tonight's verify run completes (or sooner via "Verify All" on vm/1100).
- [ ] Confirm `PbsBackupStale` for vm/1001 stays cleared (group is gone, metric won't be exported anymore).
- [ ] On next PBS rebuild, confirm bootstrap creates sync-job with `remove-vanished true` and verify-jobs with `daily` schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)