### PR TITLE
docs(readme): update data-flow diagram after iot-insights-engine split

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ flowchart TB
 
     subgraph KX[KNX]
         direction TB
-        bridge[knx-nats-bridge]
+        bridge[knx-nats-bridge<br/>bridge + ga-catalog importer]
         nodered[node-RED]
         knx[KNX Bus]
         basalte[Basalte]
@@ -170,16 +170,20 @@ flowchart TB
         ingest[redpanda-connect<br/>ingest streams]
         tsdb[(TimescaleDB)]
         rustfs[(rustfs<br/>parquet archive)]
-        mcp[iot-mcp-bridge<br/>MCP tools + jobs]
+        engine[iot-insights-engine<br/>anomaly + forecast jobs]
+        mcp[iot-mcp-bridge<br/>MCP read tools]
         claude((Claude.ai))
         ingest --> tsdb
         ingest --> rustfs
+        tsdb -- SELECT --> engine
+        engine -- INSERT mcp_anomalies + mcp_forecasts --> tsdb
         tsdb -- SELECT --> mcp
         mcp -- MCP/HTTP --> claude
     end
 
+    bridge -- INSERT ga_catalog --> tsdb
     nats -- sub --> ingest
-    mcp -- pub anomaly.> --> nats
+    engine -- pub anomaly.> --> nats
 ```
 
 The KNX bus loops back into the data pipeline: every telegram the writer puts on the bus is seen by the reader on the same tunnel, republished on `knx.<ga>`, and ingested by redpanda-connect into the `knx` hypertable — so TSDB always reflects the live bus state regardless of who originated the write.


### PR DESCRIPTION
## Summary

The Smart-Home data-flow Mermaid diagram in the lares README still showed the pre-split topology — \`iot-mcp-bridge\` with "MCP tools + jobs" plus \`anomaly.>\` originating from there. Update to reflect:

- \`iot-mcp-bridge\` → "MCP read tools" only (no jobs anymore)
- \`iot-insights-engine\` (new node) — reads TSDB, writes \`mcp_anomalies\` + \`mcp_forecasts\`, publishes \`anomaly.<uc>.<severity>\` to NATS
- \`knx-nats-bridge\` → "bridge + ga-catalog importer", with a new arrow into TSDB for the \`ga_catalog\` write path

No code changes. Architecture text below the diagram still accurate.