### PR TITLE
fix(energy-balance): cronjob image → 1.8.1 (timezone hotfix)

### DIFF
--- a/kubernetes/applications/iot-insights-engine/base/energy-balance-cronjob.yaml
+++ b/kubernetes/applications/iot-insights-engine/base/energy-balance-cronjob.yaml
@@ -26,7 +26,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: energy-balance
-              image: ghcr.io/alexander-zimmermann/iot-insights-engine:1.8.0
+              image: ghcr.io/alexander-zimmermann/iot-insights-engine:1.8.1
               command: ["iot-insights-engine", "energy-balance"]
               env:
                 - name: MCP_DB_HOST


### PR DESCRIPTION
v1.8.0 crashed every run (SET TIME ZONE %s). Bump the energy-balance CronJob to v1.8.1 directly — the 1.8.0 deploy is actively failing, so don't wait for Renovate (which will bump the sibling cronjobs). Image 1.8.1 built & verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)