### PR TITLE
chore(iot-mcp-bridge): bump to 0.8.0 + rename import Job to import-ga-catalog

### DIFF
--- a/kubernetes/applications/iot-mcp-bridge/base/detect-univariate-cronjob.yaml
+++ b/kubernetes/applications/iot-mcp-bridge/base/detect-univariate-cronjob.yaml
@@ -27,7 +27,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: detector
-              image: ghcr.io/alexander-zimmermann/iot-mcp-bridge:0.7.1
+              image: ghcr.io/alexander-zimmermann/iot-mcp-bridge:0.8.0
               command: ["iot-mcp-bridge-jobs", "detect-univariate"]
               env:
                 # Read-only DB user — required by Settings() even though

--- a/kubernetes/applications/iot-mcp-bridge/base/import-ga-catalog-job.yaml
+++ b/kubernetes/applications/iot-mcp-bridge/base/import-ga-catalog-job.yaml
@@ -1,4 +1,4 @@
-# PostSync Job that imports the KNX catalog (group address → name/room/
+# PostSync Job that imports the GA catalog (group address → name/room/
 # function/description) from the cloned knx-nats-bridge-ga-catalog ConfigMap
 # into the `knx_catalog` Postgres table. Uses admin credentials (homelab
 # role) — the read-only role the MCP server runs with cannot write.
@@ -7,7 +7,7 @@ apiVersion: batch/v1
 kind: Job
 
 metadata:
-  name: iot-mcp-bridge-import-knx-catalog
+  name: iot-mcp-bridge-import-ga-catalog
   namespace: iot-mcp-bridge
   annotations:
     argocd.argoproj.io/hook: PostSync
@@ -21,8 +21,8 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: importer
-          image: ghcr.io/alexander-zimmermann/iot-mcp-bridge:0.7.1
-          command: ["python", "-m", "iot_mcp_bridge.cli.import_knx_catalog"]
+          image: ghcr.io/alexander-zimmermann/iot-mcp-bridge:0.8.0
+          command: ["python", "-m", "iot_mcp_bridge.cli.import_ga_catalog"]
           args:
             - --catalog-path=/etc/iot-mcp-bridge/ga-catalog.yaml
           env:

--- a/kubernetes/applications/iot-mcp-bridge/base/kustomization.yaml
+++ b/kubernetes/applications/iot-mcp-bridge/base/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
   - ./namespace.yaml
   - ./certificate.yaml
   - ./ingress-route.yaml
-  - ./import-knx-catalog-job.yaml
+  - ./import-ga-catalog-job.yaml
   - ./detect-univariate-cronjob.yaml
   - ./train-iforest-cronjob.yaml
   - ./score-iforest-cronjob.yaml

--- a/kubernetes/applications/iot-mcp-bridge/base/score-iforest-cronjob.yaml
+++ b/kubernetes/applications/iot-mcp-bridge/base/score-iforest-cronjob.yaml
@@ -29,7 +29,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: scorer
-              image: ghcr.io/alexander-zimmermann/iot-mcp-bridge:0.7.1
+              image: ghcr.io/alexander-zimmermann/iot-mcp-bridge:0.8.0
               command: ["iot-mcp-bridge-jobs", "score-iforest"]
               env:
                 - name: MCP_DB_HOST

--- a/kubernetes/applications/iot-mcp-bridge/base/train-iforest-cronjob.yaml
+++ b/kubernetes/applications/iot-mcp-bridge/base/train-iforest-cronjob.yaml
@@ -28,7 +28,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: trainer
-              image: ghcr.io/alexander-zimmermann/iot-mcp-bridge:0.7.1
+              image: ghcr.io/alexander-zimmermann/iot-mcp-bridge:0.8.0
               command: ["iot-mcp-bridge-jobs", "train-iforest"]
               env:
                 - name: MCP_DB_HOST

--- a/kubernetes/applications/iot-mcp-bridge/base/values.yaml
+++ b/kubernetes/applications/iot-mcp-bridge/base/values.yaml
@@ -4,7 +4,7 @@ deployment:
   enabled: true
   image:
     repository: ghcr.io/alexander-zimmermann/iot-mcp-bridge
-    tag: 0.7.1
+    tag: 0.8.0
     pullPolicy: IfNotPresent
 
   replicas: 1

--- a/kubernetes/applications/knx-nats-bridge/base/kustomization.yaml
+++ b/kubernetes/applications/knx-nats-bridge/base/kustomization.yaml
@@ -16,7 +16,7 @@ helmCharts:
       - monitoring.coreos.com/v1
 
 # disableNameSuffixHash: cross-namespace consumers (Kyverno clone,
-# iot-mcp-bridge import-knx-catalog-job) reference these by fixed name.
+# iot-mcp-bridge import-ga-catalog-job) reference these by fixed name.
 configMapGenerator:
   - name: knx-nats-bridge-ga-catalog
     options:

--- a/kubernetes/components/admission-controller/base/clusterpolicy-secrets.yaml
+++ b/kubernetes/components/admission-controller/base/clusterpolicy-secrets.yaml
@@ -402,7 +402,7 @@ spec:
           name: timescaledb-db-grafana-ro-secret
 
     # Syncs CNPG-managed timescaledb admin-user secret into iot-mcp-bridge so
-    # the import-knx-catalog Job can write to the `knx_catalog` table (the
+    # the import-ga-catalog Job can write to the `knx_catalog` table (the
     # read-only role used by the running server has SELECT-only privileges).
     - name: sync-timescaledb-db-app-secret
       match:
@@ -422,8 +422,8 @@ spec:
           namespace: timescaledb
           name: timescaledb-db-app
 
-    # Syncs the KNX catalog ConfigMap (GA → name/room/function/description)
-    # from knx-nats-bridge into iot-mcp-bridge so the import-knx-catalog Job
+    # Syncs the GA catalog ConfigMap (GA → name/room/function/description)
+    # from knx-nats-bridge into iot-mcp-bridge so the import-ga-catalog Job
     # can mount it.
     - name: sync-knx-nats-bridge-ga-catalog-configmap
       match:


### PR DESCRIPTION
## Summary

Lares follow-up to **iot-mcp-bridge#43** (CLI rename `import_knx_catalog` → `import_ga_catalog`, 0.8.0).

| Old | New |
|---|---|
| `import-knx-catalog-job.yaml` | `import-ga-catalog-job.yaml` |
| Job `iot-mcp-bridge-import-knx-catalog` | `iot-mcp-bridge-import-ga-catalog` |
| `iot_mcp_bridge.cli.import_knx_catalog` | `iot_mcp_bridge.cli.import_ga_catalog` |
| iot-mcp-bridge image `0.7.1` (server + 3 CronJobs + Job) | `0.8.0` (all) |
| Kyverno + bridge-CM comments mentioning old Job name | updated |

## ⚠ DO NOT MERGE until

- [x] iot-mcp-bridge#43 is merged
- [x] tag v0.8.0 pushed (release workflow triggered)
- [ ] ghcr.io/alexander-zimmermann/iot-mcp-bridge:0.8.0 published

The 0.7.1 image lacks the renamed module path; pods would crash with `No module named iot_mcp_bridge.cli.import_ga_catalog`.

## NOT in this PR

Postgres `knx_catalog` table + `knx_catalog_view` view stay. Renaming the table is Layer 3 (separate PR + manual `ALTER TABLE`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)