### PR TITLE
fix(holmesgpt): tune healthcheck cadence for budget + catalog Loki scheduler noise

### DIFF
--- a/kubernetes/applications/holmesgpt/base/scheduled-healthchecks.yaml
+++ b/kubernetes/applications/holmesgpt/base/scheduled-healthchecks.yaml
@@ -24,7 +24,7 @@ metadata:
   namespace: holmesgpt
 
 spec:
-  schedule: "42 * * * *"
+  schedule: "42 */4 * * *"
   enabled: true
   mode: monitor
   timeout: 300

--- a/kubernetes/applications/holmesgpt/base/scheduled-healthchecks.yaml
+++ b/kubernetes/applications/holmesgpt/base/scheduled-healthchecks.yaml
@@ -46,18 +46,18 @@ metadata:
   namespace: holmesgpt
 
 spec:
-  schedule: "2 * * * *"
+  schedule: "2 */12 * * *"
   enabled: true
   mode: monitor
   timeout: 300
   query: >-
-    Using Loki, scan the last hour of logs across the cluster for any application
+    Using Loki, scan the last 12 hours of logs across the cluster for any application
     producing a recurring abnormal error pattern — repeated panics, stack traces,
     bursts of 5xx, or fatal/connection errors — that is not normal steady-state
     noise. Before reporting FAIL on any recurring error, always fetch the
     `known-log-noise` skill and exclude every pattern that matches an entry
     there. Report FAIL only if at least one application
-    shows such a recurring pattern in the last hour after those exclusions; name
+    shows such a recurring pattern in the last 12 hours after those exclusions; name
     the application and quote one representative line. Ignore single or occasional
     errors and known steady-state noise. If nothing abnormal stands out, report
     PASS.

--- a/kubernetes/applications/holmesgpt/base/scheduled-healthchecks.yaml
+++ b/kubernetes/applications/holmesgpt/base/scheduled-healthchecks.yaml
@@ -12,8 +12,12 @@ spec:
   timeout: 300
   query: >-
     Report FAIL only if an ArgoCD application's sync status is not Synced, or its
-    health status is not Healthy, right now. List those applications with the most
-    likely reason. If all applications are Synced and Healthy, report PASS.
+    health status is not Healthy, right now. If all applications are Synced and
+    Healthy, report PASS.
+    On FAIL, keep the summary to a single sentence naming the affected
+    application(s) and whether they are out of sync, unhealthy, or both; put the
+    per-application detail and most likely reason only in the detailed rationale,
+    and do not repeat it in the summary.
 
 ---
 apiVersion: holmesgpt.dev/v1alpha1
@@ -34,8 +38,10 @@ spec:
     endpoints, an Ingress or Traefik IngressRoute whose backend Service has no
     endpoints, a Certificate that is not Ready, or a custom resource whose
     selector matches nothing (e.g. a GrafanaDashboard with no matching Grafana
-    instance). List each with its namespace, name, and the problem. If you find
-    none, report PASS.
+    instance). If you find none, report PASS.
+    On FAIL, keep the summary to a single sentence stating how many resources are
+    affected and their kind(s); put each resource's namespace, name, and specific
+    problem only in the detailed rationale, and do not repeat it in the summary.
 
 ---
 apiVersion: holmesgpt.dev/v1alpha1
@@ -57,7 +63,10 @@ spec:
     noise. Before reporting FAIL on any recurring error, always fetch the
     `known-log-noise` skill and exclude every pattern that matches an entry
     there. Report FAIL only if at least one application
-    shows such a recurring pattern in the last 12 hours after those exclusions; name
-    the application and quote one representative line. Ignore single or occasional
-    errors and known steady-state noise. If nothing abnormal stands out, report
-    PASS.
+    shows such a recurring pattern in the last 12 hours after those exclusions.
+    Ignore single or occasional errors and known steady-state noise. If nothing
+    abnormal stands out, report PASS.
+    On FAIL, keep the summary to a single sentence naming the application and the
+    problem; put all evidence — one representative log line, affected
+    namespace/pods, rough frequency, and the likely cause — only in the detailed
+    rationale, and do not repeat it in the summary.

