### PR TITLE
fix(unifi-arm): sync on KNX EMA status GAs + confirm state back to Basalte

### DIFF
--- a/kubernetes/applications/knx-nats-bridge/base/config/writer-rules.yaml
+++ b/kubernetes/applications/knx-nats-bridge/base/config/writer-rules.yaml
@@ -291,6 +291,26 @@ mappings:
     payload_path: "$.knx_value"
     description: "Sicherheitstechnik.VÜA.Terrasse.Esszimmer.Geräusch.Einbruch"
 
+  # UniFi Protect -- "Abwesend" arm-profile confirmation (read back from /nvrs by
+  # the unifi_arm_alarm stream). Mirrors the EMA status GAs so Basalte can show a
+  # notification once UniFi has actually reached the armed/disarmed state.
+  # seed_on_start keeps the read responder warm across restarts; min_delta 0
+  # writes only on change.
+  - subject: "unifi.arm.scharf_status"
+    ga: "14/3/200"
+    dpt: "1.011"
+    payload_path: "$.knx_value"
+    min_delta: 0
+    seed_on_start: true
+    description: "Sicherheitstechnik.VÜA.Abwesend.Scharf-Status"
+  - subject: "unifi.arm.unscharf_status"
+    ga: "14/3/201"
+    dpt: "1.011"
+    payload_path: "$.knx_value"
+    min_delta: 0
+    seed_on_start: true
+    description: "Sicherheitstechnik.VÜA.Abwesend.Unscharf-Status"
+
   # EMS-ESP boiler_data
   - subject: "ems-esp.boiler_data"
     ga: "15/2/10"

--- a/kubernetes/applications/nats/base/consumers/unifi_arm_alarm.yaml
+++ b/kubernetes/applications/nats/base/consumers/unifi_arm_alarm.yaml
@@ -1,5 +1,10 @@
 # Durable consumer for the redpanda-connect unifi_arm_alarm pipeline.
-# Watches the KNX GAs in 14/1/* that the arming scenes write to.
+# Watches the EMA *status* feedback GAs (not the command GAs): disarm via
+# keypad/scene never emits the 14/1/20 command, only the status GAs change.
+# These are re-broadcast by the panel (~5 min heartbeat), so the sync is
+# self-healing — every heartbeat re-asserts the intended UniFi state.
+#   knx.14.1.26 Extern-Scharf-Status: 1 => ARM   (Abwesend enable)
+#   knx.14.1.21 Unscharf-Status:      1 => DISARM (Abwesend disable)
 apiVersion: jetstream.nats.io/v1beta2
 kind: Consumer
 metadata:
@@ -8,12 +13,14 @@ metadata:
 spec:
   streamName: KNX
   durableName: redpanda-connect-unifi-arm-alarm
-  filterSubject: knx.14.1.*
+  filterSubjects:
+    - knx.14.1.26  # Extern-Scharf-Status: 1 => ARM (Abwesend enable)
+    - knx.14.1.21  # Unscharf-Status:      1 => DISARM (Abwesend disable)
   deliverPolicy: new
   ackPolicy: explicit
   # nats-operator default surfaces as 1ns, which causes immediate re-delivery
-  # of any message slower-than-instant to ack. 10s covers the http_client RTT
-  # comfortably without leaving wedged messages locked for long after a crash.
-  ackWait: 10s
+  # of any message slower-than-instant to ack. 15s covers the POST + read-back
+  # GET round-trips comfortably without leaving wedged messages locked long.
+  ackWait: 15s
   # Drop after 5 attempts so a permanently-failing message can't loop forever.
   maxDeliver: 5

--- a/kubernetes/applications/prometheus/base/prometheus-rule.yaml
+++ b/kubernetes/applications/prometheus/base/prometheus-rule.yaml
@@ -118,3 +118,26 @@ spec:
           annotations:
             summary: "RustFS drive op {{ $labels.op }} timing out"
             description: "Drive operation {{ $labels.op }} hit the per-op timeout — consider raising the matching RUSTFS_DRIVE_*_TIMEOUT_SECS env var."
