### PR TITLE
chore(redpanda-connect): drop unifi_arm_alarm debug log and split-mapping

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/streams/unifi_arm_alarm.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/unifi_arm_alarm.yaml
@@ -11,27 +11,17 @@ input:
 
 pipeline:
   processors:
-    # Filter to the two GAs we care about, regardless of value, so the log
-    # below shows the raw shape (subject + value type) for diagnostics.
     - mapping: |
         let subj = meta("nats_subject")
-        root = if $subj == "knx.14.1.25" || $subj == "knx.14.1.20" {
-          this
+        let on  = this.value == true
+        meta protect_action = if $subj == "knx.14.1.25" && $on {
+          "enable"
+        } else if $subj == "knx.14.1.20" && $on {
+          "disable"
         } else {
           deleted()
         }
-    - log:
-        level: INFO
-        message: 'unifi_arm_alarm: subject=${! meta("nats_subject") } value=${! this.value } value_type=${! this.value.type() } raw=${! content() }'
-    # Drop falsy values (button-release "0" pulse) and tag the action.
-    - mapping: |
-        let on = this.value.bool().or(false)
-        root = if $on { this } else { deleted() }
-        meta protect_action = if meta("nats_subject") == "knx.14.1.25" {
-          "enable"
-        } else {
-          "disable"
-        }
+        root = if meta("protect_action").or(null) != null { this } else { deleted() }
 
 output:
   switch:


### PR DESCRIPTION
## Summary
After #1023 the stream works end-to-end (Unscharf via Basalte flips Protect "Abwesend" off). Revert the diagnostic scaffolding added in #1022 — back to the compact single mapping, no INFO log, no `.bool().or(false)` coercion. The TLS `enabled: true` + `skip_cert_verify: true` from #1023 stays.

## Test plan
- [ ] Pod stays running after merge.
- [ ] Trigger Unscharf via Basalte → Protect "Abwesend" still flips off (no behavior regression).
- [ ] Trigger Extern-Scharf via Basalte → "Abwesend" flips on (enable path still untested under the fixed TLS config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)