### PR TITLE
docs(readme): shorter edge labels, drop pv_surplus_to_warp node

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,22 +148,19 @@ flowchart TB
 
     nats[(NATS JetStream<br/>+ MQTT gateway<br/><br/>KNX · EMS_ESP<br/>WARP · SOLAREDGE · UNIFI)]
 
-    webhook -- pub unifi.{events,geofence}.> --> nats
+    webhook -- pub unifi.> --> nats
     ems  -- MQTT --> nats
     pv   -- MQTT --> nats
     warp -- MQTT pub --> nats
-    nats -- MQTT pub warp/meters/1/update --> warp
 
     subgraph CTRL[Control consumers]
         direction LR
         bridge[knx-nats-bridge]
         nodered[node-RED]
-        surplus[redpanda-connect<br/>pv_surplus_to_warp]
     end
 
     nats <-- pub/sub knx.> --> bridge
-    nats -- sub unifi.geofence.> via MQTT --> nodered
-    nats -- sub knx.15.1.24 --> surplus
+    nats -- MQTT sub --> nodered
 
     bridge <-- xknx tunnel --> knx
     nodered -- KNX-Ultimate --> knx


### PR DESCRIPTION
## Summary

Four small diagram tweaks after #1045:

- **pv_surplus_to_warp node removed** along with its NATS-in / MQTT-out edges. The KNX-bridge already publishes \`knx.15.1.24\` to NATS — a separate box for the thin redpanda forwarder doesn't earn its space at this altitude.
- **"MQTT pub warp/meters/1/update"** edge from NATS to WARP gone with the surplus node.
- **\`pub unifi.{events,geofence}.>\`** → **\`pub unifi.>\`** — same coverage, less width.
- **\`sub unifi.geofence.> via MQTT\`** → **\`MQTT sub\`** — matches the brevity of the other edge labels.

Pure docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)