### PR TITLE
refactor(config): converge ConfigMap reload onto kustomize hash-suffix

### DIFF
--- a/kubernetes/applications/gatus/base/kustomization.yaml
+++ b/kubernetes/applications/gatus/base/kustomization.yaml
@@ -20,10 +20,10 @@ helmCharts:
     apiVersions:
       - monitoring.coreos.com/v1
 
+# Content-hash suffix: an endpoints change produces a new ConfigMap name, so the
+# Deployment volume reference updates and ArgoCD rolls the pod natively.
 configMapGenerator:
   - name: gatus-config
-    options:
-      disableNameSuffixHash: true
     files:
       - config.yaml=config/endpoints.yaml
 

--- a/kubernetes/applications/gatus/base/values.yaml
+++ b/kubernetes/applications/gatus/base/values.yaml
@@ -2,6 +2,10 @@ applicationName: gatus
 
 deployment:
   enabled: true
+  # gatus-config uses a kustomize content-hash name (see kustomization.yaml), so a
+  # config change rolls the pod natively. The Stakater Reloader annotation is not
+  # used — there is no Reloader controller in the cluster.
+  reloadOnChange: false
   # gatus-sidecar reads IngressRoutes via the SA token; v7 flipped the chart default to false
   automountServiceAccountToken: true
   image:

--- a/kubernetes/applications/homepage/base/kustomization.yaml
+++ b/kubernetes/applications/homepage/base/kustomization.yaml
@@ -18,10 +18,10 @@ helmCharts:
     valuesFile: values.yaml
     namespace: homepage
 
+# Content-hash suffix: a config/icon change produces a new ConfigMap name, so the
+# Deployment volume references update and ArgoCD rolls the pod natively.
 configMapGenerator:
   - name: homepage-config
-    options:
-      disableNameSuffixHash: true
     files:
       - config/bookmarks.yaml
       - config/custom.css
@@ -33,8 +33,6 @@ configMapGenerator:
       - config/settings.yaml
       - config/widgets.yaml
   - name: homepage-icons
-    options:
-      disableNameSuffixHash: true
     files:
       - icons/2n.svg
       - icons/basalte.png

--- a/kubernetes/applications/homepage/base/values.yaml
+++ b/kubernetes/applications/homepage/base/values.yaml
@@ -2,6 +2,10 @@ applicationName: homepage
 
 deployment:
   enabled: true
+  # homepage-config/-icons use kustomize content-hash names (see kustomization.yaml),
+  # so a config change rolls the pod natively. The Stakater Reloader annotation is not
+  # used — there is no Reloader controller in the cluster.
+  reloadOnChange: false
   # Kubernetes widget queries the cluster API via the SA token; v7 flipped the chart default to false
   automountServiceAccountToken: true
   replicas: 1

--- a/kubernetes/applications/knx-nats-bridge/base/kustomization.yaml
+++ b/kubernetes/applications/knx-nats-bridge/base/kustomization.yaml
@@ -16,17 +16,15 @@ helmCharts:
     apiVersions:
       - monitoring.coreos.com/v1
 
-# disableNameSuffixHash: the import-ga-catalog Job mounts the ConfigMap
-# by fixed name (subPath ga-catalog.yaml).
+# Content-hash suffix: a config change produces a new ConfigMap name, so the
+# references in the Deployment and the import-ga-catalog Job both update and
+# ArgoCD rolls the pod natively. kustomize rewrites the hashed name in the
+# Helm-rendered Deployment volume and the native Job volume alike.
 configMapGenerator:
   - name: knx-nats-bridge-ga-catalog
-    options:
-      disableNameSuffixHash: true
     files:
       - ga-catalog.yaml=config/ga-catalog.yaml
   - name: knx-nats-bridge-writer-rules
-    options:
-      disableNameSuffixHash: true
     files:
       - writer-rules.yaml=config/writer-rules.yaml
 

--- a/kubernetes/applications/knx-nats-bridge/base/values.yaml
+++ b/kubernetes/applications/knx-nats-bridge/base/values.yaml
@@ -2,6 +2,10 @@ applicationName: knx-nats-bridge
 
 deployment:
   enabled: true
+  # ConfigMaps use kustomize content-hash names (see kustomization.yaml), so a
+  # config change rolls the pod natively. The Stakater Reloader annotation is
+  # not used — there is no Reloader controller in the cluster.
+  reloadOnChange: false
   image:
     repository: ghcr.io/alexander-zimmermann/knx-nats-bridge
     tag: 0.12.0


### PR DESCRIPTION
## Context

The shared `application` Helm chart stamps `reloader.stakater.com/auto: "true"` on its Deployments, but **Stakater Reloader is not installed** in the cluster. For apps using fixed-name ConfigMaps (`disableNameSuffixHash: true`), an ArgoCD-synced config change therefore did **not** restart the pod — it kept serving stale config until a manual `kubectl rollout restart` (observed on knx-nats-bridge, ~3 days stale during the anomaly + wallbox work).

Closes #1167.

## Decision: converge on the native hash-suffix path (Option 2)

Rather than running a Reloader controller we don't strictly need, this converges the affected apps onto the mechanism the repo already uses successfully elsewhere (authentik, solaredge2mqtt, …): kustomize content-hash ConfigMap names. A config change yields a new ConfigMap name → the Deployment volume reference updates → ArgoCD rolls the pod natively, no controller.

Scope was small: only **3 apps** actually mounted fixed-name ConfigMaps into a running pod. The remaining fixed-name ConfigMaps are Job/CronJob/hook scripts (timescaledb bootstrap, grafana/rustfs provisioners, crowdsec prune, …) that are re-read on each run and need no reload.

## Changes (one commit per app)

- **knx-nats-bridge** — `writer-rules` + `ga-catalog`. Verified kustomize rewrites the hashed name in **both** the Helm-rendered Deployment volume and the native PostSync import-ga-catalog Job volume, so the importer keeps working.
- **gatus** — `gatus-config`.
- **homepage** — `homepage-config` + `homepage-icons`.

Each: removed `disableNameSuffixHash` and set `deployment.reloadOnChange: false` to drop the now-dead Reloader annotation.

## Verification

`kustomize build --enable-helm` on each base: all `configMap.name` references carry the content-hash suffix, and `reloader.stakater.com` no longer appears in the rendered output. Pre-commit hooks pass.

After merge, watch the ArgoCD sync roll each pod once (the ConfigMap name changes on first apply); subsequent config edits should roll the pod automatically with no manual restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)