### PR TITLE
fix: HolmesGPT alert summaries and ArgoCD sync-failed trigger nil guard

### DIFF
--- a/kubernetes/applications/holmesgpt/base/scheduled-healthchecks.yaml
+++ b/kubernetes/applications/holmesgpt/base/scheduled-healthchecks.yaml
@@ -14,10 +14,10 @@ spec:
     Report FAIL only if an ArgoCD application's sync status is not Synced, or its
     health status is not Healthy, right now. If all applications are Synced and
     Healthy, report PASS.
-    On FAIL, keep the summary to a single sentence naming the affected
-    application(s) and whether they are out of sync, unhealthy, or both; put the
-    per-application detail and most likely reason only in the detailed rationale,
-    and do not repeat it in the summary.
+    On FAIL, begin your rationale with a single-sentence TL;DR line naming the
+    affected application(s) and whether they are out of sync, unhealthy, or
+    both, followed by a blank line and then the per-application detail and most
+    likely reason.
 
 ---
 apiVersion: holmesgpt.dev/v1alpha1
@@ -39,9 +39,9 @@ spec:
     endpoints, a Certificate that is not Ready, or a custom resource whose
     selector matches nothing (e.g. a GrafanaDashboard with no matching Grafana
     instance). If you find none, report PASS.
-    On FAIL, keep the summary to a single sentence stating how many resources are
-    affected and their kind(s); put each resource's namespace, name, and specific
-    problem only in the detailed rationale, and do not repeat it in the summary.
+    On FAIL, begin your rationale with a single-sentence TL;DR line stating how
+    many resources are affected and their kind(s), followed by a blank line and
+    then each resource's namespace, name, and specific problem.
 
 ---
 apiVersion: holmesgpt.dev/v1alpha1
@@ -66,7 +66,7 @@ spec:
     shows such a recurring pattern in the last 12 hours after those exclusions.
     Ignore single or occasional errors and known steady-state noise. If nothing
     abnormal stands out, report PASS.
-    On FAIL, keep the summary to a single sentence naming the application and the
-    problem; put all evidence — one representative log line, affected
-    namespace/pods, rough frequency, and the likely cause — only in the detailed
-    rationale, and do not repeat it in the summary.
+    On FAIL, begin your rationale with a single-sentence TL;DR line naming the
+    application and the problem, followed by a blank line and then all evidence:
+    one representative log line, affected namespace/pods, rough frequency, and
+    the likely cause.

--- a/kubernetes/applications/holmesgpt/base/scripts/alert-bridge.sh
+++ b/kubernetes/applications/holmesgpt/base/scripts/alert-bridge.sh
@@ -18,8 +18,9 @@ kubectl get healthcheck -n "$NS" -o json \
   | while IFS= read -r hc; do
       name=$(printf '%s' "$hc" | jq -r '.metadata.name')
       result=$(printf '%s' "$hc" | jq -r '.status.result // "fail"')
-      summary=$(printf '%s' "$hc" | jq -r '.status.message // "(no summary)"')
       detail=$(printf '%s' "$hc" | jq -r '.status.rationale // "(no detail)"')
+      # Holmes has no summary field; check queries lead the rationale with a one-line TL;DR.
+      summary=$(printf '%s' "$detail" | head -n 1)
       started=$(printf '%s' "$hc" | jq -r '.status.startTime // "-"')
       date=$(date -u +'%a, %d %b %Y %H:%M:%S +0000')
 

--- a/kubernetes/bootstrap/gitops-controller/base/values.yaml
+++ b/kubernetes/bootstrap/gitops-controller/base/values.yaml
@@ -153,7 +153,7 @@ notifications:
       - description: Application syncing has failed
         send:
           - app-sync-failed
-        when: app.status.operationState.phase in ['Error', 'Failed']
+        when: app.status.operationState != nil && app.status.operationState.phase in ['Error', 'Failed']
     trigger.on-health-degraded: |
       - description: Application has degraded
         send:


### PR DESCRIPTION
## Summary

Two fixes stemming from the failed `log-anomaly-20260704-000200` HolmesGPT check:

- **gitops-controller**: guard the `on-sync-failed` notification trigger with `app.status.operationState != nil`. Apps without an active or past sync operation have a nil `operationState`, so the CEL evaluation failed with `cannot fetch phase from <nil>` roughly once per hour in the notifications-controller log. Functionally harmless (a failed expression counts as false), but the recurring error tripped the log-anomaly check on every run.
- **holmesgpt**: derive the alert e-mail summary from a TL;DR line instead of `status.message`. Upstream, the check LLM's response schema has only `rationale` + `passed` — there is no summary field — and the server sets `status.message` to `"Check failed. " + rationale` (unchanged on master). Asking the query for a short summary therefore could never work, and the e-mail's Summary section duplicated the full rationale. The three check queries now instruct the model to open its rationale with a single-sentence TL;DR line, and `alert-bridge.sh` takes the first line of `status.rationale` as the summary.

## Rollout

No manual steps: ArgoCD syncs the trigger ConfigMap and ScheduledHealthChecks; the bridge script lives in a ConfigMap without a name-suffix hash, so the next CronJob run picks it up automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)