### PR TITLE
fix(authentik): cap the database connection limit to fit its memory limit

### DIFF
--- a/kubernetes/applications/authentik/base/database.yaml
+++ b/kubernetes/applications/authentik/base/database.yaml
@@ -38,6 +38,9 @@ spec:
 
   postgresql:
     parameters:
+      # Connection limit sized to fit the container memory limit
+      max_connections: "50"
+
       # Memory settings
       shared_buffers: "128MB"
       effective_cache_size: "512MB"


### PR DESCRIPTION
## Problem

The `authentik-db` primary was OOM-killed (exit 137) on 2026-07-31 at 17:46:59 UTC. The cluster recovered on its own — crash recovery completed in about a second and no failover was needed — but the configuration that allowed it is still in place.

`max_connections` was unset in the Cluster manifest and therefore defaulted to CNPG's **100**, while the container memory limit is **512Mi**. Those two numbers are incompatible:

| Item | |
|---|---|
| 100 backends × ~4.5 MiB private memory | ~446 MiB |
| Postmaster + CNPG instance manager + aux processes | ~116 MiB |
| `shared_buffers` | 128 MiB |
| **Worst case** | **~691 MiB vs. a 512Mi limit** |

Saturating the connection limit was therefore guaranteed to exceed the cgroup limit. Because containerd sets `memory.oom.group=1`, the kernel killed all 110 tasks in the cgroup including the postmaster, taking the entire instance down instead of a single backend.

## What triggered it

A crawler swarm (GPTBot, ClaudeBot, PerplexityBot, Bytespider, CCBot, meta-externalagent, DeepSeekBot, OAI-SearchBot, CensysInspect and others) hit the forward-auth protected `proxmox.zimmermann.sh` at 53 req/s. Every unauthenticated request produces a 302 into `/application/o/authorize/`, and every authorize flow creates a session row and thus a new Postgres backend. Backends went from 11 to the ceiling in roughly nine seconds.

The kernel OOM report confirms the composition at kill time: 88 freshly forked backends (PIDs 198972–199484) accounting for 392.4 MiB, with total anonymous memory at 510.8 MiB against the 524288 kB limit.

## Change

Cap `max_connections` at 50, which bounds the worst case to ~469 MiB and fits inside the existing limit. Connection exhaustion now surfaces as `too many clients` rather than destroying the instance.

## Notes

- `max_connections` is a postmaster parameter, so CNPG performs a rolling restart on sync: replica first, then switchover/restart of the primary. Expect a brief authentik interruption.
- The memory limit is deliberately left at 512Mi.
- This bounds the blast radius but does not remove the amplifier — each bot hit still costs a full OIDC flow and a database session. Blocking AI crawlers ahead of the forward-auth middleware is tracked separately.
- Worst-case headroom is ~45 MiB. Since `work_mem` is 8MB, a backend under real query load can exceed the measured 4.5 MiB. Reducing `shared_buffers` from 128MB to 64MB would free another 64 MiB if more margin is wanted later; the database is only 157 MB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)