### PR TITLE
feat(knx-nats-bridge): enable read responder

### DIFF
--- a/kubernetes/applications/knx-nats-bridge/base/values.yaml
+++ b/kubernetes/applications/knx-nats-bridge/base/values.yaml
@@ -37,6 +37,11 @@ deployment:
       value: "true"
     BRIDGE_WRITER_RULES_PATH:
       value: /etc/knx-nats-bridge/writer-rules.yaml
+    # Answer GroupValueRead for the written GAs with the last value on the bus,
+    # so a Basalte panel polling on startup gets a value for slow-changing
+    # datapoints (DHW setpoint, system pressure) instead of a default 0.
+    BRIDGE_READ_RESPONDER_ENABLED:
+      value: "true"
     LOG_FORMAT:
       value: json
     METRICS_PORT:


### PR DESCRIPTION
Set `BRIDGE_READ_RESPONDER_ENABLED=true` so the bridge answers `GroupValueRead` for the GAs it writes with the last value it put on the bus.

A Basalte panel polling those GAs on startup then gets a value for slow-changing datapoints (DHW setpoint `15/2/17`, system pressure `15/2/20`) instead of a default `0` — the values already live in NATS/TSDB but Basalte never received a startup response for them.

Requires bridge image `>= 0.10.0` (knx-nats-bridge#63), bumped by #1140. Older images ignore the unknown env var (`extra="ignore"`), so this is safe to merge in either order relative to #1140; the flag activates once 0.10.0 is deployed.

Touches a different line in `values.yaml` than #1140 (env block vs image tag), so the two merge without conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)