### PR TITLE
chore(holmesgpt): restricted-PSA securityContext + right-size memory

### DIFF
--- a/kubernetes/applications/holmesgpt/base/values.yaml
+++ b/kubernetes/applications/holmesgpt/base/values.yaml
@@ -14,6 +14,24 @@ additionalEnvVars:
   # In-cluster Prometheus query endpoint for the prometheus/metrics toolset
   - name: PROMETHEUS_URL
     value: http://prometheus-prometheus.prometheus.svc.cluster.local:9090
+  # Writable HOME (read-only rootfs; agent caches under $HOME/.holmes)
+  - name: HOME
+    value: /tmp
+
+# Satisfy the namespace's restricted Pod Security Standard (image defaults to root).
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 10001
+  runAsGroup: 10001
+  fsGroup: 10001
+  seccompProfile:
+    type: RuntimeDefault
+
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
 
 toolsets:
   # Robusta SaaS platform toolset — no Robusta account here, so it would be inert

--- a/kubernetes/applications/holmesgpt/overlays/dev/kustomization.yaml
+++ b/kubernetes/applications/holmesgpt/overlays/dev/kustomization.yaml
@@ -18,6 +18,6 @@ patches:
         value:
           requests:
             cpu: 50m
-            memory: 768Mi
+            memory: 512Mi
           limits:
-            memory: 1536Mi
+            memory: 768Mi

--- a/kubernetes/applications/holmesgpt/overlays/prod/kustomization.yaml
+++ b/kubernetes/applications/holmesgpt/overlays/prod/kustomization.yaml
@@ -5,9 +5,7 @@ resources:
   - ../../base
 
 patches:
-  # Holmes investigation server — memory floor trimmed from the 2Gi chart
-  # default (cluster is RAM-constrained); 2Gi limit keeps headroom for agent
-  # loops with large tool outputs.
+  # Sized from observed usage (~428Mi steady, flat through investigations).
   - target:
       kind: Deployment
       name: holmes-holmes
@@ -20,6 +18,6 @@ patches:
         value:
           requests:
             cpu: 50m
-            memory: 1Gi
+            memory: 512Mi
           limits:
-            memory: 2Gi
+            memory: 1Gi


### PR DESCRIPTION
Runs the holmes container as non-root (uid 10001, seccomp RuntimeDefault, drop ALL caps) to satisfy the namespace's restricted PSA (was emitting an admission warning); HOME=/tmp for the read-only rootfs. Pre-flight-verified as uid 10001. Memory right-sized from the observed ~428Mi flat working set: prod 512Mi/1Gi, dev 512Mi/768Mi.