### PR TITLE
fix(detect-pv-underperformance): cronjob image → 1.9.1

### DIFF
--- a/kubernetes/applications/iot-insights-engine/base/detect-pv-underperformance-cronjob.yaml
+++ b/kubernetes/applications/iot-insights-engine/base/detect-pv-underperformance-cronjob.yaml
@@ -27,7 +27,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: detector
-              image: ghcr.io/alexander-zimmermann/iot-insights-engine:1.9.0
+              image: ghcr.io/alexander-zimmermann/iot-insights-engine:1.9.1
               command: ["iot-insights-engine", "detect-pv-underperformance"]
               env:
                 - name: MCP_DB_HOST


### PR DESCRIPTION
v1.9.0 mis-fired (summed 15-min forecast samples → false criticals on 15/4/11). Bump to v1.9.1 (forecast time-weighted integral). Image built & verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)