### PR TITLE
feat(holmesgpt): connect grafana/loki toolset for historical logs

### DIFF
--- a/kubernetes/applications/holmesgpt/base/values.yaml
+++ b/kubernetes/applications/holmesgpt/base/values.yaml
@@ -37,3 +37,8 @@ toolsets:
   # Robusta SaaS platform toolset — no Robusta account here, so it would be inert
   robusta:
     enabled: false
+  # Historical logs (14d) — direct to in-cluster Loki (auth_enabled: false)
+  grafana/loki:
+    enabled: true
+    config:
+      api_url: http://loki.loki.svc.cluster.local:3100


### PR DESCRIPTION
Enables the `grafana/loki` toolset pointed directly at in-cluster Loki (`loki.loki.svc:3100`, auth_enabled: false — no Grafana proxy/secret). Closes the biggest data gap: Holmes had only live `kubectl logs` and was blind to logs from already-restarted/dead pods — which directly fed the hallucinated root-causes (guessing from restart counts instead of reading the actual crash logs). 14d of real log history now available.