### PR TITLE
fix(cnpg): disable unused read-only (-ro) Service on single-instance clusters

### DIFF
--- a/kubernetes/applications/timescaledb/base/database.yaml
+++ b/kubernetes/applications/timescaledb/base/database.yaml
@@ -60,6 +60,10 @@ spec:
         comment: "Grafana — SELECT only on hypertables and CAGGs"
         passwordSecret:
           name: timescaledb-db-grafana-ro-secret
+    # Single-instance cluster has no replicas — drop the never-routable read-only (-ro) Service
+    services:
+      disabledDefaultServices:
+        - ro
   postgresql:
     # Load TimescaleDB extension at server start
     shared_preload_libraries:

--- a/kubernetes/applications/wiki-js/base/database.yaml
+++ b/kubernetes/applications/wiki-js/base/database.yaml
@@ -36,6 +36,12 @@ spec:
       database: wikijs
       owner: wikijs
 
+  # Single-instance cluster has no replicas — drop the never-routable read-only (-ro) Service
+  managed:
+    services:
+      disabledDefaultServices:
+        - ro
+
   postgresql:
     parameters:
       # Memory settings


### PR DESCRIPTION
## Problem

HolmesGPT's `config-coherence` health-check fails (high priority) on two Services with zero endpoints:

- `timescaledb/timescaledb-db-ro`
- `wiki-js/wiki-js-db-ro`

Both CNPG clusters run `instances: 1`. CNPG always creates a `-ro` (replicas-only) Service, but with no replica pods it has `subsets: null` forever. It's a true positive for the check, but a benign, permanent condition — not an incident.

## Fix

The `-ro` Service is dead weight on a single-instance cluster: it can never route, and **no client references it** (repo-wide grep: zero hits). Rather than suppress the check, remove the Service at the source:

```yaml
spec:
  managed:
    services:
      disabledDefaultServices:
        - ro
```

- `timescaledb-db`: added `services:` under the existing `managed:` block.
- `wiki-js-db`: added a new `managed:` block.
- `-rw` (primary) and `-r` (any-instance) Services are unaffected.

The `config-coherence` check then passes because the zero-endpoint Service no longer exists. If either cluster is ever scaled to `instances: 2+`, drop this stanza to get read-replica routing back.

Verified with `kustomize build --enable-helm` on both prod overlays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)