### PR TITLE
fix(iot-mcp-bridge): mount nkey-seed via subPath, drop defaultMode 0400

### DIFF
--- a/kubernetes/applications/iot-mcp-bridge/base/detect-univariate-cronjob.yaml
+++ b/kubernetes/applications/iot-mcp-bridge/base/detect-univariate-cronjob.yaml
@@ -77,7 +77,8 @@ spec:
                   memory: 192Mi
               volumeMounts:
                 - name: nats-credentials
-                  mountPath: /etc/iot-mcp-bridge/nats
+                  mountPath: /etc/iot-mcp-bridge/nats/nkey-seed
+                  subPath: nkey-seed
                   readOnly: true
               securityContext:
                 allowPrivilegeEscalation: false
@@ -93,7 +94,3 @@ spec:
             - name: nats-credentials
               secret:
                 secretName: iot-mcp-bridge-credentials
-                defaultMode: 0400
-                items:
-                  - key: nkey-seed
-                    path: nkey-seed


### PR DESCRIPTION
0.6.4 detection runs clean (62 anomalies into mcp_anomalies on smoke) but the NATS-publish fails with `PermissionError: [Errno 13]` — the secret volume is a directory of projected symlinks owned by root, and `defaultMode: 0400` makes the underlying file readable only by root. The non-root container (uid 1000) can't open it.

Mirror the knx-nats-bridge pattern: mount via `subPath` so the seed lands as a regular file at the mountPath, drop the mode override (K8s default 0644 is fine; pod isolation is the boundary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)