### PR TITLE
fix(unifi_arm_alarm): stop endless retry loop on UniFi 400

### DIFF
--- a/kubernetes/applications/nats/base/consumers/unifi_arm_alarm.yaml
+++ b/kubernetes/applications/nats/base/consumers/unifi_arm_alarm.yaml
@@ -11,3 +11,9 @@ spec:
   filterSubject: knx.14.1.*
   deliverPolicy: new
   ackPolicy: explicit
+  # nats-operator default surfaces as 1ns, which causes immediate re-delivery
+  # of any message slower-than-instant to ack. 10s covers the http_client RTT
+  # comfortably without leaving wedged messages locked for long after a crash.
+  ackWait: 10s
+  # Drop after 5 attempts so a permanently-failing message can't loop forever.
+  maxDeliver: 5

--- a/kubernetes/applications/redpanda-connect/base/streams/unifi_arm_alarm.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/unifi_arm_alarm.yaml
@@ -41,6 +41,10 @@ output:
             headers:
               X-API-Key: "${UNIFI_PROTECT_API_KEY}"
               Accept: "application/json"
+            # UniFi returns 400 when the profile is already in the target state
+            # ("Attempted to disarm the alarm when it is not armed"). Treat that
+            # as success so the message gets acked and we don't loop forever.
+            drop_on: [400]
       - check: 'meta("protect_action") == "disable"'
         output:
           http_client:
@@ -49,3 +53,7 @@ output:
             headers:
               X-API-Key: "${UNIFI_PROTECT_API_KEY}"
               Accept: "application/json"
+            # UniFi returns 400 when the profile is already in the target state
+            # ("Attempted to disarm the alarm when it is not armed"). Treat that
+            # as success so the message gets acked and we don't loop forever.
+            drop_on: [400]


### PR DESCRIPTION
## Summary
Synthetic-NATS test after #1085 confirmed mapping + TLS are correct, but every test message wedged the pipeline because UniFi returns **400** for idempotency conflicts (`/disable` on already-disabled profile → `"Attempted to disarm the alarm when it is not armed"`). Combined with the consumer's effective `ackWait=1ns` (nats-operator default surfaces that way), the same message got re-delivered ~1×/s indefinitely, blocking every other event.

Two changes:
- **Consumer CRD**: `ackWait: 10s` + `maxDeliver: 5` so a wedged message can never loop forever.
- **http_client**: `drop_on: [400]` on both enable + disable outputs so an idempotency-conflict ackes immediately.

This should also explain why the real Basalte disarm earlier today never produced an API call — the pipeline was already wedged from an older event.

## Test plan
- [ ] Pod stays running after merge.
- [ ] Repeat the synthetic publish (`nats pub knx.14.1.20 …`) when Protect is already disarmed → log shows the 400 once, message gets acked, no retry loop.
- [ ] Real Basalte Unscharf → Protect "Abwesend" flips off, log shows one disable call only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)