### PR TITLE
fix(rustfs): enable mimalloc reclaim to stop RSS ratcheting into OOM

### DIFF
--- a/kubernetes/applications/rustfs/base/values.yaml
+++ b/kubernetes/applications/rustfs/base/values.yaml
@@ -58,3 +58,7 @@ extraEnv:
     value: "10"
   - name: RUSTFS_DRIVE_ACTIVE_CHECK_TIMEOUT_SECS
     value: "30"
+  # Periodic mi_collect — without it mimalloc never returns freed pages and RSS
+  # ratchets into the memory limit. Upstream's run.sh enables it, the image does not.
+  - name: RUSTFS_ALLOCATOR_RECLAIM_ENABLED
+    value: "true"


### PR DESCRIPTION
## Problem

`rustfs` was OOMKilled twice within 44h against its 1Gi limit (exit 137, last on 2026-08-01 06:34:48 UTC).

The growth is **allocator retention, not workload**. Splitting the cgroup counters over the night before the kill (MiB):

```
                  23:00  01:00  02:00  03:00  04:00  05:00  05:30  06:30
cgroup_anon         411    399    374    659    736    844    965    904
cgroup_file         498    439    440    314    174    124     19     69
allocator_committed 735    767    767   1892   1936   2012   2012   2012
```

Anon memory climbs monotonically, the kernel squeezes out page cache (498 → 19 MiB), then the OOM killer fires. Meanwhile there was no S3 load at all — `container_network_{receive,transmit}_bytes` flat at ~20 KiB/s and 1 HTTP req/s (health checks only), so the nightly CNPG/Longhorn backup window is not the trigger.

## Cause

rustfs uses mimalloc and only returns freed pages to the OS via a periodic `mi_collect()`, gated by `RUSTFS_ALLOCATOR_RECLAIM_ENABLED`. Upstream's default is off:

```rust
// crates/config/src/constants/runtime.rs
pub const DEFAULT_ALLOCATOR_RECLAIM_ENABLED: bool = false;
```

Upstream compensates in its start script:

```sh
# scripts/run.sh
if [ -z "${RUSTFS_ALLOCATOR_RECLAIM_ENABLED+x}" ]; then
    export RUSTFS_ALLOCATOR_RECLAIM_ENABLED=true
fi
```

The container image starts `/usr/bin/rustfs` directly and never sources that script, so we ran with reclaim disabled. Confirmed live: `rustfs_memory_allocator_reclaim_enabled = 0`. With the scanner cycling every 60s over ~7k objects, the allocation churn inflates the mimalloc heap and nothing is ever given back — RSS ratchets from ~350 MiB after a restart to ~950 MiB within 1–2 days.

## Change

Set `RUSTFS_ALLOCATOR_RECLAIM_ENABLED=true` in `extraEnv`. The remaining reclaim defaults are fine (30s interval, force, 3 idle intervals).

The memory limit deliberately stays at 1Gi — raising it would only delay the ratchet and mask the diagnosis. If anon memory keeps rising with reclaim active, it is a genuine leak in beta.12 and belongs upstream.

## Verification after sync

```
kubectl exec -n rustfs deploy/rustfs -c rustfs -- env | grep ALLOCATOR
```

Then watch `rustfs_memory_allocator_reclaim_enabled` (expect `1`) and `max(rustfs_memory_cgroup_anon_bytes)` over the next two nights — expected to stay around 350–450 MiB instead of climbing to 950.

🤖 Generated with [Claude Code](https://claude.com/claude-code)