### PR TITLE
fix(grafana): label wallbox charge-table time column as "Datum"

### DIFF
--- a/kubernetes/applications/grafana/base/dashboards/energy-wallbox.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/energy-wallbox.yaml
@@ -868,6 +868,10 @@ spec:
                   {
                     "id": "unit",
                     "value": "time: DD MMM Y"
+                  },
+                  {
+                    "id": "displayName",
+                    "value": "Datum"
                   }
                 ]
               },
@@ -1026,6 +1030,10 @@ spec:
                   {
                     "id": "unit",
                     "value": "time: DD MMM Y"
+                  },
+                  {
+                    "id": "displayName",
+                    "value": "Datum"
                   }
                 ]
               },


### PR DESCRIPTION
The _time column was the only field in the monthly charge tables without a displayName override, so its header showed the raw SQL alias "_time" instead of a German label like the other columns. Add displayName "Datum".