### PR TITLE
feat(iot-mcp-bridge): add detect-knx-join CronJob (PR-5)

### DIFF
--- a/kubernetes/applications/iot-mcp-bridge/base/detect-knx-join-cronjob.yaml
+++ b/kubernetes/applications/iot-mcp-bridge/base/detect-knx-join-cronjob.yaml
@@ -1,0 +1,95 @@
+# CronJob: rule-based detectors against per-room KNX-Joins
+# (knx_1h × ga_catalog). Two UCs:
+#   fbh_cold              — FBH open >50% and room stays >=1°C below
+#                           setpoint over 2h
+#   window_while_heating  — window open + FBH heating + outdoor <12°C
+# Idempotent INSERT into mcp_anomalies; NATS publish on new inserts.
+# Schedule */15 — same as detect-univariate; offset +10s of the hour
+# would gain nothing, the CAGG window doesn't shift mid-hour.
+apiVersion: batch/v1
+kind: CronJob
+
+metadata:
+  name: iot-mcp-bridge-detect-knx-join
+  namespace: iot-mcp-bridge
+
+spec:
+  schedule: "*/15 * * * *"
+  timeZone: "Etc/UTC"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  startingDeadlineSeconds: 600
+
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 86400
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: detector
+              image: ghcr.io/alexander-zimmermann/iot-mcp-bridge:0.10.0
+              command: ["iot-mcp-bridge-jobs", "detect-knx-join"]
+              env:
+                - name: MCP_DB_HOST
+                  value: timescaledb-db-rw.timescaledb.svc.cluster.local
+                - name: MCP_DB_PORT
+                  value: "5432"
+                - name: MCP_DB_NAME
+                  value: homelab
+                - name: MCP_DB_USERNAME
+                  valueFrom:
+                    secretKeyRef:
+                      name: timescaledb-db-iot-mcp-bridge-ro-secret
+                      key: username
+                - name: MCP_DB_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: timescaledb-db-iot-mcp-bridge-ro-secret
+                      key: password
+                - name: MCP_DB_WRITE_USERNAME
+                  valueFrom:
+                    secretKeyRef:
+                      name: timescaledb-db-iot-mcp-bridge-rw-secret
+                      key: username
+                - name: MCP_DB_WRITE_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: timescaledb-db-iot-mcp-bridge-rw-secret
+                      key: password
+                - name: MCP_NATS_SERVERS
+                  value: nats://nats.nats.svc.cluster.local:4222
+                - name: MCP_NATS_NKEY_SEED_FILE
+                  value: /etc/iot-mcp-bridge/nats/nkey-seed
+                - name: MCP_AUTH_ENABLED
+                  value: "false"
+                - name: TZ
+                  value: Europe/Berlin
+              resources:
+                requests:
+                  cpu: 20m
+                  memory: 96Mi
+                limits:
+                  cpu: 200m
+                  memory: 192Mi
+              volumeMounts:
+                - name: nats-credentials
+                  mountPath: /etc/iot-mcp-bridge/nats/nkey-seed
+                  subPath: nkey-seed
+                  readOnly: true
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                runAsUser: 1000
+                runAsGroup: 1000
+                capabilities:
+                  drop: ["ALL"]
+                seccompProfile:
+                  type: RuntimeDefault
+          volumes:
+            - name: nats-credentials
+              secret:
+                secretName: iot-mcp-bridge-credentials

--- a/kubernetes/applications/iot-mcp-bridge/base/kustomization.yaml
+++ b/kubernetes/applications/iot-mcp-bridge/base/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - ./ingress-route.yaml
   - ./import-ga-catalog-job.yaml
   - ./detect-univariate-cronjob.yaml
+  - ./detect-knx-join-cronjob.yaml
   - ./train-iforest-cronjob.yaml
   - ./score-iforest-cronjob.yaml
 


### PR DESCRIPTION
## Summary

Companion to alexander-zimmermann/iot-mcp-bridge#47 (v0.10.0). Adds a new CronJob that runs the rule-based KNX-join detector every 15 min.

\`iot-mcp-bridge-detect-knx-join\` — \`*/15 * * * *\`, image \`ghcr.io/alexander-zimmermann/iot-mcp-bridge:0.10.0\`, command \`["iot-mcp-bridge-jobs", "detect-knx-join"]\`. Iterates two UCs:

- **fbh_cold** — for each room, if avg(FBH-Stellwert-Status) over the last 2h is >50% and the room stayed >=1°C below setpoint, emit anomaly with severity by gap (1°/2°/3°C → info/warning/critical).
- **window_while_heating** — for each room in the last completed 1h-bucket, if a window is open AND FBH is heating AND \`ems_esp_boiler_1h.outdoortemp_avg\` is <12°C, emit anomaly with severity by stellwert (0–25 / 25–50 / >=50% → info/warning/critical).

Both insert into \`mcp_anomalies\` idempotently (\`ON CONFLICT (time, source, metric, detector) DO UPDATE\`) and publish on \`anomaly.<uc>.<severity>\` only on new inserts. NATS pub via the existing nkey-seed mount.

## Resources

Same as detect-univariate: 20m/96Mi request, 200m/192Mi limit. The SQL is two filtered JOINs over the most recent knx_1h bucket plus one cross-source JOIN to ems_esp_boiler_1h — no model load, no in-memory state, sub-second runtime expected.

## Test plan

- [x] \`kustomize build --enable-helm kubernetes/applications/iot-mcp-bridge/base\` includes 4 CronJobs (\`detect-knx-join\`, \`detect-univariate\`, \`score-iforest\`, \`train-iforest\`)
- [ ] After Argo sync: \`kubectl get cronjob -n iot-mcp-bridge\` shows 4 CronJobs, all unsuspended
- [ ] Manual smoke: \`kubectl create job --from=cronjob/iot-mcp-bridge-detect-knx-join -n iot-mcp-bridge first-run\` succeeds and logs \`detect_knx_join_done\` with \`inserted=N published=N\` — even \`0/0\` is success (no current cold rooms / open windows)
- [ ] If any anomalies appear: verify \`payload\` JSON in \`mcp_anomalies\` carries readable \`room\`, thresholds, and bucket
- [ ] knx-nats-bridge writer-rule (manual entry per UC in \`write-mapping.yaml\`) maps \`anomaly.fbh_cold.warning\` and \`anomaly.window_while_heating.warning\` to KNX GAs for Basalte push — out of scope here, user-side follow-up

## Phase-2 status after this lands

| | |
|---|---|
| PR-1 TSDB-Schema | merged |
| PR-2 Jobs-Image + Infra | merged |
| PR-3 Univariate + MCP-Tools | merged, live |
| PR-4 IsolationForest | merged, live |
| **PR-5 KNX-Join (this)** | open |
| PR-6 statsforecast + Forecast.Solar + Weekly-Report | next |

🤖 Generated with [Claude Code](https://claude.com/claude-code)