### PR TITLE
feat(cluster): expose etcd metrics for Prometheus scraping

### DIFF
--- a/cluster/patches/control-plane-settings.yaml
+++ b/cluster/patches/control-plane-settings.yaml
@@ -24,6 +24,11 @@ cluster:
   scheduler:
     extraArgs:
       bind-address: "0.0.0.0"
+  ## etcd runs as a Talos host service (no component=etcd pod), so expose its
+  ## metrics on all interfaces for Prometheus to scrape the CP nodes on :2381
+  etcd:
+    extraArgs:
+      listen-metrics-urls: http://0.0.0.0:2381
 
 machine:
   features:


### PR DESCRIPTION
etcd runs as a Talos host service (not a `component=etcd` pod), so its metrics default to 127.0.0.1 and were never scraped — `prometheus-kube-etcd` has no endpoints and `etcd_server_has_leader`/fsync metrics are absent (the monitoring blind spot from the recent CP investigation; surfaced again by the new HolmesGPT config-coherence check).

Sets etcd `listen-metrics-urls: http://0.0.0.0:2381`, mirroring the existing `controllerManager`/`scheduler` `bind-address: 0.0.0.0`. Prometheus `kubeEtcd` scrape config (CP node IPs on :2381) follows in a separate PR.

**Apply is a rolling step** (`task cluster:create -- prod`) — etcd restarts one CP at a time; quorum must hold.