### PR TITLE
fix(redpanda-connect): re-add diagnostic log + robust value coercion

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/streams/unifi_arm_alarm.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/unifi_arm_alarm.yaml
@@ -13,15 +13,22 @@ pipeline:
   processors:
     - mapping: |
         let subj = meta("nats_subject")
-        let on  = this.value == true
-        meta protect_action = if $subj == "knx.14.1.25" && $on {
-          "enable"
-        } else if $subj == "knx.14.1.20" && $on {
-          "disable"
+        root = if $subj == "knx.14.1.25" || $subj == "knx.14.1.20" {
+          this
         } else {
           deleted()
         }
-        root = if meta("protect_action").or(null) != null { this } else { deleted() }
+    - log:
+        level: INFO
+        message: 'unifi_arm_alarm: subject=${! meta("nats_subject") } value=${! this.value } value_type=${! this.value.type() } raw=${! content() }'
+    - mapping: |
+        let on = this.value.bool().or(false)
+        root = if $on { this } else { deleted() }
+        meta protect_action = if meta("nats_subject") == "knx.14.1.25" {
+          "enable"
+        } else {
+          "disable"
+        }
 
 output:
   switch:


### PR DESCRIPTION
## Summary
Stream regressed after #1024 cleanup: `input_received=31991`, `processor_sent=0` — every message dropped, no HTTP calls. Arming via Basalte today produced no API call.

Mapping form is identical to what worked during the #1022 + #1023 verification (`value_type=bool` was confirmed back then), so something subtle changed — possibly xknx returning value as integer for these specific GAs now, or a Bloblang-vs-payload type mismatch I missed.

Two diagnostic changes for the next test:
- **Split mapping**: GA filter first, then action/value tagging — so the log captures every event reaching the relevant GAs regardless of value shape.
- **Robust coercion**: `this.value.bool().or(false)` survives both `true` and `1` payloads.
- **INFO log** per arm/disarm pulse with subject + value + value_type.

## Test plan
- [ ] Pod stays running.
- [ ] One arm + one disarm via Basalte → pod log shows two `unifi_arm_alarm: subject=…` lines AND Protect "Abwesend" flips.
- [ ] If logs appear but no API call → look at HTTP error in `kubectl logs`.
- [ ] If still no log → investigate input pipeline (consumer binding, subject filter mismatch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)