### PR TITLE
chore(rustfs): drop iot-insights-engine admin clone after scoped cutover (#1017)

### DIFF
--- a/kubernetes/components/admission-controller/base/clusterpolicy-secrets.yaml
+++ b/kubernetes/components/admission-controller/base/clusterpolicy-secrets.yaml
@@ -465,29 +465,9 @@ spec:
           namespace: timescaledb
           name: timescaledb-db-iot-mcp-bridge-rw-secret
 
-    # Syncs RustFS admin credentials into iot-insights-engine so the
-    # train-iforest + train-seasonal jobs can persist models.
-    - name: sync-iot-insights-engine-rustfs
-      match:
-        any:
-          - resources:
-              kinds:
-                - Namespace
-              names:
-                - iot-insights-engine
-      generate:
-        apiVersion: v1
-        kind: Secret
-        name: rustfs-admin-credentials
-        namespace: iot-insights-engine
-        synchronize: true
-        clone:
-          namespace: rustfs
-          name: rustfs-admin-credentials
-
     # Syncs the per-app, bucket-scoped RustFS credentials into iot-insights-engine
-    # (issue #1017). Replaces the shared admin key above for this tenant once the
-    # cronjobs reference it; the admin clone stays as fallback during cutover.
+    # (issue #1017). Sole RustFS credential for this tenant — the shared admin
+    # clone was removed after the scoped-user cutover was verified end-to-end.
     - name: sync-rustfs-iot-insights-engine-credentials
       match:
         any:


### PR DESCRIPTION
## Context

Follow-up to #1117. The iot-insights-engine pilot is verified live on its per-app, bucket-scoped RustFS user — this removes the admin fallback clone, completing the cutover for this tenant (part of #1017).

## Live verification (rustfs 1.0.0-beta.8)

- `initialize-rustfs-users` Job created all 5 scoped users + `*-scoped` policies.
- Engine scoped key: read/write on its own bucket OK, **403 (AccessDenied)** on `authentik-backups` (list + put).
- `train-iforest` wrote 4 models to `iot-mcp-bridge-models`; `score-iforest` read them back — both on the scoped secret.

## Change

Remove the Kyverno rule `sync-iot-insights-engine-rustfs` (cloned `rustfs-admin-credentials` into the `iot-insights-engine` namespace). The engine no longer references it, so the admin key is dropped from the namespace — only the scoped clone remains.

The shared admin key stays in the `rustfs` namespace for in-namespace operators (bucket-init, nats-archive compactor).

## Out of scope

authentik, timescaledb, redpanda-connect, wiki-js cutovers + their admin-clone removals remain as follow-up PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
