### PR TITLE
fix(clusterpolicy-secrets): shorten new rule names below 63-byte limit

### DIFF
--- a/kubernetes/components/admission-controller/base/clusterpolicy-secrets.yaml
+++ b/kubernetes/components/admission-controller/base/clusterpolicy-secrets.yaml
@@ -508,7 +508,7 @@ spec:
     # The jobs image's Settings() validates DB_USERNAME/PASSWORD at
     # construct time even though most jobs only open the write connection.
     # Same PG-side role + secret name as iot-mcp-bridge.
-    - name: sync-timescaledb-db-iot-mcp-bridge-ro-secret-iot-insights-engine
+    - name: sync-iot-insights-engine-db-ro
       match:
         any:
           - resources:
@@ -528,7 +528,7 @@ spec:
 
     # Syncs CNPG-managed read-write DB-user secret into iot-insights-engine
     # for INSERT/UPDATE on mcp_anomalies + mcp_forecasts.
-    - name: sync-timescaledb-db-iot-mcp-bridge-rw-secret-iot-insights-engine
+    - name: sync-iot-insights-engine-db-rw
       match:
         any:
           - resources:
@@ -548,7 +548,7 @@ spec:
 
     # Syncs RustFS admin credentials into iot-insights-engine so the
     # train-iforest + train-seasonal jobs can persist models.
-    - name: sync-rustfs-admin-credentials-iot-insights-engine
+    - name: sync-iot-insights-engine-rustfs
       match:
         any:
           - resources:
@@ -569,7 +569,7 @@ spec:
     # Syncs NATS nkey-seed into iot-insights-engine for anomaly publishes
     # (`anomaly.<uc>.<severity>`). Secret name stays iot-mcp-bridge-credentials
     # to match the existing nats-auth-config NKey allowlist entry.
-    - name: sync-iot-mcp-bridge-credentials-iot-insights-engine
+    - name: sync-iot-insights-engine-nats
       match:
         any:
           - resources:
@@ -591,7 +591,7 @@ spec:
     # so the import-catalog Job can write to the `ga_catalog` table
     # (after the iot-insights-engine split, this Job runs from the
     # knx-nats-bridge image as a 2nd entrypoint alongside the bridge).
-    - name: sync-timescaledb-db-app-secret-knx-nats-bridge
+    - name: sync-knx-nats-bridge-db-app
       match:
         any:
           - resources:


### PR DESCRIPTION
Kyverno's K8s-side validation rejects ClusterPolicy.spec.rules[*].name longer than 63 bytes. The new clone rules added in the iot-insights- engine split breached the limit at 64 chars:

  sync-timescaledb-db-iot-mcp-bridge-{ro,rw}-secret-iot-insights-engine

Renamed to:
  sync-iot-insights-engine-db-{ro,rw}
  sync-iot-insights-engine-rustfs
  sync-iot-insights-engine-nats
  sync-knx-nats-bridge-db-app

Rule names are internal identifiers — the cloned resource name in generate.* stays exactly as before, so no downstream pod references need updating.