### PR TITLE
feat(pv): PV-underperformance anomaly (15/4/11) + energy GA renames

### DIFF
--- a/kubernetes/applications/iot-insights-engine/base/detect-pv-underperformance-cronjob.yaml
+++ b/kubernetes/applications/iot-insights-engine/base/detect-pv-underperformance-cronjob.yaml
@@ -1,0 +1,83 @@
+# CronJob: PV underperformance check, hourly at :20 (after forecast-solar :15).
+# Compares today's actual yield (inverter energytotal) against the weather-
+# adjusted forecast.solar expectation and publishes a severity on
+# anomaly.pv_underperformance → KNX 15/4/11. Read-only DB role; the MIN_EXPECTED
+# guard makes it a no-op (clear) outside daylight.
+apiVersion: batch/v1
+kind: CronJob
+
+metadata:
+  name: iot-insights-engine-detect-pv-underperformance
+  namespace: iot-insights-engine
+
+spec:
+  schedule: "20 * * * *"
+  timeZone: "Etc/UTC"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  startingDeadlineSeconds: 600
+
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 86400
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: detector
+              image: ghcr.io/alexander-zimmermann/iot-insights-engine:1.9.0
+              command: ["iot-insights-engine", "detect-pv-underperformance"]
+              env:
+                - name: MCP_DB_HOST
+                  value: timescaledb-db-rw.timescaledb.svc.cluster.local
+                - name: MCP_DB_PORT
+                  value: "5432"
+                - name: MCP_DB_NAME
+                  value: homelab
+                - name: MCP_DB_USERNAME
+                  valueFrom:
+                    secretKeyRef:
+                      name: timescaledb-db-iot-mcp-bridge-ro-secret
+                      key: username
+                - name: MCP_DB_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: timescaledb-db-iot-mcp-bridge-ro-secret
+                      key: password
+                # NATS — publish anomaly.pv_underperformance for KNX 15/4/11.
+                - name: MCP_NATS_SERVERS
+                  value: nats://nats.nats.svc.cluster.local:4222
+                - name: MCP_NATS_NKEY_SEED_FILE
+                  value: /etc/iot-insights-engine/nats/nkey-seed
+                - name: MCP_AUTH_ENABLED
+                  value: "false"
+                - name: TZ
+                  value: Europe/Berlin
+              resources:
+                requests:
+                  cpu: 20m
+                  memory: 64Mi
+                limits:
+                  cpu: 100m
+                  memory: 128Mi
+              volumeMounts:
+                - name: nats-credentials
+                  mountPath: /etc/iot-insights-engine/nats/nkey-seed
+                  subPath: nkey-seed
+                  readOnly: true
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                runAsUser: 1000
+                runAsGroup: 1000
+                capabilities:
+                  drop: ["ALL"]
+                seccompProfile:
+                  type: RuntimeDefault
+          volumes:
+            - name: nats-credentials
+              secret:
+                secretName: iot-mcp-bridge-credentials

--- a/kubernetes/applications/iot-insights-engine/base/kustomization.yaml
+++ b/kubernetes/applications/iot-insights-engine/base/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - ./sealed-secret.yaml
   - ./detect-univariate-cronjob.yaml
   - ./detect-knx-join-cronjob.yaml
+  - ./detect-pv-underperformance-cronjob.yaml
   - ./train-iforest-cronjob.yaml
   - ./score-iforest-cronjob.yaml
   - ./forecast-solar-cronjob.yaml

--- a/kubernetes/applications/knx-nats-bridge/base/config/ga-catalog.yaml
+++ b/kubernetes/applications/knx-nats-bridge/base/config/ga-catalog.yaml
@@ -2279,7 +2279,12 @@
 15/4/10:
   dpt: '14.056'
   function: Versorgerungstechnik
-  name: Versorgungstechnik.Photovoltaik.PV-Erzeugung-Gesamt
+  name: Versorgungstechnik.Photovoltaik.Erzeugung-Leistung
+  room: Technikraum
+15/4/11:
+  dpt: '5.010'
+  function: Versorgerungstechnik
+  name: Versorgungstechnik.Photovoltaik.Erzeugung-Leistung-Anomalie
   room: Technikraum
 15/4/2:
   dpt: '14.056'