+
+    - name: unifi-arm-sync-alerts
+      rules:
+        - alert: UnifiArmStateDrift
+          # unifi_arm_sync_ok is emitted by the redpanda-connect unifi_arm_alarm
+          # stream on every KNX status telegram (~5 min heartbeat): 1 = UniFi
+          # reached the KNX-requested state, 0 = it did not.
+          expr: min(unifi_arm_sync_ok) == 0
+          for: 10m
+          labels:
+            severity: critical
+          annotations:
+            summary: "UniFi arm state out of sync with KNX"
+            description: "UniFi has not reached the state requested by KNX for >10m. The ~5min KNX status heartbeat re-asserts every cycle, so persistent drift means the POST is not taking effect — the house may be unprotected or falsely armed."
+
+        - alert: UnifiArmSyncStale
+          expr: absent(unifi_arm_sync_ok)
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "UniFi arm-sync metric stale/absent"
+            description: "unifi_arm_sync_ok has not been reported for >15m (expected every ~5min via the KNX status heartbeat). The redpanda-connect stream, its JetStream consumer binding, or the scrape is stuck — drift detection is blind."

--- a/kubernetes/applications/redpanda-connect/base/streams/unifi_arm_alarm.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/unifi_arm_alarm.yaml
@@ -1,5 +1,26 @@
+# Syncs the KNX alarm panel's armed state to the UniFi Protect "Abwesend"
+# arm-profile, and writes the *confirmed* UniFi state back onto KNX status GAs
+# so Basalte can show it (positive confirmation, mirroring the EMA).
+#
+# Triggers on the EMA STATUS GAs (not the command GAs): disarm via keypad/scene
+# never emits the 14/1/20 command — only the status GAs change. The panel
+# re-broadcasts them every ~5 min, so the sync is self-healing: every heartbeat
+# re-asserts the intended UniFi state and refreshes the confirmation + metric.
+#   knx.14.1.26 Extern-Scharf-Status: 1 => enable  (Abwesend)
+#   knx.14.1.21 Unscharf-Status:      1 => disable
+# Do NOT invert one GA: 14/1/26=0 is ambiguous with Intern-Scharf.
+#
+# Flow (sequential, so ordering is guaranteed without a race):
+#   1. POST enable/disable. Best-effort: a 400 ("already in target state") is
+#      harmless, and a genuine UDM outage also fails the read-back below, which
+#      rejects the message for JetStream redelivery.
+#   2. GET /nvrs and read armMode — the source of truth for what UniFi actually
+#      did. Compare to the intended action -> unifi_arm_sync_ok gauge.
+#   3. Publish both status polarities to NATS; the knx-nats-bridge writer rules
+#      map them to 14/3/200 (Scharf) and 14/3/201 (Unscharf) -> Basalte.
 input:
-  # Consumer is declared as a CRD in nats/base/consumers/unifi_arm_alarm.yaml.
+  # Consumer (filterSubjects 14.1.26 + 14.1.21) is a CRD in
+  # nats/base/consumers/unifi_arm_alarm.yaml.
   nats_jetstream:
     urls: ["nats://nats.nats.svc:4222"]
     auth:
@@ -11,51 +32,91 @@ input:
 
 pipeline:
   processors:
-    # First stage: filter to the two relevant GAs regardless of value, so
-    # the second stage runs on a known subject set and `meta` assignment
-    # never has to express "drop the message" via deleted().
+    # Tag the intended action from the subject; drop the 0-half of the status
+    # pulse. `.bool().or(false)` survives both bool and int payload shapes.
     - mapping: |
         let subj = meta("nats_subject")
