### PR TITLE
fix(external-services): pool dali connections with short idle timeout

### DIFF
--- a/kubernetes/applications/external-services/base/ingress-route.yaml
+++ b/kubernetes/applications/external-services/base/ingress-route.yaml
@@ -289,7 +289,7 @@ spec:
         - name: dali-1
           port: 443
           scheme: https
-          serversTransport: no-reuse-transport
+          serversTransport: short-idle-transport
   tls:
     secretName: dali-1-tls-cert
 
@@ -316,7 +316,7 @@ spec:
         - name: dali-2
           port: 443
           scheme: https
-          serversTransport: no-reuse-transport
+          serversTransport: short-idle-transport
   tls:
     secretName: dali-2-tls-cert
 

--- a/kubernetes/applications/external-services/base/servers-transport.yaml
+++ b/kubernetes/applications/external-services/base/servers-transport.yaml
@@ -12,9 +12,12 @@ apiVersion: traefik.io/v1alpha1
 kind: ServersTransport
 
 metadata:
-  name: no-reuse-transport
+  name: short-idle-transport
 
 spec:
   insecureSkipVerify: true
-  # MDT DALI gateways bind their login token to the TCP connection; never pool upstream connections
-  maxIdleConnsPerHost: -1
+  # MDT DALI gateways: pool hot connections (slow embedded TLS collapses under parallel handshakes),
+  # drop idle ones before the device's 5s keep-alive cap and stale login-token bindings can bite
+  maxIdleConnsPerHost: 10
+  forwardingTimeouts:
+    idleConnTimeout: 3s


### PR DESCRIPTION
## Problem

#1294 fixed the dali login flow (connection-bound login tokens vs. Traefik connection pooling), but disabling reuse entirely overwhelmed the gateway's embedded TLS stack. Measured directly against the device:

- Sequential fresh connections: reliable, but 0.3–4 s **per request** (full TLS handshake each time)
- 8 parallel fresh connections: 6 succeed at 5–8 s each, 2 time out entirely

Browsers fire 5–15 parallel requests per page, so the authenticated UI loaded with missing images, empty status data (gray failure dots, zeroed tables), and intermittent `Bad request` while navigating.

## Change

Replace `no-reuse-transport` with `short-idle-transport` on the dali-1/dali-2 routes:

```yaml
maxIdleConnsPerHost: 10
forwardingTimeouts:
  idleConnTimeout: 3s
```

- **Bursts reuse hot connections** — no handshake storm; the device handles multiple requests per connection fine (verified: 4+ sequential requests on one connection, all 200).
- **Idle connections drop after 3 s** — safely below the device's own `Keep-Alive: timeout=5` cap (avoids reusing connections the device is about to close), and fast enough that a connection bound to a stale login token dies while the user is still typing credentials, so the login-token poisoning fixed in #1294 cannot resurface.
- Scanner-driven poisoning stays eliminated since both hosts sit behind Authentik as of #1294.

## Verification

After Argo sync: log in to https://dali-1.zimmermann.sh and https://dali-2.zimmermann.sh, confirm the page renders fully (MDT logo, status LEDs, failure tables populated) and navigation across tabs (Commissioning, Diagnosis, …) no longer hits `Bad request`.

Refs #691

🤖 Generated with [Claude Code](https://claude.com/claude-code)