### PR TITLE
feat(iot-mcp-bridge): IsolationForest train + score CronJobs (v0.7.0)

### DIFF
--- a/kubernetes/applications/iot-mcp-bridge/base/kustomization.yaml
+++ b/kubernetes/applications/iot-mcp-bridge/base/kustomization.yaml
@@ -8,6 +8,8 @@ resources:
   - ./ingress-route.yaml
   - ./import-knx-catalog-job.yaml
   - ./detect-univariate-cronjob.yaml
+  - ./train-iforest-cronjob.yaml
+  - ./score-iforest-cronjob.yaml
 
 helmCharts:
   - name: application

--- a/kubernetes/applications/iot-mcp-bridge/base/score-iforest-cronjob.yaml
+++ b/kubernetes/applications/iot-mcp-bridge/base/score-iforest-cronjob.yaml
@@ -1,17 +1,19 @@
-# CronJob: scan every 1h-CAGG × metric pair against its
-# `<source>_baseline_30d` hour×weekday baseline and write z-score
-# anomalies into `mcp_anomalies`. Every 15 min — the source CAGGs
-# refresh once an hour, so the same row is re-scored 4× per hour,
-# but `INSERT … ON CONFLICT DO UPDATE` keeps the table idempotent.
+# CronJob: score the last completed 1h-bucket per (uc, group) against
+# the persisted IsolationForest model. Idempotent INSERT into
+# mcp_anomalies; NATS publish on `anomaly.<uc>.<severity>` only on new
+# inserts. Cold-start safe — score-job is a no-op for a UC until train
+# has run once.
+# Schedule 5,20,35,50 — 5 min offset from the detect-univariate */15
+# tick so the two jobs don't fight for the same DB write window.
 apiVersion: batch/v1
 kind: CronJob
 
 metadata:
-  name: iot-mcp-bridge-detect-univariate
+  name: iot-mcp-bridge-score-iforest
   namespace: iot-mcp-bridge
 
 spec:
-  schedule: "*/15 * * * *"
+  schedule: "5,20,35,50 * * * *"
   timeZone: "Etc/UTC"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
@@ -26,12 +28,10 @@ spec:
         spec:
           restartPolicy: OnFailure
           containers:
-            - name: detector
+            - name: scorer
               image: ghcr.io/alexander-zimmermann/iot-mcp-bridge:0.7.0
-              command: ["iot-mcp-bridge-jobs", "detect-univariate"]
+              command: ["iot-mcp-bridge-jobs", "score-iforest"]
               env:
-                # Read-only DB user — required by Settings() even though
-                # the detector only writes via db_write_dsn.
                 - name: MCP_DB_HOST
                   value: timescaledb-db-rw.timescaledb.svc.cluster.local
                 - name: MCP_DB_PORT
@@ -48,7 +48,6 @@ spec:
                     secretKeyRef:
                       name: timescaledb-db-iot-mcp-bridge-ro-secret
                       key: password
-                # Write user — INSERT into mcp_anomalies.
                 - name: MCP_DB_WRITE_USERNAME
                   valueFrom:
                     secretKeyRef:
@@ -59,7 +58,18 @@ spec:
                     secretKeyRef:
                       name: timescaledb-db-iot-mcp-bridge-rw-secret
                       key: password
-                # NATS — publish anomaly.<uc>.<severity>.
+                - name: MCP_S3_ENDPOINT
+                  value: http://rustfs-svc.rustfs.svc.cluster.local:9000
+                - name: MCP_S3_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: rustfs-admin-credentials
+                      key: RUSTFS_ACCESS_KEY
+                - name: MCP_S3_SECRET_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: rustfs-admin-credentials
+                      key: RUSTFS_SECRET_KEY
                 - name: MCP_NATS_SERVERS
                   value: nats://nats.nats.svc.cluster.local:4222
                 - name: MCP_NATS_NKEY_SEED_FILE
@@ -70,11 +80,11 @@ spec:
                   value: Europe/Berlin
               resources:
                 requests:
-                  cpu: 20m
-                  memory: 96Mi
+                  cpu: 30m
+                  memory: 128Mi
                 limits:
-                  cpu: 200m
-                  memory: 192Mi
+                  cpu: 300m
+                  memory: 256Mi
               volumeMounts:
                 - name: nats-credentials
                   mountPath: /etc/iot-mcp-bridge/nats/nkey-seed

--- a/kubernetes/applications/iot-mcp-bridge/base/train-iforest-cronjob.yaml
+++ b/kubernetes/applications/iot-mcp-bridge/base/train-iforest-cronjob.yaml
@@ -1,37 +1,36 @@
-# CronJob: scan every 1h-CAGG × metric pair against its
-# `<source>_baseline_30d` hour×weekday baseline and write z-score
-# anomalies into `mcp_anomalies`. Every 15 min — the source CAGGs
-# refresh once an hour, so the same row is re-scored 4× per hour,
-# but `INSERT … ON CONFLICT DO UPDATE` keeps the table idempotent.
+# CronJob: nightly re-fit of IsolationForest models per (uc, group)
+# over the last `lookback_days` of source-CAGG rows. Persists one
+# joblib pickle per group into rustfs at
+# s3://iot-mcp-bridge-models/iforest/<uc>/<group>.joblib.
+# Schedule 02:30 UTC — well clear of the CAGG refresh storms at the
+# top of every hour and outside any user activity window.
 apiVersion: batch/v1
 kind: CronJob
 
 metadata:
-  name: iot-mcp-bridge-detect-univariate
+  name: iot-mcp-bridge-train-iforest
   namespace: iot-mcp-bridge
 
 spec:
-  schedule: "*/15 * * * *"
+  schedule: "30 2 * * *"
   timeZone: "Etc/UTC"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