@@ -2394,12 +2399,12 @@
 15/4/60:
   dpt: '13.013'
   function: Versorgerungstechnik
-  name: Versorgungstechnik.Photovoltaik.Erzeugung-Energie
+  name: Versorgungstechnik.Photovoltaik.Erzeugung
   room: Technikraum
 15/4/61:
   dpt: '13.013'
   function: Versorgerungstechnik
-  name: Versorgungstechnik.Photovoltaik.Verbrauch-Energie
+  name: Versorgungstechnik.Photovoltaik.Verbrauch
   room: Technikraum
 15/4/62:
   dpt: '13.013'
@@ -2449,12 +2454,12 @@
 15/4/8:
   dpt: '14.056'
   function: Versorgerungstechnik
-  name: Versorgungstechnik.Photovoltaik.Verbrauch-Gesamt
+  name: Versorgungstechnik.Photovoltaik.Verbrauch-Leistung
   room: Technikraum
 15/4/9:
   dpt: '5.010'
   function: Versorgerungstechnik
-  name: Versorgungstechnik.Photovoltaik.Verbrauch-Gesamt-Anomalie
+  name: Versorgungstechnik.Photovoltaik.Verbrauch-Leistung-Anomalie
   room: Technikraum
 15/5/102:
   dpt: '1.011'

--- a/kubernetes/applications/knx-nats-bridge/base/config/writer-rules.yaml
+++ b/kubernetes/applications/knx-nats-bridge/base/config/writer-rules.yaml
@@ -732,7 +732,16 @@ mappings:
     ga: "15/4/9"
     dpt: "5.010"
     payload_path: "$.severity_level"
-    description: "Versorgungstechnik.Photovoltaik.Verbrauch-Gesamt-Anomalie"
+    description: "Versorgungstechnik.Photovoltaik.Verbrauch-Leistung-Anomalie"
+    min_delta: 0
+    seed_on_start: true
+  # PV-Gesamt-Anomalie: today's yield vs the forecast.solar expectation
+  # (detect-pv-underperformance job). Active — uses inverter + forecast, both live.
+  - subject: "anomaly.pv_underperformance"
+    ga: "15/4/11"
+    dpt: "5.010"
+    payload_path: "$.severity_level"
+    description: "Versorgungstechnik.Photovoltaik.Erzeugung-Leistung-Anomalie"
     min_delta: 0
     seed_on_start: true
   # Batterie-Anomalien (15/4/50..56) — engine detectors stay inactive until the
@@ -1313,14 +1322,14 @@ mappings:
     ga: "15/4/60"
     dpt: "13.013"
     payload_path: "$.value"
-    description: "Versorgungstechnik.Photovoltaik.Erzeugung-Energie"
+    description: "Versorgungstechnik.Photovoltaik.Erzeugung"
     min_delta: 0
     seed_on_start: true
   - subject: "energy.pv.consumption_kwh"
     ga: "15/4/61"
     dpt: "13.013"
     payload_path: "$.value"
-    description: "Versorgungstechnik.Photovoltaik.Verbrauch-Energie"
+    description: "Versorgungstechnik.Photovoltaik.Verbrauch"
     min_delta: 0
     seed_on_start: true
   - subject: "energy.pv.self_consumption_kwh"


### PR DESCRIPTION
Companion to iot-insights-engine v1.9.0 (#39). Adds the house-level PV-underperformance anomaly and finalizes the energy GA renames.

- **ga-catalog** regenerated: new `15/4/11` (Erzeugung-Leistung-Anomalie) + the energy renames — `8` Verbrauch-Leistung, `10` Erzeugung-Leistung (momentary W), `60` Erzeugung, `61` Verbrauch (kWh). Convention: blank name = energy, `-Leistung` = power.
- **writer-rule** `anomaly.pv_underperformance → 15/4/11` (DPT 5.010, seed_on_start). Publisher = the `detect-pv-underperformance` job: today's actual yield vs the weather-adjusted forecast.solar expectation → severity 0–3.
- writer-rule **descriptions** aligned to the regenerated names (60/61/9).
- **CronJob** `detect-pv-underperformance` (hourly :20 after forecast-solar, RO DB + NATS, image 1.9.0).

Merge after the v1.9.0 image is built (CronJob pins 1.9.0). Renovate bumps the sibling cronjobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)