### PR TITLE
feat(iot-mcp-bridge): forecast-solar + statsforecast seasonal CronJobs (v0.11.0)

### DIFF
--- a/kubernetes/applications/iot-mcp-bridge/base/forecast-solar-cronjob.yaml
+++ b/kubernetes/applications/iot-mcp-bridge/base/forecast-solar-cronjob.yaml
@@ -1,0 +1,102 @@
+# CronJob: hourly Forecast.Solar pull. Personal-Plus tier with both
+# PV planes (east + west) in a single request → 24 calls/day, well
+# under the 150/day quota. Upserts into `mcp_forecasts` so the
+# Phase-4 get_pv_forecast MCP tool reads from TSDB.
+# Schedule :15 of every hour — past the CAGG refresh storms at :00.
+apiVersion: batch/v1
+kind: CronJob
+
+metadata:
+  name: iot-mcp-bridge-forecast-solar
+  namespace: iot-mcp-bridge
+
+spec:
+  schedule: "15 * * * *"
+  timeZone: "Etc/UTC"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  startingDeadlineSeconds: 600
+
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 86400
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: fetcher
+              image: ghcr.io/alexander-zimmermann/iot-mcp-bridge:0.11.0
+              command: ["iot-mcp-bridge-jobs", "forecast-solar"]
+              env:
+                - name: MCP_DB_HOST
+                  value: timescaledb-db-rw.timescaledb.svc.cluster.local
+                - name: MCP_DB_PORT
+                  value: "5432"
+                - name: MCP_DB_NAME
+                  value: homelab
+                # Settings() requires read creds even though this job only
+                # writes via db_write_dsn.
+                - name: MCP_DB_USERNAME
+                  valueFrom:
+                    secretKeyRef:
+                      name: timescaledb-db-iot-mcp-bridge-ro-secret
+                      key: username
+                - name: MCP_DB_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: timescaledb-db-iot-mcp-bridge-ro-secret
+                      key: password
+                - name: MCP_DB_WRITE_USERNAME
+                  valueFrom:
+                    secretKeyRef:
+                      name: timescaledb-db-iot-mcp-bridge-rw-secret
+                      key: username
+                - name: MCP_DB_WRITE_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: timescaledb-db-iot-mcp-bridge-rw-secret
+                      key: password
+                # Forecast.Solar location (Steinroth 20, Eupen).
+                - name: MCP_FORECAST_SOLAR_LAT
+                  value: "50.62598"
+                - name: MCP_FORECAST_SOLAR_LON
+                  value: "6.02435"
+                # East (-51° from south, 6.175 kWp) + West (+129°, 6.435 kWp),
+                # both at 17° tilt. Saddle roof with ridge along NE-SW axis.
+                - name: MCP_FORECAST_SOLAR_PLANES
+                  value: |
+                    [{"dec":17,"az":-51,"kwp":6.175},{"dec":17,"az":129,"kwp":6.435}]
+                - name: MCP_FORECAST_SOLAR_API_KEY_FILE
+                  value: /etc/forecast-solar/api-key
+                - name: MCP_AUTH_ENABLED
+                  value: "false"
+                - name: TZ
+                  value: Europe/Berlin
+              resources:
+                requests:
+                  cpu: 20m
+                  memory: 64Mi
+                limits:
+                  cpu: 100m
+                  memory: 128Mi
+              volumeMounts:
+                - name: forecast-solar-credentials
+                  mountPath: /etc/forecast-solar/api-key
+                  subPath: api-key
+                  readOnly: true
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                runAsUser: 1000
+                runAsGroup: 1000
+                capabilities:
+                  drop: ["ALL"]
+                seccompProfile:
+                  type: RuntimeDefault
+          volumes:
+            - name: forecast-solar-credentials
+              secret:
+                secretName: forecast-solar-credentials

--- a/kubernetes/applications/iot-mcp-bridge/base/kustomization.yaml
+++ b/kubernetes/applications/iot-mcp-bridge/base/kustomization.yaml
@@ -7,10 +7,14 @@ resources:
   - ./certificate.yaml
   - ./ingress-route.yaml
   - ./import-ga-catalog-job.yaml
+  - ./sealed-secret.yaml
   - ./detect-univariate-cronjob.yaml
   - ./detect-knx-join-cronjob.yaml
   - ./train-iforest-cronjob.yaml
   - ./score-iforest-cronjob.yaml
