### PR TITLE
feat(holmesgpt): add reusable known-log-noise skill

### DIFF
--- a/kubernetes/applications/holmesgpt/base/kustomization.yaml
+++ b/kubernetes/applications/holmesgpt/base/kustomization.yaml
@@ -15,6 +15,10 @@ configMapGenerator:
       disableNameSuffixHash: true
     files:
       - scripts/alert-bridge.sh
+  # Hash on: Deployment mounts this, so the holmes pod rolls when a skill changes.
+  - name: holmes-skills-custom
+    files:
+      - skills/SKILL.md
 
 helmCharts:
   - name: holmes

--- a/kubernetes/applications/holmesgpt/base/skills/SKILL.md
+++ b/kubernetes/applications/holmesgpt/base/skills/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: known-log-noise
+description: >-
+  Registry of known, steady-state log/error patterns in this homelab cluster
+  that look like failures but are expected noise. Consult this before flagging
+  any recurring log error, 5xx burst, or connection error as abnormal —
+  especially during log-anomaly health checks. If an observed pattern matches an
+  entry here, treat it as normal noise and report PASS, not an incident.
+---
+
+## Known steady-state log noise — do NOT flag as anomalies
+
+Each entry below is a sustained, high-frequency log pattern that is expected
+steady-state noise. When an investigation encounters a matching pattern, do not
+escalate it; note it as expected and move on.
+
+### kube-apiserver → etcd "operation was canceled"
+Shape: `grpc: addrConn.createTransport failed to connect to {Addr: "127.0.0.1:2379" ...}`
+`... dial tcp 127.0.0.1:2379: operation was canceled`
+- Source: kube-apiserver on all control-plane nodes (talos-cp-01/02/03), ~every 30s, continuous.
+- Why it is noise: the apiserver's own etcd clientv3 gRPC balancer churns subchannels to local
+  etcd and cancels redundant dials. "operation was canceled" = self-cancelled context, NOT etcd down.
+- A real etcd fault looks different: "connection refused" / "context deadline exceeded", etcd
+  alarms, or raft lag — and the cluster degrades. Verify via `/healthz/etcd` and
+  `talosctl etcd alarm list` before escalating.
+- Action: ignore. High volume is expected, not a signal.

--- a/kubernetes/applications/holmesgpt/base/values.yaml
+++ b/kubernetes/applications/holmesgpt/base/values.yaml
@@ -75,3 +75,16 @@ toolsets:
 # Phase 2: operator runs ScheduledHealthChecks against the holmes server (read-only)
 operator:
   enabled: true
+
+# Custom skills as real .md files (kustomize ConfigMap) — a reusable registry of known-benign
+# log noise so investigations (esp. log-anomaly) don't escalate steady-state patterns.
+customSkillPaths:
+  - /etc/holmes/skills-custom
+additionalVolumes:
+  - name: holmes-skills-custom
+    configMap:
+      name: holmes-skills-custom
+additionalVolumeMounts:
+  - name: holmes-skills-custom
+    mountPath: /etc/holmes/skills-custom
+    readOnly: true


### PR DESCRIPTION
## Why

HolmesGPT's scheduled `log-anomaly` health check paged "Hohe Priorität" for the
kube-apiserver → etcd `operation was canceled` gRPC log spam. That pattern is
expected steady-state noise (the apiserver's own etcd clientv3 balancer churns
subchannels to local etcd and cancels redundant dials — a self-cancelled
context, **not** an etcd outage). Verified live at the time: `/healthz/etcd` ok,
no etcd alarms, 3 in-sync raft members, apiservers 0 restarts.

Rather than hard-coding "ignore this" into each ScheduledHealthCheck query, this
teaches Holmes once via its native **custom skill** mechanism.

## What

- `base/skills/SKILL.md` — a reusable registry of known steady-state log noise
  (frontmatter `name: known-log-noise`). First entry documents the etcd
  `operation was canceled` pattern, how to tell it apart from a real etcd fault,
  and that it should not be escalated. New false positives = append a new
  `###` section.
- `base/kustomization.yaml` — `holmes-skills-custom` ConfigMapGenerator
  (hash **on**: it's a Deployment mount, so the pod rolls when the skill changes).
- `base/values.yaml` — `customSkillPaths` + `additionalVolumes`/`additionalVolumeMounts`
  mounting the ConfigMap at `/etc/holmes/skills-custom`. Holmes scans
  `CUSTOM_SKILL_PATHS` on startup and consults the skill across investigations;
  the `log-anomaly` query is left untouched.

## Verification

`kustomize build --enable-helm overlays/prod` renders cleanly: ConfigMap key
`SKILL.md`, the Deployment volume's `configMap.name` is rewritten to the hashed
name, the mount and `CUSTOM_SKILL_PATHS=/etc/holmes/skills-custom` are present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)