### PR TITLE
fix(wallbox): derive Freigabe-Status from WARP Slot 4, rename Ein-Aus GA

### DIFF
--- a/kubernetes/applications/knx-nats-bridge/base/config/ga-catalog.yaml
+++ b/kubernetes/applications/knx-nats-bridge/base/config/ga-catalog.yaml
@@ -2599,12 +2599,12 @@
 15/6/20:
   dpt: '1.001'
   function: Versorgungstechnik
-  name: Versorgungstechnik.Wallbox.Ein-Aus
+  name: Versorgungstechnik.Wallbox.Freigabe
   room: Garage
 15/6/21:
   dpt: '1.001'
   function: Versorgungstechnik
-  name: Versorgungstechnik.Wallbox.Ein-Aus-Status
+  name: Versorgungstechnik.Wallbox.Freigabe-Status
   room: Garage
 15/6/22:
   dpt: '5.010'

--- a/kubernetes/applications/knx-nats-bridge/base/config/writer-rules.yaml
+++ b/kubernetes/applications/knx-nats-bridge/base/config/writer-rules.yaml
@@ -504,7 +504,7 @@ mappings:
     min_delta: 0  # changes only per charge: write on change
     seed_on_start: true
 
-  # WARP control feedback (KNX<-WARP). The command GAs (Ein-Aus 15/6/20,
+  # WARP control feedback (KNX<-WARP). The command GAs (Freigabe 15/6/20,
   # Lademodi 15/6/22, per-mode buttons 15/6/25/27/29) are driven KNX->WARP by
   # redpanda-connect streams; these rules report the actual state back so
   # Basalte reflects reality.
@@ -518,8 +518,8 @@ mappings:
   - subject: "wallbox.knx.charging"
     ga: "15/6/21"
     dpt: "1.001"
-    payload_path: "$.on"  # derived in warp_charging_status (charger_state==2)
-    description: "Versorgungstechnik.Wallbox.Ein-Aus-Status"
+    payload_path: "$.on"  # derived in warp_charging_status from WARP Slot 4 release
+    description: "Versorgungstechnik.Wallbox.Freigabe-Status"
     min_delta: 0  # bool state: write only on change
     seed_on_start: true
   # Per-mode status bits for Basalte (radio: exactly one set, all 0 when Aus).

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_charging_status.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_charging_status.yaml
@@ -1,8 +1,9 @@
-# Ein-Aus-Status feedback: derives a "charging active" boolean from the WARP
-# evse state and republishes it for the knx-nats-bridge writer, which maps it
-# to KNX 15/6/21 (DPT 1.001 "Versorgungstechnik.Wallbox.Ein-Aus-Status").
-# The bridge cannot transform an enum to a bool, so the derivation lives here.
-# charger_state == 2 means the WARP is actively charging.
+# Freigabe-Status feedback: mirrors the charge release the Freigabe switch
+# (15/6/20 start/stop_charging) toggles = WARP "Slot 4". Blocked (active &&
+# max_current == 0) => off; otherwise => on. Tracks only the release intent,
+# independent of car presence or current draw — unlike charger_state, which is
+# 0 whenever no car is plugged in. The bridge can't index an array, so the bool
+# is derived here for the writer (KNX 15/6/21, DPT 1.001 …Wallbox.Freigabe-Status).
 input:
   nats_jetstream:
     urls: ["nats://nats.nats.svc:4222"]
@@ -10,15 +11,16 @@ input:
       user: redpanda-connect
       password: ${NATS_PASSWORD}
     stream: WARP
-    subject: warp.evse.state
-    durable: redpanda-connect-warp-charging-status
+    subject: warp.evse.slots
+    durable: redpanda-connect-warp-charging-status-slot4
     deliver: last
     ack_wait: 20m
     max_ack_pending: 5000
 
 pipeline:
   processors:
-    - mapping: 'root = { "on": this.charger_state == 2 }'
+    # Slot 4 = manual/button charge release; blocked == active && max_current 0.
+    - mapping: 'root = { "on": !(this.index(4).active && this.index(4).max_current == 0) }'
 
 output:
   # Core NATS publish — the bridge writer uses a core subscription, and

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_mode_buttons_from_knx.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_mode_buttons_from_knx.yaml
@@ -4,7 +4,7 @@
 #   knx.15.6.25 Lademodus-PV     -> mode 2 (PV)
 #   knx.15.6.27 Lademodus-PV+Min -> mode 3 (Min+PV)
 #   knx.15.6.29 Lademodus-Schnell-> mode 0 (Schnell)
-# "Aus" (mode 1) is not a button — that is the Ein-Aus GA (15/6/20).
+# "Aus" (mode 1) is not a button — that is the Freigabe GA (15/6/20).
 input:
   # Consumer (filterSubjects on the three GAs) is declared as a CRD in
   # nats/base/consumers/warp_mode_buttons_from_knx.yaml.

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_onoff_from_knx.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_onoff_from_knx.yaml
@@ -1,6 +1,7 @@
-# Ein-Aus charge release: forwards the KNX Ein-Aus GA (15/6/20, DPT 1.001
-# "Versorgungstechnik.Wallbox.Ein-Aus") to the WARP wallbox as a charge
+# Charge release: forwards the KNX Freigabe GA (15/6/20, DPT 1.001
+# "Versorgungstechnik.Wallbox.Freigabe") to the WARP wallbox as a charge
 # start/stop command — the equivalent of the WARP UI Start/Stop button.
+# true => start_charging (Slot 4 released), false => stop_charging (blocked).
 input:
   # Consumer is declared as a CRD in nats/base/consumers/warp_onoff_from_knx.yaml.
   nats_jetstream:


### PR DESCRIPTION
## Problem

The KNX wallbox on/off status (15/6/21) read **off while the WARP was actively charging** (verified live: `charger_state=3`, `iec61851_state=2`, ~3.7 kW) and never reliably mirrored the switch.

Root cause: the status was derived from `warp.evse.state` as `charger_state == 2`, which is wrong twice over:
1. `2` is *"ready to charge"*; **charging is `3`**.
2. `charger_state` also folds in car presence and current draw, so it can never be a faithful mirror of an on/off switch.

## Fix

The switch (15/6/20) sends `start/stop_charging`, which the [WARP API](https://docs.warp-charger.com/en/docs/interfaces/mqtt_http/api_reference/evse) documents as releasing/blocking **"Slot 4"**. So mirror exactly that: derive the status from `warp.evse.slots[4]` (`blocked = active && max_current == 0`), independent of car presence or current draw. Positive polarity is kept, so the **command path is unchanged**.

The GA pair is renamed to match what the switch actually does (manual charge release): `Ein-Aus → Freigabe`, `Ein-Aus-Status → Freigabe-Status`.

## Changes
- **warp_charging_status**: source `warp.evse.state → warp.evse.slots`, derive from Slot 4, rename the `durable` (a JetStream consumer's filter is immutable).
- **ga-catalog**: 15/6/20 + 15/6/21 names → Freigabe / Freigabe-Status.
- **writer-rules**: 15/6/21 description + comments.
- **warp_onoff_from_knx, warp_mode_buttons_from_knx**: comment name references.

## Follow-up (manual, not in this PR)
- Rename the GA + Basalte label in ETS to match (15/6/20 → Freigabe, 15/6/21 → Freigabe-Status).
- **After** this deploys, delete the now-orphaned JetStream consumer `redpanda-connect-warp-charging-status` (old filter `warp.evse.state`) from the `WARP` stream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)