### PR TITLE
chore(apps): drop dead Stakater Reloader annotations from remaining apps

### DIFF
--- a/kubernetes/applications/fritz-exporter/base/values.yaml
+++ b/kubernetes/applications/fritz-exporter/base/values.yaml
@@ -2,6 +2,10 @@ applicationName: fritz-exporter
 
 deployment:
   enabled: true
+  # ConfigMap uses a kustomize content-hash name, so a config change rolls the
+  # pod natively. The Stakater Reloader annotation is not used — there is no
+  # Reloader controller in the cluster.
+  reloadOnChange: false
   # Single instance is sufficient; fritz-exporter is stateless and scrapes one FritzBox.
   replicas: 1
   image:

--- a/kubernetes/applications/iot-mcp-bridge/base/values.yaml
+++ b/kubernetes/applications/iot-mcp-bridge/base/values.yaml
@@ -2,6 +2,9 @@ applicationName: iot-mcp-bridge
 
 deployment:
   enabled: true
+  # No ConfigMap is mounted, and there is no Stakater Reloader controller in the
+  # cluster — disable the chart's dead reloader.stakater.com/auto annotation.
+  reloadOnChange: false
   image:
     repository: ghcr.io/alexander-zimmermann/iot-mcp-bridge
     tag: 1.4.0

--- a/kubernetes/applications/kromgo/base/values.yaml
+++ b/kubernetes/applications/kromgo/base/values.yaml
@@ -2,6 +2,10 @@ applicationName: kromgo
 
 deployment:
   enabled: true
+  # ConfigMap uses a kustomize content-hash name, so a config change rolls the
+  # pod natively. The Stakater Reloader annotation is not used — there is no
+  # Reloader controller in the cluster.
+  reloadOnChange: false
   # Single instance is sufficient; kromgo is stateless and only proxies read-only Prometheus queries
   replicas: 1
   image:

--- a/kubernetes/applications/node-red/base/values.yaml
+++ b/kubernetes/applications/node-red/base/values.yaml
@@ -2,6 +2,10 @@ applicationName: node-red
 
 deployment:
   enabled: true
+  # ConfigMap uses a kustomize content-hash name, so a config change rolls the
+  # pod natively. The Stakater Reloader annotation is not used — there is no
+  # Reloader controller in the cluster.
+  reloadOnChange: false
   replicas: 1
   # Node-RED uses local state on a PVC; avoid concurrent writers.
   strategy:

--- a/kubernetes/applications/pbs-exporter/base/values.yaml
+++ b/kubernetes/applications/pbs-exporter/base/values.yaml
@@ -2,6 +2,9 @@ applicationName: pbs-exporter
 
 deployment:
   enabled: true
+  # No ConfigMap is mounted, and there is no Stakater Reloader controller in the
+  # cluster — disable the chart's dead reloader.stakater.com/auto annotation.
+  reloadOnChange: false
   image:
     repository: ghcr.io/natrontech/pbs-exporter
     tag: v0.9.1

--- a/kubernetes/applications/smtprelay/base/values.yaml
+++ b/kubernetes/applications/smtprelay/base/values.yaml
@@ -2,6 +2,10 @@ applicationName: smtprelay
 
 deployment:
   enabled: true
+  # ConfigMap uses a kustomize content-hash name, so a config change rolls the
+  # pod natively. The Stakater Reloader annotation is not used — there is no
+  # Reloader controller in the cluster.
+  reloadOnChange: false
   # Single instance is sufficient for a simple relay; scale only if you need HA.
   replicas: 1
   image:

--- a/kubernetes/applications/solaredge2mqtt/base/values.yaml
+++ b/kubernetes/applications/solaredge2mqtt/base/values.yaml
@@ -1,5 +1,9 @@
 deployment:
   enabled: true
+  # ConfigMap uses a kustomize content-hash name, so a config change rolls the
+  # pod natively. The Stakater Reloader annotation is not used — there is no
+  # Reloader controller in the cluster.
+  reloadOnChange: false
   replicas: 1
   image:
     repository: ghcr.io/deroetzi/solaredge2mqtt


### PR DESCRIPTION
## Context

Follow-up to #1183 (issue #1167). The shared `application` Helm chart stamps `reloader.stakater.com/auto: "true"` by default (`deployment.reloadOnChange: true`), but **no Stakater Reloader controller runs in the cluster**. After #1183 converged the three genuinely-affected apps onto kustomize content-hash ConfigMap names, these remaining apps still rendered the dead annotation.

This completes the "one mechanism, consistently" goal of #1167 — purely cleanup, no behaviour change.

## Why none of these are functionally broken

| App | ConfigMap | Why the annotation is dead |
|-----|-----------|----------------------------|
| fritz-exporter | HASHED | already rolls natively via content-hash name |
| kromgo | HASHED | same |
| node-red | HASHED | same |
| smtprelay | HASHED | same |
| solaredge2mqtt | HASHED | same |
| iot-mcp-bridge | none | no ConfigMap mounted at all |
| pbs-exporter | none | no ConfigMap mounted at all |

## Change

Set `deployment.reloadOnChange: false` in each app's `values.yaml` so the rendered Deployment no longer carries the misleading annotation.

## Verification

`kustomize build --enable-helm` on all seven bases: `reloader.stakater.com` no longer appears in any rendered output. Pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)