### PR TITLE
fix(ingress-controller): actually enable traefik access logs

### DIFF
--- a/kubernetes/components/ingress-controller/base/values.yaml
+++ b/kubernetes/components/ingress-controller/base/values.yaml
@@ -85,10 +85,13 @@ log:
   level: WARN
 # Access logs (HTTP requests)
 accessLog:
+  enabled: true
   format: json
   bufferingSize: 100
   filters:
     statusCodes: "400-599"
+    # Also log requests that only succeeded after a retry (e.g. dali retry-transient)
+    retryAttempts: true
 
 metrics:
   # Prometheus Monitoring


### PR DESCRIPTION
## Problem

`values.yaml` has carried an `accessLog:` block (json format, buffering, `statusCodes: 400-599` filter) for a long time — but never set `accessLog.enabled: true`, which defaults to `false` in the chart. The block was silently dead config: the running deployment has no `--accesslog` args and no access log line was ever emitted.

Noticed while debugging #691: the sporadic dali failures cannot be attributed (device 400 vs Traefik 502, which path, does retry fire?) without request-level logs.

## Change

- `accessLog.enabled: true` — emits the long-intended JSON access logs for requests with status 400–599
- `filters.retryAttempts: true` — additionally logs requests that only succeeded after a retry, making the `retry-transient` middleware (#1298) observable

Rendered args verified: `--accesslog=true`, `--accesslog.format=json`, `--accesslog.filters.statuscodes=400-599`, `--accesslog.filters.retryattempts`.

Side effects: rolling restart of the traefik pods (2 replicas, no downtime). CrowdSec, which already tails traefik stdout expecting access logs, now receives real ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)