### PR TITLE
chore(iot-mcp-bridge): cronjob image 0.6.2 → 0.6.3

### DIFF
--- a/kubernetes/applications/iot-mcp-bridge/base/detect-univariate-cronjob.yaml
+++ b/kubernetes/applications/iot-mcp-bridge/base/detect-univariate-cronjob.yaml
@@ -27,7 +27,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: detector
-              image: ghcr.io/alexander-zimmermann/iot-mcp-bridge:0.6.2
+              image: ghcr.io/alexander-zimmermann/iot-mcp-bridge:0.6.3
               command: ["iot-mcp-bridge-jobs", "detect-univariate"]
               env:
                 # Read-only DB user — required by Settings() even though


### PR DESCRIPTION
Picks up the ambiguous-column SQL fix ([iot-mcp-bridge#37](https://github.com/alexander-zimmermann/iot-mcp-bridge/pull/37)) for the 7 metrics with `group_cols` (solar, wallbox, knx). 0.6.2 ran clean on the 6 metrics without group_cols but errored out for the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)