### PR TITLE
feat(knx-nats-bridge): write-mapping with UniFi + EMS/WARP/PV mirrors

### DIFF
--- a/kubernetes/applications/knx-nats-bridge/base/config/knx-catalog.yaml
+++ b/kubernetes/applications/knx-nats-bridge/base/config/knx-catalog.yaml
@@ -1943,6 +1943,26 @@
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Einspeisung.Zählerstand-Tagtarif-1
   room: Garage
+15/2/0:
+  dpt: '1.011'
+  function: Versorgungstechnik
+  name: Versorgungstechnik.Gastherme.Brenner-Status
+15/2/1:
+  dpt: '5.001'
+  function: Versorgungstechnik
+  name: Versorgungstechnik.Gastherme.Brenner-Modulation
+15/2/10:
+  dpt: '9.001'
+  function: Versorgungstechnik
+  name: 'Versorgungstechnik.Gastherme.Vorlauf-Temperatur '
+15/2/11:
+  dpt: '9.001'
+  function: Versorgungstechnik
+  name: 'Versorgungstechnik.Gastherme.Rücklauf-Temperatur '
+15/2/2:
+  dpt: '1.001'
+  function: Versorgungstechnik
+  name: Versorgungstechnik.Gastherme.Heizung-Aktiv
 15/3/1:
   description: 4 - Vorratsraum (K4) Wohnraumlüftung
   dpt: '5.010'
@@ -2099,6 +2119,30 @@
   function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Lüftermodus-Mittel
   room: Vorratsraum
+15/4/0:
+  dpt: '14.056'
+  function: Versorgungstechnik
+  name: Versorgungstechnik.Photovoltaik.Netz-Leistung
+15/4/1:
+  dpt: '14.056'
+  function: Versorgungstechnik
+  name: Versorgungstechnik.Photovoltaik.Verbrauch-Gesamt
+15/4/10:
+  dpt: '14.056'
+  function: Versorgungstechnik
+  name: Versorgungstechnik.Photovoltaik.Inverter-1.Leistung
+15/4/11:
+  dpt: '9.001'
+  function: Versorgungstechnik
+  name: Versorgungstechnik.Photovoltaik.Inverter-1.Temperatur
+15/4/20:
+  dpt: '14.056'
+  function: Versorgungstechnik
+  name: Versorgungstechnik.Photovoltaik.Inverter-2.Leistung
+15/4/21:
+  dpt: '9.001'
+  function: Versorgungstechnik
+  name: Versorgungstechnik.Photovoltaik.Inverter-2.Temperatur
 15/5/102:
   dpt: '1.011'
   function: Versorgungstechnik
@@ -2174,6 +2218,30 @@
   function: Versorgungstechnik
   name: Versorgungstechnik.Bewässerung.Kreislauf-9.Ein/Aus-Status
   room: Garten
+15/6/0:
+  dpt: '5.010'
+  function: Versorgungstechnik
+  name: Versorgungstechnik.Wallbox.Charger-State
+15/6/1:
+  dpt: '5.010'
+  function: Versorgungstechnik
+  name: Versorgungstechnik.Wallbox.IEC61851-State
+15/6/10:
+  dpt: '7.012'
+  function: Versorgungstechnik
+  name: Versorgungstechnik.Wallbox.Allowed-Charging-Current
+15/6/2:
+  dpt: '5.010'
+  function: Versorgungstechnik
+  name: Versorgungstechnik.Wallbox.Error-State
+15/6/3:
+  dpt: '5.010'
+  function: Versorgungstechnik
+  name: Versorgungstechnik.Wallbox.Contactor-Error
+15/6/4:
+  dpt: '5.010'
+  function: Versorgungstechnik
+  name: Versorgungstechnik.Wallbox.DC-Fault-Current-State
 16/0/20:
   dpt: '1.011'
   function: Informationstechnik

--- a/kubernetes/applications/knx-nats-bridge/base/config/write-mapping.yaml
+++ b/kubernetes/applications/knx-nats-bridge/base/config/write-mapping.yaml
@@ -1,11 +1,227 @@
 # NATS-subject -> KNX-GA write mappings consumed by knx-nats-bridge when
-# BRIDGE_WRITE_ENABLED=true. Empty by default: the bridge logs "writer
-# initialized, 0 mappings, idle" and the KNX bus stays untouched.
-# Actual mappings (UniFi triggers, EMS-ESP mirror, anomaly bus, ...) are
-# added in a follow-up PR once node-RED has been migrated to publish on
-# the corresponding subjects.
+# BRIDGE_WRITE_ENABLED=true.
 #
 # Schema: see write-mapping.schema.json in the knx-nats-bridge repo.
