### PR TITLE
fix(homepage): allow probe host so HOMEPAGE_ALLOWED_HOSTS validates

### DIFF
--- a/kubernetes/applications/homepage/base/values.yaml
+++ b/kubernetes/applications/homepage/base/values.yaml
@@ -15,14 +15,11 @@ deployment:
     pullPolicy: IfNotPresent
 
   env:
-    # Required for Kubernetes liveness probes — pod IP must be in HOMEPAGE_ALLOWED_HOSTS.
-    MY_POD_IP:
-      valueFrom:
-        fieldRef:
-          fieldPath: status.podIP
-    # Domain injected via overlay replacement (delimiter: ",", index: 1).
+    # Host validation: kubelet probes send a static "localhost:3000" Host header (set on the
+    # liveness/readinessProbe below), so a fixed entry suffices instead of the dynamic pod IP.
+    # The public domain is injected via overlay replacement (delimiter: ",", index: 1).
     HOMEPAGE_ALLOWED_HOSTS:
-      value: "$(MY_POD_IP):3000,PLACEHOLDER"
+      value: "localhost:3000,PLACEHOLDER"
     # Authentik API token — cloned from authentik namespace by Kyverno.
     HOMEPAGE_VAR_AUTHENTIK_KEY:
       valueFrom:
@@ -95,6 +92,10 @@ deployment:
     httpGet:
       path: /api/healthcheck
       port: http
+      # Static Host header so the request matches HOMEPAGE_ALLOWED_HOSTS instead of the pod IP.
+      httpHeaders:
+        - name: Host
+          value: localhost:3000
     initialDelaySeconds: 5
     periodSeconds: 15
 
@@ -105,6 +106,10 @@ deployment:
     httpGet:
       path: /api/healthcheck
       port: http
+      # Static Host header so the request matches HOMEPAGE_ALLOWED_HOSTS instead of the pod IP.
+      httpHeaders:
+        - name: Host
+          value: localhost:3000
     initialDelaySeconds: 5
     periodSeconds: 15
 


### PR DESCRIPTION
## Problem

`homepage-prod` pod logs:

```
Host validation failed for: 10.244.2.233:3000.
Hint: Set the HOMEPAGE_ALLOWED_HOSTS environment variable...
```

The stakater/application chart renders `deployment.env` from a **map**, which Helm iterates in **alphabetical key order**. So `HOMEPAGE_ALLOWED_HOSTS` (`H`) is emitted *before* `MY_POD_IP` (`M`). Kubernetes only expands `$(VAR)` references to env vars defined **earlier** in the list, so `$(MY_POD_IP)` is left as a literal string. The allowed-hosts list ended up containing the literal `$(MY_POD_IP):3000`, which never matches the real pod IP → kubelet probes fail host validation.

### Why now
The env config worked when it was a raw Deployment manifest (env was an ordered **list**, `MY_POD_IP` before `HOMEPAGE_ALLOWED_HOSTS`). The regression was introduced when the app migrated to the stakater/application chart and env became a map — the ordering assumption silently broke.

## Fix

Drop the dynamic pod-IP substitution entirely:
- Give the liveness/readiness probes a static `Host: localhost:3000` header.
- Allow that fixed value via `HOMEPAGE_ALLOWED_HOSTS: "localhost:3000,PLACEHOLDER"`.

This removes the fragile cross-env-var ordering dependency and keeps the real `/api/healthcheck` HTTP probe.

## Verification

`kustomize build --enable-helm` for both overlays:
- **prod:** `HOMEPAGE_ALLOWED_HOSTS: localhost:3000,www.zimmermann.sh`
- **dev:** `HOMEPAGE_ALLOWED_HOSTS: localhost:3000,www.zimmermann.phd`
- Both probes carry `Host: localhost:3000`; no more `$(MY_POD_IP)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)