### PR TITLE
feat(knx): wire the Bordbar light to KNX

### DIFF
--- a/kubernetes/applications/knx-nats-bridge/base/config/ga-catalog.yaml
+++ b/kubernetes/applications/knx-nats-bridge/base/config/ga-catalog.yaml
@@ -7459,6 +7459,51 @@
   function: Beleuchtung
   name: Beleuchtung.G.Garten.Hochbeet.Poller.Dimmen-Status
   room: Garten
+4/2/60:
+  dpt: '1.003'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Wohnzimmer.Bordbar.Sperren
+  room: Wohnzimmer
+4/2/61:
+  dpt: '1.001'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Wohnzimmer.Bordbar.Ein/Aus
+  room: Wohnzimmer
+4/2/62:
+  dpt: '1.011'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Wohnzimmer.Bordbar.Ein/Aus-Status
+  room: Wohnzimmer
+4/2/63:
+  dpt: '1.007'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Wohnzimmer.Bordbar.Helligkeit-Schritt
+  room: Wohnzimmer
+4/2/64:
+  dpt: '1.007'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Wohnzimmer.Bordbar.Farbe-Schritt
+  room: Wohnzimmer
+4/2/65:
+  dpt: '1.007'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Wohnzimmer.Bordbar.Modus-Schritt
+  room: Wohnzimmer
+4/2/66:
+  dpt: '1.007'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Wohnzimmer.Bordbar.Geschwindigkeit-Schritt
+  room: Wohnzimmer
+4/2/67:
+  dpt: '1.015'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Wohnzimmer.Bordbar.Reset
+  room: Wohnzimmer
+4/2/68:
+  dpt: '1.011'
+  function: Beleuchtung
+  name: Beleuchtung.EG.Wohnzimmer.Bordbar.Verbindung-Status
+  room: Wohnzimmer
 4/3/60:
   dpt: '1.003'
   function: Beleuchtung

--- a/kubernetes/applications/knx-nats-bridge/base/config/writer-rules.yaml
+++ b/kubernetes/applications/knx-nats-bridge/base/config/writer-rules.yaml
@@ -1414,3 +1414,23 @@ mappings:
     description: "Raumklima.OG.Schlafzimmer-Eltern.Luftreiniger.Nachtmodus-Status"
     min_delta: 0  # bool state: write only on change
     seed_on_start: true
+
+  # Bordbar LED status feedback (KNX<-NATS). The command GAs (4/2/61/63-67) are
+  # driven KNX->device by the redpanda-connect bordbar_from_knx stream. The
+  # on/off status is what the firmware *assumes* — the LED controller has no
+  # feedback channel — and availability comes from the MQTT last will, so a dead
+  # ESP32 is visible instead of a stale status.
+  - subject: "bordbar.state"
+    ga: "4/2/62"
+    dpt: "1.011"
+    payload_path: "$.power"
+    description: "Beleuchtung.EG.Wohnzimmer.Bordbar.Ein/Aus-Status"
+    min_delta: 0  # bool state: write only on change
+    seed_on_start: true
+  - subject: "bordbar.availability"
+    ga: "4/2/68"
+    dpt: "1.011"
+    payload_path: "$.online"
+    description: "Beleuchtung.EG.Wohnzimmer.Bordbar.Verbindung-Status"
+    min_delta: 0  # bool state: write only on change
+    seed_on_start: true

--- a/kubernetes/applications/nats/base/consumers/bordbar_from_knx.yaml
+++ b/kubernetes/applications/nats/base/consumers/bordbar_from_knx.yaml
@@ -1,0 +1,33 @@
+# Durable consumer for the redpanda-connect bordbar_from_knx pipeline.
+#
+# Watches the Bordbar command GAs (written by Basalte):
+#   knx.4.2.61 Ein/Aus                 (1.001)
+#   knx.4.2.63 Helligkeit-Schritt      (1.007, true = heller)
+#   knx.4.2.64 Farbe-Schritt           (1.007)
+#   knx.4.2.65 Modus-Schritt           (1.007)
+#   knx.4.2.66 Geschwindigkeit-Schritt (1.007)
+#   knx.4.2.67 Reset                   (1.015, only 1 acts)
+# 4/2/62 and 4/2/68 are status GAs driven the other way by the writer rules.
+apiVersion: jetstream.nats.io/v1beta2
+kind: Consumer
+metadata:
+  name: redpanda-connect-bordbar-from-knx
+  namespace: nats
+spec:
+  streamName: KNX
+  durableName: redpanda-connect-bordbar-from-knx
+  filterSubjects:
+    - knx.4.2.61
+    - knx.4.2.63
+    - knx.4.2.64
+    - knx.4.2.65
+    - knx.4.2.66
+    - knx.4.2.67
+  deliverPolicy: new
+  ackPolicy: explicit
+  # nats-operator default surfaces as 1ns, which causes immediate re-delivery
+  # of any message slower-than-instant to ack. 15s covers the core republish
+  # comfortably without leaving wedged messages locked long.
+  ackWait: 15s
+  # Drop after 5 attempts so a permanently-failing message can't loop forever.
+  maxDeliver: 5

