### PR TITLE
feat(wallbox): per-mode Lademodus buttons + status bits for Basalte

### DIFF
--- a/kubernetes/applications/knx-nats-bridge/base/config/ga-catalog.yaml
+++ b/kubernetes/applications/knx-nats-bridge/base/config/ga-catalog.yaml
@@ -2474,17 +2474,42 @@
 15/6/22:
   dpt: '5.010'
   function: Versorgungstechnik
-  name: Versorgungstechnik.Wallbox.Lademodus
+  name: Versorgungstechnik.Wallbox.Lademodi
   room: Garage
 15/6/23:
   dpt: '5.010'
   function: Versorgungstechnik
-  name: Versorgungstechnik.Wallbox.Lademodus-Status
+  name: Versorgungstechnik.Wallbox.Lademodi-Status
   room: Garage
 15/6/24:
   dpt: '16.001'
   function: Versorgungstechnik
-  name: Versorgungstechnik.Wallbox.Lademodus-Statustext
+  name: Versorgungstechnik.Wallbox.Lademodi-Statustext
+  room: Garage
+15/6/25:
+  dpt: '1.001'
+  function: Versorgungstechnik
+  name: Versorgungstechnik.Wallbox.Lademodus-PV
+  room: Garage
+15/6/26:
+  dpt: '1.011'
+  function: Versorgungstechnik
+  name: Versorgungstechnik.Wallbox.Lademodus-PV-Status
+  room: Garage
+15/6/27:
+  dpt: '1.001'
+  function: Versorgungstechnik
+  name: Versorgungstechnik.Wallbox.Lademodus-PV+Min
+  room: Garage
+15/6/28:
+  dpt: '1.011'
+  function: Versorgungstechnik
+  name: Versorgungstechnik.Wallbox.Lademodus-PV+Min-Status
+  room: Garage
+15/6/29:
+  dpt: '1.001'
+  function: Versorgungstechnik
+  name: Versorgungstechnik.Wallbox.Lademodus-Schnell
   room: Garage
 15/6/3:
   dpt: '16.001'
@@ -2492,14 +2517,19 @@
   name: Versorgungstechnik.Wallbox.Ladecontroller-Statustext
   room: Garage
 15/6/30:
-  dpt: '5.010'
+  dpt: '1.011'
   function: Versorgungstechnik
-  name: Versorgungstechnik.Wallbox.Anomalie-Gesamt
+  name: Versorgungstechnik.Wallbox.Lademodus-Schnell-Status
   room: Garage
 15/6/4:
   dpt: '5.010'
   function: Versorgungstechnik
   name: Versorgungstechnik.Wallbox.IEC61851-Status
+  room: Garage
+15/6/40:
+  dpt: '5.010'
+  function: Versorgungstechnik
+  name: Versorgungstechnik.Wallbox.Anomalie-Gesamt
   room: Garage
 15/6/5:
   dpt: '16.001'

--- a/kubernetes/applications/knx-nats-bridge/base/config/writer-rules.yaml
+++ b/kubernetes/applications/knx-nats-bridge/base/config/writer-rules.yaml
@@ -476,13 +476,14 @@ mappings:
     min_delta: 0  # changes only per charge: write on change
 
   # WARP control feedback (KNX<-WARP). The command GAs (Ein-Aus 15/6/20,
-  # Lademodus 15/6/22) are driven KNX->WARP by redpanda-connect streams;
-  # these rules report the actual state back so Basalte reflects reality.
+  # Lademodi 15/6/22, per-mode buttons 15/6/25/27/29) are driven KNX->WARP by
+  # redpanda-connect streams; these rules report the actual state back so
+  # Basalte reflects reality.
   - subject: "warp.power_manager.charge_mode"
     ga: "15/6/23"
     dpt: "5.010"
     payload_path: "$.mode"  # 0=Schnell 1=Aus 2=PV 3=Min+PV
-    description: "Versorgungstechnik.Wallbox.Lademodus-Status"
+    description: "Versorgungstechnik.Wallbox.Lademodi-Status"
     min_delta: 0  # enum state: write only on change
   - subject: "wallbox.knx.charging"
     ga: "15/6/21"
@@ -490,6 +491,26 @@ mappings:
     payload_path: "$.on"  # derived in warp_charging_status (charger_state==2)
     description: "Versorgungstechnik.Wallbox.Ein-Aus-Status"
     min_delta: 0  # bool state: write only on change
