### PR TITLE
fix(control-plane): cap kube-apiserver memory at 2.75Gi to prevent node OOM

### DIFF
--- a/cluster/patches/control-plane-settings.yaml
+++ b/cluster/patches/control-plane-settings.yaml
@@ -2,15 +2,20 @@
 ## Control plane patches
 ###############################################################################
 cluster:
-  ## kube-apiserver memory tuning. CPs only have ~3.8 GiB RAM; without a
-  ## memory limit Go GC fills available memory and OOMs during RSS spikes
-  ## (e.g. OpenAPI schema rebuilds against large CRDs via ArgoCD diff).
-  ## Talos auto-injects GOMEMLIMIT=0.95*limit when resources.limits.memory
-  ## is set, so we only need to declare the limit.
+  ## kube-apiserver memory tuning. CPs only have ~3.8 GiB RAM and the
+  ## apiserver working set legitimately reaches ~2.4 GiB on the busiest CP.
+  ## A 3Gi limit was too loose: GOMEMLIMIT (=0.95*limit=2.85Gi) let RSS grow
+  ## until apiserver + etcd + system exceeded the 4 GiB VM and the kernel
+  ## triggered a node-global OOM that killed apiserver and took the whole
+  ## control plane down (e.g. OpenAPI schema rebuilds against large CRDs via
+  ## ArgoCD diff). Capping at 2.75Gi keeps GOMEMLIMIT (2.61Gi) and the cgroup
+  ## limit below the node ceiling, so a future spike is bounded by GC and, in
+  ## the worst case, OOM-killed cgroup-locally (apiserver restarts in seconds)
+  ## instead of taking the node — global OOM becomes a self-healing blip.
   apiServer:
     resources:
       limits:
-        memory: "3Gi"
+        memory: "2.75Gi"
   ## Expose metrics endpoints on all interfaces (default: 127.0.0.1)
   ## Required for Prometheus ServiceMonitor scraping from within the cluster
   controllerManager:


### PR DESCRIPTION
## Problem

Syncing **prometheus-operator-crds v30** triggered a node-global OOM on the 4 GiB control-plane VMs that killed kube-apiserver on 2 of 3 CP nodes and took the control plane down (`proxy error` on all kubectl/talosctl-via-Omni calls). etcd quorum survived; the cluster self-recovered once the OpenAPI schema-rebuild spike passed.

## Root cause

The `apiServer.resources.limits.memory: 3Gi` was too loose for these nodes. Talos derives `GOMEMLIMIT = 0.95 * limit = 2.85Gi`, so the apiserver was allowed to grow until apiserver (~2.65 GiB RSS during the CRD OpenAPI rebuild) + etcd + kubelet + system exceeded the 4 GiB VM. The kernel OOM-killer fired with `CONSTRAINT_NONE` / `global_oom` and picked apiserver (`oom_score_adj 869`) — a **node-global** kill, not a cgroup-local one.

## Fix

Lower the limit to **2.75Gi**:

- `GOMEMLIMIT` becomes **2.61Gi** → Go GCs earlier, trimming the spike.
- The cgroup `memory.max` (2.75Gi) stays below the node ceiling, so a worst-case breach is OOM-killed **cgroup-locally** — apiserver restarts in seconds — instead of taking the whole node. Global OOM → self-healing blip.
- Measured apiserver working set peaks ~2.4 GiB on the busiest CP, so 2.75Gi leaves steady-state headroom.

## Validation

Already applied live via `omnictl cluster template sync` (rolling). All 3 apiservers rolled cleanly to `limit=2816Mi` (2.75Gi), 1/1 Ready, 0 restarts; etcd quorum held throughout. Busiest CP (cp-02) dropped from 101% → 80% node memory after its apiserver restarted with cold caches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)