### PR TITLE
feat(knx-nats-bridge): seed warp.evse.state read responder on startup

### DIFF
--- a/kubernetes/applications/knx-nats-bridge/base/config/writer-rules.yaml
+++ b/kubernetes/applications/knx-nats-bridge/base/config/writer-rules.yaml
@@ -405,37 +405,44 @@ mappings:
     description: "Versorgungstechnik.Gastherme.Mischer.Vorlauf.Soll-Temperatur"
     min_delta: 0.5  # °C
 
-  # WARP wallbox
+  # WARP wallbox. warp.evse.state is event-driven (published only on change),
+  # so seed_on_start primes the read responder from JetStream after a restart —
+  # otherwise reads return no_value until the next state change.
   - subject: "warp.evse.state"
     ga: "15/6/2"
     dpt: "5.010"
     payload_path: "$.charger_state"
     description: "Versorgungstechnik.Wallbox.Ladecontroller-Status"
     min_delta: 0  # enum state: write only on change
+    seed_on_start: true
   - subject: "warp.evse.state"
     ga: "15/6/4"
     dpt: "5.010"
     payload_path: "$.iec61851_state"
     description: "Versorgungstechnik.Wallbox.IEC61851-Status"
     min_delta: 0  # enum state: write only on change
+    seed_on_start: true
   - subject: "warp.evse.state"
     ga: "15/6/0"
     dpt: "5.010"
     payload_path: "$.error_state"
     description: "Versorgungstechnik.Wallbox.Fehlerzustand-Status"
     min_delta: 0  # enum state: write only on change
+    seed_on_start: true
   - subject: "warp.evse.state"
     ga: "15/6/8"
     dpt: "5.010"
     payload_path: "$.contactor_error"
     description: "Versorgungstechnik.Wallbox.Schütz-Fehler"
     min_delta: 0  # enum state: write only on change
+    seed_on_start: true
   - subject: "warp.evse.state"
     ga: "15/6/6"
     dpt: "5.010"
     payload_path: "$.dc_fault_current_state"
     description: "Versorgungstechnik.Wallbox.DC-Fehlerstrom-Status"
     min_delta: 0  # enum state: write only on change
+    seed_on_start: true
   - subject: "warp.evse.state"
     ga: "15/6/11"
     dpt: "7.012"
@@ -443,6 +450,7 @@ mappings:
     description: "Versorgungstechnik.Wallbox.Ladestrom-Erlaubt"
     min_delta: 100  # mA
     min_delta_pct: 2
+    seed_on_start: true
 
   # WARP meter raw telemetry (republished by redpanda-connect
   # warp_knx_republish from the warp.meters.0.values array). Charged energy of


### PR DESCRIPTION
Flags the 6 `warp.evse.state` writer rules (Wallbox status GAs 15/6/0,2,4,6,8,11) with `seed_on_start: true`.

## Why

`warp.evse.state` is **event-driven** — published only when the charger state changes. The read responder answers `GroupValueRead` from an in-memory cache that is empty after every pod restart, so after a redeploy the Wallbox status GAs returned `no_value` and stayed silent (Basalte/ETS reads got no response) until the next state change — observed as the Wallbox reads not working while Grafana still showed values (Grafana reads the persisted TSDB table).

With `seed_on_start`, the bridge (>= v0.12.0, already deployed) primes its responder cache from the JetStream WARP stream at startup, so reads are answered immediately after a redeploy.

## Scope

Only `warp.evse.state` is flagged. The `ems-esp.*` / `solaredge-*` subjects publish **cyclically**, so their first post-restart message re-populates the cache within seconds (the deadband always writes the first value) — they don't have the event-driven gap and gain little from seeding. Can be extended later if desired.

## Verify after sync

- Log: `seeding read-responder cache from JetStream for 1 subjects`
- Metric: `knx_seed_total{subject="warp.evse.state",outcome="ok"}` > 0
- A `GroupValueRead` on 15/6/0 returns a response right after a `rollout restart`, without the charger state having changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)