### PR TITLE
chore(cluster): bump control-plane-prod RAM 4->5 GiB

### DIFF
--- a/cluster/homelab-machine-classes.yaml
+++ b/cluster/homelab-machine-classes.yaml
@@ -15,7 +15,7 @@ spec:
       # Resource allocation
       sockets: 1
       cores: 4
-      memory: 4096
+      memory: 5120
       disk_size: 32
 
       # CPU & memory optimizations


### PR DESCRIPTION
Raises the prod control-plane machine class from 4096 to 5120 MiB. The 3 CP VMs run at 85-92% memory; kube-apiserver baseline (~1.8 GiB for 149 CRDs) leaves too little headroom, causing sporadic etcd/apiserver latency that times out leader-election lease renewals and restarts controllers cluster-wide. 5 GiB lifts allocatable ~3.28->~4.3 GiB (CP pressure ~90%->~70%). **Apply is manual (`task cluster:init`) and must roll one CP at a time to preserve etcd quorum** — see rollout discussion before applying.