### PR TITLE
chore(redpanda-connect): drop admin clone after scoped cutover (#1017)

### DIFF
--- a/kubernetes/components/admission-controller/base/clusterpolicy-secrets.yaml
+++ b/kubernetes/components/admission-controller/base/clusterpolicy-secrets.yaml
@@ -285,28 +285,9 @@ spec:
           namespace: rustfs
           name: rustfs-admin-credentials
 
-    # Syncs RustFS admin credentials from rustfs into redpanda-connect for the cold-archive parquet output
-    - name: sync-rustfs-admin-credentials-redpanda-connect
-      match:
-        any:
-          - resources:
-              kinds:
-                - Namespace
-              names:
-                - redpanda-connect
-      generate:
-        apiVersion: v1
-        kind: Secret
-        name: rustfs-admin-credentials
-        namespace: redpanda-connect
-        synchronize: true
-        clone:
-          namespace: rustfs
-          name: rustfs-admin-credentials
-
     # Syncs the per-app, write-only-scoped RustFS credentials into redpanda-connect
-    # for the cold-archive parquet output. Replaces the shared admin clone above
-    # once the streams reference it; the admin clone stays as fallback during cutover.
+    # for the cold-archive parquet output — the sole RustFS credential for this
+    # tenant; the shared admin clone was removed after the cutover was verified.
     - name: sync-rustfs-redpanda-connect-credentials
       match:
         any:


### PR DESCRIPTION
## Context

Follow-up to #1119. redpanda-connect's cold-archive cutover to its write-only scoped RustFS user is verified live, so this removes the admin fallback.

## Verification (live)

- benthos came up clean on the scoped key (`aws_s3` outputs active, **0 `AccessDenied`**, 0 restarts).
- Fresh parquet confirmed in `nats-archive` under the scoped key: `knx/2026/06/12/18/…parquet` written 18:01 (pod started 17:42).
- Write-only policy (`s3:PutObject` on `nats-archive/*`) is sufficient — no `GetBucketLocation`/`ListBucket` needed, `private` canned ACL works.

## Change

Remove the Kyverno rule `sync-rustfs-admin-credentials-redpanda-connect`. The scoped clone remains.

## Follow-up (manual, after sync)

Kyverno does not GC the already-generated Secret on rule removal — delete the orphan once synced:
`kubectl delete secret rustfs-admin-credentials -n redpanda-connect`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