--- a/kubernetes/applications/nats/base/consumers/bordbar_from_knx.yaml
+++ b/kubernetes/applications/nats/base/consumers/bordbar_from_knx.yaml
@@ -1,13 +1,14 @@
 # Durable consumer for the redpanda-connect bordbar_from_knx pipeline.
 #
-# Watches the Bordbar command GAs (written by Basalte):
 #   knx.4.2.61 Ein/Aus                 (1.001)
 #   knx.4.2.63 Helligkeit-Schritt      (1.007, true = heller)
 #   knx.4.2.64 Farbe-Schritt           (1.007)
 #   knx.4.2.65 Modus-Schritt           (1.007)
 #   knx.4.2.66 Geschwindigkeit-Schritt (1.007)
 #   knx.4.2.67 Reset                   (1.015, only 1 acts)
-# 4/2/62 and 4/2/68 are status GAs driven the other way by the writer rules.
+#
+# The Bordbar command GAs, written by Basalte. 4/2/62 and 4/2/68 are status GAs
+# driven the other way by the writer rules.
 apiVersion: jetstream.nats.io/v1beta2
 kind: Consumer
 metadata:

--- a/kubernetes/applications/nats/base/consumers/dyson_from_knx.yaml
+++ b/kubernetes/applications/nats/base/consumers/dyson_from_knx.yaml
@@ -1,9 +1,11 @@
 # Durable consumer for the redpanda-connect dyson_from_knx pipeline.
-# Watches the Luftreiniger command GAs (written by Basalte):
+#
 #   knx.6.3.111 Ein/Aus     (1.001)
 #   knx.6.3.113 Lüfterstufe (5.010, 0 = Automatik, 1..10 manual)
 #   knx.6.3.115 Drehmodus   (5.010 enum: 0=Aus, 1=45°, 2=90°, 3=180°, 4=350°)
 #   knx.6.3.117 Nachtmodus  (1.001)
+#
+# The Luftreiniger command GAs, written by Basalte.
 apiVersion: jetstream.nats.io/v1beta2
 kind: Consumer
 metadata:

--- a/kubernetes/applications/nats/base/consumers/kustomization.yaml
+++ b/kubernetes/applications/nats/base/consumers/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - warp_charge_mode_from_knx.yaml
   - warp_mode_buttons_from_knx.yaml
   - dyson_from_knx.yaml
+  - bordbar_from_knx.yaml

--- a/kubernetes/applications/nats/base/consumers/pv_surplus_to_warp.yaml
+++ b/kubernetes/applications/nats/base/consumers/pv_surplus_to_warp.yaml
@@ -1,6 +1,8 @@
-# Durable consumer for the redpanda-connect pv_surplus_to_warp forwarder.
-# Subscribes to the bridge publish of one specific KNX GA — the grid net
-# power reading that the WARP wallbox uses for surplus charging.
+# Durable consumer for the redpanda-connect pv_surplus_to_warp pipeline.
+#
+#   knx.15.1.24 Wirkleistung-Gesamt (14.056)
+#
+# The grid net power reading the WARP wallbox uses for surplus charging.
 apiVersion: jetstream.nats.io/v1beta2
 kind: Consumer
 metadata:

--- a/kubernetes/applications/nats/base/consumers/unifi_arm_alarm.yaml
+++ b/kubernetes/applications/nats/base/consumers/unifi_arm_alarm.yaml
@@ -1,10 +1,12 @@
 # Durable consumer for the redpanda-connect unifi_arm_alarm pipeline.
-# Watches the EMA *status* feedback GAs (not the command GAs): disarm via
-# keypad/scene never emits the 14/1/20 command, only the status GAs change.
-# These are re-broadcast by the panel (~5 min heartbeat), so the sync is
-# self-healing — every heartbeat re-asserts the intended UniFi state.
-#   knx.14.1.26 Extern-Scharf-Status: 1 => ARM   (Abwesend enable)
+#
+#   knx.14.1.26 Extern-Scharf-Status: 1 => ARM    (Abwesend enable)
 #   knx.14.1.21 Unscharf-Status:      1 => DISARM (Abwesend disable)
