### PR TITLE
fix(redpanda-connect): enable tls block in unifi_arm_alarm http_client

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/streams/unifi_arm_alarm.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/unifi_arm_alarm.yaml
@@ -45,6 +45,7 @@ output:
               X-API-Key: "${UNIFI_PROTECT_API_KEY}"
               Accept: "application/json"
             tls:
+              enabled: true
               skip_cert_verify: true
       - check: 'meta("protect_action") == "disable"'
         output:
@@ -55,4 +56,5 @@ output:
               X-API-Key: "${UNIFI_PROTECT_API_KEY}"
               Accept: "application/json"
             tls:
+              enabled: true
               skip_cert_verify: true


### PR DESCRIPTION
## Summary
PR #1022 confirmed mapping is correct (info log shows `value_type=bool`, payload matches), but every POST to the UDM-Pro retries forever with:
```
tls: failed to verify certificate: x509: certificate is valid for unifi.local, localhost, [::1], not udm-pro.zimmermann.eu.com
```
The Protect cert is only valid for `unifi.local` — `skip_cert_verify: true` alone is silently ignored unless the `tls` block is explicitly `enabled: true`.

## Test plan
- [ ] After merge + sync, trigger Unscharf via Basalte → `output_sent` increments and Protect "Abwesend" flips off.
- [ ] No more `tls: failed to verify certificate` errors in pod logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)