### PR TITLE
fix(grafana): use selflowtemp for Gastherme Vorlauf-Soll series

### DIFF
--- a/kubernetes/applications/grafana/base/dashboards/hvac-heating-unit.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/hvac-heating-unit.yaml
@@ -842,7 +842,7 @@ spec:
               "editorMode": "code",
               "format": "time_series",
               "rawQuery": true,
-              "rawSql": "SELECT $__timeGroup(time, '$__interval') AS time, avg(setflowtemp) AS \"Soll Temperatur\" FROM ems_esp WHERE $__timeFilter(time) AND setflowtemp IS NOT NULL GROUP BY 1 ORDER BY 1;",
+              "rawSql": "SELECT $__timeGroup(time, '$__interval') AS time, avg(selflowtemp) AS \"Soll Temperatur\" FROM ems_esp WHERE $__timeFilter(time) AND selflowtemp IS NOT NULL GROUP BY 1 ORDER BY 1;",
               "refId": "Soll Temperatur"
             },
             {


### PR DESCRIPTION
## Problem

The **Gastherme** dashboard panel *Therme über Zeit → Soll Temperatur* queried `setflowtemp`, which EMS-ESP never publishes — the column has **0 rows** in TimescaleDB. The setpoint line was therefore always empty.

## Fix

Switch the query (and its `IS NOT NULL` filter) to `selflowtemp`, the boiler's actual selected flow temperature. This matches the KNX **Vorlauf-Soll** mapping (`15/2/11`) added in #1090.

```diff
- avg(setflowtemp) AS "Soll Temperatur" ... AND setflowtemp IS NOT NULL
+ avg(selflowtemp) AS "Soll Temperatur" ... AND selflowtemp IS NOT NULL
```

Embedded dashboard JSON re-validated after the edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)