+#
+# The EMA *status* feedback GAs, not the command GAs: disarm via keypad/scene
+# never emits the 14/1/20 command, only the status GAs change. These are
+# re-broadcast by the panel (~5 min heartbeat), so the sync is self-healing —
+# every heartbeat re-asserts the intended UniFi state.
 apiVersion: jetstream.nats.io/v1beta2
 kind: Consumer
 metadata:

--- a/kubernetes/applications/nats/base/consumers/unifi_events.yaml
+++ b/kubernetes/applications/nats/base/consumers/unifi_events.yaml
@@ -1,6 +1,9 @@
-# Durable consumer for the redpanda-connect unifi_events archive pipeline.
-# Subject filter covers both unifi.events.> (per-trigger camera detections)
-# and unifi.geofence.> (presence-change triggers).
+# Durable consumer for the redpanda-connect unifi_events pipeline.
+#
+#   unifi.events.>   per-trigger camera detections
+#   unifi.geofence.> presence-change triggers
+#
+# Both are covered by the unifi.> subject filter.
 apiVersion: jetstream.nats.io/v1beta2
 kind: Consumer
 metadata:

--- a/kubernetes/applications/nats/base/consumers/warp_charge_mode_from_knx.yaml
+++ b/kubernetes/applications/nats/base/consumers/warp_charge_mode_from_knx.yaml
@@ -1,6 +1,9 @@
-# Durable consumer for the redpanda-connect warp_charge_mode_from_knx forwarder.
-# Subscribes to the bridge publish of the Lademodus GA, which redpanda-connect
-# maps to WARP's power_manager/charge_mode_update (0=Schnell 1=Aus 2=PV 3=Min+PV).
+# Durable consumer for the redpanda-connect warp_charge_mode_from_knx pipeline.
+#
+#   knx.15.6.22 Lademodus (5.010)
+#
+# redpanda-connect maps it to WARP's power_manager/charge_mode_update
+# (0=Schnell 1=Aus 2=PV 3=Min+PV).
 apiVersion: jetstream.nats.io/v1beta2
 kind: Consumer
 metadata:

--- a/kubernetes/applications/nats/base/consumers/warp_mode_buttons_from_knx.yaml
+++ b/kubernetes/applications/nats/base/consumers/warp_mode_buttons_from_knx.yaml
@@ -1,6 +1,11 @@
-# Durable consumer for the redpanda-connect warp_mode_buttons_from_knx
-# forwarder. Subscribes to the three per-mode Basalte button GAs, which
-# redpanda-connect maps to a WARP charge mode (PV=2, PV+Min=3, Schnell=0).
+# Durable consumer for the redpanda-connect warp_mode_buttons_from_knx pipeline.
+#
+#   knx.15.6.25 Lademodus-PV      (1.001)
+#   knx.15.6.27 Lademodus-PV+Min  (1.001)
+#   knx.15.6.29 Lademodus-Schnell (1.001)
+#
+# The three per-mode Basalte button GAs, which redpanda-connect maps to a WARP
+# charge mode (PV=2, PV+Min=3, Schnell=0).
 apiVersion: jetstream.nats.io/v1beta2
 kind: Consumer
 metadata:

--- a/kubernetes/applications/nats/base/consumers/warp_onoff_from_knx.yaml
+++ b/kubernetes/applications/nats/base/consumers/warp_onoff_from_knx.yaml
@@ -1,6 +1,8 @@
-# Durable consumer for the redpanda-connect warp_onoff_from_knx forwarder.
-# Subscribes to the bridge publish of the Ein-Aus charge-release GA, which
-# redpanda-connect maps to WARP's evse/start_charging|stop_charging.
+# Durable consumer for the redpanda-connect warp_onoff_from_knx pipeline.
+#
+#   knx.15.6.20 Freigabe (1.001)
+#
+# redpanda-connect maps it to WARP's evse/start_charging | stop_charging.
 apiVersion: jetstream.nats.io/v1beta2
 kind: Consumer
 metadata:

--- a/kubernetes/applications/redpanda-connect/base/kustomization.yaml
+++ b/kubernetes/applications/redpanda-connect/base/kustomization.yaml
@@ -39,6 +39,7 @@ configMapGenerator:
       - streams/warp_mode_flags.yaml
       - streams/dyson_from_knx.yaml
       - streams/dyson_environment.yaml
+      - streams/bordbar_from_knx.yaml
 
 patches:
   # Expose redpanda-connect service via Cilium/BGP-announced LoadBalancer so

