### PR TITLE
docs(wallbox): correct warp_charging_status archive comment

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/streams/warp_charging_status.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_charging_status.yaml
@@ -23,8 +23,9 @@ pipeline:
     - mapping: 'root = { "on": !(this.index(4).active && this.index(4).max_current == 0) }'
 
 output:
-  # Core NATS publish — the bridge writer uses a core subscription, and
-  # `wallbox.>` is not bound to any JetStream, so nothing archives it.
+  # Core NATS publish for live delivery (the bridge writer subscribes core).
+  # The WALLBOX_KNX JetStream (wallbox.knx.>) still archives it, so the writer's
+  # seed_on_start can prime the read-responder from the last value on restart.
   nats:
     urls: ["nats://nats.nats.svc:4222"]
     auth:


### PR DESCRIPTION
The output comment in `warp_charging_status.yaml` claimed `wallbox.>` is not bound to any JetStream and that *"nothing archives it"*. That is wrong.

The `WALLBOX_KNX` stream binds `wallbox.knx.>` (file storage) and archives every derived `wallbox.knx.*` subject — verified live: `WALLBOX_KNX` holds the last `wallbox.knx.charging {"on":true}`. That archive is exactly what lets the bridge's `seed_on_start` prime the read-responder cache for 15/6/21 after a restart (bridge log: *"seeding read-responder cache from JetStream for 113 subjects"*, no warning for `wallbox.knx.charging`).

Comment-only change; corrects misleading documentation that nearly led to an unnecessary reliability "fix".

🤖 Generated with [Claude Code](https://claude.com/claude-code)