### PR TITLE
feat(holmesgpt): grant read access to traefik/grafana/cert-manager/cnpg CRDs

### DIFF
--- a/kubernetes/applications/holmesgpt/base/values.yaml
+++ b/kubernetes/applications/holmesgpt/base/values.yaml
@@ -1,6 +1,21 @@
 # Only overrides — chart defaults provide the read-only ClusterRole
 # (createServiceAccount + k8sRBAC=false) and the default investigation toolsets.
 
+# Extend the chart's read-only ClusterRole with CRD groups it omits (traefik/grafana/cert-manager/cnpg).
+customClusterRoleRules:
+  - apiGroups: ["traefik.io"]
+    resources: [ingressroutes, ingressroutetcps, ingressrouteudps, middlewares, traefikservices, tlsoptions, serverstransports]
+    verbs: [get, list, watch]
+  - apiGroups: ["grafana.integreatly.org"]
+    resources: [grafanas, grafanadashboards, grafanadatasources, grafanafolders]
+    verbs: [get, list, watch]
+  - apiGroups: ["cert-manager.io"]
+    resources: [certificates, certificaterequests, issuers, clusterissuers]
+    verbs: [get, list, watch]
+  - apiGroups: ["postgresql.cnpg.io"]
+    resources: [clusters, poolers, backups, scheduledbackups]
+    verbs: [get, list, watch]
+
 # LLM backend: Claude Sonnet 4.6 via the E.ON LiteLLM gateway (OpenAI-compatible).
 additionalEnvVars:
   - name: MODEL


### PR DESCRIPTION
## Problem

HolmesGPT investigations reported that whole classes of resources **don't exist** when they clearly do — e.g. "No Traefik IngressRoute resources exist" and "No GrafanaDashboard resources exist", while the cluster runs 50 IngressRoutes, 21 GrafanaDashboard CRs and 51 cert-manager Certificates.

## Root cause

The chart's investigation ClusterRole (`holmes-holmes-cluster-role`, created because `createServiceAccount: true` + `k8sRBAC: false`) **enumerates every readable API group explicitly**. It omits:

- `traefik.io` (IngressRoute, Middleware, …)
- `grafana.integreatly.org` (GrafanaDashboard, …)
- `cert-manager.io` (Certificate, …)
- `postgresql.cnpg.io` (CNPG Cluster, …)

The pod gets `Forbidden` on `list` for those groups, and Holmes conflates **Forbidden with empty** — reporting "no such resources exist". The missing `postgresql.cnpg.io` access also forced it to *infer* the benign zero-endpoint `-ro` Service condition from raw Endpoints instead of reading `Cluster.status` directly.

## Fix

Inject read-only (`get`/`list`/`watch`) rules for those four CRD groups via `customClusterRoleRules`, which the chart merges into the ClusterRole. No fork/patch needed.

Verified with `kustomize build --enable-helm` — the four groups render at the top of `holmes-holmes-cluster-role`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)