--- a/kubernetes/applications/redpanda-connect/base/streams/bordbar_from_knx.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/bordbar_from_knx.yaml
@@ -1,0 +1,60 @@
+# Bordbar LED control: Basalte command GAs -> bordbar-nats-bridge.
+#
+#   knx.4.2.61 Ein/Aus                 -> bordbar.command.power      {"value": bool}
+#   knx.4.2.63 Helligkeit-Schritt      -> bordbar.command.brightness {"value": 1|-1}
+#   knx.4.2.64 Farbe-Schritt           -> bordbar.command.color      {"value": 1|-1}
+#   knx.4.2.65 Modus-Schritt           -> bordbar.command.mode       {"value": 1|-1}
+#   knx.4.2.66 Geschwindigkeit-Schritt -> bordbar.command.speed      {"value": 1|-1}
+#   knx.4.2.67 Reset                   -> bordbar.command.reset      {}
+#
+# Core NATS only; the ESP32 subscribes through the MQTT gateway and nothing
+# archives commands.
+input:
+  # Consumer (filterSubjects on the six GAs) is declared as a CRD in
+  # nats/base/consumers/bordbar_from_knx.yaml.
+  nats_jetstream:
+    urls: ["nats://nats.nats.svc:4222"]
+    auth:
+      user: redpanda-connect
+      password: ${NATS_PASSWORD}
+    stream: KNX
+    durable: redpanda-connect-bordbar-from-knx
+    bind: true
+
+pipeline:
+  processors:
+    - mapping: |
+        # DPT 1.015 defines 0 as "no action" — only a 1 triggers the reset.
+        # Dropping it here keeps the reset branch below free of the special case.
+        root = if meta("nats_subject") == "knx.4.2.67" && !(this.value == true || this.value == 1) {
+          deleted()
+        } else {
+          this
+        }
+    - mapping: |
+        let subj = meta("nats_subject")
+        # Unmapped GAs are published raw as 0/1, so accept both forms.
+        let on = this.value == true || this.value == 1
+        root = if $subj == "knx.4.2.61" {
+          {"value": $on}
+        } else if $subj == "knx.4.2.67" {
+          {}
+        } else {
+          {"value": if $on { 1 } else { -1 }}
+        }
+        meta bordbar_subject = "bordbar.command." + (
+          if $subj == "knx.4.2.61" { "power" }
+          else if $subj == "knx.4.2.63" { "brightness" }
+          else if $subj == "knx.4.2.64" { "color" }
+          else if $subj == "knx.4.2.65" { "mode" }
+          else if $subj == "knx.4.2.66" { "speed" }
+          else { "reset" }
+        )
+
+output:
+  nats:
+    urls: ["nats://nats.nats.svc:4222"]
+    auth:
+      user: redpanda-connect
+      password: ${NATS_PASSWORD}
+    subject: ${! meta("bordbar_subject") }

--- a/kubernetes/applications/redpanda-connect/base/streams/dyson_environment.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/dyson_environment.yaml
@@ -1,7 +1,10 @@
 # Dyson Luftreiniger sensor telemetry -> TimescaleDB + parquet cold archive.
-# The bridge normalizes upstream (dyson.<device>.environment, flat scalars);
-# entry-level models (PC1) carry only the particulate sensor, and sleeping
-# sensors omit their field entirely -> typed columns stay NULL.
+#
+#   dyson.<device>.environment -> dyson_environment
+#
+# The bridge normalizes upstream (flat scalars); entry-level models (PC1) carry
+# only the particulate sensor, and sleeping sensors omit their field entirely
+# -> typed columns stay NULL.
 input:
   nats_jetstream:
     urls: ["nats://nats.nats.svc:4222"]

--- a/kubernetes/applications/redpanda-connect/base/streams/dyson_from_knx.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/dyson_from_knx.yaml
@@ -1,10 +1,11 @@
-# Luftreiniger control: forwards the Basalte command GAs to the
-# dyson-nats-bridge command subjects (core NATS; the bridge subscribes core,
-# nothing archives commands).
+# Luftreiniger control: Basalte command GAs -> dyson-nats-bridge.
+#
 #   knx.6.3.111 Ein/Aus     -> dyson.ventilator-1.command.power       {"value": bool}
 #   knx.6.3.113 Lüfterstufe -> dyson.ventilator-1.command.speed       {"value": 0..10, 0 = auto}
 #   knx.6.3.115 Drehmodus   -> dyson.ventilator-1.command.oscillation {"value": 0..4}
 #   knx.6.3.117 Nachtmodus  -> dyson.ventilator-1.command.night       {"value": bool}
+#
+# Core NATS only; the bridge subscribes core and nothing archives commands.
 input:
   # Consumer (filterSubjects on the four GAs) is declared as a CRD in
   # nats/base/consumers/dyson_from_knx.yaml.

