### PR TITLE
fix(nats): archive unifi.arm.* in a JetStream so the bridge can seed it

### DIFF
--- a/kubernetes/applications/nats/base/streams/kustomization.yaml
+++ b/kubernetes/applications/nats/base/streams/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   # Derived streams (republished/computed subjects), kept only so the
   # knx-nats-bridge read responder can be seeded after a restart.
   - wallbox-knx.yaml
+  - unifi-arm.yaml
   - anomaly.yaml
   - forecast.yaml
   - energy.yaml

--- a/kubernetes/applications/nats/base/streams/unifi-arm.yaml
+++ b/kubernetes/applications/nats/base/streams/unifi-arm.yaml
@@ -1,0 +1,19 @@
+# DERIVED stream — NOT a primary data source. The `unifi.arm.*` subjects are
+# republished by the redpanda-connect unifi_arm_alarm stream (UniFi "Abwesend"
+# arm/disarm state, confirmed by the /nvrs read-back). This stream exists only
+# so the knx-nats-bridge read responder can be seeded on startup for the
+# Scharf-/Unscharf-Status GAs (14/3/200, 14/3/201); without it those reads
+# return no_value after a redeploy until the next ~5-min status heartbeat.
+apiVersion: jetstream.nats.io/v1beta2
+kind: Stream
+metadata:
+  name: unifi-arm
+  namespace: nats
+spec:
+  name: UNIFI_ARM
+  subjects:
+    - unifi.arm.>
+  storage: file
+  retention: limits
+  maxAge: 168h
+  replicas: 1


### PR DESCRIPTION
## Problem

The knx-nats-bridge writer rules for the UniFi "Abwesend" confirmation GAs — `14/3/200` (Scharf-Status) / `14/3/201` (Unscharf-Status) — carry `seed_on_start: true`, but **no stream was bound to `unifi.arm.>`**. So the read-responder could not be seeded on startup:

```
WARN  seed: no JetStream stream for subject unifi.arm.scharf_status
WARN  seed: no JetStream stream for subject unifi.arm.unscharf_status
```

After a bridge-only restart (e.g. any writer-rules change) those GAs stayed blank in Basalte until the next ~5-min EMA status heartbeat republished them.

## Fix

Add a small **DERIVED** stream `UNIFI_ARM` (`unifi.arm.>`, file, 168h) — same pattern as `WALLBOX_KNX` — so the redpanda-connect-published confirmations are archived and `seed_on_start` works. The GAs are then correct immediately on restart.

No producer / writer-rule / permission change needed: the bridge NATS user already has `$JS.API.>` publish (covers `get_last_msg`) and `unifi.arm.>` subscribe (PR #1234).

## Verify after deploy
- `UNIFI_ARM` created & Healthy; captures `unifi.arm.scharf_status` + `unifi.arm.unscharf_status` after a heartbeat (≤5 min).
- A bridge restart no longer logs `seed: no JetStream stream for subject unifi.arm.*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)