### PR TITLE
Grafana: reorganize dashboard folders + fix Traefik metrics scraping

### DIFF
--- a/kubernetes/applications/cloudnative-pg/base/grafana-dashboard.yaml
+++ b/kubernetes/applications/cloudnative-pg/base/grafana-dashboard.yaml
@@ -1,0 +1,20 @@
+---
+# Import the chart-generated CloudNativePG dashboard via the Grafana Operator so it
+# lands in the operator-managed "Kubernetes" folder (configMapRef keeps the chart
+# as the JSON source — no copied JSON).
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+
+metadata:
+  name: cloudnative-pg
+  namespace: cloudnative-pg
+
+spec:
+  folder: "Kubernetes"
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      homelab.app: grafana
+  configMapRef:
+    name: cnpg-grafana-dashboard
+    key: cnp.json

--- a/kubernetes/applications/cloudnative-pg/base/kustomization.yaml
+++ b/kubernetes/applications/cloudnative-pg/base/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 namespace: cloudnative-pg
 resources:
   - ./namespace.yaml
+  - ./grafana-dashboard.yaml
 
 helmCharts:
   - name: cloudnative-pg-chart
@@ -12,6 +13,16 @@ helmCharts:
     version: 0.29.0
     valuesFile: values.yaml
     namespace: cloudnative-pg
+
+patches:
+  # The dashboard is imported via the Grafana Operator (grafana-dashboard.yaml) into the
+  # "Kubernetes" folder. Drop the sidecar label so it is not also auto-imported into "General".
+  - target:
+      kind: ConfigMap
+      name: cnpg-grafana-dashboard
+    patch: |-
+      - op: remove
+        path: /metadata/labels/grafana_dashboard
 
 labels:
   - includeSelectors: false

--- a/kubernetes/applications/grafana/base/dashboards/k8s-traefik.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/k8s-traefik.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: grafana
 
 spec:
-  folder: "Netzwerk"
+  folder: "Kubernetes"
   instanceSelector:
     matchLabels:
       homelab.app: grafana

--- a/kubernetes/applications/grafana/base/dashboards/network-unifi-ap.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/network-unifi-ap.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: grafana
 
 spec:
-  folder: "Netzwerk"
+  folder: "UniFi"
   instanceSelector:
     matchLabels:
       homelab.app: grafana

--- a/kubernetes/applications/grafana/base/dashboards/network-unifi-client.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/network-unifi-client.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: grafana
 
 spec:
-  folder: "Netzwerk"
+  folder: "UniFi"
   instanceSelector:
     matchLabels:
       homelab.app: grafana

--- a/kubernetes/bootstrap/cilium/base/grafana-dashboards.yaml
+++ b/kubernetes/bootstrap/cilium/base/grafana-dashboards.yaml
@@ -1,0 +1,38 @@
+---
+# Import the chart-generated Cilium dashboards via the Grafana Operator so they
+# land in the operator-managed "Kubernetes" folder (configMapRef keeps the chart
+# as the JSON source — no copied JSON, updates still flow with the chart).
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+
+metadata:
+  name: cilium-agent
+  namespace: cilium
+
+spec:
+  folder: "Kubernetes"
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      homelab.app: grafana
+  configMapRef:
+    name: cilium-dashboard
+    key: cilium-dashboard.json
+
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+
+metadata:
+  name: cilium-operator
+  namespace: cilium
+
+spec:
+  folder: "Kubernetes"
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      homelab.app: grafana
+  configMapRef:
+    name: cilium-operator-dashboard
+    key: cilium-operator-dashboard.json

--- a/kubernetes/bootstrap/cilium/base/kustomization.yaml
+++ b/kubernetes/bootstrap/cilium/base/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 namespace: cilium
 resources:
   - ./namespace.yaml
+  - ./grafana-dashboards.yaml
 
 helmCharts:
   - name: cilium
@@ -15,6 +16,22 @@ helmCharts:
     includeCRDs: true
     apiVersions:
       - monitoring.coreos.com/v1
+
+patches:
+  # These dashboards are imported via the Grafana Operator (grafana-dashboards.yaml) into the
+  # "Kubernetes" folder. Drop the sidecar label so they are not also auto-imported into "General".
+  - target:
+      kind: ConfigMap
+      name: cilium-dashboard
+    patch: |-
+      - op: remove
+        path: /metadata/labels/grafana_dashboard
+  - target:
+      kind: ConfigMap
+      name: cilium-operator-dashboard
+    patch: |-
+      - op: remove
+        path: /metadata/labels/grafana_dashboard
 
 labels:
   - includeSelectors: false

--- a/kubernetes/components/ingress-controller/base/values.yaml
+++ b/kubernetes/components/ingress-controller/base/values.yaml
@@ -133,6 +133,12 @@ ports:
       default: false
       internal: true
 
+  # Prometheus metrics (Port 9100) – only exposed on internal ClusterIP service for the ServiceMonitor
+  metrics:
+    expose:
+      default: false
+      internal: true
+
   # Web entry point (Port 80)
   web:
     exposedPort: 80


### PR DESCRIPTION
## Summary

Tidies up the Grafana dashboard folder structure and fixes the empty Traefik dashboard.

### `fix(traefik)`: scrape metrics via internal service
Traefik already exposes Prometheus metrics on the `metrics` entrypoint (port 9100) and a ServiceMonitor targets the `metrics` port — but that port wasn't exposed on any Service, so Prometheus had **no scrape target** (zero `traefik_*` series) and the dashboard showed "No data". The `metrics` port is now exposed on the **internal ClusterIP service** (not the external LoadBalancer), mirroring the existing API port.

### `refactor(grafana)`: reorganize dashboard folders
- **Traefik** dashboard moved `Netzwerk` → `Kubernetes`.
- **`Netzwerk` renamed to `UniFi`** by moving both UniFi dashboards (AP + client insights) into it.
- **Cilium** (agent + operator) and **CloudNativePG** dashboards moved into `Kubernetes`. These come from their Helm charts as sidecar ConfigMaps, so they're wrapped in `GrafanaDashboard` CRDs via `configMapRef` (`folder: Kubernetes`, chart stays the JSON source — no copied JSON), and the `grafana_dashboard` label is stripped from those ConfigMaps so the sidecar no longer double-imports them into `General`.

## Why not the alternatives
- **Sidecar folder-routing** (`foldersFromFilesStructure`) was rejected: Grafana 12 allows duplicate folder titles (verified via API), so it risks a second `Kubernetes` folder next to the operator's.
- **Disabling the dashboard sidecar** was rejected: the Grafana overlay's resource patches and OIDC-URL `replacements` are container-index-based (main container = index 2); dropping a sidecar shifts indices and breaks the build.

## Verification
- `kubectl kustomize --enable-helm` passes for all touched overlays (prod + dev).
- Rendered `traefik-internal` service now exposes `metrics:9100`; the external LB stays metrics-free.
- Rendered Cilium/CNPG ConfigMaps no longer carry the `grafana_dashboard` label; the 3 `GrafanaDashboard` CRDs resolve to `folder: Kubernetes`.

## Manual steps (folders aren't GitOps-managed)
- The empty **`grafana`** folder was already deleted via the Grafana API.
- After this syncs, the **`Netzwerk`** folder will be empty (operator doesn't GC string-`folder:` folders) — delete it via the UI / `DELETE /api/folders/<uid>`.
- Post-deploy sanity check: `count({__name__=~"traefik_.+"})` in Prometheus should be > 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)