### PR TITLE
fix(fritz-exporter): stop liveness death-loop from /metrics probes

### DIFF
--- a/kubernetes/applications/fritz-exporter/base/values.yaml
+++ b/kubernetes/applications/fritz-exporter/base/values.yaml
@@ -38,26 +38,22 @@ deployment:
       containerPort: 9787
       protocol: TCP
 
-  # Consider the exporter ready when it serves the metrics endpoint.
+  # TCP probe only: probing /metrics triggers a live FritzBox scrape that
+  # serializes under load and kills a healthy-but-slow exporter.
   readinessProbe:
     enabled: true
-    httpGet:
-      path: /metrics
+    tcpSocket:
       port: metrics
-    initialDelaySeconds: 10
+    initialDelaySeconds: 20
     periodSeconds: 30
-    timeoutSeconds: 25
     failureThreshold: 3
 
-  # Restart if the metrics endpoint stops responding.
   livenessProbe:
     enabled: true
-    httpGet:
-      path: /metrics
+    tcpSocket:
       port: metrics
     initialDelaySeconds: 30
     periodSeconds: 60
-    timeoutSeconds: 25
     failureThreshold: 5
 
   resources:
@@ -99,4 +95,5 @@ serviceMonitor:
   endpoints:
     - port: metrics
       interval: 60s
-      scrapeTimeout: 20s
+      # A single live scrape already measures ~15s; headroom to avoid gaps.
+      scrapeTimeout: 30s


### PR DESCRIPTION
## Problem

The fritz-exporter pod restart-loops every ~7 minutes, flapping the ArgoCD app between `Healthy` and `Progressing` (looks like an endless sync). It is **not** an ArgoCD sync issue — the last sync succeeded in 2s.

Root cause: both readiness and liveness probes target `/metrics`. Each call triggers a full live TR-064 scrape of the FritzBox 7530, which the exporter serializes in its async loop.

Evidence from the live cluster:
- `exitCode 137` (SIGKILL), `reason: Error` — **not** OOMKilled
- Events: `Container failed liveness probe, will be restarted` + repeated `Liveness/Readiness probe failed: .../metrics: context deadline exceeded`
- Measured latency: `/metrics` ~14.7s, even root `/` ~8.8s (single, isolated requests)

Under concurrent load (Prometheus scrape 60s + readiness 30s + liveness 60s, all hitting `/metrics`) responses exceed the 25s probe timeout → kubelet kills a healthy-but-slow exporter → restart re-reads capabilities (~18s extra load) → loop.

## Fix

- Switch both probes to `tcpSocket` on the metrics port — verifies the listener is up without invoking a scrape (canonical pattern for exporters with expensive `/metrics`). Relaxing timeouts/thresholds would only be a band-aid that keeps the self-inflicted load.
- Bump ServiceMonitor `scrapeTimeout` 20s → 30s; a single scrape already measures ~15s, leaving little headroom against gaps.

## Verification

`kubectl kustomize --enable-helm overlays/prod` renders both probes as `tcpSocket` with no remaining `httpGet: /metrics`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)