### PR TITLE
docs(holmesgpt): catalog isolated probe blips as known log noise

### DIFF
--- a/kubernetes/applications/holmesgpt/base/skills/known-log-noise/SKILL.md
+++ b/kubernetes/applications/holmesgpt/base/skills/known-log-noise/SKILL.md
@@ -52,6 +52,24 @@ false alarms on patterns that look like failures but are normal in this cluster.
   have stopped. A pod that keeps failing probes after the rollout settles, is
   CrashLooping, or a Deployment that never reaches Available is NOT this — escalate.
 
+### Isolated liveness/readiness probe blips on a stable pod (no rollout)
+- Pattern: a low count of `Unhealthy` events (`Liveness/Readiness probe failed:
+  ... context deadline exceeded`) incrementing slowly (single digits over many
+  hours) on a pod that is NOT rolling out — e.g. authentik-server. The pod stays
+  `1/1 Ready`, does not restart, and the app logs show the health route 200-ing.
+- Why benign: an occasional kubelet→pod probe is delayed past its short timeout
+  by a transient node/CNI/scheduling hiccup, so the kubelet records one Unhealthy
+  event. The failures are isolated (never failureThreshold in a row), so the pod
+  never restarts and the endpoint itself is healthy. authentik probes use a 3s
+  timeout / failureThreshold 3 → 30s of continuous failure is required to restart.
+- Confirm still benign: the pod is Ready with NO restart in the window
+  (`restartCount` unchanged, `state.running.startedAt` older than the window),
+  the Unhealthy `count` rises only by single digits over hours (not a burst), and
+  the app logs show health 200s (`kubectl logs … | grep '/-/health/' | grep -v
+  '"status": 200'` is empty; max runtime ≪ the probe timeout). A real fault
+  instead restarts the pod (`restartCount` climbing), CrashLoops, flaps the
+  Service endpoints, or logs 5xx/timeouts on the health route.
+
 ### ArgoCD application-controller "DiffFromCache: cache: key is missing"
 - Pattern: `DiffFromCache error: error getting managed resources for app <name>: cache: key is missing`,
   error-level, from `argocd-application-controller-0` (gitops-controller), low


### PR DESCRIPTION
## Why

The scheduled log-anomaly health-check escalated **authentik-server liveness probe failures** as a genuine anomaly. Investigation against the live cluster showed the opposite — it's benign steady-state noise:

- **0** non-200 health responses in the app logs over 12h (live + ready)
- Max health-endpoint runtime **207ms** vs the **3s** probe timeout (~14× margin)
- Config is a **single** web worker (`AUTHENTIK_WEB__WORKERS=1`, `PRELOAD=false`) — no gunicorn rotation storm
- Pod `1/1 Ready`, **no restart in the window** (liveness needs 3 consecutive fails / 30s to restart)

The 3 `Unhealthy` events (132→135 over 12h) were isolated single-probe blips — an occasional kubelet→pod probe delayed past its short timeout by a transient node/CNI hiccup, self-recovering, never reaching `failureThreshold`.

The check was correct that this matched **nothing** in the catalog: the existing probe entry is scoped to rollout churn only. So it had no basis to classify it as benign and escalated.

## Change

Add a `known-log-noise` catalog entry for **isolated liveness/readiness probe blips on a stable, non-rolling pod**, with a Confirm check that separates them from a real fault (`restartCount` climbing, CrashLoop, endpoint flapping, 5xx on the health route).

Docs-only change to the HolmesGPT skill catalog; no runtime/behaviour impact until ArgoCD syncs the skill ConfigMap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)