### PR TITLE
docs(readme): Stack layers heading + shorten data-flow sub labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ Standard CNCF Kubernetes manifests, grouped into `bootstrap/` (day-zero), `compo
 
 ## Architecture
 
+### Stack layers
+
+Three independent layers stacked bottom-up — Proxmox provisions VMs, Omni shapes them into a Talos cluster, Argo CD reconciles every app from `main`.
+
 ```mermaid
 flowchart TB
     subgraph L3["Layer 3: Apps — Argo CD + Manifests"]
@@ -149,12 +153,12 @@ flowchart TB
 
     bridge[knx-nats-bridge<br/>Reader + Writer]
     bridge -- pub knx.> --> nats
-    nats -- sub unifi.events.> · ems-esp.> · warp.> · solaredge-*.> --> bridge
+    nats -- sub --> bridge
     bridge <-- xknx TCP tunnel --> knx[KNX Bus]
     knx --> basalte[Basalte<br/>logic + notifications]
 
     ingest[redpanda-connect<br/>ingest streams]
-    nats -- sub knx.> · ems-esp.> · warp.> · solaredge-*.> · unifi.events.> --> ingest
+    nats -- sub --> ingest
     ingest --> tsdb[(TimescaleDB)]
     ingest --> rustfs[(rustfs<br/>parquet archive)]
 


### PR DESCRIPTION
Two small README polishes:

* New \`### Stack layers\` heading + one-line description over the original layer diagram, paired with the existing \`### Smart-Home data flow\` subsection so both diagrams sit symmetrically under \`## Architecture\`.
* The two \`sub <long subject list>\` edges on the data-flow diagram were visually heavy and overlapped the neighbouring \`pub knx.>\` label. Collapsed both to bare \`sub\` (publishers' subjects are still in the per-source \`pub\` labels and listed in the NATS-stream cylinder).

🤖 Generated with [Claude Code](https://claude.com/claude-code)