### PR TITLE
feat(wallbox): control WARP charger via KNX (Ein-Aus + Lademodus)

### DIFF
--- a/kubernetes/applications/knx-nats-bridge/base/config/ga-catalog.yaml
+++ b/kubernetes/applications/knx-nats-bridge/base/config/ga-catalog.yaml
@@ -2462,14 +2462,39 @@
   name: Versorgungstechnik.Wallbox.Ladecontroller-Status
   room: Garage
 15/6/20:
+  dpt: '1.001'
+  function: Versorgungstechnik
+  name: Versorgungstechnik.Wallbox.Ein-Aus
+  room: Garage
+15/6/21:
+  dpt: '1.001'
+  function: Versorgungstechnik
+  name: Versorgungstechnik.Wallbox.Ein-Aus-Status
+  room: Garage
+15/6/22:
   dpt: '5.010'
   function: Versorgungstechnik
-  name: Versorgungstechnik.Wallbox.Anomalie-Gesamt
+  name: Versorgungstechnik.Wallbox.Lademodus
+  room: Garage
+15/6/23:
+  dpt: '5.010'
+  function: Versorgungstechnik
+  name: Versorgungstechnik.Wallbox.Lademodus-Status
+  room: Garage
+15/6/24:
+  dpt: '16.001'
+  function: Versorgungstechnik
+  name: Versorgungstechnik.Wallbox.Lademodus-Statustext
   room: Garage
 15/6/3:
   dpt: '16.001'
   function: Versorgungstechnik
   name: Versorgungstechnik.Wallbox.Ladecontroller-Statustext
+  room: Garage
+15/6/30:
+  dpt: '5.010'
+  function: Versorgungstechnik
+  name: Versorgungstechnik.Wallbox.Anomalie-Gesamt
   room: Garage
 15/6/4:
   dpt: '5.010'

--- a/kubernetes/applications/knx-nats-bridge/base/config/writer-rules.yaml
+++ b/kubernetes/applications/knx-nats-bridge/base/config/writer-rules.yaml
@@ -475,6 +475,22 @@ mappings:
     description: "Versorgungstechnik.Wallbox.Energie.Zählerstand-Ladebeginn"
     min_delta: 0  # changes only per charge: write on change
 
+  # WARP control feedback (KNX<-WARP). The command GAs (Ein-Aus 15/6/20,
+  # Lademodus 15/6/22) are driven KNX->WARP by redpanda-connect streams;
+  # these rules report the actual state back so Basalte reflects reality.
+  - subject: "warp.power_manager.charge_mode"
+    ga: "15/6/23"
+    dpt: "5.010"
+    payload_path: "$.mode"  # 0=Schnell 1=Aus 2=PV 3=Min+PV
+    description: "Versorgungstechnik.Wallbox.Lademodus-Status"
+    min_delta: 0  # enum state: write only on change
+  - subject: "wallbox.knx.charging"
+    ga: "15/6/21"
+    dpt: "1.001"
+    payload_path: "$.on"  # derived in warp_charging_status (charger_state==2)
+    description: "Versorgungstechnik.Wallbox.Ein-Aus-Status"
+    min_delta: 0  # bool state: write only on change
+
   # SolarEdge PV (15/4: 0..3 system-wide, 20..24 Wechselrichter 1, 40..44 Wechselrichter 2)
   - subject: "solaredge-1.powerflow"
     ga: "15/4/0"
@@ -628,7 +644,7 @@ mappings:
     description: "Versorgungstechnik.Photovoltaik.Verbrauch-Gesamt-Anomalie"
     min_delta: 0
   - subject: "anomaly.wallbox_iforest.meter0"
-    ga: "15/6/20"
+    ga: "15/6/30"
     dpt: "5.010"
     payload_path: "$.severity_level"
     description: "Versorgungstechnik.Wallbox.Anomalie-Gesamt"

--- a/kubernetes/applications/nats/base/consumers/kustomization.yaml
+++ b/kubernetes/applications/nats/base/consumers/kustomization.yaml
@@ -5,3 +5,5 @@ resources:
   - unifi_events.yaml
   - pv_surplus_to_warp.yaml
   - unifi_arm_alarm.yaml
+  - warp_onoff_from_knx.yaml
+  - warp_charge_mode_from_knx.yaml

