### PR TITLE
fix(cilium): stable egress IP for dali gateways via egress gateway

### DIFF
--- a/kubernetes/bootstrap/cilium/base/values.yaml
+++ b/kubernetes/bootstrap/cilium/base/values.yaml
@@ -17,6 +17,11 @@ kubeProxyReplacement: true
 bpf:
   masquerade: true
 
+# Egress gateway: route selected pod egress via a fixed node for a stable source IP
+# (requires kubeProxyReplacement, bpf.masquerade and native routing — all set above)
+egressGateway:
+  enabled: true
+
 # Enable BGP control plane for network peering; utilize the central 'cilium'
 # namespace for peering secrets to avoid namespace sprawl
 bgpControlPlane:

--- a/kubernetes/components/cilium/base/egress-gateway-policy.yaml
+++ b/kubernetes/components/cilium/base/egress-gateway-policy.yaml
@@ -1,0 +1,23 @@
+apiVersion: cilium.io/v2
+kind: CiliumEgressGatewayPolicy
+
+metadata:
+  name: dali-stable-egress
+
+spec:
+  # MDT DALI gateways bind their web session to the client source IP; with multiple
+  # traefik replicas the SNAT source flips between nodes and the device rejects
+  # requests mid-session. Route all traefik egress to the gateways via one node
+  # (lexically first worker; survives node renames, no hostname pinning).
+  selectors:
+    - podSelector:
+        matchLabels:
+          io.kubernetes.pod.namespace: ingress-controller
+          app.kubernetes.io/name: traefik
+  destinationCIDRs:
+    - 192.168.1.191/32 # dali-1
+    - 192.168.1.179/32 # dali-2
+  egressGateway:
+    nodeSelector:
+      matchLabels:
+        node-role.kubernetes.io/worker: ""

--- a/kubernetes/components/cilium/base/kustomization.yaml
+++ b/kubernetes/components/cilium/base/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - ./bgp-peer-config.yaml
   - ./bgp-advertisement.yaml
   - ./bgp-lb-ip-pool.yaml
+  - ./egress-gateway-policy.yaml
 
 labels:
   - includeSelectors: false


### PR DESCRIPTION
## Problem

After #1294/#1295/#1298 the dali web UIs mostly work, but navigation still sporadically collapsed into `Bad request` cascades (and occasionally a Cloudflare `Bad Gateway`).

## Root cause (proven via the new access logs from #1300)

The MDT DALI gateways bind their web session to the **client source IP**. Prod runs two traefik replicas on different nodes, so the SNAT source toward the device flips between the two node IPs depending on which pod proxies a request. The WebSocket — always a fresh connection — is the most frequent victim: the device rejects it with 400, and the MDT web app reacts to a failed first WS attempt by **terminating its own session** (`terminateSession()` → `/login.shtm`), after which every request fails.

The access logs show the split conclusively — the triggering `/ws` 400 arrived via pod `fpmk9` while the (successful, therefore unlogged) session traffic ran via pod `b74rj`, which then logged the entire follow-up cascade:

```
fpmk9  12:14:29  400 GET /ws            ← trigger (other pod = other source IP)
b74rj  12:14:39+ 400 GET /login.shtm ×6 ← app self-logout cascade
b74rj  12:14:50  502 GET /login.shtm
b74rj  12:14:51+ 400/502 GET /lo?a=…
```

Sticky sessions cannot fix this: Traefik stickiness selects among backend servers (there is only one device), and L4 `sessionAffinity: ClientIP` on the traefik service keys on Cloudflare edge IPs, which vary per connection for a single user. The requirement is an egress property: all requests to *this destination* must leave with *one* source IP, regardless of which pod handles them.

## Change

- **`bootstrap/cilium/base/values.yaml`**: `egressGateway.enabled: true` — prerequisites (kube-proxy replacement, BPF masquerade, native routing) are already active. Cilium agents perform a rolling restart on sync.
- **`components/cilium/base/egress-gateway-policy.yaml`** (new): routes all traefik-pod egress to `192.168.1.191/32` (dali-1) and `192.168.1.179/32` (dali-2) via a single gateway node. The `node-role.kubernetes.io/worker` selector avoids hostname pinning (nodes use `HostnameConfig auto: stable`); with multiple matches Cilium deterministically uses the lexically first node. The manifest lives in `base` and applies unchanged to both clusters (dev runs one traefik replica anyway — the policy just makes behavior consistent).

All other egress traffic is untouched.

## Trade-offs

- The elected gateway node is a single point of failure **only for the dali web UIs** (KNX/DALI bus function is unaffected).
- First sync may race the CRD registration (the operator registers `CiliumEgressGatewayPolicy` once the feature is on); ArgoCD retry self-heals.

## Verification

After sync: browse both gateways through the ingress with repeated reloads and tab navigation; the access logs (400–599 + retried requests) should stay clean of `/ws` 400s and `/login.shtm` cascades.

Refs #691

🤖 Generated with [Claude Code](https://claude.com/claude-code)