### PR TITLE
fix(tasks): k8s:unseal handles multi-doc YAML + extracts PEM key

### DIFF
--- a/tasks/kubernetes.yaml
+++ b/tasks/kubernetes.yaml
@@ -122,6 +122,11 @@ tasks:
     desc: "unseal a sealed-secret.yaml [path/to/sealed-secret.yaml]"
     summary: |
       Decrypts a sealed-secret.yaml back to plaintext secret.yaml in the same directory.
+      Handles multi-document YAML (each `---`-separated SealedSecret is unsealed
+      and concatenated into the output). Extracts the PEM private key from the
+      controller's master-key Secret-list before invoking kubeseal — passing the
+      raw list YAML to `--recovery-private-key` made kubeseal fall back to
+      contacting the cluster, which fails outside the cluster.
       Arguments: [path/to/sealed-secret.yaml]
     vars:
       INPUT: "{{index .CLI_ARGS_LIST 0}}"
@@ -133,13 +138,26 @@ tasks:
     preconditions:
       - sh: command -v kubeseal
         msg: "kubeseal is not installed"
+      - sh: command -v yq
+        msg: "yq is not installed"
       - sh: test -f kubernetes/components/sealed-secrets-controller/base/master-key.yaml
         msg: "master-key.yaml not found"
       - sh: test -f "{{.INPUT}}"
         msg: "'{{.INPUT}}' not found"
     cmds:
-      - kubeseal \
-        --recovery-unseal \
-        --recovery-private-key kubernetes/components/sealed-secrets-controller/base/master-key.yaml \
-        < "{{.INPUT}}" \
-        -o yaml > "{{.DIR}}/secret.yaml"
+      - |
+        set -euo pipefail
+        KEY=$(mktemp -t sealed-unseal-key.XXXXXX)
+        SPLIT=$(mktemp -d -t sealed-unseal-split.XXXXXX)
+        trap 'rm -f "$KEY"; rm -rf "$SPLIT"' EXIT
+        yq '.items[0].data["tls.key"]' kubernetes/components/sealed-secrets-controller/base/master-key.yaml \
+          | base64 -d > "$KEY"
+        csplit -sz -f "$SPLIT/doc_" -b "%02d.yaml" "{{.INPUT}}" '/^---$/' '{*}'
+        OUT="{{.DIR}}/secret.yaml"
+        : > "$OUT"
+        for f in "$SPLIT"/doc_*.yaml; do
+          [ -s "$f" ] || continue
+          grep -q '^kind: SealedSecret' "$f" || continue
+          echo '---' >> "$OUT"
+          kubeseal --recovery-unseal --recovery-private-key "$KEY" -o yaml < "$f" >> "$OUT"
+        done


### PR DESCRIPTION
## Summary
- `task k8s:unseal` was broken in two ways; today's accidental overwrite of a `secret.yaml` revealed both.
- Fix #1 — **PEM key extraction:** kubeseal v0.37's `--recovery-private-key` rejects the raw master-key Secret-list YAML and falls back to contacting the in-cluster service, failing with `cannot get sealed secret service: services "sealed-secrets-controller" not found`. The task now `yq | base64 -d`-extracts `data["tls.key"]` into a temp PEM file first.
- Fix #2 — **multi-document YAML:** kubeseal `--recovery-unseal` only processes the first document of a multi-doc input, so unsealing a `sealed-secret.yaml` with several SealedSecrets returned just one. The task now splits on `^---$` via `csplit` and unseals each document separately, concatenating the results.
- Temp files (key + split dir) are cleaned up via `trap … EXIT`.

## Test plan
- [x] `task k8s:unseal -- kubernetes/applications/timescaledb/base/sealed-secret.yaml` produces a `secret.yaml` with **all 3** SealedSecrets correctly decoded (verified locally on `main`).
- [ ] Re-sealing via `task k8s:seal -- kubernetes/applications/timescaledb/base/secret.yaml` (with the unsealed output) round-trips cleanly.

## Context
Discovered during work on #980 (Phase-2 anomaly schema), when the existing broken task forced a workaround chain to recover an accidentally-overwritten plaintext `secret.yaml`. Fixing the task now prevents the same dead-end next time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)