### PR TITLE
fix(ingress): bound Authentik forwardAuth response body size

### DIFF
--- a/kubernetes/components/ingress-controller/base/middlewares.yaml
+++ b/kubernetes/components/ingress-controller/base/middlewares.yaml
@@ -161,6 +161,8 @@ spec:
   forwardAuth:
     address: "http://authentik-server.authentik.svc.cluster.local/outpost.goauthentik.io/auth/traefik"
     trustForwardHeader: true
+    # Bound auth-server response body; silences Traefik's unlimited-body DoS warning.
+    maxResponseBodySize: 1048576
     authResponseHeaders:
       - "Remote-User"
       - "Remote-Groups"


### PR DESCRIPTION
## Problem

Traefik v3.7.5 logs a warning on **every request** through the Authentik `ForwardAuth` middleware because `maxResponseBodySize` is unset:

> `maxResponseBodySize is not configured, allowing unlimited response body size which can lead to DoS attacks and memory exhaustion. Please set an appropriate limit.`

That single warning made up **~99% of Traefik's stdout** (2975 of 3000 sampled lines).

## Downstream amplification

The crowdsec agent tails Traefik's **whole stdout** as access logs (`program: traefik`). It cannot tell an access-log line from Traefik's own app warnings, so each warning is fed to `child-crowdsecurity/traefik-logs`, where `evt.Unmarshaled.traefik.*` (`ClientAddr`, `Duration`, `ClientHost`, …) is nil → **~5 nil-field parse errors per warning**. Result: the crowdsec agent log was **100% parse errors** — which is what tripped the HolmesGPT `log-anomaly` check.

This is the same class as the previously-seen "crowdsec parses whole Traefik stdout" flood, but the trigger this time is the unset `maxResponseBodySize`, not the old deprecated `ingress.class` annotation.

## Fix

Set `maxResponseBodySize: 1048576` (1 MiB) on the Authentik `forwardAuth` middleware. Authentik's `/outpost.goauthentik.io/auth/traefik` endpoint returns only headers plus tiny redirects, so the bound is generous while:

1. **Silencing the warning at the source** → Traefik stdout is clean again.
2. **Clearing the downstream crowdsec parse-error flood** → agent log usable, `log-anomaly` check green for crowdsec.
3. **Closing the actual security gap** → the auth-server response body is no longer read unbounded into memory.

## Validation

- `kustomize build --enable-helm` renders cleanly for both `overlays/dev` and `overlays/prod`.
- Confirmed `maxResponseBodySize: 1048576` lands on the `authentik` Middleware's `forwardAuth` spec in the rendered output.
- pre-commit green.

## Follow-up (post-deploy)

Once the flood is gone, re-check the crowdsec agent log for any *genuine* access-log parse errors that the warning flood may have masked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
