### PR TITLE
feat(prometheus): scrape etcd via dynamic Node discovery

### DIFF
--- a/kubernetes/applications/prometheus/base/kustomization.yaml
+++ b/kubernetes/applications/prometheus/base/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - ./ingress-route.yaml
   - ./sealed-secret.yaml
   - ./prometheus-rule.yaml
+  - ./scrape-config.yaml
 
 helmCharts:
   - name: kube-prometheus-stack

--- a/kubernetes/applications/prometheus/base/scrape-config.yaml
+++ b/kubernetes/applications/prometheus/base/scrape-config.yaml
@@ -1,0 +1,30 @@
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+
+metadata:
+  name: etcd
+  labels:
+    release: prometheus
+
+spec:
+  # Discover nodes from the Kubernetes API and keep only the control plane —
+  # etcd runs as a Talos host service, so there is no pod/IP to hardcode.
+  kubernetesSDConfigs:
+    - role: Node
+  scheme: HTTP
+  relabelings:
+    - sourceLabels: [__meta_kubernetes_node_labelpresent_node_role_kubernetes_io_control_plane]
+      action: keep
+      regex: "true"
+    - sourceLabels: [__meta_kubernetes_node_address_InternalIP]
+      targetLabel: __address__
+      regex: (.*)
+      replacement: "${1}:2381"
+    - sourceLabels: [__meta_kubernetes_node_name]
+      targetLabel: node
+    - targetLabel: job
+      replacement: etcd
+  metricRelabelings:
+    - action: keep
+      sourceLabels: [__name__]
+      regex: (etcd_server_has_leader|etcd_server_proposals_committed_total|etcd_server_proposals_applied_total|etcd_disk_wal_fsync_duration_seconds_(sum|count)|etcd_mvcc_db_total_size_in_use_bytes|process_resident_memory_bytes|process_cpu_seconds_total|go_goroutines|kubernetes_build_info)

--- a/kubernetes/applications/prometheus/base/values.yaml
+++ b/kubernetes/applications/prometheus/base/values.yaml
@@ -67,11 +67,14 @@ prometheus:
     # Required for remote_write receiver (e.g. for agent-based ingestion)
     enableRemoteWriteReceiver: true
 
-    # Opt-In Model: Only scrape ServiceMonitors/PodMonitors with 'release: prometheus'
+    # Opt-In Model: Only scrape ServiceMonitors/PodMonitors/ScrapeConfigs with 'release: prometheus'
     serviceMonitorSelector:
       matchLabels:
         release: prometheus
     podMonitorSelector:
+      matchLabels:
+        release: prometheus
+    scrapeConfigSelector:
       matchLabels:
         release: prometheus
 
@@ -171,13 +174,10 @@ kubeScheduler:
         sourceLabels: [__name__]
         regex: (scheduler_framework_extension_point_duration_seconds_(sum|count)|scheduler_scheduling_attempt_duration_seconds_(sum|count)|process_resident_memory_bytes|process_cpu_seconds_total|go_goroutines|kubernetes_build_info)
 
-# Component scraping etcd
+# etcd is scraped via a dynamic ScrapeConfig (Node discovery → CP nodes :2381),
+# not the chart's selector-based service (no component=etcd pod on Talos).
 kubeEtcd:
-  serviceMonitor:
-    metricRelabelings:
-      - action: keep
-        sourceLabels: [__name__]
-        regex: (etcd_server_has_leader|etcd_server_proposals_committed_total|etcd_server_proposals_applied_total|etcd_disk_wal_fsync_duration_seconds_(sum|count)|etcd_mvcc_db_total_size_in_use_bytes|process_resident_memory_bytes|process_cpu_seconds_total|go_goroutines|kubernetes_build_info)
+  enabled: false
 
 # Disable exporters/components that are provided via alloy
 nodeExporter:


### PR DESCRIPTION
Replaces the broken chart `kubeEtcd` scrape (selector `component=etcd` matches no pod on Talos → `prometheus-kube-etcd` had no endpoints → etcd metrics absent) with a **ScrapeConfig that discovers control-plane nodes dynamically** and scrapes their InternalIP:2381 — **no hardcoded IPs**, same config for prod and dev.

- `kubeEtcd.enabled: false` — removes the orphaned selector-based service (also clears the HolmesGPT config-coherence flag).
- `scrapeConfigSelector` added (release=prometheus) so ScrapeConfig CRs are picked up.
- `scrape-config.yaml`: Node SD → keep control-plane nodes → scrape :2381 (http) → same etcd metric allowlist.

Depends on the Talos `listen-metrics-urls` change (PR #1238) being applied first.