### PR TITLE
chore(iot-mcp-bridge): cronjob image 0.6.1 → 0.6.2

### DIFF
--- a/kubernetes/applications/iot-mcp-bridge/base/detect-univariate-cronjob.yaml
+++ b/kubernetes/applications/iot-mcp-bridge/base/detect-univariate-cronjob.yaml
@@ -27,7 +27,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: detector
-              image: ghcr.io/alexander-zimmermann/iot-mcp-bridge:0.6.1
+              image: ghcr.io/alexander-zimmermann/iot-mcp-bridge:0.6.2
               command: ["iot-mcp-bridge-jobs", "detect-univariate"]
               env:
                 # Read-only DB user — required by Settings() even though


### PR DESCRIPTION
Picks up the URL-encoding fix for \`db_dsn\` / \`db_write_dsn\` in [iot-mcp-bridge#36](https://github.com/alexander-zimmermann/iot-mcp-bridge/pull/36). The 0.6.1 binary crashed on first run because the rw-secret password contains a \`/\`, which psycopg consumed as the dbname separator.

## Test plan
- [x] Image \`ghcr.io/alexander-zimmermann/iot-mcp-bridge:0.6.2\` exists.
- [ ] After merge + ArgoCD-Sync: \`kubectl create job --from=cronjob/iot-mcp-bridge-detect-univariate manual-1 -n iot-mcp-bridge\` exits 0 and writes rows into \`mcp_anomalies\`.
- [ ] \`nats sub "anomaly.>"\` shows publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)