### PR TITLE
feat(holmesgpt): Phase 1 — HolmesGPT investigation server (Claude Sonnet 4.6, read-only)

### DIFF
--- a/kubernetes/applications/holmesgpt/base/kustomization.yaml
+++ b/kubernetes/applications/holmesgpt/base/kustomization.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: holmesgpt
+resources:
+  - ./namespace.yaml
+  - ./sealed-secret.yaml
+
+helmCharts:
+  - name: holmes
+    repo: https://robusta-charts.storage.googleapis.com
+    releaseName: holmes
+    version: 0.33.0
+    valuesFile: values.yaml
+    namespace: holmesgpt
+
+labels:
+  - includeSelectors: false
+    pairs:
+      homelab.app: holmesgpt
+
+commonAnnotations:
+  argocd.argoproj.io/sync-wave: "10"

--- a/kubernetes/applications/holmesgpt/base/namespace.yaml
+++ b/kubernetes/applications/holmesgpt/base/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+
+metadata:
+  name: holmesgpt

--- a/kubernetes/applications/holmesgpt/base/sealed-secret.yaml
+++ b/kubernetes/applications/holmesgpt/base/sealed-secret.yaml
@@ -1,0 +1,15 @@
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+
+metadata:
+  name: holmesgpt-llm
+  namespace: holmesgpt
+
+spec:
+  encryptedData:
+    anthropic-api-key: AgBrzOnvyft4JEz2yqByz8J5VMC7n0g/S7eHJuiOuDekpcNYlarMtaZWqquz2Xa9j4d1mVHMTHDWJ3nid7atEciYStwOe0D5x1djEDVFgu3dAUUEf7N3Anm9qvdHRp1M8glE9OMhThmFaWkMQgV3aJ9EFhZ1Y++zegJ9/iGdsoZ/AGNBH2T4rd/ZlC/YwjwN+BoirzyzOn1yqGv8w3nwQPjgBfOSY/IEku5QxXIQSsW8yBauRPfl3B65Ze5K6uXVMWHW0THJ9DnMcMVPBOi/iLYpoGpxXB3waWo+0wCIGzvLgaszuJcZ/lqK1g1efuY/WQ0YYsxgcj9XYM5zOvylxfaxhT0fd2P2O0eJ08dd8gf7ZlN39JXF5I6Mg/qNtD8xfd3fUCBl0gUUNK8vv67xw+pT8Nt9KfXFshw/OMcyuPVwe9u036qWfybfBovd4cCHUjG5WiXBlY4j7nDQMSJrC6e5qT7AukvAuNxgJSXFFJ+bCpsmYlmVh9XAAk7NfFqppRi9TJdVO+DqoPuZAzj/+xTlCn0j7EFrxF+WkY8rcjNf1SGMl24h1yN6gUu+blIwtcdwLJm/Z9Hi+WdDXMtzFWL8BucCnrISUpoeX0nAcSwnvTXAvTSOg0jVjrDuX/eUd0+legsvg34qdtzBGFWUFHgdicupvrCTVHu5MDJekJQZpQjAt84yPMSaRXttKoYjEEgnwamYPgsUlRaKIXsRPNwdF2UqOAXZrML93R3Qs4cUrwJpltSF59aWksxHf813gP3/w48tr5wkTTGY4O9W5UPQyJWVOJYEnfe7KOkIKqtFnC73QXdiDGKu8FKuwLELQZgP2fnFmSvwtbJW
+  template:
+    metadata:
+      name: holmesgpt-llm
+      namespace: holmesgpt
+    type: Opaque

