### PR TITLE
refactor(nats): declare non-trivial JetStream consumers as CRDs

### DIFF
--- a/kubernetes/applications/nats/base/consumers/kustomization.yaml
+++ b/kubernetes/applications/nats/base/consumers/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - unifi_events.yaml
+  - pv_surplus_to_warp.yaml
+  - unifi_arm_alarm.yaml

--- a/kubernetes/applications/nats/base/consumers/pv_surplus_to_warp.yaml
+++ b/kubernetes/applications/nats/base/consumers/pv_surplus_to_warp.yaml
@@ -1,0 +1,15 @@
+# Durable consumer for the redpanda-connect pv_surplus_to_warp forwarder.
+# Subscribes to the bridge publish of one specific KNX GA — the grid net
+# power reading that the WARP wallbox uses for surplus charging.
+apiVersion: jetstream.nats.io/v1beta2
+kind: Consumer
+metadata:
+  name: redpanda-connect-pv-surplus-to-warp
+  namespace: nats
+spec:
+  streamName: KNX
+  durableName: redpanda-connect-pv-surplus-to-warp
+  filterSubject: knx.15.1.24
+  deliverPolicy: new
+  ackPolicy: explicit
+  maxAckPending: 64

--- a/kubernetes/applications/nats/base/consumers/unifi_arm_alarm.yaml
+++ b/kubernetes/applications/nats/base/consumers/unifi_arm_alarm.yaml
@@ -1,0 +1,13 @@
+# Durable consumer for the redpanda-connect unifi_arm_alarm pipeline.
+# Watches the KNX GAs in 14/1/* that the arming scenes write to.
+apiVersion: jetstream.nats.io/v1beta2
+kind: Consumer
+metadata:
+  name: redpanda-connect-unifi-arm-alarm
+  namespace: nats
+spec:
+  streamName: KNX
+  durableName: redpanda-connect-unifi-arm-alarm
+  filterSubject: knx.14.1.*
+  deliverPolicy: new
+  ackPolicy: explicit

--- a/kubernetes/applications/nats/base/consumers/unifi_events.yaml
+++ b/kubernetes/applications/nats/base/consumers/unifi_events.yaml
@@ -1,0 +1,16 @@
+# Durable consumer for the redpanda-connect unifi_events archive pipeline.
+# Subject filter covers both unifi.events.> (per-trigger camera detections)
+# and unifi.geofence.> (presence-change triggers).
+apiVersion: jetstream.nats.io/v1beta2
+kind: Consumer
+metadata:
+  name: redpanda-connect-unifi-events
+  namespace: nats
+spec:
+  streamName: UNIFI
+  durableName: redpanda-connect-unifi-events
+  filterSubject: unifi.>
+  deliverPolicy: all
+  ackPolicy: explicit
+  ackWait: 20m
+  maxAckPending: 5000

--- a/kubernetes/applications/nats/base/kustomization.yaml
+++ b/kubernetes/applications/nats/base/kustomization.yaml
@@ -3,14 +3,11 @@ kind: Kustomization
 
 namespace: nats
 resources:
+  - ./streams/
+  - ./consumers/
   - ./certificate.yaml
   - ./ingress-route-tcp.yaml
   - ./sealed-secret.yaml
-  - ./streams/knx.yaml
-  - ./streams/solaredge.yaml
-  - ./streams/ems-esp.yaml
-  - ./streams/warp.yaml
-  - ./streams/unifi.yaml
 
 helmCharts:
   - name: nats

--- a/kubernetes/applications/nats/base/streams/kustomization.yaml
+++ b/kubernetes/applications/nats/base/streams/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - knx.yaml
+  - solaredge.yaml
+  - ems-esp.yaml
+  - warp.yaml
+  - unifi.yaml

--- a/kubernetes/applications/redpanda-connect/base/streams/pv_surplus_to_warp.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/pv_surplus_to_warp.yaml
@@ -3,16 +3,15 @@
 # Gesamt") to the WARP wallbox so its Charge Manager can balance EV
 # charging against PV surplus.
 input:
+  # Consumer is declared as a CRD in nats/base/consumers/pv_surplus_to_warp.yaml.
   nats_jetstream:
     urls: ["nats://nats.nats.svc:4222"]
     auth:
       user: redpanda-connect
       password: ${NATS_PASSWORD}
     stream: KNX
