### PR TITLE
fix(traefik): repair v3 IngressRoute rules (HeaderRegexp + drop dead ingress.class annotation)

### DIFF
--- a/kubernetes/applications/alloy/base/ingress-route.yaml
+++ b/kubernetes/applications/alloy/base/ingress-route.yaml
@@ -8,7 +8,6 @@ metadata:
     # ExternalDNS configuration for Cloudflare
     external-dns.alpha.kubernetes.io/target: PLACEHOLDER
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
-    kubernetes.io/ingress.class: traefik
     # Homepage Service Discovery
     gethomepage.dev/enabled: "true"
     gethomepage.dev/group: "Observability"

--- a/kubernetes/applications/authentik/base/ingress-route.yaml
+++ b/kubernetes/applications/authentik/base/ingress-route.yaml
@@ -51,7 +51,7 @@ spec:
           port: 80
     # Gatus bypass route — matches only requests that went through Cloudflare Access (JWT header set by CF)
     - kind: Rule
-      match: Host(`PLACEHOLDER`) && PathPrefix(`/_gatus`) && HeadersRegexp(`Cf-Access-Jwt-Assertion`, `.+`)
+      match: Host(`PLACEHOLDER`) && PathPrefix(`/_gatus`) && HeaderRegexp(`Cf-Access-Jwt-Assertion`, `.+`)
       priority: 20
       services:
         - kind: Service

--- a/kubernetes/applications/authentik/base/ingress-route.yaml
+++ b/kubernetes/applications/authentik/base/ingress-route.yaml
@@ -9,7 +9,6 @@ metadata:
     # ExternalDNS configuration for Cloudflare
     external-dns.alpha.kubernetes.io/target: PLACEHOLDER
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
-    kubernetes.io/ingress.class: traefik
     # Homepage Service Discovery
     gethomepage.dev/enabled: "true"
     gethomepage.dev/group: "Security & Identity"

--- a/kubernetes/applications/external-services/base/ingress-route.yaml
+++ b/kubernetes/applications/external-services/base/ingress-route.yaml
@@ -42,7 +42,7 @@ spec:
           scheme: https
     # Gatus bypass route — matches only requests that went through Cloudflare Access (JWT header set by CF)
     - kind: Rule
-      match: Host(`PLACEHOLDER`) && PathPrefix(`/_gatus`) && HeadersRegexp(`Cf-Access-Jwt-Assertion`, `.+`)
+      match: Host(`PLACEHOLDER`) && PathPrefix(`/_gatus`) && HeaderRegexp(`Cf-Access-Jwt-Assertion`, `.+`)
       priority: 20
       services:
         - kind: Service
@@ -94,7 +94,7 @@ spec:
           scheme: https
     # Gatus bypass route — matches only requests that went through Cloudflare Access (JWT header set by CF)
     - kind: Rule
-      match: Host(`PLACEHOLDER`) && PathPrefix(`/_gatus`) && HeadersRegexp(`Cf-Access-Jwt-Assertion`, `.+`)
+      match: Host(`PLACEHOLDER`) && PathPrefix(`/_gatus`) && HeaderRegexp(`Cf-Access-Jwt-Assertion`, `.+`)
       priority: 20
       services:
         - name: backup
@@ -146,7 +146,7 @@ spec:
           serversTransport: insecure-transport
     # Gatus bypass route — matches only requests that went through Cloudflare Access (JWT header set by CF)
     - kind: Rule
-      match: Host(`PLACEHOLDER`) && PathPrefix(`/_gatus`) && HeadersRegexp(`Cf-Access-Jwt-Assertion`, `.+`)
+      match: Host(`PLACEHOLDER`) && PathPrefix(`/_gatus`) && HeaderRegexp(`Cf-Access-Jwt-Assertion`, `.+`)
       priority: 20
       services:
         - name: omni
@@ -372,7 +372,7 @@ spec:
           passHostHeader: false
     # Gatus bypass route — matches only requests that went through Cloudflare Access (JWT header set by CF)
     - kind: Rule
-      match: Host(`PLACEHOLDER`) && PathPrefix(`/_gatus`) && HeadersRegexp(`Cf-Access-Jwt-Assertion`, `.+`)
+      match: Host(`PLACEHOLDER`) && PathPrefix(`/_gatus`) && HeaderRegexp(`Cf-Access-Jwt-Assertion`, `.+`)
       priority: 20
       services:
         - name: ems-esp
