### PR TITLE
chore(knx): add UniFi Abwesend arm-status GAs to ga-catalog

### DIFF
--- a/kubernetes/applications/knx-nats-bridge/base/config/ga-catalog.yaml
+++ b/kubernetes/applications/knx-nats-bridge/base/config/ga-catalog.yaml
@@ -1581,6 +1581,16 @@
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Fassade.Objekterkennung.Fahrzeug
   room: Fassade
+14/3/200:
+  dpt: '1.011'
+  function: Sicherheitstechnik
+  name: Sicherheitstechnik.VÜA.Abwesend.Scharf-Status
+  room: Technikraum
+14/3/201:
+  dpt: '1.011'
+  function: Sicherheitstechnik
+  name: Sicherheitstechnik.VÜA.Abwesend.Unscharf-Status
+  room: Technikraum
 14/3/3:
   dpt: '5.010'
   function: Sicherheitstechnik


### PR DESCRIPTION
Regenerated `ga-catalog.yaml` from ETS, adding the two GAs the UniFi arm-status read-back writes for the Basalte confirmation (companion to #1210):

| GA | Name | DPT | room |
|----|------|-----|------|
| 14/3/200 | Sicherheitstechnik.VÜA.Abwesend.Scharf-Status | 1.011 | Technikraum |
| 14/3/201 | Sicherheitstechnik.VÜA.Abwesend.Unscharf-Status | 1.011 | Technikraum |

Diff is exactly these two entries — an earlier regen also flipped 14/3/45–54 (Eingang cameras) to room Terrasse; root cause was those GAs being assigned to two ETS Functions (Eingang **and** Terrasse), so the parser's first-match picked Terrasse. Fixed in ETS by removing the stray GAs from the Terrasse "Sicherheitstechnik" function, so this catalog now reflects the correct rooms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)