### PR TITLE
feat(knx-bridge): publish WARP wallbox raw telemetry to KNX

### DIFF
--- a/kubernetes/applications/knx-nats-bridge/base/config/ga-catalog.yaml
+++ b/kubernetes/applications/knx-nats-bridge/base/config/ga-catalog.yaml
@@ -2414,12 +2414,12 @@
 15/6/0:
   dpt: '5.010'
   function: Versorgungstechnik
-  name: Versorgungstechnik.Wallbox.Fehler-Status
+  name: Versorgungstechnik.Wallbox.Fehlerzustand-Status
   room: Garage
 15/6/1:
-  dpt: '5.010'
+  dpt: '16.001'
   function: Versorgungstechnik
-  name: Versorgungstechnik.Wallbox.Lade-Status
+  name: Versorgungstechnik.Wallbox.Fehlerzustand-Statustext
   room: Garage
 15/6/10:
   dpt: '7.012'
@@ -2459,22 +2459,47 @@
 15/6/2:
   dpt: '5.010'
   function: Versorgungstechnik
-  name: Versorgungstechnik.Wallbox.IEC61851-Status
+  name: Versorgungstechnik.Wallbox.Ladecontroller-Status
   room: Garage
-15/6/3:
+15/6/20:
   dpt: '5.010'
   function: Versorgungstechnik
-  name: Versorgungstechnik.Wallbox.DC-Fehlerstrom-Status
+  name: Versorgungstechnik.Wallbox.Anomalie-Gesamt
+  room: Garage
+15/6/3:
+  dpt: '16.001'
+  function: Versorgungstechnik
+  name: Versorgungstechnik.Wallbox.Ladecontroller-Statustext
   room: Garage
 15/6/4:
   dpt: '5.010'
   function: Versorgungstechnik
-  name: Versorgungstechnik.Wallbox.Schütz-Fehler
+  name: Versorgungstechnik.Wallbox.IEC61851-Status
   room: Garage
 15/6/5:
+  dpt: '16.001'
+  function: Versorgungstechnik
+  name: Versorgungstechnik.Wallbox.IEC61851-Statustext
+  room: Garage
+15/6/6:
   dpt: '5.010'
   function: Versorgungstechnik
-  name: Versorgungstechnik.Wallbox.Anomalie-Gesamt
+  name: Versorgungstechnik.Wallbox.DC-Fehlerstrom-Status
+  room: Garage
+15/6/7:
+  dpt: '16.001'
+  function: Versorgungstechnik
+  name: Versorgungstechnik.Wallbox.DC-Fehlerstrom-Statustext
+  room: Garage
+15/6/8:
+  dpt: '5.010'
+  function: Versorgungstechnik
+  name: Versorgungstechnik.Wallbox.Schütz-Fehler
+  room: Garage
+15/6/9:
+  dpt: '16.001'
+  function: Versorgungstechnik
+  name: Versorgungstechnik.Wallbox.Schütz-Fehlertext
   room: Garage
 16/0/240:
   dpt: '1.011'

--- a/kubernetes/applications/knx-nats-bridge/base/config/ga-catalog.yaml
+++ b/kubernetes/applications/knx-nats-bridge/base/config/ga-catalog.yaml
@@ -2444,7 +2444,17 @@
 15/6/14:
   dpt: '13.013'
   function: Versorgungstechnik
-  name: Versorgungstechnik.Wallbox.Geladene-Energie
+  name: Versorgungstechnik.Wallbox.Energie.Geladen-Aktuell
+  room: Garage
+15/6/15:
+  dpt: '13.010'
+  function: Versorgungstechnik
+  name: Versorgungstechnik.Wallbox.Energie.Zählerstand-Aktuell
+  room: Garage
+15/6/16:
+  dpt: '13.010'
+  function: Versorgungstechnik
+  name: Versorgungstechnik.Wallbox.Energie.Zählerstand-Ladebeginn
   room: Garage
 15/6/2:
   dpt: '5.010'

--- a/kubernetes/applications/knx-nats-bridge/base/config/writer-rules.yaml
+++ b/kubernetes/applications/knx-nats-bridge/base/config/writer-rules.yaml
@@ -444,6 +444,37 @@ mappings:
     min_delta: 100  # mA
     min_delta_pct: 2
 
