### PR TITLE
fix(iot-mcp-bridge): liveness probe on /livez instead of DB-gated /healthz

### DIFF
--- a/kubernetes/applications/iot-mcp-bridge/base/values.yaml
+++ b/kubernetes/applications/iot-mcp-bridge/base/values.yaml
@@ -88,7 +88,9 @@ deployment:
   livenessProbe:
     enabled: true
     httpGet:
-      path: /healthz
+      # /livez is process-only (always 200 while the app runs) — a TSDB outage
+      # must not restart the pod; /healthz stays DB-gated for readiness below.
+      path: /livez
       port: mcp
     initialDelaySeconds: 10
     periodSeconds: 30


### PR DESCRIPTION
## Summary

`/healthz` is DB-gated (503 while TimescaleDB is unreachable). With both probes pointing at it, a DB outage sends the pod into a restart loop even though the bridge process is healthy and restarting cannot fix anything.

- **livenessProbe** → `GET /livez` (new in [iot-mcp-bridge v1.4.0](https://github.com/alexander-zimmermann/iot-mcp-bridge/pull/66); always 200 while the process runs)
- **readinessProbe** stays on the DB-gated `/healthz`, so the pod is still removed from the Service while the DB is down

## ⚠️ Merge order

Merge **together with or after** the Renovate PR bumping the image to `v1.4.0` — older images return 404 on `/livez`, which would itself trigger the restart loop this PR prevents. The v1.4.0 image is already published on ghcr.io.

🤖 Generated with [Claude Code](https://claude.com/claude-code)