### PR TITLE
feat(knx-nats-bridge): configure KNX bus barrier (rate limit + per-GA deadbands)

### DIFF
--- a/kubernetes/applications/knx-nats-bridge/base/config/writer-rules.yaml
+++ b/kubernetes/applications/knx-nats-bridge/base/config/writer-rules.yaml
@@ -297,26 +297,31 @@ mappings:
     dpt: "1.011"
     payload_path: "$.burngas"
     description: "Versorgungstechnik.Gastherme.Brenner-Status"
+    min_delta: 0  # binary status: write only on change
   - subject: "ems-esp.boiler_data"
     ga: "15/2/1"
     dpt: "5.001"
     payload_path: "$.curburnpow"
     description: "Versorgungstechnik.Gastherme.Brenner-Modulation"
+    min_delta: 2  # percent
   - subject: "ems-esp.boiler_data"
     ga: "15/2/2"
     dpt: "1.001"
     payload_path: "$.heatingactive"
     description: "Versorgungstechnik.Gastherme.Heizung-Aktiv"
+    min_delta: 0  # binary status: write only on change
   - subject: "ems-esp.boiler_data"
     ga: "15/2/10"
     dpt: "9.001"
     payload_path: "$.curflowtemp"
     description: "Versorgungstechnik.Gastherme.Vorlauf-Temperatur"
+    min_delta: 0.5  # °C
   - subject: "ems-esp.boiler_data"
     ga: "15/2/11"
     dpt: "9.001"
     payload_path: "$.rettemp"
     description: "Versorgungstechnik.Gastherme.Rücklauf-Temperatur"
+    min_delta: 0.5  # °C
 
   # WARP wallbox
   - subject: "warp.evse.state"
@@ -324,31 +329,38 @@ mappings:
     dpt: "5.010"
     payload_path: "$.charger_state"
     description: "Versorgungstechnik.Wallbox.Charger-State"
+    min_delta: 0  # enum state: write only on change
   - subject: "warp.evse.state"
     ga: "15/6/1"
     dpt: "5.010"
     payload_path: "$.iec61851_state"
     description: "Versorgungstechnik.Wallbox.IEC61851-State"
+    min_delta: 0  # enum state: write only on change
   - subject: "warp.evse.state"
     ga: "15/6/2"
     dpt: "5.010"
     payload_path: "$.error_state"
     description: "Versorgungstechnik.Wallbox.Error-State"
+    min_delta: 0  # enum state: write only on change
   - subject: "warp.evse.state"
     ga: "15/6/3"
     dpt: "5.010"
     payload_path: "$.contactor_error"
     description: "Versorgungstechnik.Wallbox.Contactor-Error"
+    min_delta: 0  # enum state: write only on change
   - subject: "warp.evse.state"
     ga: "15/6/4"
     dpt: "5.010"
     payload_path: "$.dc_fault_current_state"
     description: "Versorgungstechnik.Wallbox.DC-Fault-Current-State"
+    min_delta: 0  # enum state: write only on change
   - subject: "warp.evse.state"
     ga: "15/6/10"
     dpt: "7.012"
     payload_path: "$.allowed_charging_current"
     description: "Versorgungstechnik.Wallbox.Allowed-Charging-Current"
+    min_delta: 100  # mA
+    min_delta_pct: 2
 
   # SolarEdge PV (15/4: 0..9 system-wide, 10..19 inv 1, 20..29 inv 2)
   - subject: "solaredge-1.powerflow"
@@ -356,28 +368,38 @@ mappings:
     dpt: "14.056"
     payload_path: "$.grid.power"
     description: "Versorgungstechnik.Photovoltaik.Netz-Leistung"
+    min_delta: 25  # W
+    min_delta_pct: 2
   - subject: "solaredge-1.powerflow"
     ga: "15/4/1"
     dpt: "14.056"
     payload_path: "$.consumer.total"
     description: "Versorgungstechnik.Photovoltaik.Verbrauch-Gesamt"
