### PR TITLE
docs(readme): update smart-home flow diagram for node-RED migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,20 +142,27 @@ flowchart TB
     end
 
     cam -- HTTP webhook --> webhook[redpanda-connect<br/>unifi_webhook stream]
-    webhook -. raw forward .-> nodered[node-RED<br/>Geofence tab]
 
     ems -- MQTT --> nats
     warp -- MQTT --> nats
     pv -- MQTT --> nats
-    webhook -- pub unifi.events.> --> nats
+    webhook -- pub unifi.events.> / unifi.geofence.> --> nats
 
-    nats[(NATS JetStream<br/>KNX · EMS_ESP · WARP<br/>SOLAREDGE · UNIFI)]
+    nats[(NATS JetStream + MQTT gw<br/>KNX · EMS_ESP · WARP<br/>SOLAREDGE · UNIFI)]
 
     bridge[knx-nats-bridge<br/>Reader + Writer]
     bridge -- pub knx.> --> nats
     nats -- sub --> bridge
     bridge <-- xknx TCP tunnel --> knx[KNX Bus]
     knx --> basalte[Basalte<br/>logic + notifications]
+
+    nodered[node-RED<br/>Geofence · Feiertage · Miele]
+    nats -- sub unifi.geofence.> via MQTT --> nodered
+    nodered -- KNX-Ultimate --> knx
+
+    surplus[redpanda-connect<br/>pv_surplus_to_warp stream]
+    nats -- sub knx.15.1.24 --> surplus
+    surplus -- MQTT warp/meters/1/update --> warp
 
     ingest[redpanda-connect<br/>ingest streams]
     nats -- sub --> ingest


### PR DESCRIPTION
## Summary

Reflects the actual architecture after this session's node-RED reshape:

- **UniFi webhook hairpin removed** — redpanda-connect no longer POSTs the raw payload back to node-RED. Geofence triggers travel on their own NATS subject \`unifi.geofence.>\` and node-RED subscribes via the MQTT gateway.
- **PV-Überschussladen** moved from node-RED to a redpanda-connect stream (\`pv_surplus_to_warp\`) that subscribes to \`knx.15.1.24\` and publishes on the WARP MQTT topic \`warp/meters/1/update\`.
- **node-RED** is now labeled with its remaining three tabs (Geofence · Feiertage · Miele) and shown writing KNX directly through KNX-Ultimate, not through HTTP back into the pipeline.
- **NATS** label adds "+ MQTT gw" so the gateway path that several flows now use is visible.

Pure docs change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)