### PR TITLE
feat(redpanda-connect): scoped rustfs credentials for cold-archive (#1017)

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/values.yaml
+++ b/kubernetes/applications/redpanda-connect/base/values.yaml
@@ -34,16 +34,17 @@ env:
       secretKeyRef:
         name: timescaledb-db-connect-secret
         key: password
-  # RustFS admin credentials for the cold-archive parquet output (cloned from rustfs namespace by Kyverno)
+  # RustFS per-app scoped credentials (write-only on nats-archive) for the
+  # cold-archive parquet output (cloned from rustfs namespace by Kyverno)
   - name: RUSTFS_ACCESS_KEY
     valueFrom:
       secretKeyRef:
-        name: rustfs-admin-credentials
+        name: rustfs-redpanda-connect-credentials
         key: RUSTFS_ACCESS_KEY
   - name: RUSTFS_SECRET_KEY
     valueFrom:
       secretKeyRef:
-        name: rustfs-admin-credentials
+        name: rustfs-redpanda-connect-credentials
         key: RUSTFS_SECRET_KEY
   # UniFi Protect local API key + target arm-profile ID for the unifi_arm_alarm stream
   - name: UNIFI_PROTECT_API_KEY

--- a/kubernetes/components/admission-controller/base/clusterpolicy-secrets.yaml
+++ b/kubernetes/components/admission-controller/base/clusterpolicy-secrets.yaml
@@ -304,6 +304,27 @@ spec:
           namespace: rustfs
           name: rustfs-admin-credentials
 
+    # Syncs the per-app, write-only-scoped RustFS credentials into redpanda-connect
+    # for the cold-archive parquet output. Replaces the shared admin clone above
+    # once the streams reference it; the admin clone stays as fallback during cutover.
+    - name: sync-rustfs-redpanda-connect-credentials
+      match:
+        any:
+          - resources:
+              kinds:
+                - Namespace
+              names:
+                - redpanda-connect
+      generate:
+        apiVersion: v1
+        kind: Secret
+        name: rustfs-redpanda-connect-credentials
+        namespace: redpanda-connect
+        synchronize: true
+        clone:
+          namespace: rustfs
+          name: rustfs-redpanda-connect-credentials
+
     # Syncs KNX NATS Bridge credentials from nats into knx-nats-bridge for NATS authentication
     - name: sync-knx-nats-bridge-credentials
       match:


### PR DESCRIPTION
## Context

Follow-up to the rustfs scoped-users migration (#1017), after the verified iot-insights-engine pilot (#1117/#1118). Cuts **redpanda-connect** over from the shared admin key to its own write-only scoped user.

## Change (cutover, fallback kept)

- `values.yaml`: stream env `RUSTFS_ACCESS_KEY`/`RUSTFS_SECRET_KEY` → `rustfs-redpanda-connect-credentials`.
- `clusterpolicy-secrets.yaml`: Kyverno clone rule for the scoped secret; **admin clone kept as fallback** for now.

The scoped user (`redpanda-connect`, policy `redpanda-connect-scoped` = `s3:PutObject` on `nats-archive/*` only) already exists server-side from `initialize-rustfs-users`.

## Post-merge verification (before removing the fallback)

redpanda-connect is write-only and benthos may probe the bucket on startup, so verify live:
1. redpanda-connect pods come up clean (no S3 `AccessDenied` in logs).
2. New parquet objects keep landing in `nats-archive` (object count climbs).

If benthos needs more than `PutObject` (e.g. a startup bucket probe), widen the `writeonly` policy in `initialize-rustfs-users.sh` accordingly.

## Follow-up

Once verified: remove the `sync-rustfs-admin-credentials-redpanda-connect` rule and delete the orphaned admin clone from the redpanda-connect namespace (Kyverno does not GC it on rule removal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
