### PR TITLE
chore(knx-nats-bridge): enable Kustomize hash-suffix on ConfigMaps

### DIFF
--- a/kubernetes/applications/knx-nats-bridge/base/kustomization.yaml
+++ b/kubernetes/applications/knx-nats-bridge/base/kustomization.yaml
@@ -17,13 +17,9 @@ helmCharts:
 
 configMapGenerator:
   - name: knx-nats-bridge-catalog
-    options:
-      disableNameSuffixHash: true
     files:
       - knx-catalog.yaml=config/knx-catalog.yaml
   - name: knx-nats-bridge-write-mapping
-    options:
-      disableNameSuffixHash: true
     files:
       - write-mapping.yaml=config/write-mapping.yaml
 


### PR DESCRIPTION
Drop \`disableNameSuffixHash\` on the catalog and write-mapping ConfigMap generators so Kustomize appends a content hash. The hash flows through Kustomize's name-reference rewriting into the Deployment's volume specs — Kubernetes rolls the pod automatically on any catalog or mapping change.

Today's symptom: after #994 merged the pod kept running with the old empty mapping until a manual \`kubectl rollout restart\`. The Stakater-Reloader annotation on the deployment is harmless — the controller is not installed in this cluster.

## Test plan
- [x] \`kustomize build --enable-helm kubernetes/applications/knx-nats-bridge/base\` renders \`name: knx-nats-bridge-catalog-<hash>\` plus matching volume references in the Deployment.
- [ ] After merge: bridge pod rolls automatically (Argo sync → new ConfigMap name → Deployment volume diff → rollout). Old un-hashed ConfigMaps get pruned by Argo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)