### PR TITLE
chore(timescaledb): drop admin clone — scoped-users migration complete (#1017)

### DIFF
--- a/kubernetes/components/admission-controller/base/clusterpolicy-secrets.yaml
+++ b/kubernetes/components/admission-controller/base/clusterpolicy-secrets.yaml
@@ -270,28 +270,9 @@ spec:
           namespace: rustfs
           name: rustfs-wiki-js-credentials
 
-    # Syncs RustFS admin credentials from rustfs into timescaledb for WAL archiving/backup
-    - name: sync-rustfs-admin-credentials-timescaledb
-      match:
-        any:
-          - resources:
-              kinds:
-                - Namespace
-              names:
-                - timescaledb
-      generate:
-        apiVersion: v1
-        kind: Secret
-        name: rustfs-admin-credentials
-        namespace: timescaledb
-        synchronize: true
-        clone:
-          namespace: rustfs
-          name: rustfs-admin-credentials
-
     # Syncs the per-app, bucket-scoped RustFS credentials into timescaledb for WAL
-    # archiving/backup. Replaces the shared admin clone above once the ObjectStore
-    # references it; the admin clone stays as fallback during cutover.
+    # archiving/backup — the sole RustFS credential for this tenant; the shared
+    # admin clone was removed after the cutover was verified (WAL + backup).
     - name: sync-rustfs-timescaledb-credentials
       match:
         any:


### PR DESCRIPTION
## Context

Final step of the rustfs scoped-users migration (#1017). timescaledb's cutover to its bucket-scoped RustFS user is verified live, so this removes its admin fallback — and with it, the **last** `sync-rustfs-admin-credentials-*` clone.

## Verification (live)

- ObjectStore re-pointed to `rustfs-timescaledb-credentials`; `ContinuousArchiving=True` stayed green.
- On-demand `Backup` **completed** against `timescaledb-backups` on the scoped key (base backup streamed, `beginWal` set, ~11 min for the time-series DB, no error).

## Change

Remove the Kyverno rule `sync-rustfs-admin-credentials-timescaledb`. After this, **zero** admin clones remain; all 5 consumers run on their own bucket-scoped least-privilege users.

## Result — migration complete

The shared `rustfs-admin-credentials` now stays only in the `rustfs` namespace for in-namespace operators (bucket-init, nats-archive compactor). No application namespace holds the admin key anymore.

## Follow-up (manual, after sync)

`kubectl delete secret rustfs-admin-credentials -n timescaledb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
