### PR TITLE
fix(redpanda-connect): unifi_arm_alarm log + robust value coercion

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/streams/unifi_arm_alarm.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/unifi_arm_alarm.yaml
@@ -11,17 +11,27 @@ input:
 
 pipeline:
   processors:
+    # Filter to the two GAs we care about, regardless of value, so the log
+    # below shows the raw shape (subject + value type) for diagnostics.
     - mapping: |
         let subj = meta("nats_subject")
-        let on  = this.value == true
-        meta protect_action = if $subj == "knx.14.1.25" && $on {
-          "enable"
-        } else if $subj == "knx.14.1.20" && $on {
-          "disable"
+        root = if $subj == "knx.14.1.25" || $subj == "knx.14.1.20" {
+          this
         } else {
           deleted()
         }
-        root = if meta("protect_action").or(null) != null { this } else { deleted() }
+    - log:
+        level: INFO
+        message: 'unifi_arm_alarm: subject=${! meta("nats_subject") } value=${! this.value } value_type=${! this.value.type() } raw=${! content() }'
+    # Drop falsy values (button-release "0" pulse) and tag the action.
+    - mapping: |
+        let on = this.value.bool().or(false)
+        root = if $on { this } else { deleted() }
+        meta protect_action = if meta("nats_subject") == "knx.14.1.25" {
+          "enable"
+        } else {
+          "disable"
+        }
 
 output:
   switch:


### PR DESCRIPTION
## Summary
After #1010 the pod runs cleanly but the `unifi_arm_alarm` stream silently drops every message — metrics show `processor_received=4286 → processor_sent=0`. Today's three trigger events (14/1/25 at 17:06 + 17:14, 14/1/20 at 18:45) all should have matched but produced zero API calls.

Two changes:
- **Robust value coercion**: `this.value.bool().or(false)` instead of `this.value == true`, so an integer 0/1 payload (from raw/unmapped DPT path) doesn't silently mismatch.
- **Diagnostic log**: an INFO line per arm/disarm pulse with subject + value + value_type, so the next arming reveals whether the issue is the value comparison, the subject, or something else. Mapping is split into a GA filter first, then the value/action tagging, so the log captures the raw shape regardless.

Kept `deliver: new` on the original durable — next manual arming triggers the diagnostics, no historic replay.

## Test plan
- [ ] Pod stays running after merge.
- [ ] Briefly arm (Extern-Scharf) then disarm via Basalte — pod log must show two `unifi_arm_alarm: subject=knx.14.1.25 value=… value_type=…` lines and the Protect "Abwesend" profile must flip.
- [ ] If logs appear but no HTTP call → tighten value coercion based on observed type. If no logs appear → meta("nats_subject") form differs from expectation; investigate further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)