+  # WARP meter raw telemetry (republished by redpanda-connect
+  # warp_knx_republish from the warp.meters.0.values array). Charged energy of
+  # the current charge is computed in Basalte as Zählerstand-Aktuell minus
+  # Zählerstand-Ladebeginn — both raw counters published here in Wh.
+  - subject: "wallbox.knx.meter"
+    ga: "15/6/10"
+    dpt: "7.012"
+    payload_path: "$.ladestrom"
+    description: "Versorgungstechnik.Wallbox.Ladestrom"
+    min_delta: 100  # mA
+    min_delta_pct: 2
+  - subject: "wallbox.knx.meter"
+    ga: "15/6/12"
+    dpt: "14.056"
+    payload_path: "$.ladeleistung"
+    description: "Versorgungstechnik.Wallbox.Ladeleistung"
+    min_delta: 25  # W
+    min_delta_pct: 2
+  - subject: "wallbox.knx.meter"
+    ga: "15/6/15"
+    dpt: "13.010"
+    payload_path: "$.zaehlerstand_aktuell"
+    description: "Versorgungstechnik.Wallbox.Energie.Zählerstand-Aktuell"
+    min_delta: 10  # Wh
+  - subject: "wallbox.knx.charge"
+    ga: "15/6/16"
+    dpt: "13.010"
+    payload_path: "$.zaehlerstand_ladebeginn"
+    description: "Versorgungstechnik.Wallbox.Energie.Zählerstand-Ladebeginn"
+    min_delta: 0  # changes only per charge: write on change
+
   # SolarEdge PV (15/4: 0..3 system-wide, 20..24 Wechselrichter 1, 40..44 Wechselrichter 2)
   - subject: "solaredge-1.powerflow"
     ga: "15/4/0"

--- a/kubernetes/applications/knx-nats-bridge/base/config/writer-rules.yaml
+++ b/kubernetes/applications/knx-nats-bridge/base/config/writer-rules.yaml
@@ -407,13 +407,13 @@ mappings:
 
   # WARP wallbox
   - subject: "warp.evse.state"
-    ga: "15/6/1"
+    ga: "15/6/2"
     dpt: "5.010"
     payload_path: "$.charger_state"
-    description: "Versorgungstechnik.Wallbox.Lade-Status"
+    description: "Versorgungstechnik.Wallbox.Ladecontroller-Status"
     min_delta: 0  # enum state: write only on change
   - subject: "warp.evse.state"
-    ga: "15/6/2"
+    ga: "15/6/4"
     dpt: "5.010"
     payload_path: "$.iec61851_state"
     description: "Versorgungstechnik.Wallbox.IEC61851-Status"
@@ -422,16 +422,16 @@ mappings:
     ga: "15/6/0"
     dpt: "5.010"
     payload_path: "$.error_state"
-    description: "Versorgungstechnik.Wallbox.Fehler-Status"
+    description: "Versorgungstechnik.Wallbox.Fehlerzustand-Status"
     min_delta: 0  # enum state: write only on change
   - subject: "warp.evse.state"
-    ga: "15/6/4"
+    ga: "15/6/8"
     dpt: "5.010"
     payload_path: "$.contactor_error"
     description: "Versorgungstechnik.Wallbox.Schütz-Fehler"
     min_delta: 0  # enum state: write only on change
   - subject: "warp.evse.state"
-    ga: "15/6/3"
+    ga: "15/6/6"
     dpt: "5.010"
     payload_path: "$.dc_fault_current_state"
     description: "Versorgungstechnik.Wallbox.DC-Fehlerstrom-Status"
@@ -628,7 +628,7 @@ mappings:
     description: "Versorgungstechnik.Photovoltaik.Verbrauch-Gesamt-Anomalie"
     min_delta: 0
   - subject: "anomaly.wallbox_iforest.meter0"
-    ga: "15/6/5"
+    ga: "15/6/20"
     dpt: "5.010"
     payload_path: "$.severity_level"
     description: "Versorgungstechnik.Wallbox.Anomalie-Gesamt"

--- a/kubernetes/applications/redpanda-connect/base/kustomization.yaml
+++ b/kubernetes/applications/redpanda-connect/base/kustomization.yaml
@@ -26,6 +26,7 @@ configMapGenerator:
       - streams/warp_charge_manager.yaml
       - streams/warp_charge_tracker.yaml
       - streams/warp_meter.yaml