-    subject: knx.15.1.24
     durable: redpanda-connect-pv-surplus-to-warp
-    deliver: new
-    max_ack_pending: 64
+    bind: true
 
 pipeline:
   processors:

--- a/kubernetes/applications/redpanda-connect/base/streams/unifi_arm_alarm.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/unifi_arm_alarm.yaml
@@ -1,13 +1,13 @@
 input:
+  # Consumer is declared as a CRD in nats/base/consumers/unifi_arm_alarm.yaml.
   nats_jetstream:
     urls: ["nats://nats.nats.svc:4222"]
     auth:
       user: redpanda-connect
       password: ${NATS_PASSWORD}
     stream: KNX
-    subject: knx.14.1.*
     durable: redpanda-connect-unifi-arm-alarm
-    deliver: new
+    bind: true
 
 pipeline:
   processors:

--- a/kubernetes/applications/redpanda-connect/base/streams/unifi_events.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/unifi_events.yaml
@@ -1,15 +1,17 @@
 input:
+  # Consumer is declared as a CRD in nats/base/consumers/unifi_events.yaml
+  # (filter, deliver, ack_wait, max_ack_pending live there). bind: true tells
+  # redpanda-connect to attach only — no autocreate, so filter evolution
+  # goes through `kubectl apply` on the CRD instead of through a destructive
+  # consumer recreate.
   nats_jetstream:
     urls: ["nats://nats.nats.svc:4222"]
     auth:
       user: redpanda-connect
       password: ${NATS_PASSWORD}
     stream: UNIFI
-    subject: unifi.>
     durable: redpanda-connect-unifi-events
-    deliver: all
-    ack_wait: 20m
-    max_ack_pending: 5000
+    bind: true
 
 pipeline:
   processors:


### PR DESCRIPTION
## Summary

Brings the three consumers whose subject filters either are non-trivial or already burnt us (PR #1036) under declarative CRD management. Streams have been CRD-managed all along; consumers now match.

### New (3 Consumer CRDs)

| File | Stream | Filter |
|---|---|---|
| `nats/base/consumers/unifi_events.yaml` | `UNIFI` | `unifi.>` |
| `nats/base/consumers/pv_surplus_to_warp.yaml` | `KNX` | `knx.15.1.24` |
| `nats/base/consumers/unifi_arm_alarm.yaml` | `KNX` | `knx.14.1.*` |

### Changed (3 redpanda-connect streams)

- `unifi_events.yaml`, `pv_surplus_to_warp.yaml`, `unifi_arm_alarm.yaml`: drop inline `subject` / `deliver` / `ack_wait` / `max_ack_pending`, add `bind: true`. They only attach now; nack owns the consumer config.

### Layout

`nats/base/streams/` and `nats/base/consumers/` each get their own kustomization, parent references the directories — same pattern as `grafana/base/dashboards/`.

## Why CRDs only for these three

Catch-all consumers (`knx.>` archive, the per-feature WARP/Solaredge/EMS-ESP ones that map 1:1 to a fixed MQTT topic) stay auto-created. Their filters never need to evolve, and the durable-rename escape hatch is cheap when they do. CRD ceremony is reserved for filters that already moved or might move.

## Why this matters

NATS rejects filter mutation on a live durable consumer (`subject does not match consumer`). Auto-created consumers can only be migrated via delete + recreate, which loses the ack floor and triggers a full replay (PR #1036 was exactly this). With Consumer CRDs and `bind: true`, a filter change is `kubectl apply` — nack updates the consumer in place and the ack floor is preserved.

## Rollout

The three durables already exist in NATS (auto-created earlier). When nack reconciles the new CRDs it adopts the existing consumers and updates their config to match the CRD spec. Filter values in the CRDs match the YAML state from main, so no surprise mutation on apply.

The currently-broken `redpanda-connect-unifi-events` consumer (replay-stuck on a pre-PR-7 message with null `camera`) needs a one-time operational reset after merge — that's a separate manual op (NATS CLI), not part of this PR.

## NOT in this PR

- Operational recovery of the broken unifi_events consumer (one-shot manual NATS op, documented separately)
- Migrating the remaining catch-all consumers to CRDs (not needed unless a filter has to change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)