### PR TITLE
feat(iot-insights-engine): add forecast-weather CronJob (Open-Meteo)

### DIFF
--- a/kubernetes/applications/iot-insights-engine/base/forecast-weather-cronjob.yaml
+++ b/kubernetes/applications/iot-insights-engine/base/forecast-weather-cronjob.yaml
@@ -1,0 +1,90 @@
+# CronJob: hourly Open-Meteo weather pull. Keyless public API, DWD ICON
+# model (icon_seamless, ~2 km, covers Eupen). Upserts five hourly metrics
+# into `mcp_forecasts` (model=open_meteo) so the Phase-4 get_weather_forecast
+# MCP tool reads from TSDB. Backs heating recommendations + (later) the
+# seasonal model's weather exogenous variable.
+# Schedule :20 of every hour — staggered past forecast-solar (:15).
+apiVersion: batch/v1
+kind: CronJob
+
+metadata:
+  name: iot-insights-engine-forecast-weather
+  namespace: iot-insights-engine
+
+spec:
+  schedule: "20 * * * *"
+  timeZone: "Etc/UTC"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  startingDeadlineSeconds: 600
+
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 86400
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: fetcher
+              image: ghcr.io/alexander-zimmermann/iot-insights-engine:1.6.0
+              command: ["iot-insights-engine", "forecast-weather"]
+              env:
+                - name: MCP_DB_HOST
+                  value: timescaledb-db-rw.timescaledb.svc.cluster.local
+                - name: MCP_DB_PORT
+                  value: "5432"
+                - name: MCP_DB_NAME
+                  value: homelab
+                # Settings() requires read creds even though this job only
+                # writes via db_write_dsn.
+                - name: MCP_DB_USERNAME
+                  valueFrom:
+                    secretKeyRef:
+                      name: timescaledb-db-iot-mcp-bridge-ro-secret
+                      key: username
+                - name: MCP_DB_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: timescaledb-db-iot-mcp-bridge-ro-secret
+                      key: password
+                - name: MCP_DB_WRITE_USERNAME
+                  valueFrom:
+                    secretKeyRef:
+                      name: timescaledb-db-iot-mcp-bridge-rw-secret
+                      key: username
+                - name: MCP_DB_WRITE_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: timescaledb-db-iot-mcp-bridge-rw-secret
+                      key: password
+                # Open-Meteo location (Steinroth 20, Eupen). Keyless — the job
+                # requests timezone=UTC, so no API key or local-tz handling.
+                - name: MCP_FORECAST_WEATHER_LAT
+                  value: "50.62598"
+                - name: MCP_FORECAST_WEATHER_LON
+                  value: "6.02435"
+                - name: MCP_FORECAST_WEATHER_MODEL
+                  value: icon_seamless
+                - name: MCP_FORECAST_WEATHER_FORECAST_HOURS
+                  value: "48"
+                - name: MCP_AUTH_ENABLED
+                  value: "false"
+              resources:
+                requests:
+                  cpu: 20m
+                  memory: 64Mi
+                limits:
+                  cpu: 100m
+                  memory: 128Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                runAsUser: 1000
+                runAsGroup: 1000
+                capabilities:
+                  drop: ["ALL"]
+                seccompProfile:
+                  type: RuntimeDefault

--- a/kubernetes/applications/iot-insights-engine/base/kustomization.yaml
+++ b/kubernetes/applications/iot-insights-engine/base/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - ./train-iforest-cronjob.yaml
   - ./score-iforest-cronjob.yaml
   - ./forecast-solar-cronjob.yaml
+  - ./forecast-weather-cronjob.yaml
   - ./score-seasonal-cronjob.yaml
   - ./weekly-report-cronjob.yaml
 


### PR DESCRIPTION
## Summary

Phase 4 Part 2 — the manifest that switches the weather pipeline live (#754). Adds an hourly `forecast-weather` CronJob to the iot-insights-engine app.

- Pulls the **keyless** Open-Meteo API (DWD ICON, `icon_seamless`, ~2 km — covers Eupen) on image **1.6.0** (built from iot-insights-engine#30).
- Upserts five hourly metrics (temperature, cloud_cover, precipitation, solar_radiation, wind_speed) into `mcp_forecasts` with `model=open_meteo`.
- Read back by `get_weather_forecast` in iot-mcp-bridge (released 1.6.0).

## Details

- Cloned from `forecast-solar-cronjob.yaml`; **no API key / SealedSecret** (the job requests `timezone=UTC`, so no secret or local-tz handling).
- Scheduled `:20` to stagger past forecast-solar (`:15`).
- Existing cronjobs left on 1.5.0 — they'll align on the next engine release; no schema change (mcp_forecasts is metric-agnostic).
- `kustomize build` renders all 8 cronjobs cleanly.

## After merge / verify

- ArgoCD syncs the new CronJob → manually trigger once → check `mcp_forecasts WHERE model='open_meteo'` has ~5 metrics × 48 rows.
- Then `get_weather_forecast(hours=48)` returns the pivoted forecast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)