### PR TITLE
refactor(unifi-webhook): drop node-RED hairpin, publish geofence to dedicated NATS subject

### DIFF
--- a/kubernetes/applications/nats/base/streams/unifi.yaml
+++ b/kubernetes/applications/nats/base/streams/unifi.yaml
@@ -1,5 +1,8 @@
-# UniFi Protect Alarm Manager events published by node-RED on
-# `unifi.events.<camera>.<detection_type>` (one message per trigger).
+# UniFi Protect Alarm Manager events published by redpanda-connect:
+# - `unifi.events.<camera>.<detection_type>` — per-trigger camera events
+#   archived by the unifi_events ingest stream into TimescaleDB.
+# - `unifi.geofence.trigger`                  — admin_geolocation triggers
+#   forwarded via the NATS MQTT gateway to the node-RED Geofence tab.
 # Retention 7d is the safety puffer for redpanda-connect → TimescaleDB
 # downtime; UniFi itself does not buffer Alarm Manager webhooks.
 apiVersion: jetstream.nats.io/v1beta2
@@ -11,6 +14,7 @@ spec:
   name: UNIFI
   subjects:
     - unifi.events.>
+    - unifi.geofence.>
   storage: file
   retention: limits
   maxAge: 168h

--- a/kubernetes/applications/redpanda-connect/base/streams/unifi_webhook.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/unifi_webhook.yaml
@@ -1,7 +1,8 @@
 # UniFi Protect Alarm Manager webhook handler.
-# Fans the raw payload out to node-RED (Geofence tab still lives there),
-# splits alarm.triggers[], resolves camera MAC -> name, derives knx_value,
+# Splits alarm.triggers[], resolves camera MAC -> name, derives knx_value,
 # publishes one NATS message per trigger so knx-nats-bridge can write KNX.
+# Geofence triggers (key=admin_geolocation) get their own subject so the
+# node-RED Geofence tab can subscribe via the NATS MQTT gateway.
 input:
   http_server:
     address: 0.0.0.0:4196
@@ -10,14 +11,6 @@ input:
 
 pipeline:
   processors:
-    # Fan-out the raw payload to node-RED (Geofence tab).
-    - branch:
-        request_map: 'root = this'
-        processors:
-          - http:
-              url: http://node-red.node-red.svc.cluster.local:1880/unifi-protect
-              verb: POST
-
     # Replace the message with the triggers[] array, then split.
     - mapping: 'root = this.alarm.triggers'
     - unarchive:
@@ -54,7 +47,14 @@ pipeline:
           }
 
         root = this.assign({"knx_value": $knx_value, "camera": $camera})
-        meta nats_subject = "unifi.events." + $camera + "." + $key
+        # admin_geolocation has no camera and no direction info — route it
+        # to a dedicated subject so the node-RED Geofence tab can subscribe
+        # via NATS MQTT gateway and enrich with the iCloud notification mail.
+        meta nats_subject = if $key == "admin_geolocation" {
+            "unifi.geofence.trigger"
+          } else {
+            "unifi.events." + $camera + "." + $key
+          }
 
 output:
   nats_jetstream:


### PR DESCRIPTION
## Summary

UniFi Geofence triggers no longer take the **HTTP hairpin back to node-RED**. Redpanda already has the payload after parsing `alarm.triggers[]`; sending it back out over HTTP just so the Geofence tab can grab it is structurally backwards.

| Before | After |
|---|---|
| `unifi_webhook.yaml` branches raw payload via HTTP to `node-red.node-red.svc:1880/unifi-protect` | branch removed |
| All triggers publish to `unifi.events.<camera>.<key>` (geofence ends up on `unifi.events.unknown.admin_geolocation`) | `admin_geolocation` routes to dedicated subject `unifi.geofence.trigger` |
| UNIFI JetStream covers `unifi.events.>` | UNIFI JetStream covers `unifi.events.>` + `unifi.geofence.>` |

## What stays in node-RED

The Geofence tab itself — IMAP-poll of the iCloud notification mail + parse of `entered`/`exited` — stays. The UniFi webhook **does not** carry direction info, so email parsing is still the only source of truth.

After merge, the Geofence tab's HTTP-In gets swapped for an **MQTT-In** node on the existing `mqtt.zimmermann.eu.com:1883` broker config (same broker-config-node the WARP wallbox flow already uses) subscribing to topic `unifi/geofence/trigger`. No new NATS user, no new plugin. Done via the node-RED UI.

## Rollout

1. Merge → Argo syncs redpanda-connect + nats apps → stream picks up new subject mapping, UNIFI stream extends subjects
2. Verify: `nats sub unifi.geofence.trigger` with user `alexander` shows the next real geofence event
3. node-RED Geofence tab: replace HTTP-In with MQTT-In on `unifi/geofence/trigger`, deploy
4. Verify enter/exit: walk in/out of geofence zone, KNX GA `0/0/211`/`0/0/212` toggles as before

## Rollback

Revert this PR + revert node-RED tab change (HTTP-In back). No data loss — JetStream retains both subjects 7d.

## NOT in this PR

- PV Überschussladen migration (separate PR)
- node-RED-flows backup story

🤖 Generated with [Claude Code](https://claude.com/claude-code)