--- a/kubernetes/applications/nats/base/consumers/warp_charge_mode_from_knx.yaml
+++ b/kubernetes/applications/nats/base/consumers/warp_charge_mode_from_knx.yaml
@@ -1,0 +1,15 @@
+# Durable consumer for the redpanda-connect warp_charge_mode_from_knx forwarder.
+# Subscribes to the bridge publish of the Lademodus GA, which redpanda-connect
+# maps to WARP's power_manager/charge_mode_update (0=Schnell 1=Aus 2=PV 3=Min+PV).
+apiVersion: jetstream.nats.io/v1beta2
+kind: Consumer
+metadata:
+  name: redpanda-connect-warp-charge-mode-from-knx
+  namespace: nats
+spec:
+  streamName: KNX
+  durableName: redpanda-connect-warp-charge-mode-from-knx
+  filterSubject: knx.15.6.22
+  deliverPolicy: new
+  ackPolicy: explicit
+  maxAckPending: 64

--- a/kubernetes/applications/nats/base/consumers/warp_onoff_from_knx.yaml
+++ b/kubernetes/applications/nats/base/consumers/warp_onoff_from_knx.yaml
@@ -1,0 +1,15 @@
+# Durable consumer for the redpanda-connect warp_onoff_from_knx forwarder.
+# Subscribes to the bridge publish of the Ein-Aus charge-release GA, which
+# redpanda-connect maps to WARP's evse/start_charging|stop_charging.
+apiVersion: jetstream.nats.io/v1beta2
+kind: Consumer
+metadata:
+  name: redpanda-connect-warp-onoff-from-knx
+  namespace: nats
+spec:
+  streamName: KNX
+  durableName: redpanda-connect-warp-onoff-from-knx
+  filterSubject: knx.15.6.20
+  deliverPolicy: new
+  ackPolicy: explicit
+  maxAckPending: 64

--- a/kubernetes/applications/redpanda-connect/base/kustomization.yaml
+++ b/kubernetes/applications/redpanda-connect/base/kustomization.yaml
@@ -31,6 +31,9 @@ configMapGenerator:
       - streams/unifi_webhook.yaml
       - streams/unifi_arm_alarm.yaml
       - streams/pv_surplus_to_warp.yaml
+      - streams/warp_onoff_from_knx.yaml
+      - streams/warp_charge_mode_from_knx.yaml
+      - streams/warp_charging_status.yaml
 
 patches:
   # Expose redpanda-connect service via Cilium/BGP-announced LoadBalancer so

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_charge_mode_from_knx.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_charge_mode_from_knx.yaml
@@ -1,0 +1,28 @@
+# Lademodus control: forwards the KNX Lademodus GA (15/6/22, DPT 5.010
+# "Versorgungstechnik.Wallbox.Lademodus") to the WARP wallbox's charge mode.
+# The GA carries the WARP raw mode value directly: 0=Schnell 1=Aus 2=PV 3=Min+PV.
+input:
+  # Consumer is declared as a CRD in nats/base/consumers/warp_charge_mode_from_knx.yaml.
+  nats_jetstream:
+    urls: ["nats://nats.nats.svc:4222"]
+    auth:
+      user: redpanda-connect
+      password: ${NATS_PASSWORD}
+    stream: KNX
+    durable: redpanda-connect-warp-charge-mode-from-knx
+    bind: true
+
+pipeline:
+  processors:
+    # knx-nats-bridge publishes {ga, name, value, dpt, ...}; DPT 5.010 -> int.
+    # WARP expects power_manager/charge_mode_update payload {"mode": N}.
+    - mapping: 'root.mode = this.value'
+
+output:
+  mqtt:
+    urls: ["tcp://nats.nats.svc:1883"]
+    client_id: redpanda-connect-warp-charge-mode
+    user: redpanda-connect
+    password: ${NATS_PASSWORD}
+    topic: warp/power_manager/charge_mode_update
+    qos: 0

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_charging_status.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_charging_status.yaml
@@ -1,0 +1,31 @@
+# Ein-Aus-Status feedback: derives a "charging active" boolean from the WARP
+# evse state and republishes it for the knx-nats-bridge writer, which maps it
+# to KNX 15/6/21 (DPT 1.001 "Versorgungstechnik.Wallbox.Ein-Aus-Status").
+# The bridge cannot transform an enum to a bool, so the derivation lives here.
+# charger_state == 2 means the WARP is actively charging.
+input:
+  nats_jetstream:
+    urls: ["nats://nats.nats.svc:4222"]
+    auth:
+      user: redpanda-connect
+      password: ${NATS_PASSWORD}
+    stream: WARP
+    subject: warp.evse.state
+    durable: redpanda-connect-warp-charging-status
+    deliver: last
+    ack_wait: 20m
+    max_ack_pending: 5000
+
+pipeline:
+  processors:
+    - mapping: 'root = { "on": this.charger_state == 2 }'
+
+output:
+  # Core NATS publish — the bridge writer uses a core subscription, and
+  # `wallbox.>` is not bound to any JetStream, so nothing archives it.
+  nats:
+    urls: ["nats://nats.nats.svc:4222"]
+    auth:
+      user: redpanda-connect
+      password: ${NATS_PASSWORD}
+    subject: wallbox.knx.charging

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_onoff_from_knx.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_onoff_from_knx.yaml
@@ -1,0 +1,30 @@
+# Ein-Aus charge release: forwards the KNX Ein-Aus GA (15/6/20, DPT 1.001
+# "Versorgungstechnik.Wallbox.Ein-Aus") to the WARP wallbox as a charge
+# start/stop command — the equivalent of the WARP UI Start/Stop button.
+input:
+  # Consumer is declared as a CRD in nats/base/consumers/warp_onoff_from_knx.yaml.
+  nats_jetstream:
+    urls: ["nats://nats.nats.svc:4222"]
+    auth:
+      user: redpanda-connect
+      password: ${NATS_PASSWORD}
+    stream: KNX
+    durable: redpanda-connect-warp-onoff-from-knx
+    bind: true
+
+pipeline:
+  processors:
+    # knx-nats-bridge publishes {ga, name, value, dpt, ...}; DPT 1.001 decodes
+    # to bool. WARP toggles via two distinct command topics, payload ignored.
+    - mapping: |
+        meta topic = if this.value == true || this.value == 1 { "warp/evse/start_charging" } else { "warp/evse/stop_charging" }
+        root = null
+
+output:
+  mqtt:
+    urls: ["tcp://nats.nats.svc:1883"]
+    client_id: redpanda-connect-warp-onoff
+    user: redpanda-connect
+    password: ${NATS_PASSWORD}
+    topic: ${! meta("topic") }
+    qos: 0


