### PR TITLE
chore(redpanda-connect): drop tls skip_cert_verify after UDM-Pro LE cert

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/streams/unifi_arm_alarm.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/unifi_arm_alarm.yaml
@@ -34,9 +34,6 @@ output:
             headers:
               X-API-Key: "${UNIFI_PROTECT_API_KEY}"
               Accept: "application/json"
-            tls:
-              enabled: true
-              skip_cert_verify: true
       - check: 'meta("protect_action") == "disable"'
         output:
           http_client:
@@ -45,6 +42,3 @@ output:
             headers:
               X-API-Key: "${UNIFI_PROTECT_API_KEY}"
               Accept: "application/json"
-            tls:
-              enabled: true
-              skip_cert_verify: true


### PR DESCRIPTION
## Summary
UDM-Pro now serves a Let's Encrypt cert valid for `udm-pro.zimmermann.eu.com` (SAN matches, `curl` without `-k` returns clean 401). The `tls: { enabled: true, skip_cert_verify: true }` workaround from #1023 is no longer needed — Go's default cert verification handles it.

```
subject=CN=udm-pro.zimmermann.eu.com
issuer=C=US, O=Let's Encrypt, CN=YR2
notAfter=Aug 30 19:33:47 2026 GMT
DNS:udm-pro.zimmermann.eu.com
```

## Test plan
- [ ] Pod stays running after merge.
- [ ] Trigger Unscharf via Basalte → Protect "Abwesend" still flips off, no `tls: failed to verify` errors in pod log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)