### PR TITLE
feat(prometheus): add PodCrashLooping + ContainerOOMKilled alerts

### DIFF
--- a/kubernetes/applications/prometheus/base/prometheus-rule.yaml
+++ b/kubernetes/applications/prometheus/base/prometheus-rule.yaml
@@ -141,3 +141,27 @@ spec:
           annotations:
             summary: "UniFi arm-sync metric stale/absent"
             description: "unifi_arm_sync_ok has not been reported for >15m (expected every ~5min via the KNX status heartbeat). The redpanda-connect stream, its JetStream consumer binding, or the scrape is stuck — drift detection is blind."
+
+    - name: kubernetes-pods
+      rules:
+        - alert: PodCrashLooping
+          # Restart-rate based — also catches transient crash-loops (count persists in the window)
+          expr: increase(kube_pod_container_status_restarts_total[15m]) >= 3
+          for: 2m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Pod {{ $labels.namespace }}/{{ $labels.pod }} crash-looping"
+            description: "Container {{ $labels.container }} restarted {{ $value | humanize }} times in the last 15m."
+
+        - alert: ContainerOOMKilled
+          expr: |
+            (increase(kube_pod_container_status_restarts_total[10m]) >= 1)
+            and on(namespace, pod, container)
+            (kube_pod_container_status_last_terminated_reason{reason="OOMKilled"} == 1)
+          for: 0m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Container {{ $labels.namespace }}/{{ $labels.pod }} OOMKilled"
+            description: "Container {{ $labels.container }} was OOMKilled and restarted in the last 10m."


### PR DESCRIPTION
Continuous pod-crash detection routed to Pushover (existing `endpoints` receiver), replacing the noisy hourly HolmesGPT `pod-health` check.

- **PodCrashLooping**: `increase(kube_pod_container_status_restarts_total[15m]) >= 3` — restart-rate based, catches transient crash-loops that self-heal between scrapes (count persists in the window). The default KubePodCrashLooping depends on `kube_pod_container_status_waiting_reason`, which currently has 0 series.
- **ContainerOOMKilled**: fires only on a recent OOM (restart in 10m + last terminated reason OOMKilled) — gap not covered by defaults.

Both exprs validated live (status success, 0 results now). `KubePodNotReady` (default, uses `kube_pod_status_phase`) already works.