--- a/kubernetes/applications/redpanda-connect/base/streams/ems_esp.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/ems_esp.yaml
@@ -1,3 +1,6 @@
+# EMS-ESP heating telemetry -> TimescaleDB + parquet cold archive.
+#
+#   ems-esp.> -> ems_esp
 input:
   nats_jetstream:
     urls: ["nats://nats.nats.svc:4222"]

--- a/kubernetes/applications/redpanda-connect/base/streams/knx.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/knx.yaml
@@ -1,3 +1,9 @@
+# KNX bus telegrams -> TimescaleDB + parquet cold archive.
+#
+#   knx.> -> knx
+#
+# Only DPT-1 booleans and numeric payloads are ingested; datetime and other
+# non-numeric DPTs are dropped, raw included.
 input:
   nats_jetstream:
     urls: ["nats://nats.nats.svc:4222"]

--- a/kubernetes/applications/redpanda-connect/base/streams/pv_surplus_to_warp.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/pv_surplus_to_warp.yaml
@@ -1,7 +1,8 @@
-# PV surplus forwarder: pushes the home-grid net power reading (KNX
-# 15/1/24, DPT 14.056 "Versorgungstechnik.Energiezähler.Strom.Wirkleistung-
-# Gesamt") to the WARP wallbox so its Charge Manager can balance EV
-# charging against PV surplus.
+# PV surplus forwarder: KNX grid net power -> WARP Charge Manager.
+#
+#   knx.15.1.24 Wirkleistung-Gesamt (14.056) -> charge_manager external power
+#
+# Lets the wallbox balance EV charging against PV surplus.
 input:
   # Consumer is declared as a CRD in nats/base/consumers/pv_surplus_to_warp.yaml.
   nats_jetstream:

--- a/kubernetes/applications/redpanda-connect/base/streams/solaredge_battery.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/solaredge_battery.yaml
@@ -1,10 +1,14 @@
-# SolarEdge battery (modbus) → TimescaleDB + archive. Dormant until a battery is
-# physically connected: solaredge2mqtt only emits `solaredge-N.modbus.battery`
-# once a storage unit is present, so this durable consumer sits idle (no messages)
-# until then. The battery field names below follow the solaredge2mqtt SunSpec
-# battery model — VERIFY them against a live event at connect time and adjust the
-# mapping / table if they differ (`nats stream get SOLAREDGE --last-for
-# solaredge-1.modbus.battery`). `state_of_charge` feeds KNX 15/4/55 via writer-rule.
+# SolarEdge battery modbus readings -> TimescaleDB + parquet cold archive.
+#
+#   *.modbus.battery -> solaredge_battery
+#
+# Dormant until a battery is physically connected: solaredge2mqtt only emits
+# `solaredge-N.modbus.battery` once a storage unit is present, so this durable
+# consumer sits idle (no messages) until then. The battery field names below
+# follow the solaredge2mqtt SunSpec battery model — VERIFY them against a live
+# event at connect time and adjust the mapping / table if they differ
+# (`nats stream get SOLAREDGE --last-for solaredge-1.modbus.battery`).
+# `state_of_charge` feeds KNX 15/4/55 via writer-rule.
 input:
   nats_jetstream:
     urls: ["nats://nats.nats.svc:4222"]

--- a/kubernetes/applications/redpanda-connect/base/streams/solaredge_inverter.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/solaredge_inverter.yaml
@@ -1,3 +1,6 @@
+# SolarEdge inverter modbus readings -> TimescaleDB + parquet cold archive.
+#
+#   *.modbus.inverter -> solaredge_inverter
 input:
   nats_jetstream:
     urls: ["nats://nats.nats.svc:4222"]

--- a/kubernetes/applications/redpanda-connect/base/streams/solaredge_powerflow.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/solaredge_powerflow.yaml
@@ -1,3 +1,6 @@
+# SolarEdge powerflow readings -> TimescaleDB + parquet cold archive.
+#
+#   *.powerflow -> solaredge_powerflow
 input:
   nats_jetstream:
     urls: ["nats://nats.nats.svc:4222"]

--- a/kubernetes/applications/redpanda-connect/base/streams/unifi_arm_alarm.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/unifi_arm_alarm.yaml
@@ -1,13 +1,12 @@
-# Syncs the KNX alarm panel's armed state to the UniFi Protect "Abwesend"
-# arm-profile, and writes the *confirmed* UniFi state back onto KNX status GAs
-# so Basalte can show it (positive confirmation, mirroring the EMA).
+# EMA arm state -> UniFi Protect "Abwesend" profile, confirmed back onto KNX.
+#
+#   knx.14.1.26 Extern-Scharf-Status: 1 => enable  (Abwesend)
+#   knx.14.1.21 Unscharf-Status:      1 => disable
 #
 # Triggers on the EMA STATUS GAs (not the command GAs): disarm via keypad/scene
 # never emits the 14/1/20 command — only the status GAs change. The panel
 # re-broadcasts them every ~5 min, so the sync is self-healing: every heartbeat
 # re-asserts the intended UniFi state and refreshes the confirmation + metric.