-# Each entry: subject (NATS), ga (KNX a/b/c), dpt (e.g. 1.001),
+# Each entry: subject (NATS), ga (KNX a/b/c), dpt (e.g. 1.005),
 # payload_path ($-prefixed dot-notation), optional description.
-mappings: []
+#
+# Publish contract (node-RED side):
+#   UniFi triggers must include `knx_value` at the root, set by the
+#   webhook flow AFTER resolving camera MAC -> name and the alarm-key
+#   -> KNX-value mapping:
+#     person / face_unknown          -> knx_value: 1     (DPT 1.005 trigger)
+#     face_known / face_of_interest  -> knx_value: <int 1..4>
+#   The rest of the trigger payload (sourceEvent, eventId, alarm meta)
+#   stays untouched so redpanda-connect can still archive everything into
+#   unifi_events.
+#
+#   Mirror subjects (ems-esp.*, warp.*, solaredge-*.*) are already
+#   published by the existing MQTT bridges and solaredge2mqtt --
+#   no node-RED change needed there.
+
+mappings:
+  # =========================================================================
+  # UniFi Protect -- Person triggers (4 cameras)
+  # GAs match the existing direct-KNX flow in node-RED, so both pipelines
+  # write the same GA during the parallel rollout. Basalte rules treat
+  # these as edge triggers, so a double-fire is idempotent.
+  # =========================================================================
+  - subject: "unifi.events.fassade.person"
+    ga: "14/3/1"
+    dpt: "1.005"
+    payload_path: "$.knx_value"
+    description: "Sicherheitstechnik.VUEA.Fassade.Objekterkennung.Person"
+  - subject: "unifi.events.eingang.person"
+    ga: "14/3/41"
+    dpt: "1.005"
+    payload_path: "$.knx_value"
+    description: "Sicherheitstechnik.VUEA.Eingang.Objekterkennung.Person"
+  - subject: "unifi.events.terrasse_wohnzimmer.person"
+    ga: "14/3/81"
+    dpt: "1.005"
+    payload_path: "$.knx_value"
+    description: "Sicherheitstechnik.VUEA.Terrasse.Wohnzimmer.Objekterkennung.Person"
+  - subject: "unifi.events.terrasse_esszimmer.person"
+    ga: "14/3/121"
+    dpt: "1.005"
+    payload_path: "$.knx_value"
+    description: "Sicherheitstechnik.VUEA.Terrasse.Esszimmer.Objekterkennung.Person"
+
+  # =========================================================================
+  # UniFi Protect -- Face-Known (DPT 5.010, int 1..4 per known person)
+  # =========================================================================
+  - subject: "unifi.events.fassade.face_known"
+    ga: "14/3/3"
+    dpt: "5.010"
+    payload_path: "$.knx_value"
+    description: "Sicherheitstechnik.VUEA.Fassade.Gesichtserkennung.Gesicht-Bekannt"
+  - subject: "unifi.events.eingang.face_known"
+    ga: "14/3/43"
+    dpt: "5.010"
+    payload_path: "$.knx_value"
+    description: "Sicherheitstechnik.VUEA.Eingang.Gesichtserkennung.Gesicht-Bekannt"
+  - subject: "unifi.events.terrasse_wohnzimmer.face_known"
+    ga: "14/3/83"
+    dpt: "5.010"
+    payload_path: "$.knx_value"
+    description: "Sicherheitstechnik.VUEA.Terrasse.Wohnzimmer.Gesichtserkennung.Gesicht-Bekannt"
+  - subject: "unifi.events.terrasse_esszimmer.face_known"
+    ga: "14/3/123"
+    dpt: "5.010"
+    payload_path: "$.knx_value"
+    description: "Sicherheitstechnik.VUEA.Terrasse.Esszimmer.Gesichtserkennung.Gesicht-Bekannt"
+
+  # =========================================================================
+  # UniFi Protect -- Face-Unknown (DPT 1.005 alarm trigger)
+  # =========================================================================
+  - subject: "unifi.events.fassade.face_unknown"
+    ga: "14/3/4"
+    dpt: "1.005"
+    payload_path: "$.knx_value"
+    description: "Sicherheitstechnik.VUEA.Fassade.Gesichtserkennung.Gesicht-Unbekannt"
+  - subject: "unifi.events.eingang.face_unknown"
+    ga: "14/3/44"
+    dpt: "1.005"
+    payload_path: "$.knx_value"
+    description: "Sicherheitstechnik.VUEA.Eingang.Gesichtserkennung.Gesicht-Unbekannt"
+  - subject: "unifi.events.terrasse_wohnzimmer.face_unknown"
+    ga: "14/3/84"
+    dpt: "1.005"
+    payload_path: "$.knx_value"
+    description: "Sicherheitstechnik.VUEA.Terrasse.Wohnzimmer.Gesichtserkennung.Gesicht-Unbekannt"
+  - subject: "unifi.events.terrasse_esszimmer.face_unknown"
+    ga: "14/3/124"
+    dpt: "1.005"
+    payload_path: "$.knx_value"
+    description: "Sicherheitstechnik.VUEA.Terrasse.Esszimmer.Gesichtserkennung.Gesicht-Unbekannt"
+
+  # =========================================================================
+  # UniFi Protect -- Face-of-Interest / "marked" (DPT 5.010 int)
+  # =========================================================================
+  - subject: "unifi.events.fassade.face_of_interest"
+    ga: "14/3/5"
+    dpt: "5.010"
+    payload_path: "$.knx_value"
+    description: "Sicherheitstechnik.VUEA.Fassade.Gesichtserkennung.Gesicht-Markiert"
+  - subject: "unifi.events.eingang.face_of_interest"
+    ga: "14/3/45"
+    dpt: "5.010"
+    payload_path: "$.knx_value"
+    description: "Sicherheitstechnik.VUEA.Eingang.Gesichtserkennung.Gesicht-Markiert"
+  - subject: "unifi.events.terrasse_wohnzimmer.face_of_interest"
+    ga: "14/3/85"
+    dpt: "5.010"
+    payload_path: "$.knx_value"
+    description: "Sicherheitstechnik.VUEA.Terrasse.Wohnzimmer.Gesichtserkennung.Gesicht-Markiert"
+  - subject: "unifi.events.terrasse_esszimmer.face_of_interest"
+    ga: "14/3/125"
+    dpt: "5.010"
+    payload_path: "$.knx_value"
+    description: "Sicherheitstechnik.VUEA.Terrasse.Esszimmer.Gesichtserkennung.Gesicht-Markiert"
+
+  # =========================================================================
+  # EMS-ESP gas boiler mirrors (5 GAs in new 15/2 Gastherme middle-group).
+  # =========================================================================
+  - subject: "ems-esp.boiler_data"
+    ga: "15/2/0"
+    dpt: "1.011"
+    payload_path: "$.burngas"
+    description: "Versorgungstechnik.Gastherme.Brenner-Status (for Basalte burner_short_cycle)"
+  - subject: "ems-esp.boiler_data"
+    ga: "15/2/1"
+    dpt: "5.001"
+    payload_path: "$.curburnpow"
+    description: "Versorgungstechnik.Gastherme.Brenner-Modulation 0..100 %"
+  - subject: "ems-esp.boiler_data"
+    ga: "15/2/2"
+    dpt: "1.001"
+    payload_path: "$.heatingactive"
+    description: "Versorgungstechnik.Gastherme.Heizung-Aktiv"
+  - subject: "ems-esp.boiler_data"
+    ga: "15/2/10"
+    dpt: "9.001"
+    payload_path: "$.curflowtemp"
+    description: "Versorgungstechnik.Gastherme.Vorlauf-Temperatur °C"
+  - subject: "ems-esp.boiler_data"
+    ga: "15/2/11"
+    dpt: "9.001"
+    payload_path: "$.rettemp"
+    description: "Versorgungstechnik.Gastherme.Rücklauf-Temperatur °C"
+
+  # =========================================================================
+  # WARP wallbox state mirrors (6 GAs in new 15/6 Wallbox middle-group).
+  # State legends per WARP API reference (docs.warp-charger.com).
+  # =========================================================================
+  - subject: "warp.evse.state"
+    ga: "15/6/0"
+    dpt: "5.010"
+    payload_path: "$.charger_state"
+    description: "Versorgungstechnik.Wallbox.Charger-State 0..4"
+  - subject: "warp.evse.state"
+    ga: "15/6/1"
+    dpt: "5.010"
+    payload_path: "$.iec61851_state"
+    description: "Versorgungstechnik.Wallbox.IEC61851-State 0..4 (4=Error)"
+  - subject: "warp.evse.state"
+    ga: "15/6/2"
+    dpt: "5.010"
+    payload_path: "$.error_state"
+    description: "Versorgungstechnik.Wallbox.Error-State 0..5 (for Basalte wallbox_fault)"
+  - subject: "warp.evse.state"
+    ga: "15/6/3"
+    dpt: "5.010"
+    payload_path: "$.contactor_error"
+    description: "Versorgungstechnik.Wallbox.Contactor-Error 0..6"
+  - subject: "warp.evse.state"
+    ga: "15/6/4"
+    dpt: "5.010"
+    payload_path: "$.dc_fault_current_state"
+    description: "Versorgungstechnik.Wallbox.DC-Fault-Current-State 0..6"
+  - subject: "warp.evse.state"
+    ga: "15/6/10"
+    dpt: "7.012"
+    payload_path: "$.allowed_charging_current"
+    description: "Versorgungstechnik.Wallbox.Allowed-Charging-Current uint16 mA"
+
+  # =========================================================================
+  # SolarEdge PV mirrors (6 GAs in new 15/4 Photovoltaik middle-group).
+  # Sub-GA layout: 0..9 = system-wide (CT-meter readings, both inverters
+  # report identical values), 10..19 = inverter 1, 20..29 = inverter 2.
+  # =========================================================================
+
+  # System-wide (mirrored once from inverter 1's powerflow stream; both
+  # inverters' CTs report the same values).
+  - subject: "solaredge-1.powerflow"
+    ga: "15/4/0"
+    dpt: "14.056"
+    payload_path: "$.grid.power"
+    description: "Versorgungstechnik.Photovoltaik.Netz-Leistung W signed (+import, -export)"
+  - subject: "solaredge-1.powerflow"
+    ga: "15/4/1"
+    dpt: "14.056"
+    payload_path: "$.consumer.total"
+    description: "Versorgungstechnik.Photovoltaik.Verbrauch-Gesamt W"
+
+  # Inverter 1.
+  - subject: "solaredge-1.powerflow"
+    ga: "15/4/10"
+    dpt: "14.056"
+    payload_path: "$.pv_production"
+    description: "Versorgungstechnik.Photovoltaik.Inverter-1.Leistung W"
+  - subject: "solaredge-1.modbus.inverter"
+    ga: "15/4/11"
+    dpt: "9.001"
+    payload_path: "$.temperature"
+    description: "Versorgungstechnik.Photovoltaik.Inverter-1.Temperatur °C"
+
+  # Inverter 2.
+  - subject: "solaredge-2.powerflow"
+    ga: "15/4/20"
+    dpt: "14.056"
+    payload_path: "$.pv_production"
+    description: "Versorgungstechnik.Photovoltaik.Inverter-2.Leistung W"
+  - subject: "solaredge-2.modbus.inverter"
+    ga: "15/4/21"
+    dpt: "9.001"
+    payload_path: "$.temperature"
+    description: "Versorgungstechnik.Photovoltaik.Inverter-2.Temperatur °C"


