### PR TITLE
feat(redpanda-connect): idempotent ingest via UNIQUE indexes + ON CONFLICT

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/streams/ems_esp.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/ems_esp.yaml
@@ -118,6 +118,7 @@ output:
               ($43::numeric)::smallint, ($44::numeric)::smallint, ($45::numeric)::smallint, $46,
               $47
             )
+            ON CONFLICT (time, topic) DO NOTHING
           args_mapping: |
             root = [
               this.time,

--- a/kubernetes/applications/redpanda-connect/base/streams/unifi_events.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/unifi_events.yaml
@@ -58,6 +58,7 @@ output:
             VALUES (
               $1, $2, $3, ($4::numeric)::smallint, $5, $6, $7, $8, $9
             )
+            ON CONFLICT (time, event_id, camera, detection_type) WHERE event_id IS NOT NULL DO NOTHING
           args_mapping: |
             root = [
               this.time,

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_charge_manager.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_charge_manager.yaml
@@ -35,6 +35,7 @@ output:
           query: |
             INSERT INTO warp_charge_manager (time, sub_topic)
             VALUES ($1, $2)
+            ON CONFLICT (time, sub_topic) DO NOTHING
           args_mapping: |
             root = [
               this.time,

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_evse.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_evse.yaml
@@ -53,6 +53,7 @@ output:
               $7,
               ($8::numeric)::smallint, ($9::numeric)::smallint, ($10::numeric)::smallint
             )
+            ON CONFLICT (time, sub_topic) DO NOTHING
           args_mapping: |
             root = [
               this.time,

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_meter.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_meter.yaml
@@ -62,6 +62,7 @@ output:
               power_l1, power_l2, power_l3
             )
             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+            ON CONFLICT (time, sub_topic, meter_id) DO NOTHING
           args_mapping: |
             root = [
               this.time,

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_system.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_system.yaml
@@ -59,6 +59,7 @@ output:
           query: |
             INSERT INTO warp_system (time, sub_topic)
             VALUES ($1, $2)
+            ON CONFLICT (time, sub_topic) DO NOTHING
           args_mapping: |
             root = [
               this.time,

--- a/kubernetes/applications/timescaledb/base/scripts/bootstrap.sql
+++ b/kubernetes/applications/timescaledb/base/scripts/bootstrap.sql
@@ -187,6 +187,9 @@ CREATE TABLE ems_esp (
 );
 SELECT create_hypertable('ems_esp', 'time', chunk_time_interval => INTERVAL '1 day');
 CREATE INDEX ON ems_esp (topic, time DESC);
+-- Idempotency for redpanda-connect ingest: same (time, topic) means same
+-- source NATS message — replay after a consumer reset must not duplicate.
+CREATE UNIQUE INDEX IF NOT EXISTS ems_esp_unique ON ems_esp (time, topic);
 
 CREATE MATERIALIZED VIEW ems_esp_boiler_1h
 WITH (timescaledb.continuous, timescaledb.materialized_only = true) AS
@@ -223,6 +226,7 @@ CREATE TABLE warp_system (
 );
 SELECT create_hypertable('warp_system', 'time', chunk_time_interval => INTERVAL '1 day');
 CREATE INDEX ON warp_system (sub_topic, time DESC);
+CREATE UNIQUE INDEX IF NOT EXISTS warp_system_unique ON warp_system (time, sub_topic);
 
 -- warp.evse.state, warp.evse.low_level_state
 -- Typed: 4 state/error fields used in energy-wallbox dashboard.
@@ -240,6 +244,7 @@ CREATE TABLE warp_evse (
 );
 SELECT create_hypertable('warp_evse', 'time', chunk_time_interval => INTERVAL '1 day');
 CREATE INDEX ON warp_evse (sub_topic, time DESC);
+CREATE UNIQUE INDEX IF NOT EXISTS warp_evse_unique ON warp_evse (time, sub_topic);
 
 -- warp.charge_manager.{state, low_level_state, config, available_current, ...}
 CREATE TABLE warp_charge_manager (
@@ -248,6 +253,7 @@ CREATE TABLE warp_charge_manager (
 );
 SELECT create_hypertable('warp_charge_manager', 'time', chunk_time_interval => INTERVAL '1 day');
 CREATE INDEX ON warp_charge_manager (sub_topic, time DESC);
+CREATE UNIQUE INDEX IF NOT EXISTS warp_charge_manager_unique ON warp_charge_manager (time, sub_topic);
 
 -- warp.charge_tracker.{state, current_charge, last_charges}
 -- Typed: 4 fields from energy-wallbox dashboard.
@@ -296,6 +302,9 @@ CREATE TABLE warp_meter (
 SELECT create_hypertable('warp_meter', 'time', chunk_time_interval => INTERVAL '1 day');
 CREATE INDEX ON warp_meter (sub_topic, time DESC);
 CREATE INDEX ON warp_meter (meter_id, time DESC) WHERE meter_id IS NOT NULL;
+-- NULLS NOT DISTINCT so warp.meter.all_values rows (meter_id IS NULL) still dedupe.
+CREATE UNIQUE INDEX IF NOT EXISTS warp_meter_unique
+    ON warp_meter (time, sub_topic, meter_id) NULLS NOT DISTINCT;
 
 CREATE MATERIALIZED VIEW warp_meter_1h
 WITH (timescaledb.continuous, timescaledb.materialized_only = true) AS
@@ -337,6 +346,12 @@ SELECT create_hypertable('unifi_events', 'time', chunk_time_interval => INTERVAL
 CREATE INDEX ON unifi_events (camera, time DESC);
 CREATE INDEX ON unifi_events (detection_type, time DESC);
 CREATE INDEX ON unifi_events (event_id, time DESC) WHERE event_id IS NOT NULL;
+-- One UniFi alarm.eventId fans out to multiple triggers (e.g. line_crossed +
+-- person on the same camera), so the unique key includes detection_type.
+-- Partial index because event_id is nullable for legacy / smoke-test rows.
+CREATE UNIQUE INDEX IF NOT EXISTS unifi_events_unique
+    ON unifi_events (time, event_id, camera, detection_type)
+    WHERE event_id IS NOT NULL;
 
 -- =========================================================
 -- Continuous Aggregate Refresh Policies


### PR DESCRIPTION
## Summary

Six of the ten redpanda-connect ingest streams lacked any deduplication path. When the unifi_events durable was reset earlier today the 7-day backlog replayed and produced ~2530 duplicate rows that had to be cleaned by hand. The other five tables (ems_esp, warp_system, warp_evse, warp_charge_manager, warp_meter) carry historical dupes from similar past events — ems_esp alone has ~50000 dupes from May 19-27.

This PR closes the gap by following the pattern that knx, solaredge_*, and warp_charge_tracker already use: pin a UNIQUE index on each table's natural dedup key, append ON CONFLICT DO NOTHING to the redpanda-connect INSERT.

### Dedup keys

| Table | Key | Notes |
|---|---|---|
| `unifi_events` | `(time, event_id, camera, detection_type)` | Partial WHERE event_id NOT NULL — one alarm.eventId fans out to multiple triggers (line_crossed + person), so detection_type is required |
| `ems_esp` | `(time, topic)` | – |
| `warp_system` | `(time, sub_topic)` | – |
| `warp_evse` | `(time, sub_topic)` | – |
| `warp_charge_manager` | `(time, sub_topic)` | – |
| `warp_meter` | `(time, sub_topic, meter_id)` | NULLS NOT DISTINCT so `warp.meter.all_values` rows still dedup |

### bootstrap.sql vs live cluster

bootstrap.sql is the target state for a fresh CNPG cluster. The running DB needs a one-time dedup + CREATE INDEX migration per table. SQL is below; run chunk-wise per [project_timescaledb_memory_constraints] (1Gi RAM, 10Gi PVC).

## Manual migration (run on live cluster, chunk-wise per table)

For each table, two steps in this order: (1) DELETE existing duplicates, (2) CREATE the UNIQUE INDEX. Both must succeed before the matching redpanda stream is updated by Argo, or new INSERTs will fail until they reach the new code.

### unifi_events (was already deduped manually today)

```sql
BEGIN;
DELETE FROM unifi_events u
WHERE u.event_id IS NOT NULL
  AND EXISTS (
    SELECT 1 FROM unifi_events k
    WHERE k.event_id       = u.event_id
      AND k.camera         = u.camera
      AND k.detection_type = u.detection_type
      AND k.time           = u.time
      AND k.ctid < u.ctid
  );
CREATE UNIQUE INDEX CONCURRENTLY unifi_events_unique
  ON unifi_events (time, event_id, camera, detection_type)
  WHERE event_id IS NOT NULL;
COMMIT;
```

### ems_esp (~50k dupes — dedupe per day to fit memory)

```sql
-- Per day, repeat for each day from oldest to newest in retention:
SET work_mem = '32MB';
DELETE FROM ems_esp u
USING ems_esp k
WHERE u.time      >= '2026-05-19' AND u.time < '2026-05-20'
  AND k.time      = u.time
  AND k.topic     = u.topic
  AND k.ctid < u.ctid;
-- Repeat for 2026-05-20..2026-05-27. After the noisy window dedup is fast.
-- Then once done across the table:
CREATE UNIQUE INDEX CONCURRENTLY ems_esp_unique ON ems_esp (time, topic);
```

### warp_system / warp_evse / warp_charge_manager (low dupes, single pass works)

```sql
DELETE FROM warp_system u USING warp_system k
WHERE k.time = u.time AND k.sub_topic = u.sub_topic AND k.ctid < u.ctid;
CREATE UNIQUE INDEX CONCURRENTLY warp_system_unique ON warp_system (time, sub_topic);

-- same shape for warp_evse and warp_charge_manager
```

### warp_meter

```sql
DELETE FROM warp_meter u USING warp_meter k
WHERE k.time = u.time
  AND k.sub_topic = u.sub_topic
  AND k.meter_id IS NOT DISTINCT FROM u.meter_id
  AND k.ctid < u.ctid;
CREATE UNIQUE INDEX CONCURRENTLY warp_meter_unique
  ON warp_meter (time, sub_topic, meter_id) NULLS NOT DISTINCT;
```

## Rollout

1. Run the manual migration above (per table; can be spread over multiple sessions).
2. Merge this PR.
3. Argo syncs — redpanda-connect picks up ON CONFLICT immediately, future replays no-op cleanly.

If the index exists but the redpanda YAML still has the plain INSERT, that's fine — the unique constraint just rejects duplicates and the stream retries. The PR must merge after the indexes are in place for the conflict_target to resolve.

## Rollback

Revert the PR — INSERT goes back to plain, dupes can re-appear on next replay. The UNIQUE indexes can stay (no functional harm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)