### PR TITLE
fix(unifi_arm_alarm): treat UniFi 400 idempotency conflict as success

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/streams/unifi_arm_alarm.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/unifi_arm_alarm.yaml
@@ -41,10 +41,10 @@ output:
             headers:
               X-API-Key: "${UNIFI_PROTECT_API_KEY}"
               Accept: "application/json"
-            # UniFi returns 400 when the profile is already in the target state
-            # ("Attempted to disarm the alarm when it is not armed"). Treat that
-            # as success so the message gets acked and we don't loop forever.
-            drop_on: [400]
+            # UniFi returns 204 on success and 400 when the profile is already
+            # in the target state ("Attempted to disarm the alarm when it is
+            # not armed"). Both are terminal for us — ack and move on.
+            successful_on: [200, 204, 400]
       - check: 'meta("protect_action") == "disable"'
         output:
           http_client:
@@ -53,7 +53,7 @@ output:
             headers:
               X-API-Key: "${UNIFI_PROTECT_API_KEY}"
               Accept: "application/json"
-            # UniFi returns 400 when the profile is already in the target state
-            # ("Attempted to disarm the alarm when it is not armed"). Treat that
-            # as success so the message gets acked and we don't loop forever.
-            drop_on: [400]
+            # UniFi returns 204 on success and 400 when the profile is already
+            # in the target state ("Attempted to disarm the alarm when it is
+            # not armed"). Both are terminal for us — ack and move on.
+            successful_on: [200, 204, 400]


### PR DESCRIPTION
## Summary
Follow-up to #1086. After the consumer was re-created with `ackWait: 10s` / `maxDeliver: 5`, a synthetic disarm test still produced ~5 attempts in the pod log instead of 1: `drop_on: [400]` stops benthos' own retry loop but doesn't ack the message, so JetStream re-delivers it up to `maxDeliver` times before giving up.

`successful_on: [200, 204, 400]` flags the response as terminal — message gets acked after a single POST, no re-delivery, no log spam.

## Test plan
- [ ] Synthetic `nats pub knx.14.1.20 …` against already-disarmed Protect → exactly one `disable` POST in the log, no further attempts.
- [ ] Real Basalte arm/disarm → exactly one corresponding POST per pulse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)