### PR TITLE
docs(readme): collapse CTRL + KNX bus + Basalte into one KNX subgraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,20 +151,19 @@ flowchart TB
     pv   -- MQTT --> nats
     warp -- MQTT pub --> nats
 
-    subgraph CTRL[Control consumers]
-        direction LR
+    subgraph KX[KNX]
+        direction TB
         bridge[knx-nats-bridge]
         nodered[node-RED]
+        knx[KNX Bus]
+        basalte[Basalte]
+        bridge <-- xknx tunnel --> knx
+        nodered -- KNX-Ultimate --> knx
+        knx --> basalte
     end
 
     nats <-- pub/sub knx.> --> bridge
     nats -- MQTT sub --> nodered
-
-    knx[KNX Bus]
-    basalte[Basalte]
-    bridge <-- xknx tunnel --> knx
-    nodered -- KNX-Ultimate --> knx
-    knx --> basalte
 
     subgraph ARCH[Archive + analytics]
         direction LR


### PR DESCRIPTION
## Summary

Everything that touches the KNX bus — \`knx-nats-bridge\`, \`node-RED\`, the bus itself, \`Basalte\` downstream — was scattered across the diagram in two groups: the "Control consumers" subgraph plus two freestanding nodes.

Folding them into one \`KNX\` subgraph:

- Names the actual domain instead of the generic "Control consumers"
- Keeps the internal write paths (bridge → bus, node-RED → bus, bus → Basalte) compact inside one box
- Only the NATS edges (\`pub/sub knx.>\` and \`MQTT sub\`) cross the boundary

Pure docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)