### PR TITLE
feat(knx): wire Dyson Luftreiniger control and status GAs

### DIFF
--- a/kubernetes/applications/knx-nats-bridge/base/config/ga-catalog.yaml
+++ b/kubernetes/applications/knx-nats-bridge/base/config/ga-catalog.yaml
@@ -2582,7 +2582,7 @@
   name: Versorgungstechnik.Wallbox.Energie.Geladen-Aktuell
   room: Garage
 15/6/15:
-  dpt: '13.010'
+  dpt: '13.000'
   function: Versorgungstechnik
   name: Versorgungstechnik.Wallbox.Energie.Zählerstand-Aktuell
   room: Garage
@@ -2599,12 +2599,12 @@
 15/6/20:
   dpt: '1.001'
   function: Versorgungstechnik
-  name: Versorgungstechnik.Wallbox.Freigabe
+  name: Versorgungstechnik.Wallbox.Ein-Freigabe
   room: Garage
 15/6/21:
   dpt: '1.001'
   function: Versorgungstechnik
-  name: Versorgungstechnik.Wallbox.Freigabe-Status
+  name: Versorgungstechnik.Wallbox.Ein-Freigabe-Status
   room: Garage
 15/6/22:
   dpt: '5.010'
@@ -9060,6 +9060,46 @@
   dpt: '16.000'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.FBH.Diagnose
+  room: Schlafzimmer Eltern
+6/3/111:
+  dpt: '1.001'
+  function: Raumklima
+  name: Raumklima.OG.Schlafzimmer-Eltern.Luftreiniger.Ein/Aus
+  room: Schlafzimmer Eltern
+6/3/112:
+  dpt: '1.011'
+  function: Raumklima
+  name: Raumklima.OG.Schlafzimmer-Eltern.Luftreiniger.Ein/Aus-Status
+  room: Schlafzimmer Eltern
+6/3/113:
+  dpt: '5.010'
+  function: Raumklima
+  name: Raumklima.OG.Schlafzimmer-Eltern.Luftreiniger.Lüfterstufe
+  room: Schlafzimmer Eltern
+6/3/114:
+  dpt: '5.010'
+  function: Raumklima
+  name: Raumklima.OG.Schlafzimmer-Eltern.Luftreiniger.Lüfterstufe-Status
+  room: Schlafzimmer Eltern
+6/3/115:
+  dpt: '5.010'
+  function: Raumklima
+  name: Raumklima.OG.Schlafzimmer-Eltern.Luftreiniger.Drehmodus
+  room: Schlafzimmer Eltern
+6/3/116:
+  dpt: '5.010'
+  function: Raumklima
+  name: Raumklima.OG.Schlafzimmer-Eltern.Luftreiniger.Drehmodus-Status
+  room: Schlafzimmer Eltern
+6/3/117:
+  dpt: '1.001'
+  function: Raumklima
+  name: Raumklima.OG.Schlafzimmer-Eltern.Luftreiniger.Nachtmodus
+  room: Schlafzimmer Eltern
+6/3/118:
+  dpt: '1.011'
+  function: Raumklima
+  name: Raumklima.OG.Schlafzimmer-Eltern.Luftreiniger.Nachtmodus-Status
   room: Schlafzimmer Eltern
 6/3/120:
   dpt: '1.003'

--- a/kubernetes/applications/knx-nats-bridge/base/config/writer-rules.yaml
+++ b/kubernetes/applications/knx-nats-bridge/base/config/writer-rules.yaml
@@ -1380,3 +1380,37 @@ mappings:
     description: "Versorgungstechnik.Photovoltaik.Eigenversorgungsquote"
     min_delta: 0
     seed_on_start: true
