### PR TITLE
fix(unifi-poller): allow root so unpoller v3.3.1 container starts

### DIFF
--- a/kubernetes/applications/unifi-poller/base/values.yaml
+++ b/kubernetes/applications/unifi-poller/base/values.yaml
@@ -10,6 +10,12 @@ deployment:
     tag: v3.3.1
     pullPolicy: IfNotPresent
 
+  # The unpoller image runs as root and writes at runtime; override the chart's
+  # hardened defaults (runAsNonRoot + readOnlyRootFilesystem) that block start.
+  containerSecurityContext:
+    runAsNonRoot: false
+    readOnlyRootFilesystem: false
+
   env:
     TZ:
       value: Europe/Berlin


### PR DESCRIPTION
## Problem

After migrating to the Stakater application chart (#1243), the new pod is stuck in `CreateContainerConfigError`:

```
container has runAsNonRoot and image will run as root
```

The chart defaults the container securityContext to `runAsNonRoot: true` + `readOnlyRootFilesystem: true`, but the `unpoller` image runs as **root** (no `USER` directive) — as it did for 34d under the old chart. The namespace enforces no PodSecurity, so root is permitted.

## Fix

Override `deployment.containerSecurityContext` to `runAsNonRoot: false` + `readOnlyRootFilesystem: false`, matching the previously working behaviour.

Secret (`unifi-api-key`) and ConfigMap (`unpoller-config-*`) were already correct — securityContext was the only blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)