### PR TITLE
fix(timescaledb): bootstrap.sql drift + DO-block CAGG crash

### DIFF
--- a/kubernetes/applications/timescaledb/base/scripts/bootstrap.sql
+++ b/kubernetes/applications/timescaledb/base/scripts/bootstrap.sql
@@ -104,6 +104,10 @@ CREATE TABLE solaredge_powerflow (
 SELECT create_hypertable('solaredge_powerflow', 'time', chunk_time_interval => INTERVAL '1 day');
 CREATE INDEX ON solaredge_powerflow (inverter_id, time DESC);
 
+-- No battery installed → battery_charge/discharge are always 0; the original
+-- battery_net_avg column was dropped from the live CAGG. consumer_total_max/sum
+-- were added directly on the live cluster for peak-load / daily-cumulative
+-- dashboards; mirroring here so a fresh initdb lands at the same schema.
 CREATE MATERIALIZED VIEW solaredge_powerflow_1h
 WITH (timescaledb.continuous, timescaledb.materialized_only = true) AS
 SELECT time_bucket('1 hour', time) AS bucket, inverter_id,
@@ -113,7 +117,8 @@ SELECT time_bucket('1 hour', time) AS bucket, inverter_id,
        avg(grid_consumption) AS grid_consumption_avg,
        avg(grid_delivery) AS grid_delivery_avg,
        avg(consumer_total) AS consumer_total_avg,
-       avg(battery_charge - battery_discharge) AS battery_net_avg,
+       max(consumer_total) AS consumer_total_max,
+       sum(consumer_total) AS consumer_total_sum,
        count(*) AS sample_count
 FROM solaredge_powerflow GROUP BY bucket, inverter_id WITH NO DATA;
 
@@ -626,8 +631,15 @@ BEGIN
     FOR r IN SELECT view_name FROM timescaledb_information.continuous_aggregates LOOP
         EXECUTE format('ALTER MATERIALIZED VIEW public.%I OWNER TO homelab', r.view_name);
     END LOOP;
-    -- Plain views need their own loop — pg_views excludes hypertable views.
-    FOR r IN SELECT viewname FROM pg_views WHERE schemaname = 'public' LOOP
+    -- Plain views only — pg_views also lists continuous aggregates, but
+    -- ALTER VIEW errors on CAGGs (hint: "Use ALTER MATERIALIZED VIEW"), and
+    -- the unhandled error rolls back the entire DO block.
+    FOR r IN
+        SELECT viewname FROM pg_views WHERE schemaname = 'public'
+        AND viewname NOT IN (
+            SELECT view_name FROM timescaledb_information.continuous_aggregates
+        )
+    LOOP
         EXECUTE format('ALTER VIEW public.%I OWNER TO homelab', r.viewname);
     END LOOP;
 END$$;


### PR DESCRIPTION
## Summary
Two pre-existing bootstrap.sql bugs found during the Phase-2-PR-1 rollout (#980), now fixed so a fresh initdb lands at the correct schema and an operator-rerun of the owner-transfer block doesn't silently roll back.

### 1. `solaredge_powerflow_1h` CAGG drift
Bootstrap defined a `battery_net_avg` column that the live CAGG never had, and was missing `consumer_total_max` / `consumer_total_sum` that the live CAGG does have. With no battery installed (all `battery_charge`/`battery_discharge` values 0 in the raw table), `battery_net_avg` is meaningless — mirroring live state into bootstrap.sql.

### 2. Owner-transfer DO block crashes on CAGGs
The third loop iterated `pg_views` which also lists continuous-aggregate views, then called `ALTER VIEW` on them — PG refuses with `cannot alter continuous aggregate using ALTER VIEW; HINT: Use ALTER MATERIALIZED VIEW`. The unhandled error rolls back the entire `DO $$ ... $$` block, so the first two loops' ALTER OWNER never commit either. Filtered the loop to exclude CAGGs (which the second loop already handles via `ALTER MATERIALIZED VIEW`).

Found while re-running this exact block manually to fix a `knx` ownership drift on the live cluster — the bug meant the DO block silently failed instead of cleanly transferring ownership.

## Test plan
- [x] `kubectl kustomize kubernetes/applications/timescaledb/base/` renders without errors.
- [x] Manually applied the corrected DO block on live; all 11 public tables, 6 CAGGs and 2 plain views now owned by `homelab`.
- [ ] No live-cluster action needed for the solaredge-CAGG change (it already matches live); a fresh initdb (cluster recreate) would now create the CAGG with the live-correct columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)