### PR TITLE
fix(alloy): run alloy-receiver as single-writer Deployment

### DIFF
--- a/kubernetes/applications/alloy/base/values.yaml
+++ b/kubernetes/applications/alloy/base/values.yaml
@@ -69,6 +69,10 @@ collectors:
 
   # Alloy Receiver: Opens receivers for external data sources (syslog, OTLP)
   alloy-receiver:
+    # Single writer: VIP-fronted push receiver must not fan remote_write across pods (out-of-order rejects)
+    controller:
+      type: deployment
+      replicas: 1
     # Include loki for syslog forwarding and prometheus for OTLP metric forwarding
     includeDestinations:
       - loki


### PR DESCRIPTION
## Problem

HolmesGPT flagged a dense, sustained burst of `level=error msg="non-recoverable error"` across **all three** `alloy-alloy-receiver` pods (namespace `alloy`), firing every 1–2 minutes. Each event permanently drops hundreds to thousands of metric samples (`failedSampleCount` 19–1614). Root cause reported by Prometheus remote-write: `HTTP 400 out of order sample`.

## Root cause

The `alloy-receiver` collector inherited the chart's default `controller.type: daemonset`, so it ran as a **DaemonSet (3 pods, one per node)** behind a **single LoadBalancer VIP** (`192.168.10.200:4318`). Each pod runs its own `prometheus.remote_write` pipeline.

OTLP push sources (rustfs, PVE/PBS metric servers) are load-balanced **per connection** across the 3 pods (no session affinity). The same series therefore reaches Prometheus from multiple pods with interleaved/regressing timestamps → `out of order sample` → non-recoverable 4xx, samples dropped with no retry. The error appearing uniformly on all 3 pods confirms the multi-writer topology.

## Fix

A VIP-fronted **push** receiver must be a single logical writer per series. Pin the collector to a `Deployment` with `replicas: 1`:

```yaml
collectors:
  alloy-receiver:
    controller:
      type: deployment
      replicas: 1
```

The alloy-operator replaces the DaemonSet with a 1-pod Deployment on sync. The VIP and all ports (syslog 601/514, OTLP 4318) are unchanged; only the endpoint count drops from 3 to 1.

## Trade-off

Loses 3-way redundancy: a node drain/failure causes a brief ingestion gap until the pod reschedules (seconds to ~1 min) — acceptable for homelab metrics/syslog. HA via `sessionAffinity: ClientIP` was rejected because every pod failover reopens an out-of-order window; a single writer is the correct fix, not a workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)