### PR TITLE
fix(pv-surplus-to-warp): subscribe to correct KNX GA (15/1/24 not 16/1/24)

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/streams/pv_surplus_to_warp.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/pv_surplus_to_warp.yaml
@@ -1,8 +1,7 @@
 # PV surplus forwarder: pushes the home-grid net power reading (KNX
-# 16/1/24, DPT 14.056 "Versorgungstechnik.Energiezähler.Strom.Wirkleistung-
+# 15/1/24, DPT 14.056 "Versorgungstechnik.Energiezähler.Strom.Wirkleistung-
 # Gesamt") to the WARP wallbox so its Charge Manager can balance EV
-# charging against PV surplus. Replaces a node-RED tab that did the same
-# KNX-to-MQTT translation.
+# charging against PV surplus.
 input:
   nats_jetstream:
     urls: ["nats://nats.nats.svc:4222"]
@@ -10,7 +9,7 @@ input:
       user: redpanda-connect
       password: ${NATS_PASSWORD}
     stream: KNX
-    subject: knx.16.1.24
+    subject: knx.15.1.24
     durable: redpanda-connect-pv-surplus-to-warp
     deliver: new
     max_ack_pending: 64


### PR DESCRIPTION
## Summary

PR #1033 used GA `16/1/24` because that's what the node-RED PV-Überschussladen tab listens on. TSDB tells a different story:

| GA | Catalog | TSDB last 24h | Max W |
|---|---|---|---|
| `15/1/24` | "Versorgungstechnik.Energiezähler.Strom.Wirkleistung-Gesamt" | **11793 publishes** | 4023 |
| `16/1/24` | not in catalog | **0 publishes** | — |

The meter publishes on `15/1/24`. The node-RED tab has been listening on a dead GA — explaining why nothing ever reached WARP via that path. Stream subject corrected.

## Follow-up (NOT in this PR)

- ga-catalog entry for 15/1/24 has `dpt: '14.000'` (Acceleration) — should be `dpt: '14.056'` (Power). ETS auto-import quirk; bridge tolerates it but the catalog should be corrected, ideally in ETS first then via `task knx:catalog`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)