### PR TITLE
feat(knx-bridge): route PV + Wallbox anomalies to KNX (Phase B1)

### DIFF
--- a/kubernetes/applications/knx-nats-bridge/base/config/writer-rules.yaml
+++ b/kubernetes/applications/knx-nats-bridge/base/config/writer-rules.yaml
@@ -544,3 +544,67 @@ mappings:
     payload_path: "$.severity_level"
     description: "Schalten.EG.Küche.K15-L1.Gefrierschrank.Stromwert-Dauerbetrieb-Anomalie"
     min_delta: 0
+
+  # Phase B1: Photovoltaik (per Wechselrichter via entity inv1/inv2; grid/
+  # consumer are house-level → no entity, needs engine >= 1.4.0) + Wallbox
+  # (single meter_id 0).
+  - subject: "anomaly.pv_iforest.inv1"
+    ga: "15/4/20"
+    dpt: "5.010"
+    payload_path: "$.severity_level"
+    description: "Versorgungstechnik.Photovoltaik.Wechselrichter-1.Anomalie-Gesamt"
+    min_delta: 0
+  - subject: "anomaly.pv_production.inv1"
+    ga: "15/4/22"
+    dpt: "5.010"
+    payload_path: "$.severity_level"
+    description: "Versorgungstechnik.Photovoltaik.Wechselrichter-1.Leistung-Anomalie"
+    min_delta: 0
+  - subject: "anomaly.solar_inverter_temperature.inv1"
+    ga: "15/4/24"
+    dpt: "5.010"
+    payload_path: "$.severity_level"
+    description: "Versorgungstechnik.Photovoltaik.Wechselrichter-1.Temperatur-Anomalie"
+    min_delta: 0
+  - subject: "anomaly.pv_iforest.inv2"
+    ga: "15/4/40"
+    dpt: "5.010"
+    payload_path: "$.severity_level"
+    description: "Versorgungstechnik.Photovoltaik.Wechselrichter-2.Anomalie-Gesamt"
+    min_delta: 0
+  - subject: "anomaly.pv_production.inv2"
+    ga: "15/4/42"
+    dpt: "5.010"
+    payload_path: "$.severity_level"
+    description: "Versorgungstechnik.Photovoltaik.Wechselrichter-2.Leistung-Anomalie"
+    min_delta: 0
+  - subject: "anomaly.solar_inverter_temperature.inv2"
+    ga: "15/4/44"
+    dpt: "5.010"
+    payload_path: "$.severity_level"
+    description: "Versorgungstechnik.Photovoltaik.Wechselrichter-2.Temperatur-Anomalie"
+    min_delta: 0
+  - subject: "anomaly.grid_power"
+    ga: "15/4/1"
+    dpt: "5.010"
+    payload_path: "$.severity_level"
+    description: "Versorgungstechnik.Photovoltaik.Netz-Leistung-Anomalie"
+    min_delta: 0
+  - subject: "anomaly.consumer_total"
+    ga: "15/4/3"
+    dpt: "5.010"
+    payload_path: "$.severity_level"
+    description: "Versorgungstechnik.Photovoltaik.Verbrauch-Gesamt-Anomalie"
+    min_delta: 0
+  - subject: "anomaly.wallbox_iforest.meter0"
+    ga: "15/6/5"
+    dpt: "5.010"
+    payload_path: "$.severity_level"
+    description: "Versorgungstechnik.Wallbox.Anomalie-Gesamt"
+    min_delta: 0
+  - subject: "anomaly.wallbox_power_total.meter0"
+    ga: "15/6/13"
+    dpt: "5.010"
+    payload_path: "$.severity_level"
+    description: "Versorgungstechnik.Wallbox.Ladeleistung-Anomalie"
+    min_delta: 0


### PR DESCRIPTION
## What
Writer-rules for the grouped PV + Wallbox anomaly UCs — `severity_level` (0..3, DPT 5.010, write-on-change). A Basalte LUT turns the tier into an app notification.

| Subject | → GA | Datapoint |
|---|---|---|
| `anomaly.pv_iforest.inv1/.inv2` | 15/4/20, 40 | Wechselrichter Anomalie-Gesamt |
| `anomaly.pv_production.inv1/.inv2` | 15/4/22, 42 | Wechselrichter Leistung-Anomalie |
| `anomaly.solar_inverter_temperature.inv1/.inv2` | 15/4/24, 44 | Wechselrichter Temperatur-Anomalie |
| `anomaly.grid_power` | 15/4/1 | Netz-Leistung-Anomalie |
| `anomaly.consumer_total` | 15/4/3 | Verbrauch-Gesamt-Anomalie |
| `anomaly.wallbox_iforest.meter0` | 15/6/5 | Wallbox Anomalie-Gesamt |
| `anomaly.wallbox_power_total.meter0` | 15/6/13 | Wallbox Ladeleistung-Anomalie |

## Dependency / ordering
- `grid_power` / `consumer_total` subscribe on `anomaly.<uc>` (no entity) → need **engine >= 1.4.0** (PR #1156). The 8 per-inverter + Wallbox rules already route under 1.3.0; the two house-level rules sit idle until v1.4.0 is deployed, then route — no breakage either way.
- Builds on the Phase A anomaly rules already on main (#1155).

## Verification
All 105 writer-rules match the catalog by name + DPT, no duplicate GA, schema-valid. Bridge has no Stakater Reloader in-cluster → needs a `rollout restart` after the ConfigMap syncs (tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)