-#   knx.14.1.26 Extern-Scharf-Status: 1 => enable  (Abwesend)
-#   knx.14.1.21 Unscharf-Status:      1 => disable
 # Do NOT invert one GA: 14/1/26=0 is ambiguous with Intern-Scharf.
 #
 # Flow (sequential, so ordering is guaranteed without a race):

--- a/kubernetes/applications/redpanda-connect/base/streams/unifi_events.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/unifi_events.yaml
@@ -1,3 +1,7 @@
+# UniFi Protect detections and geofence events -> TimescaleDB + parquet archive.
+#
+#   unifi.events.>   -> unifi_events
+#   unifi.geofence.> -> unifi_events
 input:
   # Consumer is declared as a CRD in nats/base/consumers/unifi_events.yaml
   # (filter, deliver, ack_wait, max_ack_pending live there). bind: true tells

--- a/kubernetes/applications/redpanda-connect/base/streams/unifi_webhook.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/unifi_webhook.yaml
@@ -1,6 +1,7 @@
-# UniFi Protect Alarm Manager webhook handler.
-# Splits alarm.triggers[], resolves camera MAC -> name, derives knx_value,
-# publishes one NATS message per trigger so knx-nats-bridge can write KNX.
+# UniFi Protect Alarm Manager webhook handler -> per-trigger NATS messages.
+#
+# Splits alarm.triggers[], resolves camera MAC -> name, derives knx_value, and
+# publishes one message per trigger so knx-nats-bridge can write KNX.
 # Geofence triggers (key=admin_geolocation) get their own subject so the
 # node-RED Geofence tab can subscribe via the NATS MQTT gateway.
 input:

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_charge_manager.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_charge_manager.yaml
@@ -1,3 +1,6 @@
+# WARP charge-manager telemetry -> TimescaleDB + parquet cold archive.
+#
+#   warp.charge_manager.> -> warp_charge_manager
 input:
   nats_jetstream:
     urls: ["nats://nats.nats.svc:4222"]

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_charge_mode_from_knx.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_charge_mode_from_knx.yaml
@@ -1,6 +1,9 @@
-# Lademodus control: forwards the KNX Lademodus GA (15/6/22, DPT 5.010
-# "Versorgungstechnik.Wallbox.Lademodus") to the WARP wallbox's charge mode.
-# The GA carries the WARP raw mode value directly: 0=Schnell 1=Aus 2=PV 3=Min+PV.
+# Lademodus control: KNX Lademodus GA -> WARP charge mode.
+#
+#   knx.15.6.22 Lademodus (5.010) -> power_manager/charge_mode_update
+#
+# The GA carries the WARP raw mode value directly:
+# 0=Schnell 1=Aus 2=PV 3=Min+PV.
 input:
   # Consumer is declared as a CRD in nats/base/consumers/warp_charge_mode_from_knx.yaml.
   nats_jetstream:

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_charge_tracker.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_charge_tracker.yaml
@@ -1,3 +1,6 @@
+# WARP charge-tracker telemetry -> TimescaleDB + parquet cold archive.
+#
+#   warp.charge_tracker.> -> warp_charge_tracker
 input:
   nats_jetstream:
     urls: ["nats://nats.nats.svc:4222"]
@@ -44,7 +47,7 @@ pipeline:
 output:
   broker:
     # Both outputs must succeed before the NATS message is acked.
