### PR TITLE
fix(redpanda-connect): scrape ServiceMonitor + silence steady-state 400s

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/kustomization.yaml
+++ b/kubernetes/applications/redpanda-connect/base/kustomization.yaml
@@ -55,6 +55,17 @@ patches:
       - op: add
         path: /metadata/labels/bgp.cilium.io~1advertise-service
         value: default
+  # The connect chart's ServiceMonitor template hardcodes only the default
+  # app.kubernetes.io labels and ignores serviceMonitor.labels, so the
+  # `release: prometheus` label the Prometheus serviceMonitorSelector requires
+  # has to be injected here — otherwise the SM is never scraped.
+  - target:
+      kind: ServiceMonitor
+      name: redpanda-connect
+    patch: |-
+      - op: add
+        path: /metadata/labels/release
+        value: prometheus
 
 labels:
   - includeSelectors: false

--- a/kubernetes/applications/redpanda-connect/base/streams/unifi_arm_alarm.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/unifi_arm_alarm.yaml
@@ -44,9 +44,12 @@ pipeline:
         }
         meta protect_action = if $subj == "knx.14.1.26" { "enable" } else { "disable" }
 
-    # 1. POST the arm-profile enable/disable (side-effect only; response and any
-    #    error are discarded — the read-back is authoritative). The catch clears
-    #    the error flag a non-2xx (incl. 400) sets, so the read-back still runs.
+    # 1. POST the arm-profile enable/disable (side-effect only; response is
+    #    discarded — the read-back is authoritative). 204 = applied, 400 =
+    #    "already in target state"; both are success, so the ~5 min heartbeat
+    #    re-POSTing the steady state stays silent instead of logging a 400 every
+    #    cycle. A genuine 5xx/network error still sets the error flag, which the
+    #    catch clears so the read-back below can determine the real state.
     - branch:
         request_map: 'root = ""'
         processors:
@@ -57,6 +60,7 @@ pipeline:
                 X-API-Key: "${UNIFI_PROTECT_API_KEY}"
                 Accept: "application/json"
               retries: 0
+              successful_on: [200, 204, 400]
         result_map: 'root = deleted()'
     - catch:
         - mapping: 'root = this'

--- a/kubernetes/applications/redpanda-connect/base/values.yaml
+++ b/kubernetes/applications/redpanda-connect/base/values.yaml
@@ -67,6 +67,6 @@ metrics:
 serviceMonitor:
   enabled: true
   interval: 30s
-  labels:
-    # Prometheus Operator label (Opt-In)
-    release: prometheus
+  # NOTE: the chart's ServiceMonitor template ignores serviceMonitor.labels, so
+  # the `release: prometheus` selector label is injected via a kustomize patch
+  # in kustomization.yaml instead.


### PR DESCRIPTION
## Why

`UnifiArmSyncStale` (`absent(unifi_arm_sync_ok)`) fired after #1210 deployed — even though the metric **is** exposed at the pod's `:4195/metrics`. Root cause: Prometheus' `serviceMonitorSelector` requires `release: prometheus`, but the connect chart's ServiceMonitor template **hardcodes only the default `app.kubernetes.io` labels and ignores `serviceMonitor.labels`**. So the SM never carried `release: prometheus`, was never selected, and the target was never scraped. This was latent (the SM was never scraped) — it only became visible now that an alert depends on a metric from it.

The actual sync is healthy: `unifi_arm_sync_ok{intended="disable"} 1` at the pod, consumer rebound to `["knx.14.1.26","knx.14.1.21"]`. This is a scrape-wiring + log-noise fix, not a sync bug.

## Changes

- **Inject `release: prometheus`** onto the ServiceMonitor via a kustomize patch (the chart can't); drop the dead `serviceMonitor.labels` from `values.yaml`.
- **`successful_on: [200, 204, 400]`** on the arm-profile POST: the `http` *processor* (unlike the old `http_client` output) has no implicit 400 handling, so the ~5 min heartbeat re-POSTing the already-disarmed steady state logged a `400 "Attempted to disarm when not armed"` every cycle. This restores the silent-idempotent behaviour.

## Validation

- `kustomize build --enable-helm` → ServiceMonitor now renders with `release: prometheus`.
- `redpanda-connect lint` clean on the stream.

After merge+sync, Prometheus picks up the SM within a scrape interval and `UnifiArmSyncStale` resolves once `unifi_arm_sync_ok` is scraped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)