### PR TITLE
fix(redpanda-connect): bloblang meta assignment in unifi_arm_alarm

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/streams/unifi_arm_alarm.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/unifi_arm_alarm.yaml
@@ -14,14 +14,14 @@ pipeline:
     - mapping: |
         let subj = meta("nats_subject")
         let on  = this.value == true
-        meta("protect_action") = if $subj == "knx.14.1.25" && $on {
+        meta protect_action = if $subj == "knx.14.1.25" && $on {
           "enable"
         } else if $subj == "knx.14.1.20" && $on {
           "disable"
         } else {
           deleted()
         }
-        root = if meta("protect_action") != null { this } else { deleted() }
+        root = if meta("protect_action").or(null) != null { this } else { deleted() }
 
 output:
   switch:


### PR DESCRIPTION
## Summary
Fixes pod CrashLoopBackOff introduced by #1008. Bloblang LHS metadata assignment uses bare `meta name = …`; the `meta("name") = …` form is read-only.

```
Config lint error … /streams/unifi_arm_alarm.yaml(17,21) expected  or whitespace, got: ("pro
```

Also `.or(null)` on the downstream read so the `else { deleted() }` branch doesn't surface as a mapping error.

## Test plan
- [ ] ArgoCD sync succeeds, redpanda-connect pod transitions out of CrashLoopBackOff.
- [ ] `unifi_arm_alarm` stream appears as healthy in pod logs.
- [ ] Smoke test: `nats pub knx.14.1.25 '{"value":true,…}'` flips "Abwesend" arm profile on; `knx.14.1.20` flips it off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)