### PR TITLE
fix(monitoring): scrape ArgoCD metrics and alert on sync/health drift

### DIFF
--- a/kubernetes/applications/holmesgpt/base/scheduled-healthchecks.yaml
+++ b/kubernetes/applications/holmesgpt/base/scheduled-healthchecks.yaml
@@ -2,28 +2,6 @@ apiVersion: holmesgpt.dev/v1alpha1
 kind: ScheduledHealthCheck
 
 metadata:
-  name: argocd-sync
-  namespace: holmesgpt
-
-spec:
-  schedule: "22 * * * *"
-  enabled: true
-  mode: monitor
-  timeout: 300
-  query: >-
-    Report FAIL only if an ArgoCD application's sync status is not Synced, or its
-    health status is not Healthy, right now. If all applications are Synced and
-    Healthy, report PASS.
-    On FAIL, begin your rationale with a single-sentence TL;DR line naming the
-    affected application(s) and whether they are out of sync, unhealthy, or
-    both, followed by a blank line and then the per-application detail and most
-    likely reason.
-
----
-apiVersion: holmesgpt.dev/v1alpha1
-kind: ScheduledHealthCheck
-
-metadata:
   name: config-coherence
   namespace: holmesgpt
 

--- a/kubernetes/applications/prometheus/base/prometheus-rule.yaml
+++ b/kubernetes/applications/prometheus/base/prometheus-rule.yaml
@@ -142,6 +142,38 @@ spec:
             summary: "UniFi arm-sync metric stale/absent"
             description: "unifi_arm_sync_ok has not been reported for >15m (expected every ~5min via the KNX status heartbeat). The redpanda-connect stream, its JetStream consumer binding, or the scrape is stuck — drift detection is blind."
 
+    - name: argocd-alerts
+      rules:
+        - alert: ArgoCDAppOutOfSync
+          # Level-triggered: ArgoCD's own notifications only fire on a failed sync operation,
+          # so an app that just sits OutOfSync never raises one.
+          expr: argocd_app_info{sync_status!="Synced"} == 1
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "ArgoCD application {{ $labels.name }} out of sync"
+            description: "{{ $labels.name }} has been {{ $labels.sync_status }} for more than 15m — no sync operation failed, so no ArgoCD notification was sent."
+
+        - alert: ArgoCDAppNotHealthy
+          # ArgoCD notifies only on health=Degraded; Progressing/Missing/Unknown stay silent.
+          expr: argocd_app_info{health_status!="Healthy"} == 1
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "ArgoCD application {{ $labels.name }} not healthy"
+            description: "{{ $labels.name }} health is {{ $labels.health_status }} for more than 15m."
+
+        - alert: ArgoCDMetricsAbsent
+          expr: absent(argocd_app_info)
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "ArgoCD application metrics absent"
+            description: "argocd_app_info has not been scraped for more than 15m — sync/health drift detection is blind."
+
     - name: kubernetes-pods
       rules:
         - alert: PodCrashLooping

--- a/kubernetes/bootstrap/gitops-controller/base/values.yaml
+++ b/kubernetes/bootstrap/gitops-controller/base/values.yaml
@@ -65,7 +65,8 @@ controller:
     enabled: true
     serviceMonitor:
       enabled: true
-      labels:
+      # Chart key is additionalLabels; a plain `labels` block is silently ignored.
+      additionalLabels:
         release: prometheus
 
 # Repo server renders manifests; livenessProbe default 1s is too tight for /healthz?full=true


### PR DESCRIPTION
## Problem

ArgoCD metrics are not being scraped at all. `count(argocd_app_info)` returns an empty result and there is no active ArgoCD scrape target, despite the `argocd-application-controller` ServiceMonitor existing for 115 days.

Cause: Prometheus selects ServiceMonitors via `matchLabels: {release: prometheus}`, but the rendered ServiceMonitor carries no `release` label. Our values set

```yaml
controller:
  metrics:
    serviceMonitor:
      labels:            # ← ignored by the chart
        release: prometheus
```

while the argo-cd chart template reads `.Values.controller.metrics.serviceMonitor.additionalLabels`. An unrecognised key fails silently, so this looked configured but never took effect. Consequently there are also zero ArgoCD alert rules in the cluster.

## What this changes

1. **`additionalLabels`** instead of `labels`, so the ServiceMonitor is actually selected.
2. **Three alert rules** in `homelab-rules`:
   - `ArgoCDAppOutOfSync` — `argocd_app_info{sync_status!="Synced"} == 1`, `for: 15m`
   - `ArgoCDAppNotHealthy` — `argocd_app_info{health_status!="Healthy"} == 1`, `for: 15m`
   - `ArgoCDMetricsAbsent` — `absent(argocd_app_info)`, `for: 15m`
3. **Removes the holmesgpt `argocd-sync` ScheduledHealthCheck.**

## Why the alerts are not redundant with ArgoCD's Pushover notifications

The existing notification triggers are **edge-triggered** and narrowly scoped:

| Trigger | Condition |
|---|---|
| `on-sync-failed` | `operationState.phase in ['Error','Failed']` |
| `on-health-degraded` | `health.status == 'Degraded'` |

They therefore miss an app that simply sits `OutOfSync` without any failed sync operation (drift, auto-sync off, never attempted), an app stuck in `Progressing`/`Missing`/`Unknown` rather than `Degraded`, and any transition missed while the controller restarted. The new rules are level-triggered and catch the standing state.

`ArgoCDMetricsAbsent` exists so that a future selector mismatch surfaces within 15 minutes instead of going unnoticed for months, as this one did.

## Why the Holmes check goes

`argocd-sync` asked an LLM hourly whether any app was not Synced or not Healthy — the same question, answered up to an hour late. It was 24 of the 32 daily checks and roughly 40% of the LLM gateway spend (weighted by run duration). The Prometheus rules cover it in 15 minutes at no cost, leaving budget for `config-coherence` and `log-anomaly`, where interpretation actually adds value.

The 724 accumulated `HealthCheck` CRs are owned by the ScheduledHealthCheck via `ownerReferences` with `blockOwnerDeletion`, so they are garbage-collected automatically on removal.

## Verification

- `kustomize build --enable-helm` on `gitops-controller/base` now renders the ServiceMonitor with `release: prometheus`.
- The three rules render as expected in `homelab-rules`.
- `holmesgpt/base` renders only `config-coherence` and `log-anomaly`.
- All 43 applications are currently `Synced/Healthy`, so the new rules will not fire on merge.

Not verified against a live cluster: the kubeconfig token expired mid-session, so `promtool check rules` could not be run. The three expressions are plain selectors plus `absent()`.