### PR TITLE
fix(holmesgpt): qualify the operator image with its registry namespace

### DIFF
--- a/kubernetes/applications/holmesgpt/base/values.yaml
+++ b/kubernetes/applications/holmesgpt/base/values.yaml
@@ -75,8 +75,10 @@ toolsets:
 # Phase 2: operator runs ScheduledHealthChecks against the holmes server (read-only)
 operator:
   enabled: true
-  # Pinned back: the 0.37.0 image lacks the holmes package its entrypoint imports (CrashLoop).
-  image: holmes-operator:0.36.0
+  # Pinned back: the 0.37.0/0.38.0 images lack the holmes package their entrypoint imports (CrashLoop).
+  # Registry split off the image so the repository path stays resolvable for dependency lookups.
+  registry: docker.io
+  image: robustadev/holmes-operator:0.36.0
 
 # Custom skills as real .md files (kustomize ConfigMap) — a reusable registry of known-benign
 # log noise so investigations (esp. log-anomaly) don't escalate steady-state patterns.


### PR DESCRIPTION
## Problem

The Renovate dashboard (#106) reports `Failed to look up docker package holmes-operator` for `kubernetes/applications/holmesgpt/base/values.yaml`.

The holmes chart renders the operator image as `"{{ .Values.operator.registry }}/{{ .Values.operator.image }}"`. Our 0.36.0 pin only overrode `image`, leaving a bare `holmes-operator` repository. Renovate's helm-values manager parses that string as a Docker dependency and resolves it against `docker.io/library/holmes-operator`, which does not exist.

## Change

Split the registry off the image so the `image` value keeps a resolvable repository path:

```yaml
operator:
  registry: docker.io
  image: robustadev/holmes-operator:0.36.0
```

`kustomize build --enable-helm` renders `docker.io/robustadev/holmes-operator:0.36.0` — the same image as before, only fully qualified. Renovate now looks up `robustadev/holmes-operator` and resolves it.

## The pin stays

Verified against the images, not just the upstream issue:

| tag | `python -c "import holmes_operator.operator"` |
| --- | --- |
| 0.36.0 | ok |
| 0.38.0 | `ModuleNotFoundError: No module named 'holmes'` |

`operator.py` imports `holmes.common.env_vars`, and the package is still absent from the image, so [holmesgpt#2326](https://github.com/HolmesGPT/holmesgpt/issues/2326) applies to 0.38.0 as well as 0.37.0. The comment was updated accordingly.

## Notes

- The operator pod rolls once on sync (image string changed, same digest).
- Renovate will now propose `0.36.0 → 0.38.0`. That PR should be closed, not merged. It does not match the automerge allowlist, so it cannot land on its own — and it gives us the signal to re-test once upstream fixes the image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)