### PR TITLE
fix(grafana): show latest ventilation status regardless of age

### DIFF
--- a/kubernetes/applications/grafana/base/dashboards/hvac-ventilation.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/hvac-ventilation.yaml
@@ -120,7 +120,7 @@ spec:
               "editorMode": "code",
               "format": "time_series",
               "rawQuery": true,
-              "rawSql": "SELECT time, value FROM knx WHERE knx_name = 'Versorgungstechnik.KWL.Lüftermodi-Status' AND time > now() - INTERVAL '1 hour' ORDER BY time DESC LIMIT 1;",
+              "rawSql": "SELECT time, value FROM knx WHERE knx_name = 'Versorgungstechnik.KWL.Lüftermodi-Status' ORDER BY time DESC LIMIT 1;",
               "refId": "A"
             }
           ],
@@ -182,7 +182,7 @@ spec:
               "editorMode": "code",
               "format": "time_series",
               "rawQuery": true,
-              "rawSql": "SELECT time, value FROM knx WHERE knx_name = 'Versorgungstechnik.KWL.Filter-Betriebsstunden' AND time > now() - INTERVAL '1 hour' ORDER BY time DESC LIMIT 1;",
+              "rawSql": "SELECT time, value FROM knx WHERE knx_name = 'Versorgungstechnik.KWL.Filter-Betriebsstunden' ORDER BY time DESC LIMIT 1;",
               "refId": "A"
             }
           ],
@@ -262,7 +262,7 @@ spec:
               "editorMode": "code",
               "format": "time_series",
               "rawQuery": true,
-              "rawSql": "SELECT time, value FROM knx WHERE knx_name = 'Versorgungstechnik.KWL.Filterwechsel-Status' AND time > now() - INTERVAL '1 hour' ORDER BY time DESC LIMIT 1;",
+              "rawSql": "SELECT time, value FROM knx WHERE knx_name = 'Versorgungstechnik.KWL.Filterwechsel-Status' ORDER BY time DESC LIMIT 1;",
               "refId": "A"
             }
           ],
@@ -342,7 +342,7 @@ spec:
               "editorMode": "code",
               "format": "time_series",
               "rawQuery": true,
-              "rawSql": "SELECT time, value FROM knx WHERE knx_name = 'Versorgungstechnik.KWL.Wartungsmodus-Status' AND time > now() - INTERVAL '1 hour' ORDER BY time DESC LIMIT 1;",
+              "rawSql": "SELECT time, value FROM knx WHERE knx_name = 'Versorgungstechnik.KWL.Wartungsmodus-Status' ORDER BY time DESC LIMIT 1;",
               "refId": "A"
             }
           ],
@@ -422,7 +422,7 @@ spec:
               "editorMode": "code",
               "format": "time_series",
               "rawQuery": true,
-              "rawSql": "SELECT time, value FROM knx WHERE knx_name = 'Versorgungstechnik.KWL.Status' AND time > now() - INTERVAL '1 hour' ORDER BY time DESC LIMIT 1;",
+              "rawSql": "SELECT time, value FROM knx WHERE knx_name = 'Versorgungstechnik.KWL.Status' ORDER BY time DESC LIMIT 1;",
               "refId": "A"
             }
           ],
@@ -512,7 +512,7 @@ spec:
               "editorMode": "code",
               "format": "time_series",
               "rawQuery": true,
-              "rawSql": "SELECT time, value FROM knx WHERE knx_name = 'Versorgungstechnik.KWL.ComfoConnect-Status' AND time > now() - INTERVAL '1 hour' ORDER BY time DESC LIMIT 1;",
+              "rawSql": "SELECT time, value FROM knx WHERE knx_name = 'Versorgungstechnik.KWL.ComfoConnect-Status' ORDER BY time DESC LIMIT 1;",
               "refId": "A"
             }
           ],


### PR DESCRIPTION
## Problem

The **Wohnraumlüftung** dashboard showed **"No data"** on all six stat panels: Aktuelle Lüfterstufe, Betriebsstunden Filter, Filterwechsel, Wartungsmodus, Fehlerstatus Lüftungsgerät, Fehlerstatus ComfoConnect.

## Cause

Not a data-ingestion problem — the archiver is healthy and the GAs are populated. Verified against TimescaleDB:

| GA | last value | age |
|---|---|---|
| `KWL.Lüftermodi-Status` | 16:31 today | 4h 32m |
| `KWL.Filter-Betriebsstunden` | 12:54 today | 8h |
| `KWL.Filterwechsel-Status` | 12:54 today | 8h |
| `KWL.Status` | 18:32 today | 2h 31m |
| `KWL.Wartungsmodus-Status` | 2026-05-30 | 32 days |
| `KWL.ComfoConnect-Status` | 2026-05-30 | 32 days |

Each panel queried `... WHERE time > now() - INTERVAL '1 hour' ... LIMIT 1`. These are slow-changing status/counter GAs (KNX transmits them only on change), so their most recent value is regularly older than the one-hour window → nothing returned. The time-series panels (Luftstrom, temperatures, humidity) update continuously and were unaffected.

## Fix

Drop the artificial one-hour cap on all six stat panels and take the latest value: `SELECT time, value FROM knx WHERE knx_name = '…' ORDER BY time DESC LIMIT 1`. The existing `knx (knx_name, time DESC)` index keeps this an instant single-row lookup regardless of how old the last value is.

## Verification

- Row counts / last-value ages confirmed via read-only query against the `knx` hypertable.
- Embedded dashboard JSON re-parsed successfully.
- pre-commit hooks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)