### PR TITLE
fix(external-services): retry transient upstream failures for dali gateways

### DIFF
--- a/kubernetes/applications/external-services/base/ingress-route.yaml
+++ b/kubernetes/applications/external-services/base/ingress-route.yaml
@@ -285,6 +285,8 @@ spec:
       middlewares:
         - name: chain-mfa-auth
           namespace: ingress-controller
+        # gateway drops fresh TLS handshakes under load; retry transparently before failing with 502
+        - name: retry-transient
       services:
         - name: dali-1
           port: 443
@@ -312,6 +314,8 @@ spec:
       middlewares:
         - name: chain-mfa-auth
           namespace: ingress-controller
+        # gateway drops fresh TLS handshakes under load; retry transparently before failing with 502
+        - name: retry-transient
       services:
         - name: dali-2
           port: 443

--- a/kubernetes/applications/external-services/base/kustomization.yaml
+++ b/kubernetes/applications/external-services/base/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - ./namespace.yaml
   - ./services.yaml
   - ./certificate.yaml
+  - ./middlewares.yaml
   - ./ingress-route.yaml
   - ./servers-transport.yaml
 

--- a/kubernetes/applications/external-services/base/middlewares.yaml
+++ b/kubernetes/applications/external-services/base/middlewares.yaml
@@ -1,0 +1,10 @@
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+
+metadata:
+  name: retry-transient
+
+spec:
+  retry:
+    attempts: 3
+    initialInterval: 100ms


### PR DESCRIPTION
## Problem

After #1294 and #1295 the dali web UIs work, but reloads and page loads still sporadically failed (broken rendering with missing assets/status data, intermittent error pages).

## Root cause (measured against the device)

The gateway's embedded TLS stack **drops fresh handshakes while busy**: 30/30 handshakes succeed when idle, but immediately after a short request burst the next handshake is reproducibly killed with a TLS EOF (and ≥6 parallel handshakes cause timeouts). Through Traefik such a dropped upstream dial surfaces as a 502 — and since `short-idle-transport` closes idle connections after 3 s, every pause in browsing forces a new handshake on the next click or reload. Each dropped subresource request = a missing piece of the page.

A second, unfixable-at-the-proxy quirk was also isolated: requesting `/` while authenticated re-renders the login page, rotates the session id and invalidates the old one — in-flight requests and the open WebSocket (both still on the old cookie) get `400 Bad request` until a single reload. This happens on LAN too (device firmware behavior, single-session semantics); documented in #691 rather than worked around.

## Change

New `retry-transient` middleware, referenced **only** by the dali-1/dali-2 routes, placed after the auth chain so retries hit only the backend leg:

```yaml
retry:
  attempts: 3
  initialInterval: 100ms
```

Traefik's retry middleware re-sends a request only on network-level failures before a response is received. Real device responses (including 400s) are never replayed, so no DALI action can be duplicated. All other routes and the shared middleware chains are untouched.

## Verification

After Argo sync: browse both gateways through the ingress — pages should render completely and repeated reloads should no longer produce error pages. If a page ever renders partially and a single F5 fixes it, that is the documented root-URL session-rotation quirk, not a proxy failure.

Refs #691

🤖 Generated with [Claude Code](https://claude.com/claude-code)