+
+  # Luftreiniger (Dyson PC1) status feedback (KNX<-NATS). The command GAs
+  # (6/3/111/113/115/117) are driven KNX->device by the redpanda-connect
+  # dyson_from_knx stream; these rules report the actual device state back
+  # so Basalte reflects reality. Lüfterstufe 0 = Automatik; Drehmodus enum
+  # 0=Aus 1=45° 2=90° 3=180° 4=350°.
+  - subject: "dyson.ventilator-1.state"
+    ga: "6/3/112"
+    dpt: "1.011"
+    payload_path: "$.power"
+    description: "Raumklima.OG.Schlafzimmer-Eltern.Luftreiniger.Ein/Aus-Status"
+    min_delta: 0  # bool state: write only on change
+    seed_on_start: true
+  - subject: "dyson.ventilator-1.state"
+    ga: "6/3/114"
+    dpt: "5.010"
+    payload_path: "$.speed"
+    description: "Raumklima.OG.Schlafzimmer-Eltern.Luftreiniger.Lüfterstufe-Status"
+    min_delta: 0  # enum state: write only on change
+    seed_on_start: true
+  - subject: "dyson.ventilator-1.state"
+    ga: "6/3/116"
+    dpt: "5.010"
+    payload_path: "$.oscillation_mode"
+    description: "Raumklima.OG.Schlafzimmer-Eltern.Luftreiniger.Drehmodus-Status"
+    min_delta: 0  # enum state: write only on change
+    seed_on_start: true
+  - subject: "dyson.ventilator-1.state"
+    ga: "6/3/118"
+    dpt: "1.011"
+    payload_path: "$.night"
+    description: "Raumklima.OG.Schlafzimmer-Eltern.Luftreiniger.Nachtmodus-Status"
+    min_delta: 0  # bool state: write only on change
+    seed_on_start: true

--- a/kubernetes/applications/nats/base/consumers/dyson_from_knx.yaml
+++ b/kubernetes/applications/nats/base/consumers/dyson_from_knx.yaml
@@ -1,0 +1,27 @@
+# Durable consumer for the redpanda-connect dyson_from_knx pipeline.
+# Watches the Luftreiniger command GAs (written by Basalte):
+#   knx.6.3.111 Ein/Aus     (1.001)
+#   knx.6.3.113 Lüfterstufe (5.010, 0 = Automatik, 1..10 manual)
+#   knx.6.3.115 Drehmodus   (5.010 enum: 0=Aus, 1=45°, 2=90°, 3=180°, 4=350°)
+#   knx.6.3.117 Nachtmodus  (1.001)
+apiVersion: jetstream.nats.io/v1beta2
+kind: Consumer
+metadata:
+  name: redpanda-connect-dyson-from-knx
+  namespace: nats
+spec:
+  streamName: KNX
+  durableName: redpanda-connect-dyson-from-knx
+  filterSubjects:
+    - knx.6.3.111
+    - knx.6.3.113
+    - knx.6.3.115
+    - knx.6.3.117
+  deliverPolicy: new
+  ackPolicy: explicit
+  # nats-operator default surfaces as 1ns, which causes immediate re-delivery
+  # of any message slower-than-instant to ack. 15s covers the core republish
+  # comfortably without leaving wedged messages locked long.
+  ackWait: 15s
+  # Drop after 5 attempts so a permanently-failing message can't loop forever.
+  maxDeliver: 5

--- a/kubernetes/applications/nats/base/consumers/kustomization.yaml
+++ b/kubernetes/applications/nats/base/consumers/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - warp_onoff_from_knx.yaml
   - warp_charge_mode_from_knx.yaml
   - warp_mode_buttons_from_knx.yaml
+  - dyson_from_knx.yaml

--- a/kubernetes/applications/redpanda-connect/base/kustomization.yaml
+++ b/kubernetes/applications/redpanda-connect/base/kustomization.yaml
@@ -37,6 +37,7 @@ configMapGenerator:
       - streams/warp_charging_status.yaml
       - streams/warp_mode_buttons_from_knx.yaml
       - streams/warp_mode_flags.yaml
+      - streams/dyson_from_knx.yaml
 
 patches:
   # Expose redpanda-connect service via Cilium/BGP-announced LoadBalancer so

