### PR TITLE
fix(grafana): point Dach SO Luftdruck panel at the pressure GA

### DIFF
--- a/kubernetes/applications/grafana/base/dashboards/knx-sensor-exterior.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/knx-sensor-exterior.yaml
@@ -1069,7 +1069,7 @@ spec:
               "editorMode": "code",
               "format": "time_series",
               "rawQuery": true,
-              "rawSql": "SELECT time, (last_value / 100.0) AS value FROM (SELECT $__timeGroup(time, '$__interval') AS time, last(value, time) AS last_value FROM knx WHERE $__timeFilter(time) AND knx_name = 'Sensorik.A.Dach.Außensensor.SO.Luftdruck-Status' GROUP BY 1 ORDER BY 1) sub;",
+              "rawSql": "SELECT time, (last_value / 100.0) AS value FROM (SELECT $__timeGroup(time, '$__interval') AS time, last(value, time) AS last_value FROM knx WHERE $__timeFilter(time) AND knx_name = 'Sensorik.A.Dach.Außensensor.SO.Luftdruck-Relativ' GROUP BY 1 ORDER BY 1) sub;",
               "refId": "A"
             }
           ],


### PR DESCRIPTION
## Problem

On the **Dach – Außensensor SO** row (KNX Aussen sensor dashboard) the *Luftdruck* panel showed **"No data"**, while its sibling *Luftfeuchte* panel had data.

## Cause

The panel queried `Sensorik.A.Dach.Außensensor.SO.Luftdruck-Status`, which per the knx-nats-bridge catalog is a **boolean status bit (DPT 1.001)** — not a pressure reading — and is never archived, hence no rows. The actual measurement is `Sensorik.A.Dach.Außensensor.SO.Luftdruck-Relativ` (DPT 14.058, Pa). Every other Luftdruck panel in the house already uses `-Relativ`; this one was a copy-paste slip.

## Fix

Point the panel at `...SO.Luftdruck-Relativ`. The existing `/100.0` Pa→hPa conversion is unchanged.

## Verification

- Embedded dashboard JSON re-parsed successfully.
- GA name cross-checked against the knx-nats-bridge catalog (DPT 14.058, Pa).
- pre-commit hooks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)