-        root = if $subj == "knx.14.1.25" || $subj == "knx.14.1.20" {
+        let on = this.value.bool().or(false)
+        root = if $on && ($subj == "knx.14.1.26" || $subj == "knx.14.1.21") {
           this
         } else {
           deleted()
         }
-    # Second stage: drop the 0-half of the KNX command pulse, tag action.
-    # `.bool().or(false)` survives both bool and int payload shapes.
-    - mapping: |
-        let on = this.value.bool().or(false)
-        root = if $on { this } else { deleted() }
-        meta protect_action = if meta("nats_subject") == "knx.14.1.25" {
-          "enable"
-        } else {
-          "disable"
-        }
+        meta protect_action = if $subj == "knx.14.1.26" { "enable" } else { "disable" }
+
+    # 1. POST the arm-profile enable/disable (side-effect only; response and any
+    #    error are discarded — the read-back is authoritative). The catch clears
+    #    the error flag a non-2xx (incl. 400) sets, so the read-back still runs.
+    - branch:
+        request_map: 'root = ""'
+        processors:
+          - http:
+              url: 'https://udm-pro.zimmermann.eu.com/proxy/protect/integration/v1/arm-profiles/${! meta("protect_action") }?id=${UNIFI_PROTECT_ARM_PROFILE_ID}'
+              verb: POST
+              headers:
+                X-API-Key: "${UNIFI_PROTECT_API_KEY}"
+                Accept: "application/json"
+              retries: 0
+        result_map: 'root = deleted()'
+    - catch:
+        - mapping: 'root = this'
+
+    # 2. Read back the real NVR arm state. On failure the branch sets the error
+    #    flag, the result_map is skipped, and the message is rejected below for
+    #    JetStream redelivery (this is the retry path for a genuine UDM outage).
+    - branch:
+        request_map: 'root = ""'
+        processors:
+          - http:
+              url: 'https://udm-pro.zimmermann.eu.com/proxy/protect/integration/v1/nvrs'
+              verb: GET
+              headers:
+                X-API-Key: "${UNIFI_PROTECT_API_KEY}"
+                Accept: "application/json"
+              retries: 2
+        result_map: |
+          let nvr = if this.type() == "array" { this.index(0) } else { this }
+          let mode = $nvr.armMode
+          let armed = $mode.armProfileId == "${UNIFI_PROTECT_ARM_PROFILE_ID}" &&
+                      $mode.status.or("") != "disabled" &&
+                      $mode.armedAt.or(null) != null
+          meta observed_status = $mode.status.or("unknown")
+          meta knx_scharf   = if $armed { "1" } else { "0" }
+          meta knx_unscharf = if $armed { "0" } else { "1" }
+          meta sync_ok = if $armed == (meta("protect_action").or("") == "enable") { "1" } else { "0" }
 
 output:
   switch:
     cases:
-      - check: 'meta("protect_action") == "enable"'
+      # Read-back failed (UDM unreachable) -> nack for JetStream redelivery.
+      - check: errored()
         output:
-          http_client:
-            url: 'https://udm-pro.zimmermann.eu.com/proxy/protect/integration/v1/arm-profiles/enable?id=${UNIFI_PROTECT_ARM_PROFILE_ID}'
-            verb: POST
-            headers:
-              X-API-Key: "${UNIFI_PROTECT_API_KEY}"
-              Accept: "application/json"
-            # UniFi returns 204 on success and 400 when the profile is already
-            # in the target state ("Attempted to disarm the alarm when it is
-            # not armed"). Both are terminal for us — ack and move on.
-            successful_on: [200, 204, 400]
-      - check: 'meta("protect_action") == "disable"'
-        output:
-          http_client:
-            url: 'https://udm-pro.zimmermann.eu.com/proxy/protect/integration/v1/arm-profiles/disable?id=${UNIFI_PROTECT_ARM_PROFILE_ID}'
-            verb: POST
-            headers:
-              X-API-Key: "${UNIFI_PROTECT_API_KEY}"
-              Accept: "application/json"
-            # UniFi returns 204 on success and 400 when the profile is already
-            # in the target state ("Attempted to disarm the alarm when it is
-            # not armed"). Both are terminal for us — ack and move on.
-            successful_on: [200, 204, 400]
+          reject: 'unifi /nvrs read-back failed: ${! error() }'
+      # Confirmed: publish both polarities and emit the drift gauge.
+      - output:
+          broker:
+            pattern: fan_out
+            outputs:
+              - nats:
+                  urls: ["nats://nats.nats.svc:4222"]
+                  auth:
+                    user: redpanda-connect
+                    password: ${NATS_PASSWORD}
+                  subject: unifi.arm.scharf_status
+                processors:
+                  - mapping: 'root = {"knx_value": meta("knx_scharf").number()}'
+              - nats:
+                  urls: ["nats://nats.nats.svc:4222"]
+                  auth:
+                    user: redpanda-connect
+                    password: ${NATS_PASSWORD}
+                  subject: unifi.arm.unscharf_status
+                processors:
+                  - mapping: 'root = {"knx_value": meta("knx_unscharf").number()}'
+          processors:
+            - metric:
+                type: gauge
+                name: unifi_arm_sync_ok
+                value: ${! meta("sync_ok") }
+                labels:
+                  intended: ${! meta("protect_action") }

--- a/kubernetes/applications/redpanda-connect/base/values.yaml
+++ b/kubernetes/applications/redpanda-connect/base/values.yaml
@@ -58,6 +58,12 @@ env:
         name: redpanda-connect-unifi-protect
         key: UNIFI_PROTECT_ARM_PROFILE_ID
 
+# Expose connect/benthos metrics (incl. custom `metric` processors such as
+# unifi_arm_sync_ok) in Prometheus format at :4195/metrics for the
+# ServiceMonitor below to scrape.
+metrics:
+  prometheus: {}
+
 serviceMonitor:
   enabled: true
   interval: 30s


### PR DESCRIPTION
## Problem

The KNX→UniFi "Abwesend" arm-profile sync triggered on the **command** GAs `14/1/25` (arm) / `14/1/20` (disarm). Disarming via keypad/scene never emits the `14/1/20` command — only the **status** GAs change — so keypad-disarms were silently missed, UniFi stayed armed, and motion in the disarmed house triggered a false breach + siren (observed 2026-06-23 18:24; the EMA's own alarm GA `14/1/28` stayed 0, confirming the panel itself was disarmed). Recurring, because every keypad-disarm left UniFi armed.

Verified against the KNX TSDB archive vs the UniFi NVR API: no `14/1/20` command fired in the afternoon (last at 06:39), while `14/1/26`/`14/1/21` status GAs flipped to disarmed at 15:46 and 17:24.

## Fix

- **Trigger on the EMA status GAs** `14/1/26` (Extern-Scharf-Status → enable) / `14/1/21` (Unscharf-Status → disable) instead of the command GAs. The panel re-broadcasts these ~every 5 min, so the sync is self-healing — each heartbeat re-asserts the intended UniFi state (`400 = already in state` is harmless).
- **Read-back confirmation:** the stream now does `GET /nvrs` after each POST (source of truth) and publishes the confirmed state to `unifi.arm.scharf_status` / `unifi.arm.unscharf_status`. New writer-rules map these to KNX `14/3/200` (Scharf-Status) / `14/3/201` (Unscharf-Status) so **Basalte shows a positive confirmation**, mirroring the EMA. On mismatch the *actual* state is written (no false "disarmed" notification).
- **Safety net:** gauge `unifi_arm_sync_ok` (connect Prometheus exporter enabled) + `UnifiArmStateDrift` / `UnifiArmSyncStale` alerts.

### Topology note
Implemented as a single combined stream (POST → read-back → publish, sequential) rather than two streams — this guarantees POST-before-readback ordering without a cross-stream race/converge loop and reuses the existing consumer. POST errors are swallowed (the read-back is authoritative); a genuine UDM outage fails the GET → `reject` → JetStream redelivery.

## Validation
- `redpanda-connect lint` clean; behaviour-tested against the real connect binary with simulated HTTP responses (UDM untouched): disarm-match, arm-match, and mismatch→`sync_ok=0` all correct.
- writer-rules validated against the JSON schema (204 mappings OK).

## Deploy / follow-ups (manual)
1. Add `14/3/200` / `14/3/201` (DPT 1.011) in ETS, then `task knx:catalog` — `ga-catalog.yaml` is generated, not hand-edited here.
2. Configure Basalte notifications on those GAs.
3. JetStream consumer is immutable (`filterSubject`→`filterSubjects`): delete the live object + Argo sync + `kubectl rollout restart deploy/redpanda-connect -n redpanda-connect`.
4. After deploy, verify the exact exported series name at `:4195/metrics` and adjust the alert `expr` if prefixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)