### PR TITLE
fix(holmesgpt): drop solaredge2mqtt "Unreadable register" from known-log-noise

### DIFF
--- a/kubernetes/applications/holmesgpt/base/skills/known-log-noise/SKILL.md
+++ b/kubernetes/applications/holmesgpt/base/skills/known-log-noise/SKILL.md
@@ -77,17 +77,6 @@ false alarms on patterns that look like failures but are normal in this cluster.
   would be a tight hot-loop (many conflicts per second on one object) or
   CronJobs that stop scheduling — neither is this.
 
-### solaredge2mqtt "Unreadable register" at night
-- Pattern: `ERROR | solaredge2mqtt.services.modbus:_read_from_modbus:... - Unreadable register <n>`
-  (e.g. 40071), every ~5s on both solaredge2mqtt pods, during night / no-production hours.
-- Why benign: the SolarEdge inverter (SE3680H) stops serving its production registers
-  when it is not generating (night), so the poller logs the register as unreadable. It
-  reads normally again once production resumes at sunrise.
-- Confirm still benign: the errors are confined to no-production hours AND the app logs
-  successful reads during daylight (e.g. `_map_inverter ... AC <n> W`); pods are not
-  restarting. Escalate if "Unreadable register" occurs during daytime production, the
-  app stops publishing powerflow, or the pods CrashLoop.
-
 ## Synthesize findings
 
 - Matched + Confirm passes → report the pattern as expected steady-state noise;


### PR DESCRIPTION
Reverts the solaredge2mqtt entry added in #1262. That entry described the error as benign nighttime inverter sleep — which was wrong.

## What it actually is (verified from full Loki history)

- **~26/day, not ~700/hour.** All occurrences cluster in a single ~1h window around local midnight (22:00–23:00 UTC); essentially zero the rest of the day. (Loki is complete — the every-5s INFO reads show ~34.5k lines/day, so nothing is sampled away. The automated check's "every 5s / ~700/hour" was a gross over-estimate.)
- **Always register 40071**; the inverter otherwise reads perfectly 24/7.
- **Not new / not firmware-related:** stable ~26/day for the entire 14-day retention window, so it predates the SolarEdge 4.25.11 firmware push (06-29/06-30 are at the low end).

## Why remove it from the catalog

The upstream maintainer (DerOetzi/solaredge2mqtt#400) confirms the registers should be readable 24/7 per SolarEdge docs, so this is a genuine — if minor — inverter-side fault, not steady-state noise. Suppressing it as "benign" would hide a real error. The `log-anomaly` check should keep surfacing it until the inverter is fixed (maintainer suggests a SetApp Modbus disable/re-enable or a full power-cycle).

The ArgoCD cache-miss and CronJob-conflict entries from #1262 stay — those were verified genuinely benign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)