--- a/kubernetes/applications/holmesgpt/base/skills/known-log-noise/SKILL.md
+++ b/kubernetes/applications/holmesgpt/base/skills/known-log-noise/SKILL.md
@@ -77,6 +77,23 @@ false alarms on patterns that look like failures but are normal in this cluster.
   would be a tight hot-loop (many conflicts per second on one object) or
   CronJobs that stop scheduling — neither is this.
 
+### Loki querier ↔ query-scheduler "EOF" / "context canceled"
+- Pattern: `error notifying scheduler about finished query" err=EOF` and
+  `error processing requests from scheduler err="rpc error: code = Canceled
+  desc = context canceled"`, error-level, from `loki-0` (loki namespace),
+  recurring every few seconds while queries are running.
+- Why benign: normal query lifecycle. When a query finishes or its client
+  (Grafana, HolmesGPT) disconnects/cancels, the querier's gRPC stream to the
+  in-process query-scheduler closes and Loki logs that close as EOF /
+  context-canceled at error level — the query itself still succeeded. The rate
+  tracks query volume, so HolmesGPT's own scheduled Loki scans amplify it, and
+  it falls silent when query load is idle.
+- Confirm still benign: `loki-0` is Running with no recent restarts/OOM and
+  queries still return results (Grafana Explore or the Holmes loki toolset
+  answer normally). A real fault instead shows client-facing 5xx/timeouts,
+  `panic`, rejected writes (`too many outstanding requests`), or the pod
+  CrashLooping.
+
 ## Synthesize findings
 
 - Matched + Confirm passes → report the pattern as expected steady-state noise;


### PR DESCRIPTION
Adjustments to the HolmesGPT ScheduledHealthChecks, driven by a run of check failures and the monthly LLM budget hitting its cap.

## 1. Catalog Loki querier ↔ query-scheduler EOF as known noise
The log-anomaly check flagged `loki-0` for recurring error-level `error notifying scheduler about finished query err=EOF` and `processing requests from scheduler ... context canceled`. These are Loki's normal query-lifecycle logs (the querier's gRPC stream to the in-process query-scheduler closes on query completion/cancel), amplified by HolmesGPT's own scheduled Loki scans. Adds a known-benign catalog entry with a Confirm check so investigations stop escalating them. `loki-0` verified Running 37d / 0 restarts, queries return normally.

## 2. Reduce healthcheck cadence (budget mitigation)
All three ScheduledHealthChecks ran hourly (log-anomaly :02, argocd-sync :22, config-coherence :42) = 72 LLM investigations/day, the main driver of the E.ON LiteLLM monthly budget reaching its \$90 cap near month-end (which then blinds the AIOps healthchecks until the month rolls over).

- **log-anomaly** → every 12h (00:02 / 12:02 UTC), scan window widened from the last hour to the last 12 hours so the lower cadence does not leave 11h of logs unobserved.
- **config-coherence** → every 4h (00:42..20:42 UTC, 6/day); it catches slow-forming misconfig/orphan drift, so 4h coverage is fine.
- **argocd-sync** stays hourly so sync drift is still caught quickly.

Net: ~32 investigations/day, down from 72. `timeout` stays at the CRD maximum of 300s (the schema rejects higher); the 12h log-anomaly scan uses aggregating LogQL so it should still fit — if runs start timing out we'll narrow the window.

The skill ConfigMap uses a name-suffix hash, so the holmes pod rolls automatically on sync and picks up the new catalog entry.

## 3. Split terse summary from detailed rationale
The alert-bridge e-mail renders `.status.message` as **Summary** and `.status.rationale` as **Full rationale**, but nothing told the model the two fields should differ — so it wrote near-identical prose into both (a log-anomaly FAIL came through with Summary and Full rationale byte-for-byte identical). Adds an explicit contract to all three check queries: the summary is a single sentence naming the affected app/resource and the problem; all evidence (log lines, namespaces/pods, counts, likely cause) goes only in the rationale. Drops the now-redundant "list/quote …" clauses the queries used to carry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
