### PR TITLE
chore(authentik): drop admin clone after scoped cutover (#1017)

### DIFF
--- a/kubernetes/components/admission-controller/base/clusterpolicy-secrets.yaml
+++ b/kubernetes/components/admission-controller/base/clusterpolicy-secrets.yaml
@@ -209,28 +209,9 @@ spec:
           namespace: authentik
           name: node-red-oidc-secret
 
-    # Syncs RustFS admin credentials from rustfs into authentik for WAL archiving/backup
-    - name: sync-rustfs-admin-credentials-authentik
-      match:
-        any:
-          - resources:
-              kinds:
-                - Namespace
-              names:
-                - authentik
-      generate:
-        apiVersion: v1
-        kind: Secret
-        name: rustfs-admin-credentials
-        namespace: authentik
-        synchronize: true
-        clone:
-          namespace: rustfs
-          name: rustfs-admin-credentials
-
     # Syncs the per-app, bucket-scoped RustFS credentials into authentik for WAL
-    # archiving/backup. Replaces the shared admin clone above once the ObjectStore
-    # references it; the admin clone stays as fallback during cutover.
+    # archiving/backup — the sole RustFS credential for this tenant; the shared
+    # admin clone was removed after the cutover was verified (WAL + backup).
     - name: sync-rustfs-authentik-credentials
       match:
         any:


### PR DESCRIPTION
## Context

Follow-up to #1122. authentik's CNPG/barman cutover to its bucket-scoped RustFS user is verified live, so this removes the admin fallback.

## Verification (live)

- ObjectStore re-pointed to `rustfs-authentik-credentials`; `ContinuousArchiving=True` stayed green after the switch (WAL archiving on the scoped key).
- On-demand `Backup` **completed** against `authentik-backups` on the scoped key (no error) — RW policy (`Get/Put/Delete/ListBucket/GetBucketLocation`) is sufficient for barman; credentials picked up without a pod restart.

## Change

Remove the Kyverno rule `sync-rustfs-admin-credentials-authentik`. The scoped clone remains.

## Follow-up (manual, after sync)

Kyverno does not GC the already-generated Secret on rule removal:
`kubectl delete secret rustfs-admin-credentials -n authentik`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
