### PR TITLE
ci(validate): authenticate to Docker Hub registries for image checks

### DIFF
--- a/.github/workflows/ci-validate.yaml
+++ b/.github/workflows/ci-validate.yaml
@@ -157,8 +157,15 @@ jobs:
           crane: v0.19.0
           kyverno: v1.13.3
 
-      - name: Login to DHI
-        run: crane auth login dhi.io -u "${{ secrets.DHI_USER }}" -p "${{ secrets.DHI_PASS }}"
+      - name: Login to Registries
+        env:
+          REGISTRY_USER: ${{ secrets.DHI_USER }}
+          REGISTRY_PASS: ${{ secrets.DHI_PASS }}
+        run: |
+          # Hub-backed hosts share one anonymous pull quota per runner IP
+          for host in dhi.io docker.io registry-1.docker.io docker.redpanda.com; do
+            crane auth login "$host" -u "$REGISTRY_USER" -p "$REGISTRY_PASS"
+          done
 
       - name: Render Overlay (kustomize)
         run: |


### PR DESCRIPTION
## Problem

The `Validate Images (crane)` step resolves every image digest in the rendered
overlay, but the job only authenticated to `dhi.io`. All Docker Hub-backed hosts
were therefore queried anonymously and drew on the shared anonymous pull quota of
the GitHub-hosted runner IP, which is regularly exhausted.

PRs touching the redpanda-connect overlays failed reliably:

```
GET https://docker.redpanda.com/v2/redpandadata/connect/manifests/4.102.0:
TOOMANYREQUESTS: You have reached your unauthenticated pull rate limit.
```

`docker.redpanda.com` is a Docker Hub vanity domain — it advertises
`realm="https://auth.docker.io/token", service="registry.docker.io"` — so the
existing credentials apply to it. Three hosts across the repo share that quota:
`docker.io` (49 image refs), `docker.redpanda.com` (16) and `registry-1.docker.io` (3).

## Change

Log in to all Hub-backed hosts alongside `dhi.io` before the digest checks, and
move the credentials into `env:` instead of repeating the expression per host.

## Verification

This PR changes only the workflow, so no `kubernetes/**` path matches and the
overlay matrix falls back to every overlay in the repo — including
redpanda-connect. A green run here exercises the previously failing path.

## Notes

- No retry/backoff was added around `crane digest`. That would mask an exhausted
  quota rather than fix it; with authentication in place a 429 is a real signal.
- Assumes `DHI_USER`/`DHI_PASS` are Docker Hub credentials. The registry probe
  confirms the auth realm, but whether this specific token is accepted there is
  what this run verifies — the login step fails loudly if not.
- Once merged, PR #1332 needs a fresh run (Renovate rebase or a push); re-running
  the old job replays the recorded SHAs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
