### PR TITLE
docs(readme): shorten diagram edge labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ flowchart TB
 
     subgraph KX[KNX]
         direction TB
-        bridge[knx-nats-bridge<br/>bridge + ga-catalog importer]
+        bridge[knx-nats-bridge]
         nodered[node-RED]
         knx[KNX Bus]
         basalte[Basalte]
@@ -176,12 +176,11 @@ flowchart TB
         ingest --> tsdb
         ingest --> rustfs
         tsdb -- SELECT --> engine
-        engine -- INSERT mcp_anomalies + mcp_forecasts --> tsdb
+        engine -- INSERT --> tsdb
         tsdb -- SELECT --> mcp
         mcp -- MCP/HTTP --> claude
     end
 
-    bridge -- INSERT ga_catalog --> tsdb
     nats -- sub --> ingest
     engine -- pub anomaly.> --> nats
 ```


### PR DESCRIPTION
## Summary

Follow-up to #1072 — the edge labels on the lares data-flow diagram came out too verbose. Shorten:

- \`engine -- INSERT mcp_anomalies + mcp_forecasts --> tsdb\`  →  \`engine -- INSERT --> tsdb\` (parallel to the existing \`SELECT\` labels)
- \`knx-nats-bridge\` node label: revert "bridge + ga-catalog importer" annotation — the import-catalog is a PostSync one-shot, not a steady-state flow, doesn't belong in this diagram
- Drop the corresponding \`bridge -- INSERT ga_catalog --> tsdb\` edge for the same reason

No content change beyond label trimming.