+      - streams/warp_knx_republish.yaml
       - streams/unifi_events.yaml
       - streams/unifi_webhook.yaml
       - streams/unifi_arm_alarm.yaml

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_knx_republish.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_knx_republish.yaml
@@ -1,0 +1,85 @@
+# Republishes WARP wallbox telemetry as named scalar fields for the
+# knx-nats-bridge writer. The raw WARP data is unusable by the bridge as-is:
+# `warp.meters.0.values` is a float ARRAY whose order is defined by
+# `warp.meters.0.value_ids` (the bridge can only read named JSON fields, no
+# array indices). This stream pulls the values we route to KNX out of the
+# array and onto two clean subjects.
+#
+# value_ids index -> MeterValueID (current Steinroth meter config):
+#   3/4/5 = 13/17/21 phase current L1/L2/L3 (A)
+#   12    = 74       total active power (W)
+#   14    = 209      active energy import since manufacture (kWh, lifetime)
+# If the meter is reconfigured the value_ids order changes — re-check the
+# indices against `warp.meters.0.value_ids` then.
+#
+# Charged energy of the current charge is NOT a WARP field; Basalte computes
+# it as (Zählerstand-Aktuell - Zählerstand-Ladebeginn). meter_start comes from
+# warp.charge_tracker.current_charge, hence the second input.
+input:
+  broker:
+    inputs:
+      - nats_jetstream:
+          urls: ["nats://nats.nats.svc:4222"]
+          auth:
+            user: redpanda-connect
+            password: ${NATS_PASSWORD}
+          stream: WARP
+          subject: warp.meters.0.values
+          durable: redpanda-connect-warp-knx-meter
+          deliver: last
+          ack_wait: 20m
+          max_ack_pending: 5000
+      - nats_jetstream:
+          urls: ["nats://nats.nats.svc:4222"]
+          auth:
+            user: redpanda-connect
+            password: ${NATS_PASSWORD}
+          stream: WARP
+          subject: warp.charge_tracker.current_charge
+          durable: redpanda-connect-warp-knx-charge
+          deliver: last
+          ack_wait: 20m
+          max_ack_pending: 5000
+
+pipeline:
+  processors:
+    - mapping: |
+        let subj = meta("nats_subject")
+        let evt = this
+        root = if $subj == "warp.meters.0.values" {
+          # Length guard: partial arrays occur; index(14) on a short array
+          # would error and abort the mapping.
+          if $evt.type() == "array" && $evt.length() >= 15 {
+            {
+              # Phase current -> mA (DPT 7.012). max() = the active phase,
+              # works for both 1-phase (one leg) and 3-phase (balanced).
+              "ladestrom":            ([$evt.index(3), $evt.index(4), $evt.index(5)].max() * 1000).round(),
+              # Total active power -> W (DPT 14.056), no scaling.
+              "ladeleistung":         $evt.index(12),
+              # Lifetime energy kWh -> Wh (DPT 13.010) to keep sub-kWh
+              # resolution for the Basalte subtraction.
+              "zaehlerstand_aktuell": ($evt.index(14) * 1000).round(),
+            }
+          } else {
+            deleted()
+          }
+        } else if $subj == "warp.charge_tracker.current_charge" {
+          if $evt.meter_start != null {
+            { "zaehlerstand_ladebeginn": ($evt.meter_start * 1000).round() }
+          } else {
+            deleted()
+          }
+        } else {
+          deleted()
+        }
+        meta knx_subject = if $subj == "warp.meters.0.values" { "wallbox.knx.meter" } else { "wallbox.knx.charge" }
+
+output:
+  # Core NATS publish — the bridge writer uses a core subscription, and
+  # `wallbox.>` is not bound to any JetStream, so nothing archives it.
+  nats:
+    urls: ["nats://nats.nats.svc:4222"]
+    auth:
+      user: redpanda-connect
+      password: ${NATS_PASSWORD}
+    subject: ${! meta("knx_subject") }


### PR DESCRIPTION
Two related Wallbox changes.

## 1. Raw telemetry → KNX
The bridge can't read the raw WARP data: `warp.meters.0.values` is a float array whose order is defined by `warp.meters.0.value_ids`, and the writer only reads named JSON fields (no array indices). New redpanda-connect stream `warp_knx_republish` extracts the routed values onto two clean subjects + 4 writer-rules.

| GA | Wert | DPT | Quelle |
|---|---|---|---|
| 15/6/10 | Ladestrom | 7.012 (mA) | `max(current L1/L2/L3)` ×1000 |
| 15/6/12 | Ladeleistung | 14.056 (W) | total active power (ID 74) |
| 15/6/15 | Energie.Zählerstand-Aktuell | 13.010 (Wh) | lifetime energy (ID 209) ×1000 |
| 15/6/16 | Energie.Zählerstand-Ladebeginn | 13.010 (Wh) | `current_charge.meter_start` ×1000 |

Charged energy of the current charge is computed in Basalte (`(15 − 16)/1000 → 15/6/14 kWh`), so the republish is stateless. Counters in Wh keep sub-kWh resolution.

## 2. Status GA reshuffle
Each Wallbox INT status now has a sibling "Statustext" GA (DPT 16.001) for a Basalte INT→text LUT, which shifted the status addresses. Writer-rules repointed (anchor = payload_path); Statustext GAs are written by Basalte, not the bridge.

- `error_state` → 15/6/0 (Fehlerzustand-Status), `charger_state` → 15/6/2 (Ladecontroller-Status), `iec61851_state` → 15/6/4, `dc_fault_current_state` → 15/6/6, `contactor_error` → 15/6/8 (Schütz-Fehler — `contactor_error` is the fault code 0..6, confirmed vs `contactor_state`), `wallbox_iforest` → 15/6/20 (Anomalie-Gesamt).

## Verification
redpanda-connect `lint` clean, DPT encode tested (7.012/14.056/13.010), all 178 writer-rules match the catalog by name + DPT, every anomaly subject hits one GA, schema-valid. Bridge + redpanda-connect need a `rollout restart` after sync (no Reloader in-cluster).

🤖 Generated with [Claude Code](https://claude.com/claude-code)