+  - ./forecast-solar-cronjob.yaml
+  - ./train-seasonal-cronjob.yaml
+  - ./score-seasonal-cronjob.yaml
 
 helmCharts:
   - name: application

--- a/kubernetes/applications/iot-mcp-bridge/base/score-seasonal-cronjob.yaml
+++ b/kubernetes/applications/iot-mcp-bridge/base/score-seasonal-cronjob.yaml
@@ -1,0 +1,104 @@
+# CronJob: hourly statsforecast forecast + anomaly-check per UC.
+# Loads the persisted seasonal model from rustfs, writes 24h ahead
+# into mcp_forecasts, compares the last completed bucket vs its
+# forecast, and emits anomaly + NATS publish on z > sigma_threshold.
+# Schedule :25 — past the CAGG refresh + train-iforest race window.
+apiVersion: batch/v1
+kind: CronJob
+
+metadata:
+  name: iot-mcp-bridge-score-seasonal
+  namespace: iot-mcp-bridge
+
+spec:
+  schedule: "25 * * * *"
+  timeZone: "Etc/UTC"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  startingDeadlineSeconds: 600
+
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 86400
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: scorer
+              image: ghcr.io/alexander-zimmermann/iot-mcp-bridge:0.11.0
+              command: ["iot-mcp-bridge-jobs", "score-seasonal"]
+              env:
+                - name: MCP_DB_HOST
+                  value: timescaledb-db-rw.timescaledb.svc.cluster.local
+                - name: MCP_DB_PORT
+                  value: "5432"
+                - name: MCP_DB_NAME
+                  value: homelab
+                - name: MCP_DB_USERNAME
+                  valueFrom:
+                    secretKeyRef:
+                      name: timescaledb-db-iot-mcp-bridge-ro-secret
+                      key: username
+                - name: MCP_DB_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: timescaledb-db-iot-mcp-bridge-ro-secret
+                      key: password
+                - name: MCP_DB_WRITE_USERNAME
+                  valueFrom:
+                    secretKeyRef:
+                      name: timescaledb-db-iot-mcp-bridge-rw-secret
+                      key: username
+                - name: MCP_DB_WRITE_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: timescaledb-db-iot-mcp-bridge-rw-secret
+                      key: password
+                - name: MCP_S3_ENDPOINT
+                  value: http://rustfs-svc.rustfs.svc.cluster.local:9000
+                - name: MCP_S3_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: rustfs-admin-credentials
+                      key: RUSTFS_ACCESS_KEY
+                - name: MCP_S3_SECRET_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: rustfs-admin-credentials
+                      key: RUSTFS_SECRET_KEY
+                - name: MCP_NATS_SERVERS
+                  value: nats://nats.nats.svc.cluster.local:4222
+                - name: MCP_NATS_NKEY_SEED_FILE
+                  value: /etc/iot-mcp-bridge/nats/nkey-seed
+                - name: MCP_AUTH_ENABLED
+                  value: "false"
+                - name: TZ
+                  value: Europe/Berlin
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 256Mi
+                limits:
+                  cpu: 500m
+                  memory: 512Mi
+              volumeMounts:
+                - name: nats-credentials
+                  mountPath: /etc/iot-mcp-bridge/nats/nkey-seed
+                  subPath: nkey-seed
+                  readOnly: true
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                runAsUser: 1000
+                runAsGroup: 1000
+                capabilities:
+                  drop: ["ALL"]
+                seccompProfile:
+                  type: RuntimeDefault
+          volumes:
+            - name: nats-credentials
+              secret:
+                secretName: iot-mcp-bridge-credentials

