### PR TITLE
feat(authentik): scoped rustfs credentials for CNPG backups (#1017)

### DIFF
--- a/kubernetes/applications/authentik/base/database.yaml
+++ b/kubernetes/applications/authentik/base/database.yaml
@@ -93,10 +93,10 @@ spec:
     endpointURL: http://rustfs-svc.rustfs.svc.cluster.local:9000
     s3Credentials:
       accessKeyId:
-        name: rustfs-admin-credentials
+        name: rustfs-authentik-credentials
         key: RUSTFS_ACCESS_KEY
       secretAccessKey:
-        name: rustfs-admin-credentials
+        name: rustfs-authentik-credentials
         key: RUSTFS_SECRET_KEY
     wal:
       compression: bzip2

--- a/kubernetes/components/admission-controller/base/clusterpolicy-secrets.yaml
+++ b/kubernetes/components/admission-controller/base/clusterpolicy-secrets.yaml
@@ -228,6 +228,27 @@ spec:
           namespace: rustfs
           name: rustfs-admin-credentials
 
+    # Syncs the per-app, bucket-scoped RustFS credentials into authentik for WAL
+    # archiving/backup. Replaces the shared admin clone above once the ObjectStore
+    # references it; the admin clone stays as fallback during cutover.
+    - name: sync-rustfs-authentik-credentials
+      match:
+        any:
+          - resources:
+              kinds:
+                - Namespace
+              names:
+                - authentik
+      generate:
+        apiVersion: v1
+        kind: Secret
+        name: rustfs-authentik-credentials
+        namespace: authentik
+        synchronize: true
+        clone:
+          namespace: rustfs
+          name: rustfs-authentik-credentials
+
     # Syncs SolarEdge2MQTT credentials from nats into solaredge2mqtt for MQTT authentication
     - name: sync-solaredge2mqtt-credentials
       match:


### PR DESCRIPTION
## Context

Follow-up in the rustfs scoped-users migration (#1017), after the verified iot-insights-engine (#1117/#1118) and redpanda-connect (#1119/#1121) cutovers. Cuts **authentik** (CNPG/barman) over to its own read-write scoped user.

## Change (cutover, fallback kept)

- `database.yaml`: ObjectStore `s3Credentials` → `rustfs-authentik-credentials`.
- `clusterpolicy-secrets.yaml`: Kyverno clone rule for the scoped secret; **admin clone kept as fallback** for now.

The scoped user (`authentik`, policy `authentik-scoped` = RW on `authentik-backups` only) already exists server-side from `initialize-rustfs-users`.

## Post-merge verification (before removing the fallback)

CNPG/barman needs Get/Put/Delete/List — verify a full round-trip:
1. WAL archiving continues (no errors in the CNPG cluster / barman sidecar logs).
2. Trigger an on-demand `Backup` and confirm base backup + WALs land in `authentik-backups` under the scoped key.
3. Ideally validate a restore into a scratch cluster.

## Follow-up

Once verified: remove the `sync-rustfs-admin-credentials-authentik` rule and delete the orphaned admin clone from the authentik namespace (Kyverno does not GC it on rule removal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