+    min_delta: 25  # W
+    min_delta_pct: 2
   - subject: "solaredge-1.powerflow"
     ga: "15/4/10"
     dpt: "14.056"
     payload_path: "$.pv_production"
     description: "Versorgungstechnik.Photovoltaik.Inverter-1.Leistung"
+    min_delta: 25  # W
+    min_delta_pct: 2
   - subject: "solaredge-1.modbus.inverter"
     ga: "15/4/11"
     dpt: "9.001"
     payload_path: "$.temperature"
     description: "Versorgungstechnik.Photovoltaik.Inverter-1.Temperatur"
+    min_delta: 0.5  # °C
   - subject: "solaredge-2.powerflow"
     ga: "15/4/20"
     dpt: "14.056"
     payload_path: "$.pv_production"
     description: "Versorgungstechnik.Photovoltaik.Inverter-2.Leistung"
+    min_delta: 25  # W
+    min_delta_pct: 2
   - subject: "solaredge-2.modbus.inverter"
     ga: "15/4/21"
     dpt: "9.001"
     payload_path: "$.temperature"
     description: "Versorgungstechnik.Photovoltaik.Inverter-2.Temperatur"
+    min_delta: 0.5  # °C

--- a/kubernetes/applications/knx-nats-bridge/base/values.yaml
+++ b/kubernetes/applications/knx-nats-bridge/base/values.yaml
@@ -19,6 +19,9 @@ deployment:
       value: knx-ip.zimmermann.eu.com
     KNX_GATEWAY_PORT:
       value: "3671"
+    # Cap writer-side bus telegrams to N/s so NATS bursts don't overload the TP1 bus
+    KNX_RATE_LIMIT:
+      value: "10"
     NATS_SERVERS:
       value: nats://nats.nats.svc.cluster.local:4222
     NATS_SUBJECT_PREFIX:


### PR DESCRIPTION
Companion config for **knx-nats-bridge 0.8.0** (alexander-zimmermann/knx-nats-bridge#55), which adds writer-side bus pacing so NATS→KNX writes can't overload the shared TP1 bus.

## Changes

- **`values.yaml`** — `KNX_RATE_LIMIT=10`: cap outgoing bus telegrams to 10/s (xknx paces sends by `1/N` s). The 0.8.0 image already defaults to 10, so this just makes it explicit/tunable.
- **`config/writer-rules.yaml`** — add `min_delta` / `min_delta_pct` deadbands to the noisy, periodic GAs (17 rules) so jitter stops spamming the bus:
  - PV power (`14.056`, W) and wallbox current (`7.012`, mA): absolute floor + 2% relative band.
  - Inverter/heating temps (`9.001`) and burner modulation (`5.001`): absolute band.
  - Wallbox state enums (`5.010`) and boiler binary status (`1.x`): `min_delta: 0` → write only on change.
  - UniFi event GAs (`14/3/*`): left unbounded (edge events should always go through).

Validated against the 0.8.0 writer-rules schema and `kustomize build` renders cleanly.

## ⚠️ Merge ordering

The 0.8.0 schema adds `min_delta` support; the **older 0.7.0** schema has `additionalProperties: false` and would reject it. The ConfigMap uses `disableNameSuffixHash` + a `subPath` mount, so a running 0.7.0 pod won't reload it — but a coincidental restart in the gap would crash-loop.

**Merge this together with / right after the Renovate 0.8.0 image-bump PR — not while `0.7.0` is still the deployed tag.**

## Verify after deploy

- `knx_writes_total{outcome="suppressed"}` rises for PV/wallbox GAs vs `outcome="ok"`.
- ETS group monitor: same GAs no longer written on every micro-delta; ≥100 ms spacing within bursts.
- `knx_tunnel_connected` / `/healthz` stay green; no `knx_write_errors{reason="bus"}` spikes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)