-    # If RustFS is down, NATS will retry → TS-Insert is also delayed.
+    # If RustFS is down, NATS will retry -> TS-Insert is also delayed.
     # That is the desired behavior: cold archive must keep up with TS.
     pattern: fan_out
     outputs:

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_charging_status.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_charging_status.yaml
@@ -1,9 +1,12 @@
-# Freigabe-Status feedback: mirrors the charge release the Freigabe switch
-# (15/6/20 start/stop_charging) toggles = WARP "Slot 4". Blocked (active &&
-# max_current == 0) => off; otherwise => on. Tracks only the release intent,
-# independent of car presence or current draw — unlike charger_state, which is
-# 0 whenever no car is plugged in. The bridge can't index an array, so the bool
-# is derived here for the writer (KNX 15/6/21, DPT 1.001 …Wallbox.Freigabe-Status).
+# Freigabe-Status feedback: WARP charge release -> KNX Freigabe status GA.
+#
+#   WARP Slot 4 release -> wallbox.knx.charging $.on -> knx.15.6.21 (1.001)
+#
+# Mirrors the charge release that the Freigabe switch (15/6/20
+# start/stop_charging) toggles. Blocked (active && max_current == 0) => off;
+# otherwise => on. Tracks only the release intent, independent of car presence
+# or current draw — unlike charger_state, which is 0 whenever no car is plugged
+# in. The bridge can't index an array, so the bool is derived here.
 input:
   nats_jetstream:
     urls: ["nats://nats.nats.svc:4222"]

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_evse.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_evse.yaml
@@ -1,3 +1,6 @@
+# WARP wallbox EVSE telemetry -> TimescaleDB + parquet cold archive.
+#
+#   warp.evse.> -> warp_evse
 input:
   nats_jetstream:
     urls: ["nats://nats.nats.svc:4222"]

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_knx_republish.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_knx_republish.yaml
@@ -1,9 +1,9 @@
-# Republishes WARP wallbox telemetry as named scalar fields for the
-# knx-nats-bridge writer. The raw WARP data is unusable by the bridge as-is:
-# `warp.meters.0.values` is a float ARRAY whose order is defined by
-# `warp.meters.0.value_ids` (the bridge can only read named JSON fields, no
-# array indices). This stream pulls the values we route to KNX out of the
-# array and onto two clean subjects.
+# WARP telemetry -> named scalar fields the knx-nats-bridge writer can read.
+#
+# The raw WARP data is unusable by the bridge as-is: `warp.meters.0.values` is a
+# float ARRAY whose order is defined by `warp.meters.0.value_ids`, and the
+# bridge can only read named JSON fields, no array indices. This stream pulls
+# the values we route to KNX out of the array and onto two clean subjects.
 #
 # value_ids index -> MeterValueID (current Steinroth meter config):
 #   3/4/5 = 13/17/21 phase current L1/L2/L3 (A)

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_meter.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_meter.yaml
@@ -1,3 +1,6 @@
+# WARP wallbox meter telemetry -> TimescaleDB + parquet cold archive.
+#
+#   warp.meters.> -> warp_meter
 input:
   nats_jetstream:
     urls: ["nats://nats.nats.svc:4222"]
@@ -25,7 +28,7 @@ pipeline:
         #  - payload is an array with at least 9 elements (V/A/W per phase).
         # Some warp.meters.<N>.values messages carry partial / 1-element arrays;
         # without the length guard, $evt.index(1) errors and aborts the whole