@@ -424,7 +424,7 @@ spec:
           port: 80
     # Gatus bypass route — matches only requests that went through Cloudflare Access (JWT header set by CF)
     - kind: Rule
-      match: Host(`PLACEHOLDER`) && PathPrefix(`/_gatus`) && HeadersRegexp(`Cf-Access-Jwt-Assertion`, `.+`)
+      match: Host(`PLACEHOLDER`) && PathPrefix(`/_gatus`) && HeaderRegexp(`Cf-Access-Jwt-Assertion`, `.+`)
       priority: 20
       services:
         - name: fritzbox
@@ -476,7 +476,7 @@ spec:
           passHostHeader: false
     # Gatus bypass route — matches only requests that went through Cloudflare Access (JWT header set by CF)
     - kind: Rule
-      match: Host(`PLACEHOLDER`) && PathPrefix(`/_gatus`) && HeadersRegexp(`Cf-Access-Jwt-Assertion`, `.+`)
+      match: Host(`PLACEHOLDER`) && PathPrefix(`/_gatus`) && HeaderRegexp(`Cf-Access-Jwt-Assertion`, `.+`)
       priority: 20
       services:
         - name: knx-ip

--- a/kubernetes/applications/external-services/base/ingress-route.yaml
+++ b/kubernetes/applications/external-services/base/ingress-route.yaml
@@ -7,7 +7,6 @@ metadata:
     # ExternalDNS configuration for Cloudflare
     external-dns.alpha.kubernetes.io/target: PLACEHOLDER
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
-    kubernetes.io/ingress.class: traefik
     # Gatus — automated status page discovery (probes via /_gatus path with CF Access Service Token)
     gatus.home-operations.com/enabled: "true"
     gatus.home-operations.com/endpoint: |
@@ -62,7 +61,6 @@ metadata:
     # ExternalDNS configuration for Cloudflare
     external-dns.alpha.kubernetes.io/target: PLACEHOLDER
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
-    kubernetes.io/ingress.class: traefik
     # Gatus — automated status page discovery (probes via /_gatus path with CF Access Service Token)
     gatus.home-operations.com/enabled: "true"
     gatus.home-operations.com/endpoint: |
@@ -113,7 +111,6 @@ metadata:
     # ExternalDNS configuration for Cloudflare
     external-dns.alpha.kubernetes.io/target: PLACEHOLDER
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
-    kubernetes.io/ingress.class: traefik
     # Gatus — automated status page discovery (probes via /_gatus path with CF Access Service Token)
     gatus.home-operations.com/enabled: "true"
     gatus.home-operations.com/endpoint: |
@@ -166,7 +163,6 @@ metadata:
     # ExternalDNS configuration for Cloudflare
     external-dns.alpha.kubernetes.io/target: PLACEHOLDER
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
-    kubernetes.io/ingress.class: traefik
 
 spec:
   entryPoints:
@@ -195,7 +191,6 @@ metadata:
     # ExternalDNS configuration for Cloudflare
     external-dns.alpha.kubernetes.io/target: PLACEHOLDER
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
-    kubernetes.io/ingress.class: traefik
 
 spec:
   entryPoints:
@@ -224,7 +219,6 @@ metadata:
     # ExternalDNS configuration for Cloudflare
     external-dns.alpha.kubernetes.io/target: PLACEHOLDER
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
-    kubernetes.io/ingress.class: traefik
 
 spec:
   entryPoints:
@@ -253,7 +247,6 @@ metadata:
     # ExternalDNS configuration for Cloudflare
     external-dns.alpha.kubernetes.io/target: PLACEHOLDER
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
-    kubernetes.io/ingress.class: traefik
 
 spec:
   entryPoints:
@@ -282,7 +275,6 @@ metadata:
     # ExternalDNS configuration for Cloudflare
     external-dns.alpha.kubernetes.io/target: PLACEHOLDER
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
-    kubernetes.io/ingress.class: traefik
 
 spec:
   entryPoints:
@@ -311,7 +303,6 @@ metadata:
     # ExternalDNS configuration for Cloudflare
     external-dns.alpha.kubernetes.io/target: PLACEHOLDER
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
-    kubernetes.io/ingress.class: traefik
 spec:
   entryPoints:
     - websecure
@@ -339,7 +330,6 @@ metadata:
     # ExternalDNS configuration for Cloudflare
     external-dns.alpha.kubernetes.io/target: PLACEHOLDER
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
-    kubernetes.io/ingress.class: traefik
     # Gatus — automated status page discovery (probes via /_gatus path with CF Access Service Token;
     # higher failure tolerance for flaky ESP32 devices)
     gatus.home-operations.com/enabled: "true"