--- a/kubernetes/applications/iot-mcp-bridge/base/sealed-secret.yaml
+++ b/kubernetes/applications/iot-mcp-bridge/base/sealed-secret.yaml
@@ -1,0 +1,15 @@
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+
+metadata:
+  name: forecast-solar-credentials
+  namespace: iot-mcp-bridge
+
+spec:
+  encryptedData:
+    api-key: AgCXxOMPLhWPtla5e5CYY3nVnP0CbgLgld41/CVkxfsX0kZyGWmGXXSWvxj2pdhKn74QYTkoM6w6e6pCPuokhA5FUYwUapR0j5fQGdpfLybyeUfEjxUbXq6H4+bcH9fV97CWL2T6vgPaXgaC8XPAaCPRtkBCyolkPVRFRAxOchio6aNP+21odoT1qmK9ELUdL8+yjSirfFmLKGzCy6MR0m74uYzwAEYlIZB7H/kx46+mxJNa4FsHBHW2tmLuuALaiiKW22D7qmgelqEaA3DQiZpeNVhnxBkyVxRmTDErt+VnFEhdMMifj1J99pp3uPTrS6JfADXt9OETO0+twU5uEzSc6Ow48ruoDlfte17bAGtcwTwiyaWaFBycEgkpQUHC5mht1sy3xJoAibpSMbzhDHgMSkx2ICXwKPPB5AQImsMwALTtE1pDE0LK62OuWGQeFac/jvoHlI5A11GLfFNpmPROSNeAVn5y6PR8mTEHoHe6rHGM/zsX8YaPGqwaM3CWMLcMuhKd+Pyi6ZlKGOt+QVtTcVgzjUT3XzSnzM/qwp9tQtIAjnwU7ARmU8ocZZ8SjKWzU4IAio2zdlbhgjHyI41DmB2K5Ei4ZPCiqHAof8mkRUsjyUwNifvrser0aLN2hroPFe803bo9vANDn7SL02hBIMOoAlX7fdMHoeYALvXmPoqWhFcr7QBG0gOZdrEWxM9rTrD+m0m46fLIHqnaycs+
+  template:
+    metadata:
+      name: forecast-solar-credentials
+      namespace: iot-mcp-bridge
+    type: Opaque

--- a/kubernetes/applications/iot-mcp-bridge/base/train-seasonal-cronjob.yaml
+++ b/kubernetes/applications/iot-mcp-bridge/base/train-seasonal-cronjob.yaml
@@ -1,0 +1,91 @@
+# CronJob: daily fit of statsforecast MSTL+AutoARIMA per registered
+# seasonal UC. Persists fitted pipeline + residual_stddev to rustfs
+# (s3://iot-mcp-bridge-models/seasonal/<uc>.joblib).
+# Schedule 03:30 UTC — outside CAGG refresh and user activity windows.
+apiVersion: batch/v1
+kind: CronJob
+
+metadata:
+  name: iot-mcp-bridge-train-seasonal
+  namespace: iot-mcp-bridge
+
+spec:
+  schedule: "30 3 * * *"
+  timeZone: "Etc/UTC"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  startingDeadlineSeconds: 1800
+
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 86400
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: trainer
+              image: ghcr.io/alexander-zimmermann/iot-mcp-bridge:0.11.0
+              command: ["iot-mcp-bridge-jobs", "train-seasonal"]
+              env:
+                - name: MCP_DB_HOST
+                  value: timescaledb-db-rw.timescaledb.svc.cluster.local
+                - name: MCP_DB_PORT
+                  value: "5432"
+                - name: MCP_DB_NAME
+                  value: homelab
+                - name: MCP_DB_USERNAME
+                  valueFrom:
+                    secretKeyRef:
+                      name: timescaledb-db-iot-mcp-bridge-ro-secret
+                      key: username
+                - name: MCP_DB_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: timescaledb-db-iot-mcp-bridge-ro-secret
+                      key: password
+                - name: MCP_DB_WRITE_USERNAME
+                  valueFrom:
+                    secretKeyRef:
+                      name: timescaledb-db-iot-mcp-bridge-rw-secret
+                      key: username
+                - name: MCP_DB_WRITE_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: timescaledb-db-iot-mcp-bridge-rw-secret
+                      key: password
+                # rustfs — persist fitted statsforecast pipelines.
+                - name: MCP_S3_ENDPOINT
+                  value: http://rustfs-svc.rustfs.svc.cluster.local:9000
+                - name: MCP_S3_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: rustfs-admin-credentials
+                      key: RUSTFS_ACCESS_KEY
+                - name: MCP_S3_SECRET_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: rustfs-admin-credentials
+                      key: RUSTFS_SECRET_KEY
+                - name: MCP_AUTH_ENABLED
+                  value: "false"
+                - name: TZ
+                  value: Europe/Berlin
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 384Mi
+                limits:
+                  cpu: 1000m
+                  memory: 1Gi
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                runAsUser: 1000
+                runAsGroup: 1000
+                capabilities:
+                  drop: ["ALL"]
+                seccompProfile:
+                  type: RuntimeDefault


