### PR TITLE
fix(prometheus): keep etcd fsync buckets + correct db-size/leader-change metrics

### DIFF
--- a/kubernetes/applications/prometheus/base/scrape-config.yaml
+++ b/kubernetes/applications/prometheus/base/scrape-config.yaml
@@ -27,4 +27,4 @@ spec:
   metricRelabelings:
     - action: keep
       sourceLabels: [__name__]
-      regex: (etcd_server_has_leader|etcd_server_proposals_committed_total|etcd_server_proposals_applied_total|etcd_disk_wal_fsync_duration_seconds_(sum|count)|etcd_mvcc_db_total_size_in_use_bytes|process_resident_memory_bytes|process_cpu_seconds_total|go_goroutines|kubernetes_build_info)
+      regex: (etcd_server_has_leader|etcd_server_leader_changes_seen_total|etcd_server_proposals_committed_total|etcd_server_proposals_applied_total|etcd_disk_wal_fsync_duration_seconds_(sum|count|bucket)|etcd_mvcc_db_total_size_in_bytes|process_resident_memory_bytes|process_cpu_seconds_total|go_goroutines|kubernetes_build_info)


### PR DESCRIPTION
Follow-up to the etcd-monitoring fix. The inherited allowlist kept fsync `sum|count` but not `_bucket` (no p99), and named the DB-size metric `etcd_mvcc_db_total_size_in_use_bytes` — etcd emits `etcd_mvcc_db_total_size_in_bytes`, so it was dropped.

- fsync: add `_bucket` → enables `histogram_quantile` p99 (the signal for the CP lease-timeout investigation)
- db size: corrected to `etcd_mvcc_db_total_size_in_bytes`
- add `etcd_server_leader_changes_seen_total` (instability signal)

Verified against live etcd `/metrics` on :2381.