### PR TITLE
fix(grafana): keep watt unit off the hourly barchart x-axis

### DIFF
--- a/kubernetes/applications/grafana/base/dashboards/energy-inverter.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/energy-inverter.yaml
@@ -1393,7 +1393,7 @@ spec:
                   }
                 ]
               },
-              "unit": "watt"
+              "unit": "short"
             },
             "overrides": [
               {
@@ -1408,6 +1408,10 @@ spec:
                       "fixedColor": "dark-red",
                       "mode": "fixed"
                     }
+                  },
+                  {
+                    "id": "unit",
+                    "value": "watt"
                   }
                 ]
               },
@@ -1423,6 +1427,10 @@ spec:
                       "fixedColor": "dark-yellow",
                       "mode": "fixed"
                     }
+                  },
+                  {
+                    "id": "unit",
+                    "value": "watt"
                   }
                 ]
               }


### PR DESCRIPTION
## What

Follow-up to #1230. After switching the per-hour grid-mean barchart to a `watt` unit, the unit was also rendered onto the **numeric x-axis** (hour 0–23), turning the axis labels into "0 W, 1 W, 2 W …".

Fix: revert the panel's default unit to `short` and scope `watt` to the `Verbrauch` and `Einspeisung` value series via field overrides instead, so only the bars/legend show watts while the hour labels stay clean.

The "Mittel pro Wochentag" barchart is unaffected (its x-axis is weekday text, not numeric).

## Test
- Parsed the embedded dashboard JSON (valid); confirmed default unit `short` and per-series `watt` overrides on Verbrauch/Einspeisung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)