### PR TITLE
fix(omni): drop Authentik layer on public route, allow Auth0 in CSP

### DIFF
--- a/kubernetes/applications/external-services/base/ingress-route.yaml
+++ b/kubernetes/applications/external-services/base/ingress-route.yaml
@@ -134,7 +134,7 @@ spec:
     - kind: Rule
       match: Host(`PLACEHOLDER`)
       middlewares:
-        - name: chain-mfa-auth
+        - name: chain-standard
           namespace: ingress-controller
       services:
         - name: omni

--- a/kubernetes/components/ingress-controller/base/middlewares.yaml
+++ b/kubernetes/components/ingress-controller/base/middlewares.yaml
@@ -51,15 +51,17 @@ spec:
     browserXssFilter: true
     referrerPolicy: 'same-origin'
     permissionsPolicy: 'accelerometer=(), autoplay=(self), camera=(), encrypted-media=(), fullscreen=(), geolocation=(self), gyroscope=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(self), usb=()'
+    # Auth0 tenant in connect-src/frame-src: Omni public login (token exchange + silent-auth iframe)
     contentSecurityPolicy: >
       default-src 'self' *.zimmermann.sh;
       frame-ancestors https://*.zimmermann.sh;
+      frame-src 'self' *.zimmermann.sh dev-und3se8p6egpmqec.eu.auth0.com;
       script-src 'self' 'unsafe-inline' 'unsafe-eval' traefik.github.io static.cloudflareinsights.com ajax.cloudflare.com www.gstatic.com;
       img-src 'self' grafana.com data:;
       style-src 'self' 'unsafe-inline' www.gstatic.com blob:;
       font-src 'self' data:;
       object-src 'none';
-      connect-src 'self' cloudflareinsights.com grafana.com
+      connect-src 'self' cloudflareinsights.com grafana.com dev-und3se8p6egpmqec.eu.auth0.com;
       worker-src 'self' blob:
     customResponseHeaders:
       X-Robots-Tag: 'none,noarchive,nosnippet,notranslate,noimageindex'


### PR DESCRIPTION
## Problem

Public `omni.zimmermann.sh` chained two OIDC providers — Authentik (Traefik forwardAuth via `chain-mfa-auth`) and Auth0 (Omni's mandatory OIDC) — and the Auth0 redirect failed after the second hop. Auth0 alone already enforces MFA, so the Authentik layer is redundant.

## Changes

- **external-services**: switch the omni route from `chain-mfa-auth` to `chain-standard` — Authentik removed, cookie/header stripping kept. The `/_gatus` bypass route is unchanged, and the dev overlay (`omni.zimmermann.phd`) inherits the change from base.
- **security-headers CSP**: allow the Auth0 tenant in `connect-src` (code→token exchange) and a new explicit `frame-src` (silent-auth iframe — Omni's frontend re-authenticates silently every ~2 min due to `max_age: 120`). Also fixes a pre-existing missing `;` after `connect-src`, which had merged `worker-src 'self' blob:` into connect-src; `worker-src` is now a real directive.

Without the CSP change the login would still fail after removing Authentik: the token exchange fetch and the silent-auth iframe to the Auth0 tenant were blocked on any host behind Traefik.

## Verified

- `kustomize build` clean on all four affected overlays (external-services + ingress-controller, prod + dev); rendered output confirms `chain-standard` on both omni hosts and a correctly assembled CSP.
- Auth0 application allowlist updated (dashboard) and probed via `/authorize`: `omni.zimmermann.sh`, `omni.zimmermann.phd`, and `omni.zimmermann.eu.com` are accepted (302), unknown redirect URIs rejected (403).
- Post-merge: browser login incl. MFA on both public hosts, >2 min idle to confirm silent re-auth, Gatus endpoint stays green.

Closes #694

🤖 Generated with [Claude Code](https://claude.com/claude-code)