### PR TITLE
feat(tsdb): archive Dyson Luftreiniger sensor telemetry

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/kustomization.yaml
+++ b/kubernetes/applications/redpanda-connect/base/kustomization.yaml
@@ -38,6 +38,7 @@ configMapGenerator:
       - streams/warp_mode_buttons_from_knx.yaml
       - streams/warp_mode_flags.yaml
       - streams/dyson_from_knx.yaml
+      - streams/dyson_environment.yaml
 
 patches:
   # Expose redpanda-connect service via Cilium/BGP-announced LoadBalancer so

--- a/kubernetes/applications/redpanda-connect/base/streams/dyson_environment.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/dyson_environment.yaml
@@ -1,0 +1,75 @@
+# Dyson Luftreiniger sensor telemetry -> TimescaleDB + parquet cold archive.
+# The bridge normalizes upstream (dyson.<device>.environment, flat scalars);
+# entry-level models (PC1) carry only the particulate sensor, and sleeping
+# sensors omit their field entirely -> typed columns stay NULL.
+input:
+  nats_jetstream:
+    urls: ["nats://nats.nats.svc:4222"]
+    auth:
+      user: redpanda-connect
+      password: ${NATS_PASSWORD}
+    stream: DYSON
+    subject: dyson.*.environment
+    durable: redpanda-connect-dyson-environment
+    deliver: all
+    ack_wait: 20m
+    max_ack_pending: 5000
+
+pipeline:
+  processors:
+    - mapping: |
+        root = {
+          "time":   meta("nats_timestamp").or(now().ts_format("2006-01-02T15:04:05.999999Z")),
+          "device": meta("nats_subject").split(".").index(1),
+          "pm25":   this.pm25 | null,
+          "pm10":   this.pm10 | null,
+          "raw":    this,
+        }
+
+output:
+  broker:
+    pattern: fan_out
+    outputs:
+      - sql_raw:
+          driver: pgx
+          max_in_flight: 16
+          dsn: postgres://${PGUSER}:${PGPASSWORD}@timescaledb-db-pooler.timescaledb.svc.cluster.local:5432/homelab?sslmode=disable
+          init_statement: |
+            SET timezone = 'UTC';
+          query: |
+            INSERT INTO dyson_environment (time, device, pm25, pm10)
+            VALUES ($1, $2, $3, $4)
+            ON CONFLICT (time, device) DO NOTHING
+          args_mapping: |
+            root = [
+              this.time,
+              this.device,
+              this.pm25,
+              this.pm10,
+            ]
+      - aws_s3:
+          bucket: nats-archive
+          object_canned_acl: private
+          region: us-east-1
+          endpoint: http://rustfs-svc.rustfs.svc.cluster.local:9000
+          force_path_style_urls: true
+          credentials:
+            id: ${RUSTFS_ACCESS_KEY}
+            secret: ${RUSTFS_SECRET_KEY}
+          path: dyson/${!now().ts_format("2006/01/02/15")}/${!uuid_v4()}.parquet
+          batching:
+            count: 2000
+            period: 15m
+            processors:
+              - mapping: |
+                  root = {
+                    "time":    this.time,
+                    "subject": meta("nats_subject"),
+                    "payload": this.raw.format_json(),
+                  }
+              - parquet_encode:
+                  default_compression: zstd
+                  schema:
+                    - { name: time,    type: UTF8 }
+                    - { name: subject, type: UTF8 }
+                    - { name: payload, type: UTF8 }

--- a/kubernetes/applications/timescaledb/base/scripts/bootstrap.sql
+++ b/kubernetes/applications/timescaledb/base/scripts/bootstrap.sql
@@ -405,6 +405,21 @@ CREATE UNIQUE INDEX IF NOT EXISTS unifi_events_unique
     WHERE event_id IS NOT NULL;
 
 -- =========================================================
+-- Dyson Luftreiniger (dyson-nats-bridge → dyson.<device>.environment)
+-- Own bridge, schema is under our control. Entry-level PC1 carries only
+-- the particulate sensor; sleeping sensors omit their field → NULL.
+-- =========================================================
+CREATE TABLE dyson_environment (
+    time    TIMESTAMPTZ NOT NULL,
+    device  TEXT        NOT NULL,
+    pm25    SMALLINT,
+    pm10    SMALLINT,
+    PRIMARY KEY (time, device)
+);
+SELECT create_hypertable('dyson_environment', 'time', chunk_time_interval => INTERVAL '1 day');
+CREATE INDEX ON dyson_environment (device, time DESC);
+
+-- =========================================================
 -- Continuous Aggregate Refresh Policies
 -- =========================================================
 SELECT add_continuous_aggregate_policy('knx_1h',
@@ -470,6 +485,9 @@ ALTER TABLE warp_charge_tracker SET (timescaledb.compress,
 ALTER TABLE warp_meter SET (timescaledb.compress,
     timescaledb.compress_segmentby = 'meter_id',
     timescaledb.compress_orderby = 'time DESC');
+ALTER TABLE dyson_environment SET (timescaledb.compress,
+    timescaledb.compress_segmentby = 'device',
+    timescaledb.compress_orderby = 'time DESC');
 ALTER TABLE unifi_events SET (timescaledb.compress,
     timescaledb.compress_segmentby = 'camera',
     timescaledb.compress_orderby = 'time DESC');
@@ -484,6 +502,7 @@ SELECT add_compression_policy('warp_evse',           INTERVAL '2 days');
 SELECT add_compression_policy('warp_charge_manager', INTERVAL '2 days');
 SELECT add_compression_policy('warp_charge_tracker', INTERVAL '2 days');
 SELECT add_compression_policy('warp_meter',          INTERVAL '2 days');
+SELECT add_compression_policy('dyson_environment',   INTERVAL '2 days');
 SELECT add_compression_policy('unifi_events',        INTERVAL '7 days');
 
 -- =========================================================
@@ -501,6 +520,7 @@ SELECT add_retention_policy('warp_evse',           INTERVAL '365 days');
 SELECT add_retention_policy('warp_charge_manager', INTERVAL '365 days');
 SELECT add_retention_policy('warp_charge_tracker', INTERVAL '365 days');
 SELECT add_retention_policy('warp_meter',          INTERVAL '365 days');
+SELECT add_retention_policy('dyson_environment',   INTERVAL '365 days');
 
 -- =========================================================
 -- GA catalog — GA → name/room/function/description lookup,


### PR DESCRIPTION
Completes phase 4 of the Dyson integration: sensor telemetry lands in TimescaleDB and the parquet cold archive.

- **`dyson_environment` hypertable** (bootstrap.sql, already applied manually as role `homelab`): time/device/pm25/pm10 (SMALLINT, NULL for sleeping sensors — the PC1 only carries the particulate sensor), PK `(time, device)`, 1-day chunks, compression after 2 days segmented by device, 365d retention. Grants need no change (`connect` role covers new tables via default privileges).
- **`dyson_environment` stream**: JetStream input on `dyson.*.environment` (durable, deliver all), timestamp from `nats_timestamp` (stable across redeliveries), device slug from the subject; `fan_out` to `sql_raw` (pgx via pooler, `ON CONFLICT DO NOTHING`) and parquet under `nats-archive/dyson/` — mirrors the knx/warp ingest streams.

Verification: Bloblang linted (`redpandadata/connect lint`), prod overlay builds; after sync `SELECT count(*), max(time) FROM dyson_environment` grows per poll (~60 s) and parquet objects appear after the first 15-min batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)