### PR TITLE
feat(unifi-webhook): unify face_map + plate_map into person_map

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/streams/unifi_webhook.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/unifi_webhook.yaml
@@ -31,21 +31,22 @@ pipeline:
           "1C6A1B83322C": "terrasse_wohnzimmer",
           "28704E12AEEE": "terrasse_esszimmer",
         }
-        let face_map = {
+        # UniFi reuses the same friendly name across face and license-plate
+        # of-interest/known triggers, so one person -> int lookup serves both.
+        let person_map = {
           "Alexander Zimmermann": 1,
           "Vanessa Zimmermann":   2,
           "Luis Zimmermann":      3,
           "Gregory Zimmermann":   4,
         }
-        let plate_map = {}   # populate when 'Vehicle of Interest' plates exist
 
         let camera = $camera_map.get(this.device).or("unknown")
         let key    = this.key
 
-        let knx_value = if $key == "face_known" || $key == "face_of_interest" {
-            $face_map.get(this.value).or(0)
-          } else if $key == "license_plate_known" || $key == "license_plate_of_interest" {
-            $plate_map.get(this.value).or(0)
+        let knx_value =
+          if $key == "face_known" || $key == "face_of_interest" ||
+             $key == "license_plate_known" || $key == "license_plate_of_interest" {
+            $person_map.get(this.value).or(0)
           } else {
             1
           }


### PR DESCRIPTION
UniFi reuses the same friendly name across \`face_known\`/\`of_interest\` and \`license_plate_known\`/\`of_interest\` triggers — when a known plate is registered under the same person identity as the face, the webhook's \`value\` field is the person's name in both cases (\`Alexander Zimmermann\`, …). Verified in TSDB \`unifi_events\` rows.

Before: \`face_map\` populated, \`plate_map\` empty TODO → every \`license_plate_known\`/\`of_interest\` bridge-write landed on KNX with \`knx_value = 0\`, and \`14/3/6\` / \`14/3/8\` showed bridge \`outcome=ok\` but no bus echo (the gateway appears to swallow DPT 5.010 telegrams with value 0).

After: one shared \`person_map\`, the plate triggers resolve to a non-zero int just like the face triggers — bus echo (and any Basalte rule on those GAs) starts working.

\`license_plate_unknown\` stays a boolean (DPT 1.005 trigger), raw plate (\`1VCS469\`, \`QE518E\`, …) keeps landing in TSDB \`unifi_events\` for forensic lookup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)