-        # root mapping → time + sub_topic + raw never get set → NULL-time INSERT.
+        # root mapping -> time + sub_topic + raw never get set -> NULL-time INSERT.
         let is_indexed_values = $parts.length() == 4 && $parts.index(3) == "values"
         let is_full_array = $is_indexed_values && $evt.type() == "array" && $evt.length() >= 9
         root = {

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_mode_buttons_from_knx.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_mode_buttons_from_knx.yaml
@@ -1,10 +1,12 @@
-# Per-mode Lademodus buttons: forwards the three Basalte 1-bit button GAs to
-# the WARP charge mode. Each button GA, when pressed (value true), selects one
-# WARP charge mode via power_manager/charge_mode_update:
-#   knx.15.6.25 Lademodus-PV     -> mode 2 (PV)
-#   knx.15.6.27 Lademodus-PV+Min -> mode 3 (Min+PV)
-#   knx.15.6.29 Lademodus-Schnell-> mode 0 (Schnell)
-# "Aus" (mode 1) is not a button — that is the Freigabe GA (15/6/20).
+# Lademodus buttons: the three Basalte 1-bit button GAs -> WARP charge mode.
+#
+#   knx.15.6.25 Lademodus-PV      -> mode 2 (PV)
+#   knx.15.6.27 Lademodus-PV+Min  -> mode 3 (Min+PV)
+#   knx.15.6.29 Lademodus-Schnell -> mode 0 (Schnell)
+#
+# Each button selects its mode when pressed (value true) via
+# power_manager/charge_mode_update. "Aus" (mode 1) is not a button — that is the
+# Freigabe GA (15/6/20).
 input:
   # Consumer (filterSubjects on the three GAs) is declared as a CRD in
   # nats/base/consumers/warp_mode_buttons_from_knx.yaml.

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_mode_flags.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_mode_flags.yaml
@@ -1,6 +1,9 @@
-# Per-mode status bits: derives one boolean per charge mode from the WARP
-# charge mode and republishes them for the knx-nats-bridge writer, which maps
-# them to the Basalte per-mode status GAs (15/6/26/28/30, DPT 1.011).
+# Per-mode status bits: WARP charge mode -> KNX Lademodus status GAs.
+#
+#   mode 2 (PV)      -> wallbox.knx.mode_flags $.pv    -> knx.15.6.26 (1.011)
+#   mode 3 (Min+PV)  -> wallbox.knx.mode_flags $.pvmin -> knx.15.6.28 (1.011)
+#   mode 0 (Schnell) -> wallbox.knx.mode_flags $.fast  -> knx.15.6.30 (1.011)
+#
 # Exactly one is true; all false when mode is Aus (1). The bridge cannot do
 # enum->bool, so the derivation lives here.
 input:

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_onoff_from_knx.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_onoff_from_knx.yaml
@@ -1,7 +1,9 @@
-# Charge release: forwards the KNX Freigabe GA (15/6/20, DPT 1.001
-# "Versorgungstechnik.Wallbox.Freigabe") to the WARP wallbox as a charge
-# start/stop command — the equivalent of the WARP UI Start/Stop button.
-# true => start_charging (Slot 4 released), false => stop_charging (blocked).
+# Charge release: KNX Freigabe GA -> WARP start/stop charging.
+#
+#   knx.15.6.20 Freigabe (1.001) -> evse/start_charging | stop_charging
+#
+# The equivalent of the WARP UI Start/Stop button: true => start_charging
+# (Slot 4 released), false => stop_charging (blocked).
 input:
   # Consumer is declared as a CRD in nats/base/consumers/warp_onoff_from_knx.yaml.
   nats_jetstream:

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_system.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_system.yaml
@@ -1,3 +1,8 @@
+# WARP wallbox system telemetry -> TimescaleDB + parquet cold archive.
+#
+#   warp.rtc.>   -> warp_system
+#   warp.esp32.> -> warp_system
+#   warp.ntp.>   -> warp_system
 input:
   broker:
     inputs:


### PR DESCRIPTION
Completes the Bordbar integration. The light is a fixed-code 433 MHz PT2262
controller driven by an ESP32+CC1101 running
[bordbar-nats-bridge](https://github.com/alexander-zimmermann/bordbar-nats-bridge),
already connected to the NATS MQTT gateway (#1381). This adds the KNX side.

## Group addresses 4/2/60-68

| GA | DPT | Purpose |
|---|---|---|
| 4/2/60 | 1.003 | Sperren (catalogued, not yet acted on) |
| 4/2/61 | 1.001 | Ein/Aus |
| 4/2/62 | 1.011 | Ein/Aus-Status |
| 4/2/63-66 | 1.007 | Helligkeit / Farbe / Modus / Geschwindigkeit, one step per press |
| 4/2/67 | 1.015 | Reset |
| 4/2/68 | 1.011 | Verbindung-Status |

**1.007 rather than 3.007** for the step GAs: xknx decodes 3.007 into a
dataclass that reaches NATS as its repr string, which the pipeline would have to
parse by regex. 1.007 gives a plain boolean and matches the remote anyway, which
steps once per press rather than ramping.

**Reset** is 1.015, where 0 means "no action" — the pipeline drops those so only
a 1 reboots the device. It exists because the light has no feedback channel and
its power button is a toggle: after someone uses the physical remote, the
firmware's assumption and reality are inverted. Switch the light off by hand,
send reset, and both are off again.

**4/2/68** carries the MQTT last will, so a dead ESP32 is visible instead of a
stale status — the worst failure mode for a device that never reports back.

## Main groups renamed

In ETS, "Beleuchtung Dali" became "Beleuchtung Gebäude" (built in, part of the
electrical installation) and "Beleuchtung Hue" became "Beleuchtung Einrichtung"
(added later, part of the furnishing). A 433 MHz bar cabinet is neither Dali nor
Hue, and the next retrofitted lamp would not have been either. The labels never
reach the catalog, so the rename produces no diff.

## Also included

Stream and consumer comment headers are unified in a separate commit: ten stream
configs had no header at all, the rest ranged from three lines to eighteen, and
consumers called themselves "pipeline", "forwarder" or "archive pipeline"
interchangeably. Every file now leads with a one-line title, then the subject or
GA mapping, then the rationale. Comment lines only; no content dropped.

## Verification

- Bloblang mapping run against sample payloads for all six command GAs,
  including that a reset with value 0 is dropped.
- `connect lint` passes on all 23 streams.
- Catalog validates (2514 entries); all 210 writer-rule GAs resolve, and the
  DPTs of the Bordbar rules and consumer subjects match the catalog.
- All affected overlays render.

Still to prove after merge: a command travelling the full chain from Basalte to
the light, and the status GAs following.

🤖 Generated with [Claude Code](https://claude.com/claude-code)