### PR DESCRIPTION
## What

Adds **KNX → WARP control** and **WARP → KNX status feedback** for the wallbox, mirroring the existing `pv_surplus_to_warp` pattern. From Basalte/KNX you can now switch charging on/off and select the charge mode (PV, Min+PV, Schnell).

| GA | Name | DPT | Direction |
|---|---|---|---|
| 15/6/20 | Ein-Aus | 1.001 | KNX → WARP (`evse/start\|stop_charging`) |
| 15/6/22 | Lademodus | 5.010 | KNX → WARP (`power_manager/charge_mode_update`) |
| 15/6/21 | Ein-Aus-Status | 1.001 | WARP → KNX (`charger_state==2`) |
| 15/6/23 | Lademodus-Status | 5.010 | WARP → KNX (`warp.power_manager.charge_mode`) |
| 15/6/30 | Anomalie-Gesamt | 5.010 | moved from 15/6/20 |

Charge mode carries the WARP raw value directly: `0=Schnell 1=Aus 2=PV 3=Min+PV`.

## Changes

- **redpanda-connect streams:** `warp_onoff_from_knx`, `warp_charge_mode_from_knx`, `warp_charging_status` (+ registered in kustomization).
- **nats consumers:** durable CRDs for `knx.15.6.20` and `knx.15.6.22` (+ registered).
- **writer-rules:** feedback rules for `15/6/23` and `15/6/21`; **moved `Anomalie-Gesamt` `15/6/20` → `15/6/30`** — `15/6/20` is now the Ein-Aus charge command in ETS, so leaving the anomaly there would have written severity onto the charge command.
- **ga-catalog:** wallbox control/feedback GAs (`15/6/20-24`, `30`).

## Verification

Subjects and payloads verified against the live WARP via `nats stream get`:
- `warp.power_manager.charge_mode` → `{"mode":N}` (so `payload_path: $.mode` is correct; `power_manager`, not `charge_manager`)
- `warp.evse.state` contains `charger_state`
- `kubectl kustomize --enable-helm` builds green for `nats/base`, `redpanda-connect/base` and `knx-nats-bridge/base`.

No NATS auth/SealedSecret change needed (redpanda-connect is unrestricted; the bridge already has `knx.>` publish and `warp.>`/`wallbox.knx.>` subscribe).

## Deploy notes

- **Reloader is not installed** → after sync, `kubectl rollout restart deploy/knx-nats-bridge -n knx-nats-bridge` (writer-rules + catalog CM) and `kubectl rollout restart deploy/redpanda-connect -n redpanda-connect` (streams CM). PostSync `import-ga-catalog` job runs after the catalog change.
- The anomaly move (20 → 30) and the Ein-Aus control go live together — never the control before the move.
- **Lademodus-Statustext (15/6/24)** is intentionally not wired here (owned separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)