### PR TITLE
fix(backups): stagger nightly backups to stop the 02:00 UTC etcd stall

### DIFF
--- a/infrastructure/manifest/00-cluster/pve-cluster-backup-jobs.yaml
+++ b/infrastructure/manifest/00-cluster/pve-cluster-backup-jobs.yaml
@@ -1,6 +1,6 @@
 pve_cluster_backup_jobs:
   daily-backup:
-    schedule: "*-*-* 04:00"
+    schedule: "*-*-* 23:00"
     storage: pbs-primary
     mode: snapshot
     compress: zstd

--- a/kubernetes/applications/wiki-js/base/database.yaml
+++ b/kubernetes/applications/wiki-js/base/database.yaml
@@ -76,7 +76,7 @@ metadata:
   namespace: wiki-js
 
 spec:
-  schedule: "0 0 2 * * *"
+  schedule: "0 0 0 * * *"
   immediate: false
   backupOwnerReference: cluster
   cluster:

--- a/kubernetes/components/csi-block-storage-controller/base/recurring-jobs.yaml
+++ b/kubernetes/components/csi-block-storage-controller/base/recurring-jobs.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: csi-block-storage-controller
 
 spec:
-  cron: "0 2 * * *" # Every day at 2am
+  cron: "0 4 * * *" # Every day at 4am
   task: backup
   groups:
     - default
@@ -36,7 +36,7 @@ metadata:
   namespace: csi-block-storage-controller
 
 spec:
-  cron: "0 5 * * *" # Every day at 5am, after backup-daily (02:00)
+  cron: "0 5 * * *" # Every day at 5am, after backup-daily (04:00)
   task: snapshot-cleanup
   groups:
     - default


### PR DESCRIPTION
## Problem
A nightly ~45s kube-apiserver disruption (`http: Handler timeout`, etcd `leader changed`) around 02:00 UTC, flagged by the HolmesGPT log-anomaly check.

## Root cause (confirmed via Prometheus, 2026-07-01 02:02Z)
etcd `wal_fsync` p99 jumps **2.3ms → 114ms**, coincident with the single Proxmox host `pve-1` iowait **3 → 60** (20×) and load1 **2.7 → 12.7** — a sharp 2-minute host-disk-I/O burst at backup *start*. `pve-1` runs both the etcd control-plane VMs and the backed-up guests on shared storage.

It's a **thundering herd**: four heavy backups all fire at 02:00 UTC:
- Longhorn `backup-daily` (`0 2 * * *`)
- authentik CNPG backup (`0 0 2 * * *`)
- wiki-js CNPG backup (`0 0 2 * * *`)
- Proxmox `windows_01` vzdump (`04:00` Europe/Berlin = 02:00Z in summer)

Ruled out as the cause: the transfer/bandwidth phase (Proxmox→PBS at 03:02Z caused only iowait 16 and **no** etcd blip; Longhorn uploaded ~0 bytes). So the fix is to **separate the snapshot-start bursts in time**, not throttle bandwidth.

## Change — one heavy job per window
| UTC | Job | Change |
|-----|-----|--------|
| 00:00 | wiki-js CNPG | `0 0 2` → `0 0 0` |
| 02:00 | authentik CNPG | unchanged (now alone) |
| 03:00 | timescaledb CNPG | unchanged (already alone) |
| 04:00 | Longhorn backup-daily | `0 2` → `0 4` |
| 21:00Z / 22:00Z | Proxmox vzdump | Berlin `04:00` → `23:00` (DST-safe: empty in both seasons) |

`snapshot-cleanup` stays at 05:00, still after the (now 04:00) Longhorn backup.

## Apply / follow-up
- The two Kubernetes changes (Longhorn RecurringJob, wiki-js ScheduledBackup) auto-apply via ArgoCD.
- The Proxmox vzdump change is **OpenTofu** — run `tofu apply` in `infrastructure/` to take effect.
- Re-measure the next night: if a lone backup's snapshot burst still stalls etcd, the structural fix is dedicated/isolated storage for the etcd CP VMs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)