### PR TITLE
chore(redpanda-connect): drop misleading coredns.io/hostname annotation

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/kustomization.yaml
+++ b/kubernetes/applications/redpanda-connect/base/kustomization.yaml
@@ -45,9 +45,6 @@ patches:
       - op: add
         path: /metadata/labels/bgp.cilium.io~1advertise-service
         value: default
-      - op: add
-        path: /metadata/annotations/coredns.io~1hostname
-        value: unifi-webhook.zimmermann.eu.com
 
 labels:
   - includeSelectors: false


### PR DESCRIPTION
The annotation was copied from the NATS values.yaml pattern, but no controller in this cluster consumes it — `*.zimmermann.eu.com` records are managed manually on the UDM Pro, not via external-dns or any CoreDNS plugin. Leaving the annotation on the Service implied an automatic publish that doesn't happen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)