### PR TITLE
fix(fritz-exporter): HTTP liveness probe to catch wedged scrapes

### DIFF
--- a/kubernetes/applications/fritz-exporter/base/values.yaml
+++ b/kubernetes/applications/fritz-exporter/base/values.yaml
@@ -48,13 +48,19 @@ deployment:
     periodSeconds: 30
     failureThreshold: 3
 
+  # HTTP liveness so a wedged-but-listening exporter (TCP stays green while /metrics
+  # hangs on a stuck TR-064 call) gets restarted. Generous timeout + failureThreshold
+  # avoid false positives on a normal ~15s scrape. Readiness stays TCP-only so a slow
+  # scrape never drops the pod from Service endpoints (spurious TargetDown).
   livenessProbe:
     enabled: true
-    tcpSocket:
+    httpGet:
+      path: /metrics
       port: metrics
-    initialDelaySeconds: 30
-    periodSeconds: 60
-    failureThreshold: 5
+    initialDelaySeconds: 60
+    periodSeconds: 120
+    timeoutSeconds: 30
+    failureThreshold: 3
 
   resources:
     # Ensure Burstable QoS (no BestEffort) and prevent runaway usage.


### PR DESCRIPTION
## Problem

A firing `TargetDown` alert showed `fritz-exporter` at `up == 0` for >10 min. Investigation found:

- Pod `Running 1/1`, 0 restarts, FRITZ!Box healthy (TR-064 `tr64desc.xml` answers in ~8 ms).
- `/metrics` hung past the 30 s scrape timeout (normal scrape ~15 s) → `up == 0`.
- Exporter logged nothing since startup ~2 days earlier — the single-threaded `/metrics` handler was wedged on a stuck TR-064 call (`pdreker/fritz_exporter` has no per-call timeout).
- The **TCP-only liveness probe stayed green** (port still listening), so the wedged exporter was never restarted.

Pod was restarted manually to restore metrics; this PR prevents recurrence.

## Change

- Liveness probe → `httpGet /metrics` so a wedged-but-listening exporter gets restarted.
- `timeoutSeconds: 30` (~2× normal scrape) + `failureThreshold: 3` at low frequency → only a sustained hang restarts; a normal/transiently-slow scrape does not.
- Readiness stays **TCP-only** on purpose: an HTTP readiness would drop the pod from Service endpoints on a slow scrape and cause a spurious `TargetDown`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)