### PR TITLE
fix(infra): throttle windows_01 vzdump CPU/IO to protect etcd

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -102,6 +102,12 @@ module "pve_cluster_backup_jobs" {
   ## Backup options
   mode     = try(each.value.mode, "snapshot")
   compress = try(each.value.compress, "zstd")
+
+  ## Host CPU/IO throttling (optional)
+  zstd        = try(each.value.zstd, null)
+  max_workers = try(each.value.max_workers, null)
+  ionice      = try(each.value.ionice, null)
+  bwlimit     = try(each.value.bwlimit, null)
 }
 
 

--- a/infrastructure/manifest/00-cluster/pve-cluster-backup-jobs.yaml
+++ b/infrastructure/manifest/00-cluster/pve-cluster-backup-jobs.yaml
@@ -4,5 +4,9 @@ pve_cluster_backup_jobs:
     storage: pbs-primary
     mode: snapshot
     compress: zstd
+    # Throttle host CPU/IO so the vzdump doesn't starve etcd on the shared node
+    zstd: 1
+    max_workers: 2
+    ionice: 8
     vmids:
       - 1100 # windows_01

--- a/infrastructure/modules/00-pve-cluster-backup-jobs/main.tf
+++ b/infrastructure/modules/00-pve-cluster-backup-jobs/main.tf
@@ -21,4 +21,13 @@ resource "proxmox_backup_job" "this" {
   vmid     = var.vmids
   mode     = var.mode
   compress = var.compress
+
+  ## Host CPU/IO throttling — null keeps the Proxmox defaults
+  zstd    = var.zstd
+  ionice  = var.ionice
+  bwlimit = var.bwlimit
+
+  performance = var.max_workers == null ? null : {
+    max_workers = var.max_workers
+  }
 }

--- a/infrastructure/modules/00-pve-cluster-backup-jobs/variables.tf
+++ b/infrastructure/modules/00-pve-cluster-backup-jobs/variables.tf
@@ -91,3 +91,46 @@ variable "compress" {
     error_message = "compress must be one of: 0, 1, gzip, lzo, zstd."
   }
 }
+
+
+###############################################################################
+## Resource throttling (host CPU / IO impact) — all optional, null = PVE default
+###############################################################################
+variable "zstd" {
+  description = <<EOT
+    Number of threads zstd uses for compression. 0 (Proxmox default) uses half
+    of the host's cores; set to 1 to cap compression to a single thread and keep
+    the backup from spiking host CPU load. Null leaves the Proxmox default.
+  EOT
+  type        = number
+  default     = null
+}
+
+variable "max_workers" {
+  description = <<EOT
+    Maximum number of parallel backup workers (Proxmox default 16). Lowering it
+    reduces concurrent CPU/IO pressure on the host. Null leaves the default.
+  EOT
+  type        = number
+  default     = null
+}
+
+variable "ionice" {
+  description = <<EOT
+    I/O priority (0-8) for the backup; in snapshot mode this applies to the
+    compressor. 8 runs it in the idle I/O class. Null leaves the Proxmox default.
+  EOT
+  type        = number
+  default     = null
+
+  validation {
+    condition     = var.ionice == null ? true : (var.ionice >= 0 && var.ionice <= 8)
+    error_message = "ionice must be between 0 and 8."
+  }
+}
+
+variable "bwlimit" {
+  description = "Backup I/O bandwidth limit in KiB/s. Null leaves it unlimited (Proxmox default)."
+  type        = number
+  default     = null
+}


### PR DESCRIPTION
## Why
Staggering the nightly backups off 02:00 UTC (#1278) removed the 4-way collision, but the now-isolated Proxmox `windows_01` vzdump **still triggers one brief etcd leader election** at its start (verified 2026-07-01 21:05Z).

This time it's **not** disk starvation — etcd `wal_fsync` stayed healthy at 7.6ms. It's **host CPU/load**: `zstd` defaults to using half the host cores for compression, pushing `pve-1` load1 to **20.6** and starving the etcd control-plane VMs' CPU on the shared single-NVMe node. Storage isolation (the "real" fix) isn't possible with one NVMe, so we cap the backup's host footprint instead.

## What
Add optional CPU/IO throttling passthrough to the `00-pve-cluster-backup-jobs` module (`zstd`, `max_workers`, `ionice`, `bwlimit` — all optional, `null` keeps Proxmox defaults, so other jobs are unaffected) and set on `daily-backup`:

| Option | Value | Effect |
|--------|-------|--------|
| `zstd` | `1` | single-threaded compression (was: half the host cores) — the main lever |
| `performance.max_workers` | `2` | fewer parallel backup workers (Proxmox default 16) |
| `ionice` | `8` | run the compressor in the idle I/O class |

`tofu validate` passes (confirms the `performance` nested-attribute syntax).

## Apply / verify
- **OpenTofu** — run `tofu apply` / `task infra:update` (not ArgoCD).
- Re-check the next night: `pve-1` load1 during the 21:00Z vzdump should drop well below 20, and `etcd_server_leader_changes_seen_total` should stay flat. If a leader change still slips through, the remaining knob is `bwlimit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)