### PR TITLE
Omit Grafana dashboard sidecar label via chart values (drop kustomize patches)

### DIFF
--- a/kubernetes/applications/cloudnative-pg/base/kustomization.yaml
+++ b/kubernetes/applications/cloudnative-pg/base/kustomization.yaml
@@ -14,16 +14,6 @@ helmCharts:
     valuesFile: values.yaml
     namespace: cloudnative-pg
 
-patches:
-  # The dashboard is imported via the Grafana Operator (grafana-dashboard.yaml) into the
-  # "Kubernetes" folder. Drop the sidecar label so it is not also auto-imported into "General".
-  - target:
-      kind: ConfigMap
-      name: cnpg-grafana-dashboard
-    patch: |-
-      - op: remove
-        path: /metadata/labels/grafana_dashboard
-
 labels:
   - includeSelectors: false
     pairs:

--- a/kubernetes/applications/cloudnative-pg/base/values.yaml
+++ b/kubernetes/applications/cloudnative-pg/base/values.yaml
@@ -8,6 +8,8 @@ monitoring:
   # Prometheus Operator label (Opt-In)
   podMonitorAdditionalLabels:
     release: prometheus
-  # Grafana Dashboard
+  # Grafana Dashboard — imported via the Grafana Operator (configMapRef), so drop the
+  # sidecar label (empty overrides the chart default) to avoid a duplicate import into "General".
   grafanaDashboard:
     create: true
+    sidecarLabel: ""

--- a/kubernetes/bootstrap/cilium/base/kustomization.yaml
+++ b/kubernetes/bootstrap/cilium/base/kustomization.yaml
@@ -17,22 +17,6 @@ helmCharts:
     apiVersions:
       - monitoring.coreos.com/v1
 
-patches:
-  # These dashboards are imported via the Grafana Operator (grafana-dashboards.yaml) into the
-  # "Kubernetes" folder. Drop the sidecar label so they are not also auto-imported into "General".
-  - target:
-      kind: ConfigMap
-      name: cilium-dashboard
-    patch: |-
-      - op: remove
-        path: /metadata/labels/grafana_dashboard
-  - target:
-      kind: ConfigMap
-      name: cilium-operator-dashboard
-    patch: |-
-      - op: remove
-        path: /metadata/labels/grafana_dashboard
-
 labels:
   - includeSelectors: false
     pairs:

--- a/kubernetes/bootstrap/cilium/base/values.yaml
+++ b/kubernetes/bootstrap/cilium/base/values.yaml
@@ -106,10 +106,11 @@ hubble:
     enabled: true
     label: grafana_dashboard
 
-# Grafana Dashboards for Cilium Agent
+# Grafana Dashboards for Cilium Agent — imported via the Grafana Operator (configMapRef),
+# so drop the sidecar label to avoid a duplicate import into Grafana's "General" folder.
 dashboards:
   enabled: true
-  label: grafana_dashboard
+  label: null
 
 # Prometheus: Enable metrics for Cilium agent and create ServiceMonitor
 prometheus:
@@ -132,7 +133,8 @@ operator:
       labels:
         release: prometheus
 
-  # Grafana Dashboards for Operator
+  # Grafana Dashboards for Operator — imported via the Grafana Operator (configMapRef),
+  # so drop the sidecar label to avoid a duplicate import into Grafana's "General" folder.
   dashboards:
     enabled: true
-    label: grafana_dashboard
+    label: null


### PR DESCRIPTION
## Summary

Follow-up cleanup to #1288. Replaces the kustomize `op: remove` patches (which stripped the `grafana_dashboard` label from the chart-generated Cilium and CloudNativePG dashboard ConfigMaps) with **chart-native values** — no patch needed.

| App | Before | After |
|-----|--------|-------|
| Cilium (agent + operator) | kustomize `op: remove` label | `dashboards.label: null` / `operator.dashboards.label: null` |
| CloudNativePG | kustomize `op: remove` label | `monitoring.grafanaDashboard.sidecarLabel: ""` |

The Cilium chart already guards the sidecar label with `{{- if .Values.dashboards.label }}`, and the CloudNativePG chart with `{{- if .Values.grafanaDashboard.sidecarLabel }}`, so setting them empty/null omits the label at render time — no downstream patch required. These dashboards are managed by the Grafana Operator via `configMapRef`, so the sidecar label is unwanted.

## No live impact
Rendered ConfigMaps are **byte-identical** to the previous patched output (no `grafana_dashboard` label; other labels unchanged), so ArgoCD sees no diff. This also removes the reliance on ServerSideApply to strip a label that a non-ArgoCD field manager (`talos`) owned on the Cilium ConfigMaps — which was the root cause of the earlier `deleteDashboardByUID 400` / Degraded state.

## Verification
`kubectl kustomize --enable-helm` passes for cilium + cloudnative-pg overlays (prod + dev); rendered dashboard ConfigMaps carry no `grafana_dashboard` label and the `GrafanaDashboard` CRDs still resolve to `folder: Kubernetes`.

> Note: `cnpg` `sidecarLabel` is marked deprecated upstream ("use labels instead"), but it is the only lever to empty the chart default `grafana_dashboard` — kept with an explanatory comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)