### PR TITLE
fix(external-services): stop upstream connection reuse for dali gateways

### DIFF
--- a/kubernetes/applications/external-services/base/ingress-route.yaml
+++ b/kubernetes/applications/external-services/base/ingress-route.yaml
@@ -283,13 +283,13 @@ spec:
     - match: Host(`PLACEHOLDER`)
       kind: Rule
       middlewares:
-        - name: chain-standard
+        - name: chain-mfa-auth
           namespace: ingress-controller
       services:
         - name: dali-1
           port: 443
           scheme: https
-          serversTransport: insecure-transport
+          serversTransport: no-reuse-transport
   tls:
     secretName: dali-1-tls-cert
 
@@ -316,7 +316,7 @@ spec:
         - name: dali-2
           port: 443
           scheme: https
-          serversTransport: insecure-transport
+          serversTransport: no-reuse-transport
   tls:
     secretName: dali-2-tls-cert
 

--- a/kubernetes/applications/external-services/base/servers-transport.yaml
+++ b/kubernetes/applications/external-services/base/servers-transport.yaml
@@ -6,3 +6,15 @@ metadata:
 
 spec:
   insecureSkipVerify: true
+
+---
+apiVersion: traefik.io/v1alpha1
+kind: ServersTransport
+
+metadata:
+  name: no-reuse-transport
+
+spec:
+  insecureSkipVerify: true
+  # MDT DALI gateways bind their login token to the TCP connection; never pool upstream connections
+  maxIdleConnsPerHost: -1


### PR DESCRIPTION
## Problem

The MDT DALI gateway web UIs at dali-1/dali-2.zimmermann.sh rendered broken through the Traefik ingress (missing CSS/fonts/JS) and answered `400 Bad request` after login, while direct LAN access worked fine. Earlier attempts (`passHostHeader: false`, Authentik cookie stripping) didn't help.

## Root cause (empirically confirmed via live probing)

The gateway firmware binds its login-token session to the **TCP connection**: once a connection has served `GET /` (login page, issues token + csrf + `id` cookie), that connection only accepts the cookie issued there — any other (even valid) session cookie on the same connection gets `400 Bad request`, and a concurrent foreign `GET /` within the ~60 s token window gets `409`. On fresh connections any valid cookie is accepted and sessions coexist.

Traefik pools upstream connections and multiplexes **all** clients over them — including internet scanners constantly probing the publicly exposed dali-1. Every foreign `GET /` re-binds the pooled connection to a new token, so the real user's asset requests and login POST riding the same connection return 400.

Proof points from the diagnosis:
- Ingress flow: `GET /` 200 → `js/3rdparty.min.js` 400 + login POST 400; identical flow direct: all 200, POST 303.
- Host header, `X-Forwarded-*`, `Accept-Encoding`, and cookie loss in transit were all ruled out via oracle tests directly against the device.
- Same-connection test: assets with the cookie issued on that connection = 200; asset with a *different* valid cookie on such a connection = 400.
- Earlier css "successes" via ingress were Cloudflare cache HITs (`Cache-Control: max-age=86400`) that never reached the device.

## Changes

- New `ServersTransport` `no-reuse-transport` (`insecureSkipVerify: true`, `maxIdleConnsPerHost: -1`) — the CRD-sanctioned way to disable idle-connection pooling, giving every request its own fresh upstream connection, matching the proven-working direct-access behavior. `insecure-transport` stays untouched for omni/verso/ai-pro.
- dali-1 and dali-2 IngressRoutes now reference `no-reuse-transport`.
- dali-1 moved back behind Authentik (`chain-standard` → `chain-mfa-auth`): auth parity with dali-2, device login no longer exposed to the public internet, scanner traffic no longer reaches the device.

## Verification plan (after merge + Argo sync)

1. `GET https://dali-1.zimmermann.sh/` → 200 with `Set-Cookie: id=…`
2. Fetch `css/3rdparty.min.css`, `css/custom-root.css`, `js/3rdparty.min.js` with that cookie → 200/200/200 (js was deterministically 400 before)
3. `POST /np` with fresh token+csrf+cookie and dummy credentials → 303 redirect, not 400
4. Repeat js fetch 5× for stability; same spot-check for dali-2; real browser login on both hosts

Fixes #691

🤖 Generated with [Claude Code](https://claude.com/claude-code)