### PR TITLE
refactor!: rename TSDB knx_catalog table to ga_catalog (Layer 3)

### DIFF
--- a/kubernetes/applications/iot-mcp-bridge/base/detect-univariate-cronjob.yaml
+++ b/kubernetes/applications/iot-mcp-bridge/base/detect-univariate-cronjob.yaml
@@ -27,7 +27,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: detector
-              image: ghcr.io/alexander-zimmermann/iot-mcp-bridge:0.8.0
+              image: ghcr.io/alexander-zimmermann/iot-mcp-bridge:0.9.0
               command: ["iot-mcp-bridge-jobs", "detect-univariate"]
               env:
                 # Read-only DB user — required by Settings() even though

--- a/kubernetes/applications/iot-mcp-bridge/base/import-ga-catalog-job.yaml
+++ b/kubernetes/applications/iot-mcp-bridge/base/import-ga-catalog-job.yaml
@@ -21,7 +21,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: importer
-          image: ghcr.io/alexander-zimmermann/iot-mcp-bridge:0.8.0
+          image: ghcr.io/alexander-zimmermann/iot-mcp-bridge:0.9.0
           command: ["python", "-m", "iot_mcp_bridge.cli.import_ga_catalog"]
           args:
             - --catalog-path=/etc/iot-mcp-bridge/ga-catalog.yaml

--- a/kubernetes/applications/iot-mcp-bridge/base/score-iforest-cronjob.yaml
+++ b/kubernetes/applications/iot-mcp-bridge/base/score-iforest-cronjob.yaml
@@ -29,7 +29,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: scorer
-              image: ghcr.io/alexander-zimmermann/iot-mcp-bridge:0.8.0
+              image: ghcr.io/alexander-zimmermann/iot-mcp-bridge:0.9.0
               command: ["iot-mcp-bridge-jobs", "score-iforest"]
               env:
                 - name: MCP_DB_HOST

--- a/kubernetes/applications/iot-mcp-bridge/base/train-iforest-cronjob.yaml
+++ b/kubernetes/applications/iot-mcp-bridge/base/train-iforest-cronjob.yaml
@@ -28,7 +28,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: trainer
-              image: ghcr.io/alexander-zimmermann/iot-mcp-bridge:0.8.0
+              image: ghcr.io/alexander-zimmermann/iot-mcp-bridge:0.9.0
               command: ["iot-mcp-bridge-jobs", "train-iforest"]
               env:
                 - name: MCP_DB_HOST

--- a/kubernetes/applications/iot-mcp-bridge/base/values.yaml
+++ b/kubernetes/applications/iot-mcp-bridge/base/values.yaml
@@ -4,7 +4,7 @@ deployment:
   enabled: true
   image:
     repository: ghcr.io/alexander-zimmermann/iot-mcp-bridge
-    tag: 0.8.0
+    tag: 0.9.0
     pullPolicy: IfNotPresent
 
   replicas: 1

--- a/kubernetes/applications/timescaledb/base/scripts/bootstrap.sql
+++ b/kubernetes/applications/timescaledb/base/scripts/bootstrap.sql
@@ -426,13 +426,13 @@ SELECT add_retention_policy('warp_charge_tracker', INTERVAL '365 days');
 SELECT add_retention_policy('warp_meter',          INTERVAL '365 days');
 
 -- =========================================================
--- KNX catalog — GA → name/room/function/description lookup,
--- populated by the iot-mcp-bridge import-knx-catalog Job from
--- the knx-nats-bridge ConfigMap. The `knx_catalog_view` view
+-- GA catalog — GA → name/room/function/description lookup,
+-- populated by the iot-mcp-bridge import-ga-catalog Job from
+-- the knx-nats-bridge ConfigMap. The `ga_catalog_view` view
 -- joins `knx` against the catalog so MCP tools can filter / group by
 -- room or function in plain SQL.
 -- =========================================================