### PR DESCRIPTION
## Summary
Fills the `write-mapping.yaml` ConfigMap (empty since #985) with 33 mappings and regenerates `knx-catalog.yaml` for the new 15/{2,4,6}/* mirror GAs.

- **16 UniFi** (4 cameras × {person, face_known, face_unknown, face_of_interest}) target the same `14/3/x` GAs the existing direct-KNX flow in node-RED uses, so both pipelines write the same GA during the parallel rollout. Basalte treats these as edge triggers — a double-fire is idempotent.
- **5 EMS-ESP** mirrors on new `15/2 Gastherme`: burner status / modulation / heating-active / flow temp / return temp.
- **6 WARP** mirrors on new `15/6 Wallbox`: charger / iec61851 / error / contactor-error / dc-fault states plus `allowed_charging_current` (uint16 mA).
- **6 SolarEdge PV** mirrors on new `15/4 Photovoltaik` with a per-device sub-GA layout: `0..9` system-wide (`grid.power`, `consumer.total`), `10..19` inverter 1 (`pv_production`, `temperature`), `20..29` inverter 2.

**UniFi publish contract** (file header): node-RED enriches each trigger with `knx_value` at the root — `1` for boolean trigger keys, int 1..4 for face-name lookups ({Alexander: 1, Vanessa: 2, Luis: 3, Gregory: 4}) — before splitting and publishing on `unifi.events.<camera>.<key>`. The rest of the trigger payload is preserved so redpanda-connect can still archive everything into `unifi_events`.

Mirror subjects (`ems-esp.*`, `warp.*`, `solaredge-*.*`) are already published by existing services — no node-RED change needed there.

## User-side work tracked separately
- [ ] Update the node-RED `Unifi Protect` tab to publish on NATS in addition to the existing KNX writes (parallel rollout). After 24-48h of clean operation, disable the direct-KNX writes.
- [ ] Wire Basalte rules: `burner_short_cycle` on `15/2/0`, `wallbox_fault` on `15/6/2` & co., PV-underperformance on `15/4/10+15/4/20`.

## Test plan
- [x] `kustomize build --enable-helm kubernetes/applications/knx-nats-bridge/base` renders 33 `- subject:` entries.
- [x] DPT-by-DPT cross-check between `knx-catalog.yaml` and `write-mapping.yaml` for all 17 new GAs in `15/{2,4,6}/*` — all match.
- [ ] After merge: bridge pod log shows `writer enabled: 33 mappings across N subjects` plus N× `writer subscribed: <subject>`.
- [ ] Smoke: `nats pub ems-esp.boiler_data '{"burngas":1,"curburnpow":50,"heatingactive":1,"curflowtemp":55,"rettemp":50}'` → 5 bus telegrams on `15/2/{0,1,2,10,11}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)