-  startingDeadlineSeconds: 600
+  startingDeadlineSeconds: 1800
 
   jobTemplate:
     spec:
-      backoffLimit: 2
+      backoffLimit: 1
       ttlSecondsAfterFinished: 86400
       template:
         spec:
           restartPolicy: OnFailure
           containers:
-            - name: detector
+            - name: trainer
               image: ghcr.io/alexander-zimmermann/iot-mcp-bridge:0.7.0
-              command: ["iot-mcp-bridge-jobs", "detect-univariate"]
+              command: ["iot-mcp-bridge-jobs", "train-iforest"]
               env:
-                # Read-only DB user — required by Settings() even though
-                # the detector only writes via db_write_dsn.
                 - name: MCP_DB_HOST
                   value: timescaledb-db-rw.timescaledb.svc.cluster.local
                 - name: MCP_DB_PORT
@@ -48,7 +47,9 @@ spec:
                     secretKeyRef:
                       name: timescaledb-db-iot-mcp-bridge-ro-secret
                       key: password
-                # Write user — INSERT into mcp_anomalies.
+                # Train reads from the source-CAGGs (SELECT-only), but
+                # Settings.db_write_dsn is required to construct the
+                # write_connection() the loader uses.
                 - name: MCP_DB_WRITE_USERNAME
                   valueFrom:
                     secretKeyRef:
@@ -59,27 +60,30 @@ spec:
                     secretKeyRef:
                       name: timescaledb-db-iot-mcp-bridge-rw-secret
                       key: password
-                # NATS — publish anomaly.<uc>.<severity>.
-                - name: MCP_NATS_SERVERS
-                  value: nats://nats.nats.svc.cluster.local:4222
-                - name: MCP_NATS_NKEY_SEED_FILE
-                  value: /etc/iot-mcp-bridge/nats/nkey-seed
+                # rustfs — persist trained pipelines + thresholds.
+                - name: MCP_S3_ENDPOINT
+                  value: http://rustfs-svc.rustfs.svc.cluster.local:9000
+                - name: MCP_S3_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: rustfs-admin-credentials
+                      key: RUSTFS_ACCESS_KEY
+                - name: MCP_S3_SECRET_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: rustfs-admin-credentials
+                      key: RUSTFS_SECRET_KEY
                 - name: MCP_AUTH_ENABLED
                   value: "false"
                 - name: TZ
                   value: Europe/Berlin
               resources:
                 requests:
-                  cpu: 20m
-                  memory: 96Mi
+                  cpu: 50m
+                  memory: 256Mi
                 limits:
-                  cpu: 200m
-                  memory: 192Mi
-              volumeMounts:
-                - name: nats-credentials
-                  mountPath: /etc/iot-mcp-bridge/nats/nkey-seed
-                  subPath: nkey-seed
-                  readOnly: true
+                  cpu: 500m
+                  memory: 512Mi
               securityContext:
                 allowPrivilegeEscalation: false
                 readOnlyRootFilesystem: true
@@ -90,7 +94,3 @@ spec:
                   drop: ["ALL"]
                 seccompProfile:
                   type: RuntimeDefault
-          volumes:
-            - name: nats-credentials
-              secret:
-                secretName: iot-mcp-bridge-credentials


### PR DESCRIPTION
## Summary

Companion to alexander-zimmermann/iot-mcp-bridge#41 (PR-4 of the Phase-2 plan). Wires up two new CronJobs against the v0.7.0 image and bumps the existing detect-univariate CronJob to the same tag so all three jobs ship the same code.

- **iot-mcp-bridge-train-iforest** — \`30 2 * * *\`, fits IsolationForest pipelines per (uc, group), persists to rustfs (\`s3://iot-mcp-bridge-models/iforest/<uc>/<group>.joblib\`)
- **iot-mcp-bridge-score-iforest** — \`5,20,35,50 * * * *\`, scores last completed 1h-bucket per (uc, group), idempotent insert into \`mcp_anomalies\`, NATS publish on new
- **iot-mcp-bridge-detect-univariate** — image 0.6.4 → 0.7.0 (no behaviour change)

## S3 access

Uses the existing \`rustfs-admin-credentials\` clone (already in the namespace via Kyverno rule \`sync-rustfs-admin-credentials-iot-mcp-bridge\`). Same pattern as authentik / wiki-js / timescaledb / redpanda-connect.

A future migration to per-app scoped users (rustfs/cli v0.1.19 now supports this) is tracked separately as #1017 — out of scope here.

## Schedules

- train 02:30 UTC — well clear of CAGG refresh storms and user activity
- score :05/:20/:35/:50 — 5 min offset from \`detect-univariate\` (:00/:15/:30/:45) so the two jobs don't fight for the same DB write window

## Resources

| Job              | requests          | limits           |
|------------------|-------------------|------------------|
| train-iforest    | 50m / 256Mi       | 500m / 512Mi     |
| score-iforest    | 30m / 128Mi       | 300m / 256Mi     |

## Test plan

- [x] \`kustomize build --enable-helm kubernetes/applications/iot-mcp-bridge/base\` includes all 3 CronJobs
- [ ] After merge + sync: \`kubectl get cronjob -n iot-mcp-bridge\` shows 3 CronJobs, all \`SUSPEND=False\`
- [ ] Manually trigger train-iforest first time (\`kubectl create job --from=cronjob/iot-mcp-bridge-train-iforest first-train\`) — verify joblib artifacts appear in rustfs bucket
- [ ] Then let score-iforest tick — verify scoring runs, no spurious anomalies during warm-up (severity demoted to info)

## Follow-ups

PR-5 (IF with KNX-joins) and PR-6 (statsforecast + Forecast.Solar + Weekly-Report) per the Phase-2 plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)