### PR TITLE
fix(grafana): correct energy-inverter units and wire battery panel

### DIFF
--- a/kubernetes/applications/grafana/base/dashboards/energy-inverter.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/energy-inverter.yaml
@@ -111,7 +111,7 @@ spec:
                   }
                 ]
               },
-              "unit": "kwatth"
+              "unit": "watth"
             },
             "overrides": [
               {
@@ -280,7 +280,7 @@ spec:
                   }
                 ]
               },
-              "unit": "kwatth"
+              "unit": "watth"
             },
             "overrides": [
               {
@@ -790,7 +790,7 @@ spec:
                   }
                 ]
               },
-              "unit": "kwatth"
+              "unit": "watth"
             },
             "overrides": [
               {
@@ -1131,7 +1131,7 @@ spec:
                   }
                 ]
               },
-              "unit": "kwatth"
+              "unit": "watth"
             },
             "overrides": [
               {
@@ -1257,8 +1257,6 @@ spec:
                 }
               },
               "mappings": [],
-              "max": 100,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -1272,9 +1270,40 @@ spec:
                   }
                 ]
               },
-              "unit": "percent"
+              "unit": "watt"
             },
-            "overrides": []
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Laden"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "dark-green",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Entladen"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "dark-orange",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
           },
           "gridPos": {
             "h": 8,
@@ -1311,7 +1340,7 @@ spec:
               "editorMode": "code",
               "format": "table",
               "rawQuery": true,
-              "rawSql": "SELECT NULL::timestamptz AS _time, NULL::numeric AS _value WHERE false;",
+              "rawSql": "SELECT time_bucket('${agg}'::interval, time) - INTERVAL '1 second' AS _time, avg(battery_charge) AS \"Laden\", avg(battery_discharge) AS \"Entladen\" FROM solaredge_powerflow WHERE $__timeFilter(time) AND inverter_id = ${inverter_id} GROUP BY 1 ORDER BY 1;",
               "refId": "A"
             }
           ],
@@ -1364,7 +1393,7 @@ spec:
                   }
                 ]
               },
-              "unit": "short"
+              "unit": "watt"
             },
             "overrides": [
               {
@@ -1495,7 +1524,7 @@ spec:
                   }
                 ]
               },
-              "unit": "kwatth"
+              "unit": "watth"
             },
             "overrides": [
               {


### PR DESCRIPTION
## What

Two fixes to the SolarEdge inverter dashboard (`energy-inverter.yaml`):

### 1. Unit fix (factor 1000)
The energy panels compute `avg(W) × hours = Wh` but were formatted as `kwatth` (kWh), inflating values 1000x — e.g. "22 MWh/day" instead of the realistic ~22 kWh. Switched to `watth` so Grafana auto-scales correctly to kWh:
- Produktion AC, Verbrauch, Produktion DC, Netzzähler, "Mittel pro Wochentag"

Also "Netzzähler – Mittel pro Stunde": `short` → `watt` (it shows average power).

The genuine percent panels (Verbrauchsverteilung, Autarkiequote) stay `percent`.

### 2. Battery panel wired up
The panel was a placeholder (`SELECT NULL … WHERE false`, `percent`/max 100, intended as state-of-charge). But `solaredge_powerflow` has **no SoC column** — only power. So it now runs a real query on `battery_charge`/`battery_discharge` as **Laden/Entladen (W)**, unit `watt`, with colour overrides.

## Test
- Parsed the embedded dashboard JSON after the edits (11 panels, valid)
- Smoke-tested the battery query against the DB: runs, currently returns flat `0` (battery still dormant) → panel shows a 0 line instead of "No data" and fills automatically once the battery comes online

## Deliberately unchanged
The empty grid/feed-in panels stay empty until a SolarEdge energy meter is attached (`grid_consumption`/`grid_delivery` are consistently 0 in the DB) — that's missing hardware, not a dashboard bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)