### PR TITLE
fix(omni): lego v5 CLI, certificate validity check, renewal deploy, persistent NFS backup mount

### DIFF
--- a/infrastructure/manifest/30-cloud-init/ci-vendor-config.yaml
+++ b/infrastructure/manifest/30-cloud-init/ci-vendor-config.yaml
@@ -53,7 +53,7 @@ ci_vendor_config:
           "storage.zimmermann.eu.com:/var/nfs/shared/omni",
           "/mnt/backup",
           "nfs",
-          "defaults,_netdev,noauto,nofail,vers=3,rw,nolock,x-systemd.after=cloud-init-network.service",
+          "defaults,_netdev,noauto,nofail,x-systemd.automount,vers=3,rw,nolock,x-systemd.after=cloud-init-network.service",
           "0",
           "0",
         ]
@@ -69,6 +69,8 @@ ci_vendor_config:
       ## Symlinks for snap packages
       - ["ln", "-s", "/snap/bin/lego", "/usr/local/bin/lego"]
       - ["ln", "-s", "/snap/bin/task", "/usr/local/bin/task"]
+      ## Hold lego snap so auto-refresh cannot introduce breaking CLI changes
+      - ["snap", "refresh", "--hold", "lego"]
       ## Manually mount NFS share (after nfs-common install)
       - ["mount", "/mnt/backup"]
       ## Set permissions for data disk and config directory