### PR DESCRIPTION
## Summary

Companion to alexander-zimmermann/iot-mcp-bridge#51 (v0.11.0). Wires three new background jobs into the cluster.

- **forecast-solar** — \`15 * * * *\`, hourly Forecast.Solar pull (Personal-Plus, both PV planes in one HTTPS request) → upserts \`mcp_forecasts\` model=\`forecast_solar\`, metric=\`pv_production\`. Single call covers east + west; 24 calls/day total, under PP's 150/day quota.
- **train-seasonal** — \`30 3 * * *\`, daily statsforecast fit per registered UC, persists to rustfs \`s3://iot-mcp-bridge-models/seasonal/\`. Currently one UC: \`heating_activity_seasonal\`.
- **score-seasonal** — \`25 * * * *\`, loads the persisted model, writes 24h forecasts to \`mcp_forecasts\`, then compares the last completed bucket against its forecast — anomaly + NATS publish on z > sigma_threshold.

## Secrets

- New SealedSecret \`forecast-solar-credentials\` with key \`api-key\` (Personal-Plus tier). Mounted via subPath into \`/etc/forecast-solar/api-key\`, read by the job through \`MCP_FORECAST_SOLAR_API_KEY_FILE\`.
- Reuses existing rustfs-admin-credentials + timescaledb RW secret (Kyverno clones already in place).
- score-seasonal reuses the existing iot-mcp-bridge nkey-seed for NATS pub.

## Config (non-secret env on forecast-solar pod)

- \`MCP_FORECAST_SOLAR_LAT=50.62598\` (Steinroth 20, Eupen)
- \`MCP_FORECAST_SOLAR_LON=6.02435\`
- \`MCP_FORECAST_SOLAR_PLANES='[{"dec":17,"az":-51,"kwp":6.175},{"dec":17,"az":129,"kwp":6.435}]'\` (east + west, both 17° tilt, NE-SW ridge)

## Resources

| Job | requests | limits |
|---|---|---|
| forecast-solar | 20m / 64Mi | 100m / 128Mi |
| train-seasonal | 100m / 384Mi | 1000m / 1Gi |
| score-seasonal | 50m / 256Mi | 500m / 512Mi |

train-seasonal is the heavy one — MSTL+AutoARIMA on ~1 year of hourly samples fits in 384Mi but can spike. The 1Gi limit avoids OOM during AutoARIMA model selection.

## Out of scope

- Bumping the four existing CronJobs (\`detect-univariate\`, \`detect-knx-join\`, \`train-iforest\`, \`score-iforest\`) from 0.10.0 → 0.11.0 — Renovate handles it in a separate PR.
- PR-6c \`weekly-report\` — follow-up.
- iot-insights-engine split — separate effort (#754 referenced for context).

## Test plan

- [x] \`kustomize build --enable-helm kubernetes/applications/iot-mcp-bridge/base\` lists 7 CronJobs + 1 SealedSecret (forecast-solar-credentials)
- [ ] After Argo sync: \`kubectl get cronjob -n iot-mcp-bridge\` shows 7 CronJobs, all unsuspended
- [ ] \`kubectl get secret forecast-solar-credentials -n iot-mcp-bridge\` exists with key \`api-key\`
- [ ] Manual smoke \`forecast-solar\`: \`kubectl create job --from=cronjob/iot-mcp-bridge-forecast-solar -n iot-mcp-bridge first-solar\` succeeds, log line \`forecast_solar_done points=<N> upserted=<N>\` with N ≥ 24
- [ ] \`SELECT count(*) FROM mcp_forecasts WHERE model='forecast_solar' AND forecast_for > now()\` returns > 0
- [ ] Manual smoke \`train-seasonal\`: \`kubectl create job --from=cronjob/iot-mcp-bridge-train-seasonal -n iot-mcp-bridge first-train-seasonal\` succeeds, log line \`seasonal_trained uc=heating_activity_seasonal residual_stddev=<N>\`
- [ ] Rustfs has \`iot-mcp-bridge-models/seasonal/heating_activity_seasonal.joblib\`
- [ ] First \`score-seasonal\` tick after train completes writes 24 rows to \`mcp_forecasts\` for \`model=seasonal:heating_activity_seasonal\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)