### PR TITLE
feat(holmesgpt): refocus scheduled checks on metric-blind areas

### DIFF
--- a/kubernetes/applications/holmesgpt/base/scheduled-healthchecks.yaml
+++ b/kubernetes/applications/holmesgpt/base/scheduled-healthchecks.yaml
@@ -2,24 +2,6 @@ apiVersion: holmesgpt.dev/v1alpha1
 kind: ScheduledHealthCheck
 
 metadata:
-  name: pod-health
-  namespace: holmesgpt
-
-spec:
-  schedule: "7 * * * *"
-  enabled: true
-  mode: monitor
-  timeout: 300
-  query: >-
-    Are any pods across the cluster crash-looping, OOMKilled, or stuck not-Ready
-    right now? For each, give the namespace, pod, and the most likely root cause
-    from logs, events and metrics.
-
----
-apiVersion: holmesgpt.dev/v1alpha1
-kind: ScheduledHealthCheck
-
-metadata:
   name: argocd-sync
   namespace: holmesgpt
 
@@ -29,23 +11,50 @@ spec:
   mode: monitor
   timeout: 300
   query: >-
-    Are all ArgoCD applications Synced and Healthy? List any that are OutOfSync,
-    Degraded, Progressing or Missing, with the most likely reason.
+    Report FAIL only if an ArgoCD application's sync status is not Synced, or its
+    health status is not Healthy, right now. List those applications with the most
+    likely reason. If all applications are Synced and Healthy, report PASS.
 
 ---
 apiVersion: holmesgpt.dev/v1alpha1
 kind: ScheduledHealthCheck
 
 metadata:
-  name: control-plane-pressure
+  name: config-coherence
   namespace: holmesgpt
 
 spec:
-  schedule: "37 * * * *"
+  schedule: "42 * * * *"
   enabled: true
   mode: monitor
   timeout: 300
   query: >-
-    Are the control-plane nodes under memory pressure (>85% of allocatable), or
-    are any leader-election controllers (kube-scheduler, kube-controller-manager,
-    operators) restarting due to lease-renewal timeouts? Summarize with evidence.
+    Report FAIL only if you find a currently misconfigured or orphaned resource:
+    a PVC stuck Pending or unbound, a Service whose selector has no Ready
+    endpoints, an Ingress or Traefik IngressRoute whose backend Service has no
+    endpoints, a Certificate that is not Ready, or a custom resource whose
+    selector matches nothing (e.g. a GrafanaDashboard with no matching Grafana
+    instance). List each with its namespace, name, and the problem. If you find
+    none, report PASS.
+
+---
+apiVersion: holmesgpt.dev/v1alpha1
+kind: ScheduledHealthCheck
+
+metadata:
+  name: log-anomaly
+  namespace: holmesgpt
+
+spec:
+  schedule: "2 * * * *"
+  enabled: true
+  mode: monitor
+  timeout: 300
+  query: >-
+    Using Loki, scan the last hour of logs across the cluster for any application
+    producing a recurring abnormal error pattern — repeated panics, stack traces,
+    bursts of 5xx, or fatal/connection errors — that is not normal steady-state
+    noise. Report FAIL only if at least one application shows such a recurring
+    pattern in the last hour; name the application and quote one representative
+    line. Ignore single or occasional errors and known steady-state noise. If
+    nothing abnormal stands out, report PASS.


### PR DESCRIPTION
Pod crashes / OOM / not-Ready / node memory are now covered continuously by Prometheus alerts (PR #1235), so the sampled hourly LLM checks for those were redundant and noisy.

- **Drops** `pod-health` and `control-plane-pressure` (covered by PodCrashLooping / ContainerOOMKilled / KubePodNotReady / NodeMemoryHighUtilization).
- **argocd-sync**: sharpened to current-state (fires only on a currently OutOfSync/unhealthy app) — genuinely Holmes-only (argocd metrics not scraped).
- **config-coherence** (new): orphaned/misconfigured resources metrics can't express (unbound PVCs, Services without endpoints, not-Ready Certificates, CRs matching nothing).
- **log-anomaly** (new): recurring abnormal error patterns in Loki not covered by any alert.

Current-state queries → verdict = real present problem. Pushover bridge unchanged; fires only on real findings now.