### PR TITLE
chore(iot-mcp-bridge): bump image tag 0.5.2 → 0.6.0

### DIFF
--- a/kubernetes/applications/iot-mcp-bridge/base/values.yaml
+++ b/kubernetes/applications/iot-mcp-bridge/base/values.yaml
@@ -4,7 +4,7 @@ deployment:
   enabled: true
   image:
     repository: ghcr.io/alexander-zimmermann/iot-mcp-bridge
-    tag: 0.5.2
+    tag: 0.6.0
     pullPolicy: IfNotPresent
 
   replicas: 1


### PR DESCRIPTION
## Summary
Picks up the unified server+jobs entrypoint image ([iot-mcp-bridge v0.6.0](https://github.com/alexander-zimmermann/iot-mcp-bridge/releases/tag/v0.6.0)).

The running MCP server is API-compatible (no behaviour change for the read-only tools \`list_data_sources\`, \`query_timeseries\`, \`query_energy_flow\`, \`query_heating_cycles\`, \`query_room_climate\`, \`query_knx_events\`, \`query_unifi_events\`, \`correlate_events\`). The new \`iot-mcp-bridge-jobs\` binary is bundled in but not invoked until a CronJob references it.

## Test plan
- [x] \`kubectl kustomize --enable-helm kubernetes/applications/iot-mcp-bridge/overlays/prod/\` renders cleanly.
- [ ] After merge + ArgoCD-Sync: \`kubectl rollout status deployment/iot-mcp-bridge -n iot-mcp-bridge\` succeeds.
- [ ] \`curl https://mcp.zimmermann.eu.com/healthz\` returns 200.
- [ ] claude.ai connector still responds to a sample query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)