--- a/kubernetes/applications/redpanda-connect/base/streams/dyson_from_knx.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/dyson_from_knx.yaml
@@ -1,0 +1,42 @@
+# Luftreiniger control: forwards the Basalte command GAs to the
+# dyson-nats-bridge command subjects (core NATS; the bridge subscribes core,
+# nothing archives commands).
+#   knx.6.3.111 Ein/Aus     -> dyson.ventilator-1.command.power       {"value": bool}
+#   knx.6.3.113 Lüfterstufe -> dyson.ventilator-1.command.speed       {"value": 0..10, 0 = auto}
+#   knx.6.3.115 Drehmodus   -> dyson.ventilator-1.command.oscillation {"value": 0..4}
+#   knx.6.3.117 Nachtmodus  -> dyson.ventilator-1.command.night       {"value": bool}
+input:
+  # Consumer (filterSubjects on the four GAs) is declared as a CRD in
+  # nats/base/consumers/dyson_from_knx.yaml.
+  nats_jetstream:
+    urls: ["nats://nats.nats.svc:4222"]
+    auth:
+      user: redpanda-connect
+      password: ${NATS_PASSWORD}
+    stream: KNX
+    durable: redpanda-connect-dyson-from-knx
+    bind: true
+
+pipeline:
+  processors:
+    - mapping: |
+        let subj = meta("nats_subject")
+        root = if $subj == "knx.6.3.113" || $subj == "knx.6.3.115" {
+          {"value": this.value.number()}
+        } else {
+          {"value": this.value == true || this.value == 1}
+        }
+        meta dyson_subject = "dyson.ventilator-1.command." + (
+          if $subj == "knx.6.3.111" { "power" }
+          else if $subj == "knx.6.3.113" { "speed" }
+          else if $subj == "knx.6.3.115" { "oscillation" }
+          else { "night" }
+        )
+
+output:
+  nats:
+    urls: ["nats://nats.nats.svc:4222"]
+    auth:
+      user: redpanda-connect
+      password: ${NATS_PASSWORD}
+    subject: ${! meta("dyson_subject") }


### PR DESCRIPTION
Connects the Dyson Purifier Cool PC1 (deployed in #1327) to KNX in both directions, using the regenerated GA catalog (new GAs 6/3/111–118, Raumklima OG Schlafzimmer Eltern).

## Status path (device → KNX)

Four writer rules on `dyson.ventilator-1.state`, all `min_delta: 0` + `seed_on_start: true` (DYSON JetStream backs the read-responder seeding):

| payload | GA | DPT |
|---|---|---|
| `$.power` | 6/3/112 Ein/Aus-Status | 1.011 |
| `$.speed` | 6/3/114 Lüfterstufe-Status (0 = Automatik) | 5.010 |
| `$.oscillation_mode` | 6/3/116 Drehmodus-Status (0=Aus, 1=45°, 2=90°, 3=180°, 4=350°) | 5.010 |
| `$.night` | 6/3/118 Nachtmodus-Status | 1.011 |

## Command path (KNX → device)

Durable consumer on the `KNX` stream (`filterSubjects` 6.3.111/113/115/117, `ackWait: 15s`, `maxDeliver: 5`) feeding the `dyson_from_knx` redpanda-connect stream, which maps each GA to `dyson.ventilator-1.command.{power,speed,oscillation,night}` on core NATS (bool for DPT 1.001, number for 5.010).

## Verification

- writer-rules validated against the bridge's JSON schema (4 dyson rules)
- Bloblang linted via `redpandadata/connect lint` (clean)
- consumer CRD + knx-nats-bridge/redpanda-connect prod overlays build

Note: the Drehmodus enum needs bridge 0.2.0 (#1328); power/speed/night already work with 0.1.0. Full loop test after sync: ETS group write 6/3/111 → fan on → status telegram 6/3/112.

🤖 Generated with [Claude Code](https://claude.com/claude-code)