### PR TITLE
fix(unifi_arm_alarm): restore split mapping after #1088 regression

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/streams/unifi_arm_alarm.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/unifi_arm_alarm.yaml
@@ -11,17 +11,26 @@ input:
 
 pipeline:
   processors:
+    # First stage: filter to the two relevant GAs regardless of value, so
+    # the second stage runs on a known subject set and `meta` assignment
+    # never has to express "drop the message" via deleted().
     - mapping: |
         let subj = meta("nats_subject")
-        let on  = this.value == true
-        meta protect_action = if $subj == "knx.14.1.25" && $on {
-          "enable"
-        } else if $subj == "knx.14.1.20" && $on {
-          "disable"
+        root = if $subj == "knx.14.1.25" || $subj == "knx.14.1.20" {
+          this
         } else {
           deleted()
         }
-        root = if meta("protect_action").or(null) != null { this } else { deleted() }
+    # Second stage: drop the 0-half of the KNX command pulse, tag action.
+    # `.bool().or(false)` survives both bool and int payload shapes.
+    - mapping: |
+        let on = this.value.bool().or(false)
+        root = if $on { this } else { deleted() }
+        meta protect_action = if meta("nats_subject") == "knx.14.1.25" {
+          "enable"
+        } else {
+          "disable"
+        }
 
 output:
   switch:


### PR DESCRIPTION
## Summary
After #1088 cleanup the stream regressed: `processor_received == processor_sent` reads 15616 → 0 and yesterday's real 14/1/25 arm pulse at 06-06 16:50 UTC never produced an API call. Synthetic publish today reproduces — the compact single mapping drops every message.

Suspect: `meta protect_action = if … else { deleted() }` — `deleted()` as the RHS of a `meta` assignment appears to drop the entire message in some Bloblang code paths, not just the metadata write. The split form from #1085/#1087 worked end-to-end.

Restore split:
- first stage filters to the two relevant GAs (clean `root = … else { deleted() }`)
- second stage uses `.bool().or(false)` defensive coercion and only assigns `meta protect_action` on surviving messages

Diagnostic INFO log stays out — the split mapping is enough.

## Test plan
- [ ] Synthetic `nats pub knx.14.1.25 …` → `out_en_sent` increments, one POST, no retries.
- [ ] Real Basalte arm/disarm pulse → Protect "Abwesend" flips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)