### PR TITLE
feat(holmesgpt): connect argocd/core toolset (read-only, auto-provisioned token)

### DIFF
--- a/kubernetes/applications/holmesgpt/base/values.yaml
+++ b/kubernetes/applications/holmesgpt/base/values.yaml
@@ -17,6 +17,16 @@ additionalEnvVars:
   # Writable HOME (read-only rootfs; agent caches under $HOME/.holmes)
   - name: HOME
     value: /tmp
+  # ArgoCD read-only token (Kyverno-cloned) + in-cluster server for the argocd/core toolset
+  - name: ARGOCD_AUTH_TOKEN
+    valueFrom:
+      secretKeyRef:
+        name: argocd-holmes-token
+        key: token
+  - name: ARGOCD_SERVER
+    value: argocd-server.gitops-controller.svc.cluster.local:80
+  - name: ARGOCD_OPTS
+    value: --plaintext --grpc-web
 
 # Satisfy the namespace's restricted Pod Security Standard (image defaults to root).
 podSecurityContext:
@@ -42,3 +52,6 @@ toolsets:
     enabled: true
     config:
       api_url: http://loki.loki.svc.cluster.local:3100
+  # GitOps state/drift/sync status (read-only token; default role:readonly)
+  argocd/core:
+    enabled: true

--- a/kubernetes/bootstrap/gitops-controller/base/values.yaml
+++ b/kubernetes/bootstrap/gitops-controller/base/values.yaml
@@ -16,6 +16,8 @@ configs:
           - "*"
     # Homepage service account – read-only API key for the homepage widget
     accounts.homepage: apiKey
+    # HolmesGPT service account – read-only API key for the AIOps agent's argocd toolset
+    accounts.holmes: apiKey
     # ArgoCD server URL – PLACEHOLDER is replaced per environment via overlay replacements
     url: https://argocd.PLACEHOLDER
     # OIDC via bundled Dex with Authentik upstream — PLACEHOLDER replaced per env

--- a/kubernetes/components/admission-controller/base/clusterpolicy-secrets.yaml
+++ b/kubernetes/components/admission-controller/base/clusterpolicy-secrets.yaml
@@ -171,6 +171,25 @@ spec:
           namespace: gitops-controller
           name: argocd-homepage-token
 
+    # Syncs the ArgoCD Holmes read-only token from gitops-controller into holmesgpt for the argocd/core toolset
+    - name: sync-argocd-holmes-token
+      match:
+        any:
+          - resources:
+              kinds:
+                - Namespace
+              names:
+                - holmesgpt
+      generate:
+        apiVersion: v1
+        kind: Secret
+        name: argocd-holmes-token
+        namespace: holmesgpt
+        synchronize: true
+        clone:
+          namespace: gitops-controller
+          name: argocd-holmes-token
+
     # Syncs Redis password from redis namespace into ingress-controller for CrowdSec bouncer
     - name: sync-redis-password
       match:

--- a/kubernetes/components/gitops-controller/base/scripts/service-accounts.yaml
+++ b/kubernetes/components/gitops-controller/base/scripts/service-accounts.yaml
@@ -2,3 +2,6 @@ service_accounts:
   - account: homepage
     secret_name: argocd-homepage-token
     secret_namespace: gitops-controller
+  - account: holmes
+    secret_name: argocd-holmes-token
+    secret_namespace: gitops-controller


### PR DESCRIPTION
Adds read-only ArgoCD visibility to HolmesGPT, reusing the existing token-provisioner pattern (no manual token/seal).

- **argocd account `holmes`** (apiKey) in the argocd values; `policy.default: role:readonly` keeps it read-only with no extra RBAC.
- **Provisioner**: `service-accounts.yaml` entry → the PostSync Job generates the token into `argocd-holmes-token` (gitops-controller ns), idempotent.
- **Kyverno** clones the secret into the `holmesgpt` namespace (mirrors the homepage rule).
- **holmes values**: `argocd/core` enabled + `ARGOCD_AUTH_TOKEN` (from the cloned secret), `ARGOCD_SERVER=argocd-server.gitops-controller.svc:80`, `ARGOCD_OPTS=--plaintext --grpc-web` (server runs insecure).

Verify on deploy: if `argocd/core` stays `failed`, adjust ARGOCD_OPTS/port.