--- a/kubernetes/applications/holmesgpt/base/values.yaml
+++ b/kubernetes/applications/holmesgpt/base/values.yaml
@@ -1,0 +1,21 @@
+# Only overrides — chart defaults provide the read-only ClusterRole
+# (createServiceAccount + k8sRBAC=false) and the default investigation toolsets.
+
+# LLM backend: Claude Sonnet 4.6 via litellm. The API key comes from the
+# SealedSecret; MODEL selects the default model for every investigation.
+additionalEnvVars:
+  - name: MODEL
+    value: anthropic/claude-sonnet-4-6
+  - name: ANTHROPIC_API_KEY
+    valueFrom:
+      secretKeyRef:
+        name: holmesgpt-llm
+        key: anthropic-api-key
+  # In-cluster Prometheus query endpoint for the prometheus/metrics toolset
+  - name: PROMETHEUS_URL
+    value: http://prometheus-prometheus.prometheus.svc.cluster.local:9090
+
+toolsets:
+  # Robusta SaaS platform toolset — no Robusta account here, so it would be inert
+  robusta:
+    enabled: false

--- a/kubernetes/applications/holmesgpt/overlays/dev/kustomization.yaml
+++ b/kubernetes/applications/holmesgpt/overlays/dev/kustomization.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+patches:
+  # Smaller footprint for dev; same single-container Holmes server.
+  - target:
+      kind: Deployment
+      name: holmes-holmes
+    patch: |-
+      - op: test
+        path: /spec/template/spec/containers/0/name
+        value: holmes
+      - op: add
+        path: /spec/template/spec/containers/0/resources
+        value:
+          requests:
+            cpu: 50m
+            memory: 768Mi
+          limits:
+            memory: 1536Mi

--- a/kubernetes/applications/holmesgpt/overlays/prod/kustomization.yaml
+++ b/kubernetes/applications/holmesgpt/overlays/prod/kustomization.yaml
@@ -1,0 +1,25 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+patches:
+  # Holmes investigation server — memory floor trimmed from the 2Gi chart
+  # default (cluster is RAM-constrained); 2Gi limit keeps headroom for agent
+  # loops with large tool outputs.
+  - target:
+      kind: Deployment
+      name: holmes-holmes
+    patch: |-
+      - op: test
+        path: /spec/template/spec/containers/0/name
+        value: holmes
+      - op: add
+        path: /spec/template/spec/containers/0/resources
+        value:
+          requests:
+            cpu: 50m
+            memory: 1Gi
+          limits:
+            memory: 2Gi


### PR DESCRIPTION
## What

Phase 1 of the HolmesGPT AIOps roadmap: a standalone, read-only **investigation server** under `kubernetes/applications/holmesgpt/`.

HolmesGPT (CNCF Sandbox, `robusta/holmes` chart) is the AIOps agent for the stack — it investigates Prometheus/Kubernetes signals and produces root-cause analysis. Keep and the Robusta runner were both evaluated and rejected; the PR-creating endgame (operator + GitHub PRs) lives on this *same* chart, so the whole roadmap grows from this one deployment.

## This PR (Phase 1 — investigation-only)

- `robusta/holmes` v0.33.0 (classic helm repo), image from Docker Hub.
- **Claude Sonnet 4.6** via litellm (`MODEL` + `ANTHROPIC_API_KEY` from the `holmesgpt-llm` SealedSecret).
- **Read-only ClusterRole** (chart default, `k8sRBAC=false`) — no mutating access; Prometheus + Kubernetes toolsets, Robusta-SaaS toolset disabled.
- Memory trimmed from the 2Gi chart default via overlay JSON patches (prod 1Gi/2Gi, dev 768Mi/1536Mi) for the RAM-constrained cluster.
- Auto-discovered by the applications ApplicationSet, sync-wave 10. No ingress, no auto-trigger.

Validated: `kustomize build --enable-helm` renders cleanly for prod and dev; ClusterRole confirmed to have no write verbs.

## How it's used (for now)

Manual, on-demand — the pod is otherwise idle (no LLM cost until asked):

```bash
kubectl exec -it deploy/holmes-holmes -n holmesgpt -- holmes ask "why is pod X in namespace Y unhealthy"
```

The first job is to verify RCA quality against known runbooks (Traefik-stale after a Proxmox reboot, SealedSecret "already exists", NFS-PVC after a storage IP change) before any automation is added.

## Follow-ups (not in this PR)

- #1215 — Phase 2: proactive `ScheduledHealthCheck`s via the operator (read-only reporting)
- #1216 — Phase 3: operator opens suggested-fix PRs against `lares` (GitHub MCP, human-merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
