### PR TITLE
chore(unifi_arm_alarm): drop diagnostic log + split mapping

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/streams/unifi_arm_alarm.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/unifi_arm_alarm.yaml
@@ -13,22 +13,15 @@ pipeline:
   processors:
     - mapping: |
         let subj = meta("nats_subject")
-        root = if $subj == "knx.14.1.25" || $subj == "knx.14.1.20" {
-          this
+        let on  = this.value == true
+        meta protect_action = if $subj == "knx.14.1.25" && $on {
+          "enable"
+        } else if $subj == "knx.14.1.20" && $on {
+          "disable"
         } else {
           deleted()
         }
-    - log:
-        level: INFO
-        message: 'unifi_arm_alarm: subject=${! meta("nats_subject") } value=${! this.value } value_type=${! this.value.type() } raw=${! content() }'
-    - mapping: |
-        let on = this.value.bool().or(false)
-        root = if $on { this } else { deleted() }
-        meta protect_action = if meta("nats_subject") == "knx.14.1.25" {
-          "enable"
-        } else {
-          "disable"
-        }
+        root = if meta("protect_action").or(null) != null { this } else { deleted() }
 
 output:
   switch:


### PR DESCRIPTION
## Summary
End-to-end verified after #1087 (synthetic enable produced HTTP 204, disable on already-disabled returned 400 ack'd via `successful_on`, 1 POST per pulse, no retry-loop). Drop the diagnostic scaffolding from #1085 — back to the compact single mapping. `successful_on: [200, 204, 400]` stays.

## Test plan
- [ ] Pod stays running.
- [ ] Synthetic `nats pub knx.14.1.20 …` → one disable POST, no retries.
- [ ] Real Basalte Extern-Scharf → Protect "Abwesend" flips on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)