### PR TITLE
fix(holmesgpt): pin operator image to 0.36.0

### DIFF
--- a/kubernetes/applications/holmesgpt/base/values.yaml
+++ b/kubernetes/applications/holmesgpt/base/values.yaml
@@ -75,6 +75,8 @@ toolsets:
 # Phase 2: operator runs ScheduledHealthChecks against the holmes server (read-only)
 operator:
   enabled: true
+  # Pinned back: the 0.37.0 image lacks the holmes package its entrypoint imports (CrashLoop).
+  image: holmes-operator:0.36.0
 
 # Custom skills as real .md files (kustomize ConfigMap) — a reusable registry of known-benign
 # log noise so investigations (esp. log-anomaly) don't escalate steady-state patterns.


### PR DESCRIPTION
## Problem

`holmes-operator` has been in `CrashLoopBackOff` since the chart 0.36.0 → 0.37.0 bump (#1364) rolled out:

```
Traceback (most recent call last):
  File "/app/holmes_operator/operator.py", line 10, in <module>
    from holmes.common.env_vars import ENABLE_JSON_LOGS_FORMAT
ModuleNotFoundError: No module named 'holmes'
```

This is an upstream packaging bug in the `robustadev/holmes-operator:0.37.0` image, not a configuration problem on our side. Two upstream changes landed together in 0.37.0:

- `operator.py` newly imports `holmes.common.env_vars` and `holmes.utils.log`, backing the chart's new `ENABLE_JSON_LOGS_FORMAT` env var.
- `Dockerfile.operator` still runs `poetry install --no-root` and copies only `holmes_operator/`, so the `holmes` package is never installed into the image.

Any 0.37.0 operator deployment is affected. There is no 0.37.1 on Docker Hub yet.

## Fix

Pin only the operator image back to 0.36.0; the `holmes` server stays on 0.37.0, since it is a separate image that does ship the package and is running healthy.

## Verification

- CRDs are byte-identical between chart 0.36.0 and 0.37.0, so the 0.36.0 operator is compatible with the 0.37.0 chart.
- The only operator-facing chart change in 0.37.0 is the new `ENABLE_JSON_LOGS_FORMAT` env var, which the 0.36.0 operator simply ignores.
- `kustomize build --enable-helm` renders `robustadev/holmes:0.37.0` and `robustadev/holmes-operator:0.36.0` as intended.

The pin should be reverted once upstream ships a fixed operator image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)