### PR TITLE
docs(rustfs): drop issue-number refs from code comments

### DIFF
--- a/kubernetes/applications/rustfs/base/initialize-rustfs-users.yaml
+++ b/kubernetes/applications/rustfs/base/initialize-rustfs-users.yaml
@@ -1,5 +1,5 @@
-# Post-sync Job that provisions per-app, bucket-scoped RustFS IAM users
-# (issue #1017). Replaces the shared admin key for application tenants: every
+# Post-sync Job that provisions per-app, bucket-scoped RustFS IAM users.
+# Replaces the shared admin key for application tenants: every
 # consumer gets its own access key with a least-privilege policy limited to its
 # own bucket. The shared admin key stays only for in-namespace operators.
 #

--- a/kubernetes/applications/rustfs/base/scripts/initialize-rustfs-users.sh
+++ b/kubernetes/applications/rustfs/base/scripts/initialize-rustfs-users.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eu
 
-# Provisions per-app, bucket-scoped RustFS IAM users (issue #1017). Each consumer
+# Provisions per-app, bucket-scoped RustFS IAM users. Each consumer
 # gets its own access key with a least-privilege policy limited to its own bucket;
 # the shared admin key stays only for in-namespace operators (bucket-init,
 # nats-archive compactor).

--- a/kubernetes/components/admission-controller/base/clusterpolicy-secrets.yaml
+++ b/kubernetes/components/admission-controller/base/clusterpolicy-secrets.yaml
@@ -466,8 +466,8 @@ spec:
           name: timescaledb-db-iot-mcp-bridge-rw-secret
 
     # Syncs the per-app, bucket-scoped RustFS credentials into iot-insights-engine
-    # (issue #1017). Sole RustFS credential for this tenant — the shared admin
-    # clone was removed after the scoped-user cutover was verified end-to-end.
+    # — the sole RustFS credential for this tenant; the shared admin clone was
+    # removed after the scoped-user cutover was verified end-to-end.
     - name: sync-rustfs-iot-insights-engine-credentials
       match:
         any:


### PR DESCRIPTION
## Context

Convention cleanup for the rustfs scoped-users work: code/manifest comments should describe intent, not carry issue numbers (those belong in the commit/PR).

## Change

Drop the `(issue #1017)` references from three comments merged in #1117/#1118:
- `rustfs/base/initialize-rustfs-users.yaml` (Job header)
- `rustfs/base/scripts/initialize-rustfs-users.sh` (script header)
- `admission-controller/base/clusterpolicy-secrets.yaml` (iot-insights-engine scoped rule)

Comment-only change; `kustomize build` for rustfs and admission-controller unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
