### PR TITLE
refactor(unifi-poller): run unpoller as distroless nonroot (65532)

### DIFF
--- a/kubernetes/applications/unifi-poller/base/values.yaml
+++ b/kubernetes/applications/unifi-poller/base/values.yaml
@@ -10,11 +10,20 @@ deployment:
     tag: v3.3.1
     pullPolicy: IfNotPresent
 
-  # The unpoller image runs as root and writes at runtime; override the chart's
-  # hardened defaults (runAsNonRoot + readOnlyRootFilesystem) that block start.
+  # unpoller is a static distroless binary that writes nothing to disk; run it
+  # as the distroless nonroot user (65532) with a read-only root filesystem.
   containerSecurityContext:
-    runAsNonRoot: false
-    readOnlyRootFilesystem: false
+    runAsNonRoot: true
+    runAsUser: 65532
+    runAsGroup: 65532
+    readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop: [ALL]
+    seccompProfile:
+      type: RuntimeDefault
+  securityContext:
+    fsGroup: 65532
 
   env:
     TZ:


### PR DESCRIPTION
## Why

#1245 restored unpoller by allowing root (`runAsNonRoot: false`) — a workaround, since the Stakater application chart defaults to a hardened securityContext. Upstream check shows root is **not** required:

- unpoller v3.3.1 image is `gcr.io/distroless/static-debian11` with **no `USER` directive** → defaults to root only by omission.
- It's a static Go binary (`/usr/bin/unpoller`, world-executable) that **writes nothing to disk** (logs → stdout, config → read-only mounts, scrape cache in-memory, port 9130 unprivileged).
- distroless `static` ships the `nonroot` user **UID 65532**.

So it runs fine non-root with a read-only rootfs.

## What

Replace the root workaround with a `restricted`-PSA-compliant securityContext:

- `runAsNonRoot: true`, `runAsUser/Group: 65532`
- `readOnlyRootFilesystem: true`
- `allowPrivilegeEscalation: false`, `capabilities.drop: [ALL]`, `seccompProfile: RuntimeDefault`
- pod `fsGroup: 65532`

## Verification

The deploy is the test: pod must come up as UID 65532 and keep `up{namespace="unifi-poller"} == 1` with `unpoller_*` metrics flowing. Fallback if 65532 misbehaves is a one-line revert to the root workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)