### PR TITLE
chore(iot-mcp-bridge): cronjob image 0.6.3 → 0.6.4

### DIFF
--- a/kubernetes/applications/iot-mcp-bridge/base/detect-univariate-cronjob.yaml
+++ b/kubernetes/applications/iot-mcp-bridge/base/detect-univariate-cronjob.yaml
@@ -27,7 +27,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: detector
-              image: ghcr.io/alexander-zimmermann/iot-mcp-bridge:0.6.3
+              image: ghcr.io/alexander-zimmermann/iot-mcp-bridge:0.6.4
               command: ["iot-mcp-bridge-jobs", "detect-univariate"]
               env:
                 # Read-only DB user — required by Settings() even though


### PR DESCRIPTION
Picks up [iot-mcp-bridge#38](https://github.com/alexander-zimmermann/iot-mcp-bridge/pull/38) — `nats-py[nkeys]` so NKey-seed auth works.

0.6.3 detection ran clean on the smoke job (65 anomalies into mcp_anomalies) but every NATS-publish failed with `ModuleNotFoundError: 'nkeys'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)