@@ -391,7 +381,6 @@ metadata:
     # ExternalDNS configuration for Cloudflare
     external-dns.alpha.kubernetes.io/target: PLACEHOLDER
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
-    kubernetes.io/ingress.class: traefik
     # Gatus — automated status page discovery (probes via /_gatus path with CF Access Service Token;
     # alert only after several consecutive failures to tolerate brief device hiccups)
     gatus.home-operations.com/enabled: "true"
@@ -442,7 +431,6 @@ metadata:
     # ExternalDNS configuration for Cloudflare
     external-dns.alpha.kubernetes.io/target: PLACEHOLDER
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
-    kubernetes.io/ingress.class: traefik
     # Gatus — automated status page discovery (probes via /_gatus path with CF Access Service Token;
     # alert only after several consecutive failures to tolerate brief device hiccups)
     gatus.home-operations.com/enabled: "true"
@@ -495,7 +483,6 @@ metadata:
     # ExternalDNS configuration for Cloudflare
     external-dns.alpha.kubernetes.io/target: PLACEHOLDER
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
-    kubernetes.io/ingress.class: traefik
 
 spec:
   entryPoints:
@@ -524,7 +511,6 @@ metadata:
     # ExternalDNS configuration for Cloudflare
     external-dns.alpha.kubernetes.io/target: PLACEHOLDER
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
-    kubernetes.io/ingress.class: traefik
 
 spec:
   entryPoints:

--- a/kubernetes/applications/gatus/base/ingress-route.yaml
+++ b/kubernetes/applications/gatus/base/ingress-route.yaml
@@ -8,7 +8,6 @@ metadata:
     # ExternalDNS configuration for Cloudflare
     external-dns.alpha.kubernetes.io/target: PLACEHOLDER
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
-    kubernetes.io/ingress.class: traefik
     # Homepage Service Discovery
     gethomepage.dev/enabled: "true"
     gethomepage.dev/group: "Observability"

--- a/kubernetes/applications/grafana/base/ingress-route.yaml
+++ b/kubernetes/applications/grafana/base/ingress-route.yaml
@@ -55,7 +55,7 @@ spec:
           port: 80
     # Gatus bypass route — matches only requests that went through Cloudflare Access (JWT header set by CF)
     - kind: Rule
-      match: Host(`PLACEHOLDER`) && PathPrefix(`/_gatus`) && HeadersRegexp(`Cf-Access-Jwt-Assertion`, `.+`)
+      match: Host(`PLACEHOLDER`) && PathPrefix(`/_gatus`) && HeaderRegexp(`Cf-Access-Jwt-Assertion`, `.+`)
       priority: 20
       services:
         - kind: Service

--- a/kubernetes/applications/grafana/base/ingress-route.yaml
+++ b/kubernetes/applications/grafana/base/ingress-route.yaml
@@ -8,7 +8,6 @@ metadata:
     # ExternalDNS configuration for Cloudflare
     external-dns.alpha.kubernetes.io/target: PLACEHOLDER
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
-    kubernetes.io/ingress.class: traefik
     # Homepage Service Discovery
     gethomepage.dev/enabled: "true"
     gethomepage.dev/group: "Observability"

--- a/kubernetes/applications/homepage/base/ingress-route.yaml
+++ b/kubernetes/applications/homepage/base/ingress-route.yaml
@@ -8,7 +8,6 @@ metadata:
     # ExternalDNS configuration for Cloudflare
     external-dns.alpha.kubernetes.io/target: PLACEHOLDER
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
-    kubernetes.io/ingress.class: traefik
     # Homepage Service Discovery
     gethomepage.dev/enabled: "true"
     gethomepage.dev/group: "Productivity"

--- a/kubernetes/applications/homepage/base/ingress-route.yaml
+++ b/kubernetes/applications/homepage/base/ingress-route.yaml
@@ -49,7 +49,7 @@ spec:
           port: 3000
     # Gatus bypass route — matches only requests that went through Cloudflare Access (JWT header set by CF)
     - kind: Rule
-      match: Host(`PLACEHOLDER`) && PathPrefix(`/_gatus`) && HeadersRegexp(`Cf-Access-Jwt-Assertion`, `.+`)
+      match: Host(`PLACEHOLDER`) && PathPrefix(`/_gatus`) && HeaderRegexp(`Cf-Access-Jwt-Assertion`, `.+`)
       priority: 20
       services:
         - kind: Service

