### PR TITLE
docs(readme): update Wi-Fi AP inventory (4× U7 Pro, 1× U6-LR)

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,8 +221,8 @@ All-Ubiquiti stack — one uplink per tier, 10 GbE between switches, PoE on the 
 | [USW Pro Max 48](https://ui.com/switching/usw-pro-max-48) | Aggregation switch (10 GbE uplink to USW Pro HD 24)  |
 | [USW Pro 48 PoE](https://ui.com/switching/usw-pro-48-poe) | Access switch (10 GbE uplink, PoE for APs & cameras) |
 | [USP-RPS](https://ui.com/power-backup/usp-rps)            | Redundant power supply for the rack                  |
-| 3× [U7 Pro](https://ui.com/wifi/flagship/u7-pro)          | Wi-Fi 7 APs                                          |
-| 2× [U6-LR](https://ui.com/wifi/long-range/u6-long-range)  | Wi-Fi 6 long-range APs                               |
+| 4× [U7 Pro](https://ui.com/wifi/flagship/u7-pro)          | Wi-Fi 7 APs                                          |
+| 1× [U6-LR](https://ui.com/wifi/long-range/u6-long-range)  | Wi-Fi 6 long-range APs                               |
 
 ### Storage (shared)
 


### PR DESCRIPTION
Updates the network hardware table in the README to match the current Wi-Fi deployment: 4× U7 Pro (Wi-Fi 7) and 1× U6-LR (Wi-Fi 6 long-range), replacing the previous 3×/2× split.

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)