+  # Per-mode status bits for Basalte (radio: exactly one set, all 0 when Aus).
+  # Derived in warp_mode_flags from warp.power_manager.charge_mode.
+  - subject: "wallbox.knx.mode_flags"
+    ga: "15/6/26"
+    dpt: "1.011"
+    payload_path: "$.pv"  # mode == 2
+    description: "Versorgungstechnik.Wallbox.Lademodus-PV-Status"
+    min_delta: 0
+  - subject: "wallbox.knx.mode_flags"
+    ga: "15/6/28"
+    dpt: "1.011"
+    payload_path: "$.pvmin"  # mode == 3
+    description: "Versorgungstechnik.Wallbox.Lademodus-PV+Min-Status"
+    min_delta: 0
+  - subject: "wallbox.knx.mode_flags"
+    ga: "15/6/30"
+    dpt: "1.011"
+    payload_path: "$.fast"  # mode == 0
+    description: "Versorgungstechnik.Wallbox.Lademodus-Schnell-Status"
+    min_delta: 0
 
   # SolarEdge PV (15/4: 0..3 system-wide, 20..24 Wechselrichter 1, 40..44 Wechselrichter 2)
   - subject: "solaredge-1.powerflow"
@@ -644,7 +665,7 @@ mappings:
     description: "Versorgungstechnik.Photovoltaik.Verbrauch-Gesamt-Anomalie"
     min_delta: 0
   - subject: "anomaly.wallbox_iforest.meter0"
-    ga: "15/6/30"
+    ga: "15/6/40"
     dpt: "5.010"
     payload_path: "$.severity_level"
     description: "Versorgungstechnik.Wallbox.Anomalie-Gesamt"

--- a/kubernetes/applications/nats/base/consumers/kustomization.yaml
+++ b/kubernetes/applications/nats/base/consumers/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - unifi_arm_alarm.yaml
   - warp_onoff_from_knx.yaml
   - warp_charge_mode_from_knx.yaml
+  - warp_mode_buttons_from_knx.yaml

--- a/kubernetes/applications/nats/base/consumers/warp_mode_buttons_from_knx.yaml
+++ b/kubernetes/applications/nats/base/consumers/warp_mode_buttons_from_knx.yaml
@@ -1,0 +1,18 @@
+# Durable consumer for the redpanda-connect warp_mode_buttons_from_knx
+# forwarder. Subscribes to the three per-mode Basalte button GAs, which
+# redpanda-connect maps to a WARP charge mode (PV=2, PV+Min=3, Schnell=0).
+apiVersion: jetstream.nats.io/v1beta2
+kind: Consumer
+metadata:
+  name: redpanda-connect-warp-mode-buttons-from-knx
+  namespace: nats
+spec:
+  streamName: KNX
+  durableName: redpanda-connect-warp-mode-buttons-from-knx
+  filterSubjects:
+    - knx.15.6.25  # Lademodus-PV
+    - knx.15.6.27  # Lademodus-PV+Min
+    - knx.15.6.29  # Lademodus-Schnell
+  deliverPolicy: new
+  ackPolicy: explicit
+  maxAckPending: 64

--- a/kubernetes/applications/redpanda-connect/base/kustomization.yaml
+++ b/kubernetes/applications/redpanda-connect/base/kustomization.yaml
@@ -34,6 +34,8 @@ configMapGenerator:
       - streams/warp_onoff_from_knx.yaml
       - streams/warp_charge_mode_from_knx.yaml
       - streams/warp_charging_status.yaml
+      - streams/warp_mode_buttons_from_knx.yaml
+      - streams/warp_mode_flags.yaml
 
 patches:
   # Expose redpanda-connect service via Cilium/BGP-announced LoadBalancer so

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_mode_buttons_from_knx.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_mode_buttons_from_knx.yaml
@@ -1,0 +1,39 @@
+# Per-mode Lademodus buttons: forwards the three Basalte 1-bit button GAs to
+# the WARP charge mode. Each button GA, when pressed (value true), selects one
+# WARP charge mode via power_manager/charge_mode_update:
+#   knx.15.6.25 Lademodus-PV     -> mode 2 (PV)
+#   knx.15.6.27 Lademodus-PV+Min -> mode 3 (Min+PV)
+#   knx.15.6.29 Lademodus-Schnell-> mode 0 (Schnell)
+# "Aus" (mode 1) is not a button — that is the Ein-Aus GA (15/6/20).
+input:
+  # Consumer (filterSubjects on the three GAs) is declared as a CRD in
+  # nats/base/consumers/warp_mode_buttons_from_knx.yaml.
+  nats_jetstream:
+    urls: ["nats://nats.nats.svc:4222"]
+    auth:
+      user: redpanda-connect
+      password: ${NATS_PASSWORD}
+    stream: KNX
+    durable: redpanda-connect-warp-mode-buttons-from-knx
+    bind: true
+
+pipeline:
+  processors:
+    # Only a button press (value true/1) selects a mode; release (0) is ignored.
+    - mapping: |
+        let subj = meta("nats_subject")
+        root = if this.value == true || this.value == 1 {
+          if $subj == "knx.15.6.25" { {"mode": 2} }
+          else if $subj == "knx.15.6.27" { {"mode": 3} }
+          else if $subj == "knx.15.6.29" { {"mode": 0} }
+          else { deleted() }
+        } else { deleted() }
+
+output:
+  mqtt:
+    urls: ["tcp://nats.nats.svc:1883"]
+    client_id: redpanda-connect-warp-mode-buttons
+    user: redpanda-connect
+    password: ${NATS_PASSWORD}
+    topic: warp/power_manager/charge_mode_update
+    qos: 0

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_mode_flags.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_mode_flags.yaml
@@ -1,0 +1,36 @@
+# Per-mode status bits: derives one boolean per charge mode from the WARP
+# charge mode and republishes them for the knx-nats-bridge writer, which maps
+# them to the Basalte per-mode status GAs (15/6/26/28/30, DPT 1.011).
+# Exactly one is true; all false when mode is Aus (1). The bridge cannot do
+# enum->bool, so the derivation lives here.
+input:
+  nats_jetstream:
+    urls: ["nats://nats.nats.svc:4222"]
+    auth:
+      user: redpanda-connect
+      password: ${NATS_PASSWORD}
+    stream: WARP
+    subject: warp.power_manager.charge_mode
+    durable: redpanda-connect-warp-mode-flags
+    deliver: last
+    ack_wait: 20m
+    max_ack_pending: 5000
+
+pipeline:
+  processors:
+    - mapping: |
+        root = {
+          "pv":    this.mode == 2,
+          "pvmin": this.mode == 3,
+          "fast":  this.mode == 0,
+        }
+
+output:
+  # Core NATS publish — the bridge writer uses a core subscription, and
+  # `wallbox.>` is not bound to any JetStream, so nothing archives it.
+  nats:
+    urls: ["nats://nats.nats.svc:4222"]
+    auth:
+      user: redpanda-connect
+      password: ${NATS_PASSWORD}
+    subject: wallbox.knx.mode_flags


