### PR TITLE
feat(wiki-js): scoped rustfs credentials for CNPG backups (#1017)

### DIFF
--- a/kubernetes/applications/wiki-js/base/database.yaml
+++ b/kubernetes/applications/wiki-js/base/database.yaml
@@ -93,10 +93,10 @@ spec:
     endpointURL: http://rustfs-svc.rustfs.svc.cluster.local:9000
     s3Credentials:
       accessKeyId:
-        name: rustfs-admin-credentials
+        name: rustfs-wiki-js-credentials
         key: RUSTFS_ACCESS_KEY
       secretAccessKey:
-        name: rustfs-admin-credentials
+        name: rustfs-wiki-js-credentials
         key: RUSTFS_SECRET_KEY
     wal:
       compression: bzip2

--- a/kubernetes/components/admission-controller/base/clusterpolicy-secrets.yaml
+++ b/kubernetes/components/admission-controller/base/clusterpolicy-secrets.yaml
@@ -268,6 +268,27 @@ spec:
           namespace: rustfs
           name: rustfs-admin-credentials
 
+    # Syncs the per-app, bucket-scoped RustFS credentials into wiki-js for WAL
+    # archiving/backup. Replaces the shared admin clone above once the ObjectStore
+    # references it; the admin clone stays as fallback during cutover.
+    - name: sync-rustfs-wiki-js-credentials
+      match:
+        any:
+          - resources:
+              kinds:
+                - Namespace
+              names:
+                - wiki-js
+      generate:
+        apiVersion: v1
+        kind: Secret
+        name: rustfs-wiki-js-credentials
+        namespace: wiki-js
+        synchronize: true
+        clone:
+          namespace: rustfs
+          name: rustfs-wiki-js-credentials
+
     # Syncs RustFS admin credentials from rustfs into timescaledb for WAL archiving/backup
     - name: sync-rustfs-admin-credentials-timescaledb
       match:


### PR DESCRIPTION
## Context

Follow-up in the rustfs scoped-users migration (#1017). Cuts **wiki-js** (CNPG/barman) over to its own read-write scoped user — the 4th of 5 consumers (iot-insights-engine, redpanda-connect, authentik already done).

## Change (cutover, fallback kept)

- `database.yaml`: ObjectStore `s3Credentials` → `rustfs-wiki-js-credentials`.
- `clusterpolicy-secrets.yaml`: Kyverno clone rule for the scoped secret; **admin clone kept as fallback**.

The scoped user (`wiki-js`, policy `wiki-js-scoped` = RW on `wiki-js-backups`) already exists server-side; the `wiki-js-backups` bucket is created by the bucket-init job (added in #1117).

## Post-merge verification (before removing the fallback)

1. `ContinuousArchiving=True` stays green after the ObjectStore re-point.
2. On-demand `Backup` completes against `wiki-js-backups` on the scoped key.

## Follow-up

Once verified: remove `sync-rustfs-admin-credentials-wiki-js` and delete the orphaned admin clone from the wiki-js namespace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
