### PR TITLE
feat(holmesgpt): Phase 2 — operator + ScheduledHealthChecks (read-only)

### DIFF
--- a/kubernetes/applications/holmesgpt/base/kustomization.yaml
+++ b/kubernetes/applications/holmesgpt/base/kustomization.yaml
@@ -5,6 +5,7 @@ namespace: holmesgpt
 resources:
   - ./namespace.yaml
   - ./sealed-secret.yaml
+  - ./scheduled-healthchecks.yaml
 
 helmCharts:
   - name: holmes
@@ -13,6 +14,7 @@ helmCharts:
     version: 0.33.0
     valuesFile: values.yaml
     namespace: holmesgpt
+    includeCRDs: true
 
 labels:
   - includeSelectors: false

--- a/kubernetes/applications/holmesgpt/base/scheduled-healthchecks.yaml
+++ b/kubernetes/applications/holmesgpt/base/scheduled-healthchecks.yaml
@@ -1,0 +1,51 @@
+apiVersion: holmesgpt.dev/v1alpha1
+kind: ScheduledHealthCheck
+
+metadata:
+  name: pod-health
+  namespace: holmesgpt
+
+spec:
+  schedule: "7 * * * *"
+  enabled: true
+  mode: monitor
+  timeout: 300
+  query: >-
+    Are any pods across the cluster crash-looping, OOMKilled, or stuck not-Ready
+    right now? For each, give the namespace, pod, and the most likely root cause
+    from logs, events and metrics.
+
+---
+apiVersion: holmesgpt.dev/v1alpha1
+kind: ScheduledHealthCheck
+
+metadata:
+  name: argocd-sync
+  namespace: holmesgpt
+
+spec:
+  schedule: "22 * * * *"
+  enabled: true
+  mode: monitor
+  timeout: 300
+  query: >-
+    Are all ArgoCD applications Synced and Healthy? List any that are OutOfSync,
+    Degraded, Progressing or Missing, with the most likely reason.
+
+---
+apiVersion: holmesgpt.dev/v1alpha1
+kind: ScheduledHealthCheck
+
+metadata:
+  name: control-plane-pressure
+  namespace: holmesgpt
+
+spec:
+  schedule: "37 * * * *"
+  enabled: true
+  mode: monitor
+  timeout: 300
+  query: >-
+    Are the control-plane nodes under memory pressure (>85% of allocatable), or
+    are any leader-election controllers (kube-scheduler, kube-controller-manager,
+    operators) restarting due to lease-renewal timeouts? Summarize with evidence.

--- a/kubernetes/applications/holmesgpt/base/values.yaml
+++ b/kubernetes/applications/holmesgpt/base/values.yaml
@@ -56,3 +56,7 @@ toolsets:
   # GitOps state/drift/sync status (read-only token; default role:readonly)
   argocd/core:
     enabled: true
+
+# Phase 2: operator runs ScheduledHealthChecks against the holmes server (read-only)
+operator:
+  enabled: true


### PR DESCRIPTION
Implements #1215. Enables the bundled `holmes-operator` + installs the HealthCheck/ScheduledHealthCheck CRDs (`includeCRDs: true`), and defines three hourly **monitor-mode** checks (read-only, no external sink):

- **pod-health** — cluster-wide crash-loops / OOMKilled / not-Ready
- **argocd-sync** — OutOfSync/Degraded ArgoCD apps
- **control-plane-pressure** — CP memory pressure + leader-election restarts

`mode: monitor` → results land in the HealthCheck CR status + operator logs (→ Loki/Grafana), no notifications wired yet. The operator only writes its own CRs + events; cluster read access stays on the holmes server's read-only ClusterRole. Alert-mode destinations (Pushover/email) are a follow-up once check quality is confirmed.

Closes #1215.