### PR TITLE
docs(readme): IoT top + DBs bottom — move KNX/Basalte out of IoT subgraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,6 @@ flowchart TB
         ems[EMS-ESP]
         pv[solaredge2mqtt]
         warp[WARP Wallbox]
-        knx[KNX Bus]
-        basalte[Basalte]
     end
 
     webhook[redpanda-connect<br/>unifi_webhook]
@@ -162,6 +160,8 @@ flowchart TB
     nats <-- pub/sub knx.> --> bridge
     nats -- MQTT sub --> nodered
 
+    knx[KNX Bus]
+    basalte[Basalte]
     bridge <-- xknx tunnel --> knx
     nodered -- KNX-Ultimate --> knx
     knx --> basalte


### PR DESCRIPTION
## Summary

With \`knx\` and \`basalte\` inside the IoT subgraph, the back-edges from \`bridge\` and \`node-RED\` (which sit in CTRL) pinned the whole IoT cluster to the right edge of the canvas. Mermaid auto-layout had no choice — it couldn't put IoT at the top because IoT needed to be adjacent to CTRL.

Pulling \`knx\` + \`basalte\` out as freestanding nodes between CTRL and ARCH frees IoT to sit as a horizontal bar at the top, with the DBs / analytics at the bottom — the layout the diagram is actually trying to describe.

Pure docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)