### PR TITLE
fix(holmesgpt): catalog ArgoCD cache-miss, CronJob-conflict & solaredge night-register noise

### DIFF
--- a/kubernetes/applications/holmesgpt/base/scheduled-healthchecks.yaml
+++ b/kubernetes/applications/holmesgpt/base/scheduled-healthchecks.yaml
@@ -54,9 +54,9 @@ spec:
     Using Loki, scan the last hour of logs across the cluster for any application
     producing a recurring abnormal error pattern — repeated panics, stack traces,
     bursts of 5xx, or fatal/connection errors — that is not normal steady-state
-    noise. Before reporting FAIL on any recurring connection, gRPC, 5xx, or
-    probe error, fetch the `known-log-noise` skill and exclude every pattern
-    that matches an entry there. Report FAIL only if at least one application
+    noise. Before reporting FAIL on any recurring error, always fetch the
+    `known-log-noise` skill and exclude every pattern that matches an entry
+    there. Report FAIL only if at least one application
     shows such a recurring pattern in the last hour after those exclusions; name
     the application and quote one representative line. Ignore single or occasional
     errors and known steady-state noise. If nothing abnormal stands out, report

--- a/kubernetes/applications/holmesgpt/base/skills/known-log-noise/SKILL.md
+++ b/kubernetes/applications/holmesgpt/base/skills/known-log-noise/SKILL.md
@@ -30,8 +30,9 @@ false alarms on patterns that look like failures but are normal in this cluster.
 ## Known-benign catalog
 
 ### kube-apiserver → etcd "operation was canceled"
-- Pattern: `grpc: addrConn.createTransport failed to connect to {Addr: "127.0.0.1:2379" ...}` /
-  `dial tcp 127.0.0.1:2379: operation was canceled`, W-level, on all
+- Pattern: `grpc: addrConn.createTransport failed to connect to {Addr: "127.0.0.1:2379" ...}`,
+  ending in `operation was canceled` / `context canceled` /
+  `authentication handshake failed: context canceled`, W-level, on all
   control-plane nodes (talos-cp-01/02/03), ~every 30s, continuous.
 - Why benign: the apiserver's own etcd clientv3 gRPC balancer cancels redundant
   dials. "operation was canceled" is a self-cancelled context, not etcd down.
@@ -50,6 +51,42 @@ false alarms on patterns that look like failures but are normal in this cluster.
 - Confirm still benign: the new ReplicaSet's pod is now Ready and the failures
   have stopped. A pod that keeps failing probes after the rollout settles, is
   CrashLooping, or a Deployment that never reaches Available is NOT this — escalate.
+
+### ArgoCD application-controller "DiffFromCache: cache: key is missing"
+- Pattern: `DiffFromCache error: error getting managed resources for app <name>: cache: key is missing`,
+  error-level, from `argocd-application-controller-0` (gitops-controller), low
+  rate but recurring across many apps over hours.
+- Why benign: ArgoCD's managed-resources diff cache (in argocd-redis) misses or
+  expires entries (TTL/eviction); the controller falls back to a live diff and
+  logs the miss at error level. Apps still reconcile correctly.
+- Confirm still benign: `argocd-redis` and `argocd-application-controller-0` are
+  Running with no recent restarts/OOM, AND every ArgoCD Application is
+  Synced + Healthy (the live-diff fallback works). A real fault instead shows
+  apps going OutOfSync/Unknown, redis CrashLooping/OOM, or a high and rising
+  miss rate.
+
+### kube-controller-manager CronJob "the object has been modified"
+- Pattern: `"Unhandled Error" err="error syncing CronJobController <ns>/<name>: Operation cannot be fulfilled on cronjobs.batch ...: the object has been modified"`,
+  error-level, every ~5-10 min across multiple CronJobs.
+- Why benign: optimistic-concurrency retry — the CronJob controller updates
+  `.status` while another writer (e.g. an ArgoCD reconcile) touches the same
+  object; the controller logs the conflict and requeues, succeeding on retry.
+  The cadence tracks the CronJob schedules.
+- Confirm still benign: the affected CronJobs still fire on schedule
+  (`.status.lastScheduleTime` advancing, their Jobs completing). A real fault
+  would be a tight hot-loop (many conflicts per second on one object) or
+  CronJobs that stop scheduling — neither is this.
+
+### solaredge2mqtt "Unreadable register" at night
+- Pattern: `ERROR | solaredge2mqtt.services.modbus:_read_from_modbus:... - Unreadable register <n>`
+  (e.g. 40071), every ~5s on both solaredge2mqtt pods, during night / no-production hours.
+- Why benign: the SolarEdge inverter (SE3680H) stops serving its production registers
+  when it is not generating (night), so the poller logs the register as unreadable. It
+  reads normally again once production resumes at sunrise.
+- Confirm still benign: the errors are confined to no-production hours AND the app logs
+  successful reads during daylight (e.g. `_map_inverter ... AC <n> W`); pods are not
+  restarting. Escalate if "Unreadable register" occurs during daytime production, the
+  app stops publishing powerflow, or the pods CrashLoop.
 
 ## Synthesize findings
 


### PR DESCRIPTION
Follow-up to the known-log-noise work (#1255 / #1259). The hourly `log-anomaly` check kept FAILing on benign recurring patterns that weren't in the catalog yet. All three were triaged live and confirmed benign.

## New catalog entries (each with a Confirm step so a real fault still escalates)

- **ArgoCD `DiffFromCache: cache: key is missing`** — `argocd-application-controller` logs this at error level when its managed-resources diff cache misses/expires; it falls back to a live diff and apps still reconcile. Verified live: `argocd-redis` (18d) and the controller (3d20h) healthy with 0 restarts, **all Applications Synced+Healthy**. Confirm: escalate if apps go OutOfSync/Unknown or redis crash-loops.
- **kube-controller-manager CronJob `the object has been modified`** — optimistic-concurrency retry (controller updates `.status` while another writer touches the object); requeues and succeeds. Confirm: escalate only on a tight hot-loop or CronJobs that stop scheduling.
- **solaredge2mqtt `Unreadable register` at night** — the SolarEdge SE3680H stops serving production registers when not generating, so the poller logs the register as unreadable every ~5 s overnight (~700 ERROR/night). Verified live: during daytime production the same pods read the inverter cleanly (0 errors in 15 min). Confirm: escalate if it occurs during daytime production or the app stops publishing. Reported upstream: DerOetzi/solaredge2mqtt#400.

## Also

- Broaden the kube-apiserver entry to the `context canceled` wording actually seen in logs (it matched anyway, but be precise).
- **Generalize the query trigger**: consult `known-log-noise` before **any** FAIL, not just connection/gRPC/5xx/probe errors. Previously the catalog was only reached when such an error happened to be present in the scan; now it's always consulted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)