--- a/infrastructure/templates/30-cloud-init/cluster-mgmt/omni-bootstrap.sh
+++ b/infrastructure/templates/30-cloud-init/cluster-mgmt/omni-bootstrap.sh
@@ -94,9 +94,9 @@ download_omnictl() {
 setup_certificates() {
   mkdir -p "${OMNI_CERT_DIR}"
 
-  ## Check if certificates exist locally (either from backup extraction or previous run)
-  if [[ -f "${OMNI_TLS_CERT_PATH}" ]]; then
-    info "Certificates found in local cert directory. Skipping generation."
+  ## Reuse local certificates only if still valid for at least 30 more days
+  if [[ -f "${OMNI_TLS_CERT_PATH}" ]] && openssl x509 -checkend 2592000 -noout -in "${OMNI_TLS_CERT_PATH}" &> /dev/null; then
+    info "Valid certificates found in local cert directory. Skipping generation."
     return 0
   fi
 
@@ -109,16 +109,17 @@ setup_certificates() {
     domain_flags+=("--domains=${domain}")
   done
 
-  ## Running lego to generate certificates
-  info "Certificates not found. Generating new certificates via Let's Encrypt..."
+  ## Running lego to generate certificates (v5 CLI: flags are subcommand options)
+  info "No valid certificates found. Generating new certificates via Let's Encrypt..."
+  ## Fixed propagation wait: outbound :53 is blocked and split-DNS hides the TXT record from the local resolver
   CLOUDFLARE_DNS_API_TOKEN="${ACME_CF_TOKEN}" \
   CLOUDFLARE_EMAIL="${ACME_EMAIL}" \
-  lego \
+  lego run \
     --email="${ACME_EMAIL}" \
     --dns="cloudflare" \
+    --dns.propagation.wait 30s \
     --accept-tos \
-    "${domain_flags[@]}" \
-    run &> /dev/null || die "Failed to generate certificates for ${ACME_DOMAINS}."
+    "${domain_flags[@]}" || die "Failed to generate certificates for ${ACME_DOMAINS}."
 
   ## Copy certificates into local cert directory
   info "Copying new certificates to ${OMNI_CERT_DIR}..."

--- a/infrastructure/templates/30-cloud-init/cluster-mgmt/systemd/omni-renew-cert.sh
+++ b/infrastructure/templates/30-cloud-init/cluster-mgmt/systemd/omni-renew-cert.sh
@@ -29,29 +29,36 @@ die() {
 ###############################################################################
 ## Main Script
 ###############################################################################
-## Construct domain flags for running lego
+## Construct domain flags for running lego (xargs trims whitespace around commas)
 info "Configuring domains..."
 domain_flags=("--domains=${ACME_PRIMARY_DOMAIN}")
-IFS=',' read -ra domains_arr <<< "${ACME_SAN_DOMAINS:-}"
+readarray -t domains_arr <<< "$(echo "${ACME_SAN_DOMAINS:-}" | tr ',' '\n' | xargs -n1)"
 for domain in "${domains_arr[@]}"; do
-  domain_flags+=("--domains=${domain}")
+  if [[ -n "${domain}" ]]; then
+    domain_flags+=("--domains=${domain}")
+  fi
 done
 
-## Define Renew Hook. Copies renewed certs to the Omni cert dir and restarts Omni
-hook_cmd="cp \"${LEGO_CERT_DIR}/\"* \"${OMNI_CERT_DIR}\" && \
-          chown -R \"${OMNI_OWNER}\" \"${OMNI_CERT_DIR}\" && \
-          docker restart omni"
-
-## Run lego renew. This runs ONLY if the certificate is actually renewed
+## Run lego (v5 merged renew into run: renews only when due, ARI/lifetime-based)
 info "Checking for SSL renewal..."
+before_mtime=$(stat -c %Y "${LEGO_CERT_DIR}/${ACME_PRIMARY_DOMAIN}.crt" 2>/dev/null || echo 0)
+## Fixed propagation wait: outbound :53 is blocked and split-DNS hides the TXT record from the local resolver
 CLOUDFLARE_DNS_API_TOKEN="${ACME_CF_TOKEN}" \
 CLOUDFLARE_EMAIL="${ACME_EMAIL}" \
-lego \
+lego run \
   --email="${ACME_EMAIL}" \
   --dns="cloudflare" \
+  --dns.propagation.wait 30s \
   --accept-tos \
-  "${domain_flags[@]}" \
-  renew \
-  --renew-hook "${hook_cmd}" || die "Failed to renew SSL certificate for ${ACME_PRIMARY_DOMAIN}."
+  "${domain_flags[@]}" || die "Failed to renew SSL certificate for ${ACME_PRIMARY_DOMAIN}."
+
+## Deploy to Omni only when the certificate actually changed
+after_mtime=$(stat -c %Y "${LEGO_CERT_DIR}/${ACME_PRIMARY_DOMAIN}.crt" 2>/dev/null || echo 0)
+if [[ "${after_mtime}" != "${before_mtime}" ]]; then
+  info "Certificate renewed. Deploying to Omni..."
+  cp "${LEGO_CERT_DIR}/"* "${OMNI_CERT_DIR}"
+  chown -R "${OMNI_OWNER}" "${OMNI_CERT_DIR}"
+  docker restart omni
+fi
 
 success "SSL renewal check completed."


### PR DESCRIPTION
## Summary

The Omni endpoint certificate expired on 2026-07-05 because the weekly renewal had never worked since first boot. Four stacked root causes, all fixed here in the cloud-init templates:

1. **lego v5 CLI break**: the lego snap tracks `latest/stable` and auto-refreshed v4→v5 (2026-06-02), which moved all flags to the subcommand and removed `lego renew`. Both scripts now use `lego run` (renews only when due, ARI/lifetime-based), and cloud-init holds the snap (`snap refresh --hold lego`) so a running VM can never be silently broken again.
2. **DNS-01 propagation checks can't work in this network**: the internal DNS view returns NXDOMAIN for `_acme-challenge.*` and outbound UDP/53 is blocked, so both recursive and authoritative checks stall until timeout. Replaced with `--dns.propagation.wait 30s` (Cloudflare records are live in ~2s; Let's Encrypt validates on its own resolvers anyway).
3. **Expired-certificate restore trap**: bootstrap reused restored certificates on file existence alone, resurrecting expired certificates after a redeploy. Now reused only if valid for ≥30 more days; lego output is no longer discarded to `/dev/null`.
4. **Backup NFS mount didn't survive reboots**: `noauto` plus a one-shot cloud-init `mount` meant the mount silently disappeared after the first reboot and backups went to the root disk (unnoticed since the NAS IP change in May). Now mounted lazily via `x-systemd.automount`.

Also: SAN domain parsing in the renewal script now trims whitespace (same `xargs` pattern as bootstrap), and deployment to Omni happens explicitly when the certificate file changed instead of via a fragile `--renew-hook` command string.

## Verification

VM 1002 was redeployed from these templates: bootstrap ran clean end-to-end (backup restore → fresh certificate valid until 2026-10-03 → full compose stack healthy), the renewal service completed its first-ever green run, and the NFS automount survives reboots by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)