### PR TITLE
chore(knx-nats-bridge): bump to 0.6.0

### DIFF
--- a/kubernetes/applications/knx-nats-bridge/base/values.yaml
+++ b/kubernetes/applications/knx-nats-bridge/base/values.yaml
@@ -4,7 +4,7 @@ deployment:
   enabled: true
   image:
     repository: ghcr.io/alexander-zimmermann/knx-nats-bridge
-    tag: 0.5.0
+    tag: 0.6.0
     pullPolicy: IfNotPresent
 
   # KNX tunnel allows only one connection per credential; never run two replicas.


### PR DESCRIPTION
## Summary

Picks up [knx-nats-bridge#48](https://github.com/alexander-zimmermann/knx-nats-bridge/pull/48) — the reader callback is now registered with `match_for_outgoing=True`, so the bridge sees its own writes locally and publishes them to NATS regardless of whether the MDT SCN-IP000.03 echoes tunnel writes back as `L_Data.ind`.

This fixes the long-standing "14/3/* writes never reach the archive" issue traced in the ETS Bus-Monitor session.

## Possible side effect

If a line coupler or second IP-Interface echoes a bridge write back as `L_Data.ind`, the reader callback fires twice for that telegram → two TSDB rows with slightly different `ts`. None of the current GAs hit that path in today's setup; will follow up with a `Nats-Msg-Id` dedup if duplicates show up in the next few days.

## DO NOT MERGE until

- [ ] knx-nats-bridge v0.6.0 image published to ghcr (release workflow triggered, ~2 min build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)