### PR TITLE
feat(iot-mcp-bridge): scaffold platform for batch-jobs CLI

### DIFF
--- a/kubernetes/applications/iot-mcp-bridge/base/kustomization.yaml
+++ b/kubernetes/applications/iot-mcp-bridge/base/kustomization.yaml
@@ -23,6 +23,7 @@ labels:
     pairs:
       homelab.app: iot-mcp-bridge
 
-# Wave 30 = after timescaledb (wave 3) and Kyverno-cloned secret is in place.
+# Wave 11 = after Kyverno (-4), timescaledb (3), nats-operator (9) and
+# knx-nats-bridge (10); aligns with the other consumer apps at wave 10.
 commonAnnotations:
-  argocd.argoproj.io/sync-wave: "30"
+  argocd.argoproj.io/sync-wave: "11"

--- a/kubernetes/applications/rustfs/base/initialize-buckets-job.yaml
+++ b/kubernetes/applications/rustfs/base/initialize-buckets-job.yaml
@@ -51,7 +51,7 @@ spec:
               done
           env:
             - name: BUCKETS
-              value: "authentik-backups longhorn-backups timescaledb-backups nats-archive influxdb-archive"
+              value: "authentik-backups longhorn-backups timescaledb-backups nats-archive influxdb-archive iot-mcp-bridge-models"
             - name: RCLONE_CONFIG_RUSTFS_TYPE
               value: s3
             - name: RCLONE_CONFIG_RUSTFS_PROVIDER

--- a/kubernetes/components/admission-controller/base/clusterpolicy-secrets.yaml
+++ b/kubernetes/components/admission-controller/base/clusterpolicy-secrets.yaml
@@ -442,3 +442,64 @@ spec:
         clone:
           namespace: knx-nats-bridge
           name: knx-nats-bridge-catalog
+
+    # Syncs CNPG-managed iot-mcp-bridge read-write DB-user secret from
+    # timescaledb into iot-mcp-bridge for the batch-jobs CLI (INSERT/UPDATE
+    # on mcp_anomalies + mcp_forecasts).
+    - name: sync-timescaledb-db-iot-mcp-bridge-rw-secret
+      match:
+        any:
+          - resources:
+              kinds:
+                - Namespace
+              names:
+                - iot-mcp-bridge
+      generate:
+        apiVersion: v1
+        kind: Secret
+        name: timescaledb-db-iot-mcp-bridge-rw-secret
+        namespace: iot-mcp-bridge
+        synchronize: true
+        clone:
+          namespace: timescaledb
+          name: timescaledb-db-iot-mcp-bridge-rw-secret
+
+    # Syncs RustFS admin credentials into iot-mcp-bridge so the batch-jobs CLI
+    # can persist trained models in the iot-mcp-bridge-models bucket.
+    - name: sync-rustfs-admin-credentials-iot-mcp-bridge
+      match:
+        any:
+          - resources:
+              kinds:
+                - Namespace
+              names:
+                - iot-mcp-bridge
+      generate:
+        apiVersion: v1
+        kind: Secret
+        name: rustfs-admin-credentials
+        namespace: iot-mcp-bridge
+        synchronize: true
+        clone:
+          namespace: rustfs
+          name: rustfs-admin-credentials
+
+    # Syncs NATS user/password from nats into iot-mcp-bridge for the batch-jobs
+    # CLI to publish anomaly events on `anomaly.<uc>.<severity>`.
+    - name: sync-iot-mcp-bridge-nats-credentials
+      match:
+        any:
+          - resources:
+              kinds:
+                - Namespace
+              names:
+                - iot-mcp-bridge
+      generate:
+        apiVersion: v1
+        kind: Secret
+        name: iot-mcp-bridge-credentials
+        namespace: iot-mcp-bridge
+        synchronize: true
+        clone:
+          namespace: nats
+          name: iot-mcp-bridge-credentials


### PR DESCRIPTION
## Summary
Three companion changes so the new `iot-mcp-bridge-jobs` CLI (shipping in [iot-mcp-bridge#28](https://github.com/alexander-zimmermann/iot-mcp-bridge/pull/28)) has the platform plumbing it needs at runtime.

### 1. Kyverno clones into `iot-mcp-bridge`
Three new clone rules in [clusterpolicy-secrets.yaml](kubernetes/components/admission-controller/base/clusterpolicy-secrets.yaml) so the jobs CLI can mount the secrets it needs:
- `timescaledb-db-iot-mcp-bridge-rw-secret` (from `timescaledb`) — INSERT/UPDATE on `mcp_anomalies` + `mcp_forecasts`.
- `rustfs-admin-credentials` (from `rustfs`) — joblib pickle storage in the new `iot-mcp-bridge-models` bucket.
- `iot-mcp-bridge-credentials` (from `nats`) — publish on `anomaly.<uc>.<severity>` subjects. **Pre-requisite**: NATS user `iot-mcp-bridge` with publish-only ACL on `anomaly.>` + matching Secret in the `nats` namespace must exist for this clone to actually generate. Kyverno silently no-ops until the source exists, so this PR is safe to merge before the NATS-side setup.

### 2. `iot-mcp-bridge-models` bucket
Appended to the rustfs [initialize-buckets job's](kubernetes/applications/rustfs/base/initialize-buckets-job.yaml) `BUCKETS` env-var. The next ArgoCD-Sync triggers the Job to create the new bucket via rclone-mkdir.

### 3. Drive-by: sync-wave `30` → `11`
The iot-mcp-bridge app was at wave `30` — an outlier with no other apps at that wave. Bumped to `11` so it aligns with the other consumer apps (knx-nats-bridge, external-services, fritz-exporter all at `10`). Still after Kyverno (-4), timescaledb (3), nats-operator (9), and knx-nats-bridge (10).

## Test plan
- [x] `kubectl kustomize --enable-helm` clean for the four changed kustomizations (admission-controller, rustfs, iot-mcp-bridge base + prod overlay).
- [ ] After merge + ArgoCD-Sync:
      `kubectl get secret -n iot-mcp-bridge timescaledb-db-iot-mcp-bridge-rw-secret` → exists
      `kubectl get secret -n iot-mcp-bridge rustfs-admin-credentials` → exists
      `mc ls rustfs/iot-mcp-bridge-models` → bucket exists
- [ ] NATS-side `iot-mcp-bridge` user provisioning is a separate manual step (sealed in `nats-auth-config`) — the third clone rule waits silently until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)