### PR TITLE
feat(iot-mcp-bridge): add detect-univariate CronJob

### DIFF
--- a/kubernetes/applications/iot-mcp-bridge/base/detect-univariate-cronjob.yaml
+++ b/kubernetes/applications/iot-mcp-bridge/base/detect-univariate-cronjob.yaml
@@ -27,7 +27,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: detector
-              image: ghcr.io/alexander-zimmermann/iot-mcp-bridge:0.6.0
+              image: ghcr.io/alexander-zimmermann/iot-mcp-bridge:0.6.1
               command: ["iot-mcp-bridge-jobs", "detect-univariate"]
               env:
                 # Read-only DB user — required by Settings() even though

--- a/kubernetes/applications/iot-mcp-bridge/base/detect-univariate-cronjob.yaml
+++ b/kubernetes/applications/iot-mcp-bridge/base/detect-univariate-cronjob.yaml
@@ -1,0 +1,99 @@
+# CronJob: scan every 1h-CAGG × metric pair against its
+# `<source>_baseline_30d` hour×weekday baseline and write z-score
+# anomalies into `mcp_anomalies`. Every 15 min — the source CAGGs
+# refresh once an hour, so the same row is re-scored 4× per hour,
+# but `INSERT … ON CONFLICT DO UPDATE` keeps the table idempotent.
+apiVersion: batch/v1
+kind: CronJob
+
+metadata:
+  name: iot-mcp-bridge-detect-univariate
+  namespace: iot-mcp-bridge
+
+spec:
+  schedule: "*/15 * * * *"
+  timeZone: "Etc/UTC"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  startingDeadlineSeconds: 600
+
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 86400
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: detector
+              image: ghcr.io/alexander-zimmermann/iot-mcp-bridge:0.6.0
+              command: ["iot-mcp-bridge-jobs", "detect-univariate"]
+              env:
+                # Read-only DB user — required by Settings() even though
+                # the detector only writes via db_write_dsn.
+                - name: MCP_DB_HOST
+                  value: timescaledb-db-rw.timescaledb.svc.cluster.local
+                - name: MCP_DB_PORT
+                  value: "5432"
+                - name: MCP_DB_NAME
+                  value: homelab
+                - name: MCP_DB_USERNAME
+                  valueFrom:
+                    secretKeyRef:
+                      name: timescaledb-db-iot-mcp-bridge-ro-secret
+                      key: username
+                - name: MCP_DB_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: timescaledb-db-iot-mcp-bridge-ro-secret
+                      key: password
+                # Write user — INSERT into mcp_anomalies.
+                - name: MCP_DB_WRITE_USERNAME
+                  valueFrom:
+                    secretKeyRef:
+                      name: timescaledb-db-iot-mcp-bridge-rw-secret
+                      key: username
+                - name: MCP_DB_WRITE_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: timescaledb-db-iot-mcp-bridge-rw-secret
+                      key: password
+                # NATS — publish anomaly.<uc>.<severity>.
+                - name: MCP_NATS_SERVERS
+                  value: nats://nats.nats.svc.cluster.local:4222
+                - name: MCP_NATS_NKEY_SEED_FILE
+                  value: /etc/iot-mcp-bridge/nats/nkey-seed
+                - name: MCP_AUTH_ENABLED
+                  value: "false"
+                - name: TZ
+                  value: Europe/Berlin
+              resources:
+                requests:
+                  cpu: 20m
+                  memory: 96Mi
+                limits:
+                  cpu: 200m
+                  memory: 192Mi
+              volumeMounts:
+                - name: nats-credentials
+                  mountPath: /etc/iot-mcp-bridge/nats
+                  readOnly: true
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                runAsUser: 1000
+                runAsGroup: 1000
+                capabilities:
+                  drop: ["ALL"]
+                seccompProfile:
+                  type: RuntimeDefault
+          volumes:
+            - name: nats-credentials
+              secret:
+                secretName: iot-mcp-bridge-credentials
+                defaultMode: 0400
+                items:
+                  - key: nkey-seed
+                    path: nkey-seed

--- a/kubernetes/applications/iot-mcp-bridge/base/kustomization.yaml
+++ b/kubernetes/applications/iot-mcp-bridge/base/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - ./certificate.yaml
   - ./ingress-route.yaml
   - ./import-knx-catalog-job.yaml
+  - ./detect-univariate-cronjob.yaml
 
 helmCharts:
   - name: application


### PR DESCRIPTION
## Summary
Schedules \`iot-mcp-bridge-jobs detect-univariate\` from the 0.6.0 image to scan every 1h-CAGG × metric pair against its \`<source>_baseline_30d\` baseline every 15 minutes. Writes z-score hits to \`mcp_anomalies\` (idempotent via PK upsert) and publishes new inserts on \`anomaly.<uc>.<severity>\` for the knx-nats-bridge write-mapping to route on.

Companion to [iot-mcp-bridge#35](https://github.com/alexander-zimmermann/iot-mcp-bridge/pull/35) (the detector implementation + insights MCP tools).

## Mounts
Three Kyverno-cloned secrets, already present in the namespace from earlier PRs:
- \`timescaledb-db-iot-mcp-bridge-ro-secret\` — read creds (Settings() validates these even though the detector only writes via \`db_write_dsn\`)
- \`timescaledb-db-iot-mcp-bridge-rw-secret\` — INSERT on \`mcp_anomalies\` + \`mcp_forecasts\`
- \`iot-mcp-bridge-credentials\` — NATS NKey-seed (publish-only on \`anomaly.>\`)

## Security
Restricted SecurityContext (readOnlyRootFilesystem, runAsNonRoot, caps dropped, seccomp RuntimeDefault) — passes PodSecurity \`restricted\` cleanly.

## Test plan
- [x] \`kubectl kustomize --enable-helm kubernetes/applications/iot-mcp-bridge/overlays/prod/\` renders clean.
- [ ] After iot-mcp-bridge#35 merges + a fresh \`v0.6.1\` image is tagged (or use \`v0.6.0\` if no functional change) + this PR merges:
      - \`kubectl get cronjob -n iot-mcp-bridge\` shows the CronJob with \`Last Schedule < 15m\`.
      - \`kubectl create job --from=cronjob/iot-mcp-bridge-detect-univariate manual-1 -n iot-mcp-bridge\` exits 0 and inserts rows into \`mcp_anomalies\`.
      - \`nats sub "anomaly.>"\` shows publishes corresponding to those rows.
      - Claude.ai → \`detect_anomalies()\` returns the rows.

## Follow-ups
The 2b (IsolationForest) and 2c (statsforecast / Forecast.Solar) detectors will land as separate \`{train,score}-{iforest,seasonal}-cronjob.yaml\` files in subsequent PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)