### PR TITLE
fix(alertmanager): drop dead Node-RED container-status webhook

### DIFF
--- a/kubernetes/applications/prometheus/base/values.yaml
+++ b/kubernetes/applications/prometheus/base/values.yaml
@@ -9,7 +9,7 @@ grafana:
   enabled: false
 
 alertmanager:
-  # Alertmanager configuration with Pushover and Node-RED integrations
+  # Alertmanager configuration with Pushover integration
   config:
     global:
       resolve_timeout: 5m
@@ -33,10 +33,6 @@ alertmanager:
           - token_file: /etc/alertmanager/secrets/alertmanager-pushover-tokens/token
             user_key_file: /etc/alertmanager/secrets/alertmanager-pushover-tokens/user_key
             sound: siren
-        # Node-RED endpoint for container status events
-        webhook_configs:
-          - url: "http://node-red.zimmermann.eu.com:1880/container-status"
-            send_resolved: true
       - name: "watchdog-pushover"
         pushover_configs:
           - token_file: /etc/alertmanager/secrets/alertmanager-pushover-tokens/token


### PR DESCRIPTION
## Problem

Alertmanager fired two alerts continuously:

- `AlertmanagerFailedToSendAlerts`
- `AlertmanagerClusterFailedToSendAlerts` (single replica → one failing receiver = 100 % cluster failure ratio)

Root cause: the default `endpoints` receiver POSTed every alert to the Node-RED webhook `http://node-red.zimmermann.eu.com:1880/container-status`. Node-RED itself is up (editor returns 200), but the flow serving that HTTP-in endpoint no longer exists — `flows.json` (and its backup) contain zero `http in` nodes and no `container-status` reference, so every POST returns `404 Cannot POST /container-status`.

The endpoint has been decommissioned and won't come back.

## Fix

Remove the dead `webhook_configs` block from the `endpoints` receiver. The receiver keeps its Pushover integration, and the `watchdog-pushover` receiver is untouched, so notifications continue to work. Section comment updated to match.

Once ArgoCD reconciles this, the Prometheus Operator regenerates `alertmanager.yaml` and both alerts resolve on their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)