### PR TITLE
feat(redpanda-connect): add pv_surplus_to_warp stream

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/kustomization.yaml
+++ b/kubernetes/applications/redpanda-connect/base/kustomization.yaml
@@ -29,6 +29,7 @@ configMapGenerator:
       - streams/unifi_events.yaml
       - streams/unifi_webhook.yaml
       - streams/unifi_arm_alarm.yaml
+      - streams/pv_surplus_to_warp.yaml
 
 patches:
   # Expose redpanda-connect service via Cilium/BGP-announced LoadBalancer so

--- a/kubernetes/applications/redpanda-connect/base/streams/pv_surplus_to_warp.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/pv_surplus_to_warp.yaml
@@ -1,0 +1,32 @@
+# PV surplus forwarder: pushes the home-grid net power reading (KNX
+# 16/1/24, DPT 14.056 "Versorgungstechnik.Energiezähler.Strom.Wirkleistung-
+# Gesamt") to the WARP wallbox so its Charge Manager can balance EV
+# charging against PV surplus. Replaces a node-RED tab that did the same
+# KNX-to-MQTT translation.
+input:
+  nats_jetstream:
+    urls: ["nats://nats.nats.svc:4222"]
+    auth:
+      user: redpanda-connect
+      password: ${NATS_PASSWORD}
+    stream: KNX
+    subject: knx.16.1.24
+    durable: redpanda-connect-pv-surplus-to-warp
+    deliver: new
+    max_ack_pending: 64
+
+pipeline:
+  processors:
+    # knx-nats-bridge publishes {ga, name, value, dpt, ...}.
+    # WARP firmware expects /meters/1/update payload as a single-element
+    # array of watts.
+    - mapping: 'root = [this.value]'
+
+output:
+  mqtt:
+    urls: ["tcp://nats.nats.svc:1883"]
+    client_id: redpanda-connect-pv-surplus
+    user: redpanda-connect
+    password: ${NATS_PASSWORD}
+    topic: warp/meters/1/update
+    qos: 0


### PR DESCRIPTION
## Summary

Replaces the node-RED **PV Überschussladen** tab. The new redpanda-connect stream:

1. Subscribes to NATS JetStream subject \`knx.16.1.24\` — KNX-bridge publish of \"Versorgungstechnik.Energiezähler.Strom.Wirkleistung-Gesamt\" (DPT 14.056)
2. Wraps the watts value in a single-element array (\`root = [this.value]\`)
3. Publishes on MQTT topic \`warp/meters/1/update\` via the NATS MQTT gateway (\`tcp://nats.nats.svc:1883\`)

WARP firmware listens on the same topic for its Charge Manager external-meter feed. Same protocol, same broker, same topic the node-RED tab uses today.

## Rollout

1. Merge → Argo syncs redpanda-connect → new durable consumer attaches to KNX stream
2. Verify: \`kubectl logs -n redpanda-connect deploy/redpanda-connect | grep pv-surplus\` shows consumer subscribed; next bridge publish on knx.16.1.24 triggers an MQTT publish
3. Verify on WARP web UI → Charge Manager → External Meter → \"Last Update\" timestamp advances
4. **Parallel-Betrieb**: node-RED PV-Überschussladen-Tab läuft mit, beide publishen denselben Wert (idempotent für WARP)
5. node-RED UI → \"PV Überschussladen\" Tab löschen, deploy → einzige Quelle = redpanda-connect

## Rollback

Revert the merge → consumer disappears. node-RED tab (still running) takes over again. If tab was already deleted, re-import from JSON backup before reverting.

## NOT in this PR

- Geofence hairpin removal (PR #1032)
- node-RED-flows backup story

🤖 Generated with [Claude Code](https://claude.com/claude-code)