### PR TITLE
fix(knx-bridge): add Badezimmer-Kinder fbh_cold anomaly (6/3/48)

### DIFF
--- a/kubernetes/applications/knx-nats-bridge/base/config/ga-catalog.yaml
+++ b/kubernetes/applications/knx-nats-bridge/base/config/ga-catalog.yaml
@@ -8534,7 +8534,7 @@
 6/3/48:
   dpt: '5.010'
   function: Raumklima
-  name: Raumklima.OG.Badezimmer-Kinder..FBHAktiv-Anomalie
+  name: Raumklima.OG.Badezimmer-Kinder.FBH.Aktiv-Anomalie
   room: Badezimmer Kinder
 6/3/49:
   dpt: '5.010'

--- a/kubernetes/applications/knx-nats-bridge/base/config/writer-rules.yaml
+++ b/kubernetes/applications/knx-nats-bridge/base/config/writer-rules.yaml
@@ -959,6 +959,12 @@ mappings:
     payload_path: "$.severity_level"
     description: "Raumklima.OG.Abstellraum.FBH.Aktiv-Fenster-Auf-Anomalie"
     min_delta: 0
+  - subject: "anomaly.fbh_cold.og-badezimmer-kinder"
+    ga: "6/3/48"
+    dpt: "5.010"
+    payload_path: "$.severity_level"
+    description: "Raumklima.OG.Badezimmer-Kinder.FBH.Aktiv-Anomalie"
+    min_delta: 0
   - subject: "anomaly.window_while_heating.og-badezimmer-kinder"
     ga: "6/3/49"
     dpt: "5.010"


### PR DESCRIPTION
Follow-up to Phase B3 (#1160). The `6/3/48` GA name was malformed in the ETS export (`Raumklima.OG.Badezimmer-Kinder..FBHAktiv-Anomalie` — double dot + missing dot) and was held back. ETS is now fixed and the catalog regenerated to `Raumklima.OG.Badezimmer-Kinder.FBH.Aktiv-Anomalie`.

This adds:
- the 1-line catalog correction (regenerated),
- the matching writer-rule `anomaly.fbh_cold.og-badezimmer-kinder` → 6/3/48.

Completes per-room Raumklima routing — every EG/OG room now has both `fbh_cold` + `window_while_heating`. Verified: 174 rules, all match the catalog by name + DPT, every anomaly subject hits exactly one GA, schema-valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)