### PR TITLE
fix(knx-nats-bridge): re-disable ConfigMap hash-suffix

### DIFF
--- a/kubernetes/applications/knx-nats-bridge/base/kustomization.yaml
+++ b/kubernetes/applications/knx-nats-bridge/base/kustomization.yaml
@@ -15,11 +15,17 @@ helmCharts:
     apiVersions:
       - monitoring.coreos.com/v1
 
+# disableNameSuffixHash: cross-namespace consumers (Kyverno clone,
+# iot-mcp-bridge import-knx-catalog-job) reference these by fixed name.
 configMapGenerator:
   - name: knx-nats-bridge-catalog
+    options:
+      disableNameSuffixHash: true
     files:
       - knx-catalog.yaml=config/knx-catalog.yaml
   - name: knx-nats-bridge-write-mapping
+    options:
+      disableNameSuffixHash: true
     files:
       - write-mapping.yaml=config/write-mapping.yaml
 


### PR DESCRIPTION
## Summary
Commit 757a713b enabled the Kustomize hash-suffix on both knx-nats-bridge ConfigMaps but didn't update the cross-namespace consumers. The result: the Kyverno clone-rule \`sync-knx-nats-bridge-catalog-configmap\` and the iot-mcp-bridge \`import-knx-catalog-job\` both reference \`knx-nats-bridge-catalog\` by fixed name, so the suffix broke them — \`iot-mcp-bridge-prod\` ArgoCD-sync is stuck on a missing ConfigMap mount.

Re-enable \`disableNameSuffixHash: true\` on both generators and add a short comment so this doesn't get reverted by accident.

## Test plan
- [x] \`kubectl kustomize --enable-helm kubernetes/applications/knx-nats-bridge/overlays/prod/\` clean.
- [ ] After merge + ArgoCD-Sync: ConfigMap \`knx-nats-bridge-catalog\` (without suffix) exists in \`knx-nats-bridge\` ns; clone reaches \`iot-mcp-bridge\` ns; \`import-knx-catalog-job\` completes; \`iot-mcp-bridge-prod\` app goes Synced/Healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)