--- a/kubernetes/applications/iot-mcp-bridge/base/ingress-route.yaml
+++ b/kubernetes/applications/iot-mcp-bridge/base/ingress-route.yaml
@@ -8,7 +8,6 @@ metadata:
     # ExternalDNS configuration for Cloudflare
     external-dns.alpha.kubernetes.io/target: PLACEHOLDER
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
-    kubernetes.io/ingress.class: traefik
 
 spec:
   entryPoints:

--- a/kubernetes/applications/kromgo/base/ingress-route.yaml
+++ b/kubernetes/applications/kromgo/base/ingress-route.yaml
@@ -8,7 +8,6 @@ metadata:
     # ExternalDNS configuration for Cloudflare
     external-dns.alpha.kubernetes.io/target: PLACEHOLDER
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
-    kubernetes.io/ingress.class: traefik
 
 spec:
   entryPoints:

--- a/kubernetes/applications/nats/base/ingress-route-tcp.yaml
+++ b/kubernetes/applications/nats/base/ingress-route-tcp.yaml
@@ -8,7 +8,6 @@ metadata:
     # ExternalDNS configuration for Cloudflare (no proxy — TCP traffic)
     external-dns.alpha.kubernetes.io/target: PLACEHOLDER
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "false"
-    kubernetes.io/ingress.class: traefik
 
 spec:
   entryPoints:

--- a/kubernetes/applications/node-red/base/ingress-route.yaml
+++ b/kubernetes/applications/node-red/base/ingress-route.yaml
@@ -8,7 +8,6 @@ metadata:
     # ExternalDNS configuration for Cloudflare
     external-dns.alpha.kubernetes.io/target: PLACEHOLDER
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
-    kubernetes.io/ingress.class: traefik
     # Homepage Service Discovery
     gethomepage.dev/enabled: "true"
     gethomepage.dev/group: "Smart Home Integration"

--- a/kubernetes/applications/prometheus/base/ingress-route.yaml
+++ b/kubernetes/applications/prometheus/base/ingress-route.yaml
@@ -8,7 +8,6 @@ metadata:
     # ExternalDNS configuration for Cloudflare
     external-dns.alpha.kubernetes.io/target: PLACEHOLDER
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
-    kubernetes.io/ingress.class: traefik
     # Homepage Service Discovery
     gethomepage.dev/enabled: "true"
     gethomepage.dev/group: "Observability"
@@ -59,7 +58,6 @@ metadata:
     # ExternalDNS configuration for Cloudflare
     external-dns.alpha.kubernetes.io/target: PLACEHOLDER
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
-    kubernetes.io/ingress.class: traefik
     # Homepage annotations
     gethomepage.dev/enabled: "true"
     gethomepage.dev/group: "Observability"

--- a/kubernetes/applications/rustfs/base/ingress-route.yaml
+++ b/kubernetes/applications/rustfs/base/ingress-route.yaml
@@ -8,7 +8,6 @@ metadata:
     # ExternalDNS configuration for Cloudflare
     external-dns.alpha.kubernetes.io/target: PLACEHOLDER
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
-    kubernetes.io/ingress.class: traefik
     # Homepage Service Discovery
     gethomepage.dev/enabled: "true"
     gethomepage.dev/group: "Data & AI"

--- a/kubernetes/applications/wiki-js/base/ingress-route.yaml
+++ b/kubernetes/applications/wiki-js/base/ingress-route.yaml
@@ -50,7 +50,7 @@ spec:
           port: 80
     # Gatus bypass route — matches only requests that went through Cloudflare Access (JWT header set by CF)
     - kind: Rule
-      match: Host(`PLACEHOLDER`) && PathPrefix(`/_gatus`) && HeadersRegexp(`Cf-Access-Jwt-Assertion`, `.+`)
+      match: Host(`PLACEHOLDER`) && PathPrefix(`/_gatus`) && HeaderRegexp(`Cf-Access-Jwt-Assertion`, `.+`)
       priority: 20
       services:
         - kind: Service

--- a/kubernetes/applications/wiki-js/base/ingress-route.yaml
+++ b/kubernetes/applications/wiki-js/base/ingress-route.yaml
@@ -8,7 +8,6 @@ metadata:
     # ExternalDNS configuration for Cloudflare
     external-dns.alpha.kubernetes.io/target: PLACEHOLDER
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
-    kubernetes.io/ingress.class: traefik
     # Homepage Service Discovery
     gethomepage.dev/enabled: "true"
     gethomepage.dev/group: "Productivity"