-CREATE TABLE IF NOT EXISTS knx_catalog (
+CREATE TABLE IF NOT EXISTS ga_catalog (
     ga          TEXT PRIMARY KEY,
     name        TEXT NOT NULL,
     room        TEXT,
@@ -441,13 +441,13 @@ CREATE TABLE IF NOT EXISTS knx_catalog (
     dpt         TEXT NOT NULL,
     updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
 );
-CREATE INDEX IF NOT EXISTS knx_catalog_room_idx     ON knx_catalog (room) WHERE room IS NOT NULL;
-CREATE INDEX IF NOT EXISTS knx_catalog_function_idx ON knx_catalog (function);
+CREATE INDEX IF NOT EXISTS ga_catalog_room_idx     ON ga_catalog (room) WHERE room IS NOT NULL;
+CREATE INDEX IF NOT EXISTS ga_catalog_function_idx ON ga_catalog (function);
 
-CREATE OR REPLACE VIEW knx_catalog_view AS
+CREATE OR REPLACE VIEW ga_catalog_view AS
 SELECT k.time, k.ga, k.knx_main, k.knx_middle, k.knx_sub, k.dpt, k.value,
        n.name AS ga_name, n.room, n.function, n.description
-FROM knx k LEFT JOIN knx_catalog n USING (ga);
+FROM knx k LEFT JOIN ga_catalog n USING (ga);
 
 -- =========================================================
 -- TimescaleDB Toolkit — adds stats_agg / percentile_agg / rollup
@@ -526,7 +526,7 @@ FROM solaredge_powerflow_1h
 GROUP BY day, inverter_id, hour_of_day, weekday WITH NO DATA;
 
 -- knx_1h has one row per (bucket, ga) → baseline is per (day, ga, hour, weekday).
--- Many GAs are binary; detectors filter via knx_catalog (function/room) at query time.
+-- Many GAs are binary; detectors filter via ga_catalog (function/room) at query time.
 CREATE MATERIALIZED VIEW knx_baseline_30d
 WITH (timescaledb.continuous, timescaledb.materialized_only = true) AS
 SELECT time_bucket('1 day', bucket) AS day,


### PR DESCRIPTION
## Summary

Layer 3 of the catalog rename. Renames the Postgres table `knx_catalog` → `ga_catalog`, the view `knx_catalog_view` → `ga_catalog_view`, and the two indexes. Bumps iot-mcp-bridge image (Job + 3 CronJobs + Deployment) to **0.9.0**, which tracks iot-mcp-bridge#44 (SQL rewritten to query `ga_catalog`).

## ⚠ Coordinated rollout — DBA action required

`bootstrap.sql` is idempotent (`CREATE TABLE IF NOT EXISTS ga_catalog`); a fresh cluster lands directly on the new name. The running DB has the old table, so we need a manual ALTER **before** Argo syncs the 0.9.0 image, otherwise every MCP tool query crashes with `relation "ga_catalog" does not exist`.

### SQL (metadata-only, ~ms, no rewrite, no OOM risk)

\`\`\`sql
BEGIN;
ALTER TABLE knx_catalog RENAME TO ga_catalog;
ALTER INDEX knx_catalog_pkey         RENAME TO ga_catalog_pkey;
ALTER INDEX knx_catalog_room_idx     RENAME TO ga_catalog_room_idx;
ALTER INDEX knx_catalog_function_idx RENAME TO ga_catalog_function_idx;
DROP VIEW knx_catalog_view;
CREATE VIEW ga_catalog_view AS
  SELECT k.time, k.ga, k.knx_main, k.knx_middle, k.knx_sub, k.dpt, k.value,
         n.name AS ga_name, n.room, n.function, n.description
  FROM knx k LEFT JOIN ga_catalog n USING (ga);
COMMIT;
\`\`\`

### Rollout sequence

1. Suspend Argo auto-sync on iot-mcp-bridge so the merge doesn't roll new pods before ALTER.
2. Merge this PR.
3. Run the ALTER TX above (psql, admin role).
4. Re-enable Argo auto-sync, trigger sync.
5. New iot-mcp-bridge:0.9.0 pods come up and query ga_catalog. PostSync import-ga-catalog Job idempotently re-imports the YAML.

### Rollback

Revert the merge + revert the ALTER (rename back). Both are metadata-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)