### PR TITLE
feat(timescaledb,nats): unifi_events hypertable + UNIFI JetStream

### DIFF
--- a/kubernetes/applications/nats/base/kustomization.yaml
+++ b/kubernetes/applications/nats/base/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - ./streams/solaredge.yaml
   - ./streams/ems-esp.yaml
   - ./streams/warp.yaml
+  - ./streams/unifi.yaml
 
 helmCharts:
   - name: nats

--- a/kubernetes/applications/nats/base/streams/unifi.yaml
+++ b/kubernetes/applications/nats/base/streams/unifi.yaml
@@ -1,0 +1,17 @@
+# UniFi Protect Alarm Manager events published by node-RED on
+# `unifi.events.<camera>.<detection_type>` (one message per trigger).
+# Retention 7d is the safety puffer for redpanda-connect → TimescaleDB
+# downtime; UniFi itself does not buffer Alarm Manager webhooks.
+apiVersion: jetstream.nats.io/v1beta2
+kind: Stream
+metadata:
+  name: unifi
+  namespace: nats
+spec:
+  name: UNIFI
+  subjects:
+    - unifi.events.>
+  storage: file
+  retention: limits
+  maxAge: 168h
+  replicas: 1

--- a/kubernetes/applications/timescaledb/base/scripts/bootstrap.sql
+++ b/kubernetes/applications/timescaledb/base/scripts/bootstrap.sql
@@ -308,6 +308,32 @@ FROM warp_meter WHERE meter_id IS NOT NULL
 GROUP BY bucket, meter_id WITH NO DATA;
 
 -- =========================================================
+-- UniFi Protect Alarm Manager events
+-- (node-RED HTTP webhook /unifi-protect enriches each trigger in
+--  payload.alarm.triggers[] with alarm-level context, splits, and
+--  publishes one NATS message per trigger to
+--  unifi.events.<camera>.<detection_type>, where <camera> is the
+--  human-readable name resolved from the device MAC.)
+-- Typed columns for fields used in queries; everything else lives in raw.
+-- Only own property recorded → no retention policy.
+-- =========================================================
+CREATE TABLE IF NOT EXISTS unifi_events (
+    time            TIMESTAMPTZ NOT NULL,
+    camera          TEXT        NOT NULL,    -- resolved name (fassade, eingang, terrasse_wohnzimmer, terrasse_esszimmer)
+    detection_type  TEXT        NOT NULL,    -- trigger.key: person, motion, line_crossed, face_known, vehicle, license_plate_*, audio_alarm_*, admin_geolocation
+    score           SMALLINT,                -- sourceEvent.score 0..100 (0 for plain motion)
+    event_type      TEXT,                    -- sourceEvent.type: motion, smartDetectZone, smartDetectLine, ...
+    value           TEXT,                    -- face name / license plate / geofence phrase; NULL for plain person/motion
+    event_id        TEXT,                    -- trigger.eventId (UUID, also sourceEvent.id)
+    event_link      TEXT,                    -- alarm.eventLocalLink (enriched onto trigger in node-RED before split)
+    raw             JSONB
+);
+SELECT create_hypertable('unifi_events', 'time', chunk_time_interval => INTERVAL '7 days');
+CREATE INDEX ON unifi_events (camera, time DESC);
+CREATE INDEX ON unifi_events (detection_type, time DESC);
+CREATE INDEX ON unifi_events (event_id, time DESC) WHERE event_id IS NOT NULL;
+
+-- =========================================================
 -- Continuous Aggregate Refresh Policies
 -- =========================================================
 SELECT add_continuous_aggregate_policy('knx_1h',
@@ -364,6 +390,9 @@ ALTER TABLE warp_charge_tracker SET (timescaledb.compress,
 ALTER TABLE warp_meter SET (timescaledb.compress,
     timescaledb.compress_segmentby = 'meter_id',
     timescaledb.compress_orderby = 'time DESC');
+ALTER TABLE unifi_events SET (timescaledb.compress,
+    timescaledb.compress_segmentby = 'camera',
+    timescaledb.compress_orderby = 'time DESC');
 
 SELECT add_compression_policy('knx',                 INTERVAL '2 days');
 SELECT add_compression_policy('solaredge_inverter',  INTERVAL '2 days');
@@ -374,6 +403,7 @@ SELECT add_compression_policy('warp_evse',           INTERVAL '2 days');
 SELECT add_compression_policy('warp_charge_manager', INTERVAL '2 days');
 SELECT add_compression_policy('warp_charge_tracker', INTERVAL '2 days');
 SELECT add_compression_policy('warp_meter',          INTERVAL '2 days');
+SELECT add_compression_policy('unifi_events',        INTERVAL '7 days');
 
 -- =========================================================
 -- Retention policies — 365d on every hot hypertable. Raw chunks past


### PR DESCRIPTION
## Summary
- New `unifi_events` TimescaleDB hypertable archiving UniFi Protect Alarm Manager triggers; typed columns mirror the actual webhook fields (`trigger.key`, `sourceEvent.score`/`type`, `alarm.eventLocalLink`) — everything else stays in `raw` JSONB. No retention policy (only own property recorded).
- New `UNIFI` JetStream on `unifi.events.>`, 168h, file-storage — registered in the `nats` Kustomization.
- Foundation for the bidirectional knx-nats-bridge pipeline: node-RED will publish UniFi triggers to NATS, redpanda-connect ingests into this hypertable, and knx-nats-bridge writes selected triggers back to KNX.

## Test plan
- [x] DDL applied manually via psql on `homelab` (per memory feedback_schema_migration): hypertable id 75, compression policy id 1074, indexes on `(camera, time)`, `(detection_type, time)`, `(event_id, time) WHERE event_id IS NOT NULL`.
- [x] Grants verified: `connect` has INSERT+SELECT, `iot_mcp_bridge_ro` + `grafana_ro` have SELECT (`iot_mcp_bridge_rw` role does not yet exist in DB — loop skips cleanly).
- [x] Smoke INSERT as `SET ROLE connect` succeeded; row deleted afterwards (table is empty).
- [ ] After merge: ArgoCD syncs `nats-prod` app → `UNIFI` JetStream materialises in cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)