### PR TITLE
feat(timescaledb): scoped rustfs credentials for CNPG backups (#1017)

### DIFF
--- a/kubernetes/applications/timescaledb/base/database.yaml
+++ b/kubernetes/applications/timescaledb/base/database.yaml
@@ -125,10 +125,10 @@ spec:
     endpointURL: http://rustfs-svc.rustfs.svc.cluster.local:9000
     s3Credentials:
       accessKeyId:
-        name: rustfs-admin-credentials
+        name: rustfs-timescaledb-credentials
         key: RUSTFS_ACCESS_KEY
       secretAccessKey:
-        name: rustfs-admin-credentials
+        name: rustfs-timescaledb-credentials
         key: RUSTFS_SECRET_KEY
     wal:
       compression: bzip2

--- a/kubernetes/components/admission-controller/base/clusterpolicy-secrets.yaml
+++ b/kubernetes/components/admission-controller/base/clusterpolicy-secrets.yaml
@@ -289,6 +289,27 @@ spec:
           namespace: rustfs
           name: rustfs-admin-credentials
 
+    # Syncs the per-app, bucket-scoped RustFS credentials into timescaledb for WAL
+    # archiving/backup. Replaces the shared admin clone above once the ObjectStore
+    # references it; the admin clone stays as fallback during cutover.
+    - name: sync-rustfs-timescaledb-credentials
+      match:
+        any:
+          - resources:
+              kinds:
+                - Namespace
+              names:
+                - timescaledb
+      generate:
+        apiVersion: v1
+        kind: Secret
+        name: rustfs-timescaledb-credentials
+        namespace: timescaledb
+        synchronize: true
+        clone:
+          namespace: rustfs
+          name: rustfs-timescaledb-credentials
+
     # Syncs the per-app, write-only-scoped RustFS credentials into redpanda-connect
     # for the cold-archive parquet output — the sole RustFS credential for this
     # tenant; the shared admin clone was removed after the cutover was verified.


### PR DESCRIPTION
## Context

Final consumer in the rustfs scoped-users migration (#1017). Cuts **timescaledb** (CNPG/barman) over to its own read-write scoped user. iot-insights-engine, redpanda-connect, authentik and wiki-js are already done.

## Change (cutover, fallback kept)

- `database.yaml`: ObjectStore `s3Credentials` → `rustfs-timescaledb-credentials`.
- `clusterpolicy-secrets.yaml`: Kyverno clone rule for the scoped secret; **admin clone kept as fallback**.

The scoped user (`timescaledb`, policy `timescaledb-scoped` = RW on `timescaledb-backups`) already exists server-side.

## Post-merge verification (before removing the fallback)

This is the homelab's primary time-series DB, so verify carefully:
1. `ContinuousArchiving=True` stays green after the ObjectStore re-point.
2. On-demand `Backup` completes against `timescaledb-backups` on the scoped key.

## Follow-up

Once verified: remove `sync-rustfs-admin-credentials-timescaledb`, delete the orphaned admin clone from the timescaledb namespace — and the migration is complete (root admin key then stays only for in-namespace operators: bucket-init, nats-archive compactor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