### PR DESCRIPTION
## What

Basalte needs **individual 1-bit values per charge mode** (button + status) instead of the single enum. Adds per-mode control and feedback on top of #1174, and moves the anomaly GA again.

| GA | Name | DPT | Direction |
|---|---|---|---|
| 15/6/25 | Lademodus-PV | 1.001 | KNX → WARP (mode 2) |
| 15/6/27 | Lademodus-PV+Min | 1.001 | KNX → WARP (mode 3) |
| 15/6/29 | Lademodus-Schnell | 1.001 | KNX → WARP (mode 0) |
| 15/6/26 | Lademodus-PV-Status | 1.011 | WARP → KNX (mode==2) |
| 15/6/28 | Lademodus-PV+Min-Status | 1.011 | WARP → KNX (mode==3) |
| 15/6/30 | Lademodus-Schnell-Status | 1.011 | WARP → KNX (mode==0) |
| 15/6/40 | Anomalie-Gesamt | 5.010 | moved from 15/6/30 |

"Aus" (WARP mode 1) is **not** a button — that is the Ein-Aus GA (15/6/20) via `stop_charging`. Charge mode and charge release are orthogonal; the status bits reflect the **mode**, not whether charging is released.

## Changes

- **redpanda-connect `warp_mode_buttons_from_knx`:** one consumer with `filterSubjects` on `knx.15.6.25/27/29` (server 2.14.2 supports multi-filter), bloblang maps the pressed button → `power_manager/charge_mode_update {"mode":N}`. Releases (value 0) are dropped.
- **redpanda-connect `warp_mode_flags`:** derives `{pv,pvmin,fast}` booleans from `warp.power_manager.charge_mode` → `wallbox.knx.mode_flags`.
- **writer-rules:** per-mode status bits `15/6/26/28/30` from `wallbox.knx.mode_flags`; **moved `Anomalie-Gesamt` `15/6/30` → `15/6/40`** (15/6/30 is now Lademodus-Schnell-Status); `Lademodus-Status` → `Lademodi-Status`.
- **ga-catalog:** wallbox per-mode GAs (`15/6/25-30`), `Anomalie-Gesamt` at `15/6/40`, `Lademodus` → `Lademodi` for `15/6/22-24`.

The enum Lademodi control (`15/6/22`) + status (`15/6/23`) from #1174 remain unchanged.

## Verification

- `kubectl kustomize --enable-helm` builds green for `nats/base` and `redpanda-connect/base`; the `filterSubjects` consumer and both streams render.
- DPTs match the regenerated catalog (command bits `1.001`, status bits `1.011`).

No NATS auth/SealedSecret change (redpanda-connect unrestricted; bridge already has `knx.>`/`warp.>`/`wallbox.knx.>`).

## Deploy notes

- **Reloader not installed** → after sync, `kubectl rollout restart deploy/knx-nats-bridge -n knx-nats-bridge` + `deploy/redpanda-connect -n redpanda-connect`.
- Anomaly move (30 → 40) goes live together with the per-mode status bits (15/6/30 is reused).
- ga-catalog must be regenerated from the updated ETS export (already included here for the wallbox block; the parallel Miele `17/1` block is intentionally left out for its own PR — note its names still need fixing in ETS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)