### PR TITLE
fix(grafana): normalize Smart Home dashboard titles and tags

### DIFF
--- a/kubernetes/applications/grafana/base/dashboards/knx-alarm-attic.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/knx-alarm-attic.yaml
@@ -848,7 +848,10 @@ spec:
         }
       ],
       "schemaVersion": 39,
-      "tags": [],
+      "tags": [
+        "timescaledb",
+        "knx"
+      ],
       "templating": {
         "list": []
       },

--- a/kubernetes/applications/grafana/base/dashboards/knx-alarm-basement.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/knx-alarm-basement.yaml
@@ -3151,7 +3151,10 @@ spec:
         }
       ],
       "schemaVersion": 39,
-      "tags": [],
+      "tags": [
+        "timescaledb",
+        "knx"
+      ],
       "templating": {
         "list": []
       },

--- a/kubernetes/applications/grafana/base/dashboards/knx-alarm-exterior.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/knx-alarm-exterior.yaml
@@ -1232,7 +1232,10 @@ spec:
       ],
       "refresh": "",
       "schemaVersion": 39,
-      "tags": [],
+      "tags": [
+        "timescaledb",
+        "knx"
+      ],
       "templating": {
         "list": []
       },

--- a/kubernetes/applications/grafana/base/dashboards/knx-alarm-ground-floor.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/knx-alarm-ground-floor.yaml
@@ -3044,7 +3044,10 @@ spec:
         }
       ],
       "schemaVersion": 39,
-      "tags": [],
+      "tags": [
+        "timescaledb",
+        "knx"
+      ],
       "templating": {
         "list": []
       },

--- a/kubernetes/applications/grafana/base/dashboards/knx-alarm-upper-floor.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/knx-alarm-upper-floor.yaml
@@ -1277,7 +1277,10 @@ spec:
         }
       ],
       "schemaVersion": 39,
-      "tags": [],
+      "tags": [
+        "timescaledb",
+        "knx"
+      ],
       "templating": {
         "list": []
       },

--- a/kubernetes/applications/grafana/base/dashboards/knx-sensor-attic.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/knx-sensor-attic.yaml
@@ -662,7 +662,7 @@ spec:
       },
       "timepicker": {},
       "timezone": "",
-      "title": "4. Dachgeschoss",
+      "title": "4. Dachgeschoss - Klima",
       "uid": "NKQ-rrM7k",
       "version": 14,
       "weekStart": ""

--- a/kubernetes/applications/grafana/base/dashboards/knx-sensor-basement.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/knx-sensor-basement.yaml
@@ -3965,7 +3965,7 @@ spec:
       },
       "timepicker": {},
       "timezone": "",
-      "title": "1. Kellergeschoss — Strom",
+      "title": "1. Kellergeschoss - Strom",
       "uid": "2zZVkZn7k",
       "version": 63,
       "weekStart": ""

--- a/kubernetes/applications/grafana/base/dashboards/knx-sensor-basement2.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/knx-sensor-basement2.yaml
@@ -2591,7 +2591,7 @@ spec:
       },
       "timepicker": {},
       "timezone": "",
-      "title": "1. Kellergeschoss — Klima",
+      "title": "1. Kellergeschoss - Klima",
       "uid": "fGuhSLM7k",
       "version": 34,
       "weekStart": ""

--- a/kubernetes/applications/grafana/base/dashboards/knx-sensor-exterior.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/knx-sensor-exterior.yaml
@@ -1702,7 +1702,7 @@ spec:
       },
       "timepicker": {},
       "timezone": "",
-      "title": "5. Außen",
+      "title": "5. Außen - Klima",
       "uid": "i3XTkev7k",
       "version": 29,
       "weekStart": ""

--- a/kubernetes/applications/grafana/base/dashboards/knx-sensor-ground-floor.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/knx-sensor-ground-floor.yaml
@@ -3898,7 +3898,7 @@ spec:
       },
       "timepicker": {},
       "timezone": "",
-      "title": "2. Erdgeschoss — Strom",
+      "title": "2. Erdgeschoss - Strom",
       "uid": "2xEu1c7nz",
       "version": 51,
       "weekStart": ""

--- a/kubernetes/applications/grafana/base/dashboards/knx-sensor-ground-floor2.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/knx-sensor-ground-floor2.yaml
@@ -2262,7 +2262,7 @@ spec:
       },
       "timepicker": {},
       "timezone": "",
-      "title": "2. Erdgeschoss — Heizung & Klima",
+      "title": "2. Erdgeschoss - Heizung & Klima",
       "uid": "EtFiKlGnz",
       "version": 25,
       "weekStart": ""

--- a/kubernetes/applications/grafana/base/dashboards/knx-sensor-upper-floor.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/knx-sensor-upper-floor.yaml
@@ -2836,7 +2836,7 @@ spec:
       },
       "timepicker": {},
       "timezone": "",
-      "title": "3. Obergeschoss",
+      "title": "3. Obergeschoss - Klima",
       "uid": "dyH6_rG7z",
       "version": 28,
       "weekStart": ""


### PR DESCRIPTION
## What

Makes the KNX/TimescaleDB **Smart Home** Grafana dashboards consistent.

| Before | After |
|---|---|
| `3. Obergeschoss` | `3. Obergeschoss - Klima` |
| `4. Dachgeschoss` | `4. Dachgeschoss - Klima` |
| `5. Außen` | `5. Außen - Klima` |
| `1. Kellergeschoss — Strom` | `1. Kellergeschoss - Strom` |
| `1. Kellergeschoss — Klima` | `1. Kellergeschoss - Klima` |
| `2. Erdgeschoss — Strom` | `2. Erdgeschoss - Strom` |
| `2. Erdgeschoss — Heizung & Klima` | `2. Erdgeschoss - Heizung & Klima` |

## Changes

1. **Name the suffix-less climate dashboards `- Klima`** — `Obergeschoss`, `Dachgeschoss`, `Außen` (sensor dashboards).
2. **Add the missing `knx` / `timescaledb` tags** to the five `- Alarm` dashboards, which had an empty `tags` array.
3. **Replace em-dashes (`—`) with hyphens (`-`)** in the basement/ground-floor sensor titles so all titles use the short dash.

All 12 embedded dashboard JSON blocks were validated to still parse after the edits.