### PR TITLE
fix(fritz-exporter): bind listen_address to 0.0.0.0 for v3.0.0

### DIFF
--- a/kubernetes/applications/fritz-exporter/base/config/fritz-exporter.yaml
+++ b/kubernetes/applications/fritz-exporter/base/config/fritz-exporter.yaml
@@ -1,3 +1,6 @@
+# fritz_exporter 3.0.0 changed the default listen_address from 0.0.0.0 to 127.0.0.1.
+# Bind to all interfaces so kubelet probes and Prometheus can reach the pod port.
+listen_address: 0.0.0.0
 devices:
 - hostname: http://fritzbox.zimmermann.eu.com
   username: fritz-exporter


### PR DESCRIPTION
## Problem

The Renovate major bump `pdreker/fritz_exporter` **2.6.2 → 3.0.0** (commit 11abf2db) shipped a breaking default change: `listen_address` went from `0.0.0.0` to **`127.0.0.1`** ([upstream #402](https://github.com/pdreker/fritz_exporter/issues/402)).

Result in-cluster:
- Exporter bound to localhost only — `Starting listener at 127.0.0.1:9787`.
- kubelet probes + Prometheus hit the pod IP → `dial tcp <podIP>:9787: connection refused`.
- Readiness never passed (pod stuck `0/1`); liveness killed the container in a restart loop. `fritz-exporter-prod` went `Degraded`.

The FritzBox login itself was fine — purely a binding regression.

## Fix

Set `listen_address: 0.0.0.0` explicitly in the exporter config. Restores pre-3.0.0 reachability while staying on 3.0.0, and is resilient to future bumps. The `configMapGenerator` hash changes, so the pod rolls automatically on Argo sync.

## Follow-up (not in this PR)

Consider constraining `fritz_exporter` to minor/patch in Renovate so a breaking major doesn't auto-merge untested again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)