### PR TITLE
chore(knx-nats-bridge): bump to 0.5.0 + rename env vars

### DIFF
--- a/kubernetes/applications/knx-nats-bridge/base/values.yaml
+++ b/kubernetes/applications/knx-nats-bridge/base/values.yaml
@@ -4,7 +4,7 @@ deployment:
   enabled: true
   image:
     repository: ghcr.io/alexander-zimmermann/knx-nats-bridge
-    tag: 0.4.0
+    tag: 0.5.0
     pullPolicy: IfNotPresent
 
   # KNX tunnel allows only one connection per credential; never run two replicas.
@@ -26,13 +26,13 @@ deployment:
     # NKey seed mounted as a file from the synced Secret (Kyverno clones from `nats` namespace)
     NATS_NKEY_SEED_FILE:
       value: /etc/knx-nats-bridge/nkey-seed
-    KNX_NATS_CATALOG_PATH:
+    BRIDGE_GA_CATALOG_PATH:
       value: /etc/knx-nats-bridge/ga-catalog.yaml
     KNX_NATS_UNMAPPED_POLICY:
       value: skip
-    BRIDGE_WRITE_ENABLED:
+    BRIDGE_WRITER_ENABLED:
       value: "true"
-    BRIDGE_WRITE_MAPPING_PATH:
+    BRIDGE_WRITER_RULES_PATH:
       value: /etc/knx-nats-bridge/writer-rules.yaml
     LOG_FORMAT:
       value: json

--- a/tasks/knx.yaml
+++ b/tasks/knx.yaml
@@ -56,7 +56,7 @@ tasks:
     summary: |
       Check the rendered ConfigMap source against the upstream JSON-Schema.
     vars:
-      SCHEMA: "{{.KNX_BRIDGE_DIR}}/src/knx_nats_bridge/_schemas/knx-catalog.schema.json"
+      SCHEMA: "{{.KNX_BRIDGE_DIR}}/src/knx_nats_bridge/_schemas/ga-catalog.schema.json"
     cmds:
       - >
         uv run --directory {{.KNX_BRIDGE_DIR}} python -c


### PR DESCRIPTION
## Summary

Lares follow-up to **knx-nats-bridge#46** (Layer 2 of the rename plan). Bumps the bridge image to `0.5.0` and renames the env vars to match the new BRIDGE_* namespace.

| Old | New |
|---|---|
| `KNX_NATS_CATALOG_PATH` | `BRIDGE_GA_CATALOG_PATH` |
| `BRIDGE_WRITE_ENABLED` | `BRIDGE_WRITER_ENABLED` |
| `BRIDGE_WRITE_MAPPING_PATH` | `BRIDGE_WRITER_RULES_PATH` |
| schema `knx-catalog.schema.json` (task) | `ga-catalog.schema.json` |

## ⚠ DO NOT MERGE until

- [ ] knx-nats-bridge#46 is merged
- [ ] ghcr.io/alexander-zimmermann/knx-nats-bridge:0.5.0 is published

The 0.4.0 image ignores the new env-var names and would fail to find the catalog/rules paths.

## Rollout

Argo will roll the bridge pod (Recreate). On startup the new pod loads from the renamed env vars; existing ConfigMap mounts (`ga-catalog`, `writer-rules`) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)