### PR TITLE
chore(knx-nats-bridge): finish ga-catalog rename in headers + docstrings

### DIFF
--- a/kubernetes/applications/knx-nats-bridge/base/config/writer-rules.yaml
+++ b/kubernetes/applications/knx-nats-bridge/base/config/writer-rules.yaml
@@ -1,4 +1,4 @@
-# NATS-subject -> KNX-GA write mappings (schema: write-mapping.schema.json).
+# NATS-subject -> KNX-GA writer rules (schema: writer-rules.schema.json).
 # UniFi mappings rely on `knx_value` being set by the redpanda-connect
 # unifi_webhook stream (1 for boolean alarms, int 1..4 for face/plate lookups).
 

--- a/scripts/knx_enrich_catalog.py
+++ b/scripts/knx_enrich_catalog.py
@@ -3,7 +3,7 @@
 # requires-python = ">=3.11"
 # dependencies = ["pyyaml>=6.0"]
 # ///
-"""Project-specific enrichment of the raw knx-catalog.yaml.
+"""Project-specific enrichment of the raw ga-catalog.yaml.
 
 The upstream `knxproj-to-yaml` tool (in the knx-nats-bridge repo) only
 emits what ETS itself defines. This post-processor adds the conventions
@@ -141,9 +141,9 @@ def enrich(catalog: dict[str, Any]) -> dict[str, Any]:
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
-        description="Apply project-specific enrichment to a raw knx-catalog.yaml"
+        description="Apply project-specific enrichment to a raw ga-catalog.yaml"
     )
-    parser.add_argument("path", type=Path, help="Path to knx-catalog.yaml (modified in place)")
+    parser.add_argument("path", type=Path, help="Path to ga-catalog.yaml (modified in place)")
     args = parser.parse_args(argv)
 
     raw = yaml.safe_load(args.path.read_text(encoding="utf-8")) or {}


### PR DESCRIPTION
## Summary

Cosmetic Layer-1 leftovers from PR #1021. Two spots still mention the old `knx-catalog.yaml` / `write-mapping.schema.json` names:

- `writer-rules.yaml` header references the renamed schema (`writer-rules.schema.json`)
- `scripts/knx_enrich_catalog.py` docstring + argparse help now mention `ga-catalog.yaml`

Pure comments/docstrings — no functional change. Safe to merge before or after the bridge image bump (#1027).

🤖 Generated with [Claude Code](https://claude.com/claude-code)