### PR TITLE
chore(wiki-js): drop admin clone after scoped cutover (#1017)

### DIFF
--- a/kubernetes/components/admission-controller/base/clusterpolicy-secrets.yaml
+++ b/kubernetes/components/admission-controller/base/clusterpolicy-secrets.yaml
@@ -249,28 +249,9 @@ spec:
           namespace: nats
           name: solaredge2mqtt-credentials
 
-    # Syncs RustFS admin credentials from rustfs into wiki-js for WAL archiving/backup
-    - name: sync-rustfs-admin-credentials-wiki-js
-      match:
-        any:
-          - resources:
-              kinds:
-                - Namespace
-              names:
-                - wiki-js
-      generate:
-        apiVersion: v1
-        kind: Secret
-        name: rustfs-admin-credentials
-        namespace: wiki-js
-        synchronize: true
-        clone:
-          namespace: rustfs
-          name: rustfs-admin-credentials
-
     # Syncs the per-app, bucket-scoped RustFS credentials into wiki-js for WAL
-    # archiving/backup. Replaces the shared admin clone above once the ObjectStore
-    # references it; the admin clone stays as fallback during cutover.
+    # archiving/backup — the sole RustFS credential for this tenant; the shared
+    # admin clone was removed after the cutover was verified (WAL + backup).
     - name: sync-rustfs-wiki-js-credentials
       match:
         any:


### PR DESCRIPTION
## Context

Follow-up to #1125. wiki-js's CNPG/barman cutover to its bucket-scoped RustFS user is verified live, so this removes the admin fallback.

## Verification (live)

- ObjectStore re-pointed to `rustfs-wiki-js-credentials`; `ContinuousArchiving=True` stayed green.
- On-demand `Backup` **completed** against `wiki-js-backups` on the scoped key (no error).

## Change

Remove the Kyverno rule `sync-rustfs-admin-credentials-wiki-js`. The scoped clone remains.

## Follow-up (manual, after sync)

`kubectl delete secret rustfs-admin-credentials -n wiki-js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