--- a/kubernetes/components/cilium/base/ingress-route.yaml
+++ b/kubernetes/components/cilium/base/ingress-route.yaml
@@ -8,7 +8,6 @@ metadata:
     # ExternalDNS configuration for Cloudflare
     external-dns.alpha.kubernetes.io/target: PLACEHOLDER
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
-    kubernetes.io/ingress.class: traefik
     # Homepage Service Discovery
     gethomepage.dev/enabled: "true"
     gethomepage.dev/group: "Observability"

--- a/kubernetes/components/csi-block-storage-controller/base/ingress-route.yaml
+++ b/kubernetes/components/csi-block-storage-controller/base/ingress-route.yaml
@@ -8,7 +8,6 @@ metadata:
     # ExternalDNS configuration for Cloudflare
     external-dns.alpha.kubernetes.io/target: PLACEHOLDER
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
-    kubernetes.io/ingress.class: traefik
     # Homepage Service Discovery
     gethomepage.dev/enabled: "true"
     gethomepage.dev/group: "Data & AI"

--- a/kubernetes/components/gitops-controller/base/ingress-route.yaml
+++ b/kubernetes/components/gitops-controller/base/ingress-route.yaml
@@ -63,7 +63,7 @@ spec:
           scheme: h2c
     # Gatus bypass route — matches only requests that went through Cloudflare Access (JWT header set by CF)
     - kind: Rule
-      match: Host(`PLACEHOLDER`) && PathPrefix(`/_gatus`) && HeadersRegexp(`Cf-Access-Jwt-Assertion`, `.+`)
+      match: Host(`PLACEHOLDER`) && PathPrefix(`/_gatus`) && HeaderRegexp(`Cf-Access-Jwt-Assertion`, `.+`)
       priority: 20
       services:
         - kind: Service

--- a/kubernetes/components/gitops-controller/base/ingress-route.yaml
+++ b/kubernetes/components/gitops-controller/base/ingress-route.yaml
@@ -8,7 +8,6 @@ metadata:
     # ExternalDNS configuration for Cloudflare
     external-dns.alpha.kubernetes.io/target: PLACEHOLDER
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
-    kubernetes.io/ingress.class: traefik
     # Homepage Service Discovery
     gethomepage.dev/enabled: "true"
     gethomepage.dev/group: "GitOps"


### PR DESCRIPTION
Two Traefik-v3 migration leftovers on the `IngressRoute` CRDs, both surfaced by the HolmesGPT log-anomaly checks.

## 1. `HeadersRegexp` → `HeaderRegexp` (routing bug)
Traefik v3 removed the v2 plural matcher `HeadersRegexp` (renamed to the singular `HeaderRegexp`). Running **v3.7.5**, every `/_gatus` Cloudflare-Access bypass rule failed to parse (`unsupported function: HeadersRegexp`), so Traefik **silently dropped those rules on every dynamic-config reload** — 11 rules across argocd, homepage, authentik, grafana, wiki-js and six external-services. The rest of each file already used the v3 singular `Header(...)`, so only these gatus lines were stale.

## 2. Drop deprecated `kubernetes.io/ingress.class: traefik` annotation
On every kubernetescrd provider refresh Traefik logged a WARN per IngressRoute carrying this deprecated annotation — 30 objects, flooding the traefik stdout stream. The annotation is a **no-op** on IngressRoute CRDs (`providers.kubernetesCRD` sets no `ingressClass` filter), so it is removed rather than migrated to `spec.ingressClassName` (which only applies to `networking.k8s.io/Ingress`).

Side effect it fixes: the crowdsec agent ingests traefik pod stdout as `type=traefik` and parses every line as an access log; these general WARN lines have no access-log fields, so its `traefik-logs` parser emitted ~3/s `reflect.Value.Type on zero Value` / nil-interface warnings. Removing the annotation flood clears that noise at the source.

## Verification
- `providers.kubernetesCRD` has no `ingressClass` → removal is safe.
- Post-change: 0 `HeadersRegexp(` remaining, 11 `HeaderRegexp(`, 0 `kubernetes.io/ingress.class: traefik` remaining.
- Effective once ArgoCD syncs and Traefik reloads its dynamic config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)