### PR TITLE
fix(holmesgpt): trigger known-log-noise skill from log-anomaly query

### DIFF
--- a/kubernetes/applications/holmesgpt/base/scheduled-healthchecks.yaml
+++ b/kubernetes/applications/holmesgpt/base/scheduled-healthchecks.yaml
@@ -54,7 +54,10 @@ spec:
     Using Loki, scan the last hour of logs across the cluster for any application
     producing a recurring abnormal error pattern — repeated panics, stack traces,
     bursts of 5xx, or fatal/connection errors — that is not normal steady-state
-    noise. Report FAIL only if at least one application shows such a recurring
-    pattern in the last hour; name the application and quote one representative
-    line. Ignore single or occasional errors and known steady-state noise. If
-    nothing abnormal stands out, report PASS.
+    noise. Before reporting FAIL on any recurring connection, gRPC, 5xx, or
+    probe error, fetch the `known-log-noise` skill and exclude every pattern
+    that matches an entry there. Report FAIL only if at least one application
+    shows such a recurring pattern in the last hour after those exclusions; name
+    the application and quote one representative line. Ignore single or occasional
+    errors and known steady-state noise. If nothing abnormal stands out, report
+    PASS.

--- a/kubernetes/applications/holmesgpt/base/skills/SKILL.md
+++ b/kubernetes/applications/holmesgpt/base/skills/SKILL.md
@@ -24,3 +24,14 @@ Shape: `grpc: addrConn.createTransport failed to connect to {Addr: "127.0.0.1:23
   alarms, or raft lag — and the cluster degrades. Verify via `/healthz/etcd` and
   `talosctl etcd alarm list` before escalating.
 - Action: ignore. High volume is expected, not a signal.
+
+### Transient readiness/liveness probe failures during a rollout
+Shape: `Readiness probe failed: Get "http://<pod-ip>:<port>/ready": context deadline exceeded`
+or `Liveness/Readiness probe failed: ... connect: connection refused`, clustered around a Deployment rollout.
+- Source: any app mid-rollout — the OLD pod failing readiness while it terminates, or the NEW
+  pod failing liveness/readiness for a few seconds before its port is open.
+- Why it is noise: expected rollout churn. The events cluster at the rollout timestamp and stop
+  once the new pod reports Ready.
+- NOT covered — escalate: a pod that keeps failing probes after the rollout settles, is
+  CrashLooping/restarting, or a Deployment that never reaches Available. That is a real failure.
+- Action: ignore ONLY if the new ReplicaSet's pod is now Ready and the failures have stopped.


### PR DESCRIPTION
## Problem

The hourly `log-anomaly` ScheduledHealthCheck kept FAILing (high-priority pushes every hour) on **benign** kube-apiserver logs:

- `W ... grpc: addrConn.createTransport failed to connect to {Addr: "127.0.0.1:2379" ...} Err: ... "dial tcp 127.0.0.1:2379: operation was canceled"` on all three control-plane pods, ~every 30s.
- Plus one-off readiness/liveness probe churn from a normal `redpanda-connect` rollout.

Both are noise. Verified live: `talosctl etcd status` shows all members on the same RAFT index, stable leader (term 95), no alarms; apiserver pods `Running` with 0 restarts; `/readyz` passes. The gRPC line is the apiserver's own etcd clientv3 balancer cancelling redundant dials — not an etcd fault (a real fault shows `connection refused` / `context deadline exceeded`, etcd alarms, raft lag, and the cluster degrades).

## Root cause

The pattern was **already** documented in the `known-log-noise` SKILL.md registry — it just never got consulted. Self-hosted Holmes surfaces skills **on-demand**: the prompt only sees `name | description` per skill, the full body loads via the `fetch_skill` tool, and the prompt template explicitly says *"do not fetch speculatively"*. On a generic "scan everything for anomalies" check the agent treats the gRPC error as the anomaly and never fetches the noise registry.

The always-injected path (`global_instructions`) is sourced only from the Robusta SaaS / Supabase DAL, which we don't run, and the `ScheduledHealthCheck` CRD exposes no instructions/skill/runbook field — only `query`. So the query is the only injection point Holmes' design gives us.

## Fix

- **`scheduled-healthchecks.yaml`**: the `log-anomaly` query now names the skill explicitly — *"Before reporting FAIL on any recurring connection, gRPC, 5xx, or probe error, fetch the `known-log-noise` skill and exclude every pattern that matches an entry there."* Naming a skill is the documented `fetch_skill` trigger. **Patterns stay solely in `SKILL.md` (single source of truth) — not duplicated into the query.**
- **`skills/SKILL.md`**: adds a scoped entry for transient rollout readiness/liveness probe churn (ignored only if the new ReplicaSet pod is now Ready; a stuck/CrashLooping pod or a Deployment that never reaches Available still escalates).

## Verification

- Both files parse as valid YAML; the rendered `log-anomaly` query reads as a single folded string as intended.
- No pattern duplication between the query and the registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)