### PR TITLE
docs(holmesgpt): catalog prometheus-operator webhook & Loki cache-store noise

### DIFF
--- a/kubernetes/applications/holmesgpt/base/skills/known-log-noise/SKILL.md
+++ b/kubernetes/applications/holmesgpt/base/skills/known-log-noise/SKILL.md
@@ -41,6 +41,24 @@ false alarms on patterns that look like failures but are normal in this cluster.
   restarts; `/readyz` passes. A real fault instead shows `connection refused` /
   `context deadline exceeded`, etcd alarms, or raft lag, and the cluster degrades.
 
+### kube-apiserver → prometheus-operator admission webhook, "failing open"
+- Pattern: `Failed calling webhook, failing open prometheusrulemutate.monitoring.coreos.com:
+  ... Post "https://prometheus-operator.prometheus.svc:443/admission-prometheusrules/mutate?timeout=10s":
+  context deadline exceeded` (or `connect: connection refused`), W-level from
+  `dispatcher.go:210`, each one echoed as an E-level `dispatcher.go:214
+  "Unhandled Error"`. Short bursts of seconds on one kube-apiserver pod, not continuous.
+- Why benign: the three `prometheus-admission` webhooks are `failurePolicy: Ignore`,
+  and the apiserver states the outcome itself — "failing open". prometheus-operator
+  runs a single replica, so while it restarts (chart upgrade, node drain, eviction)
+  its Service has no endpoint and in-flight PrometheusRule / AlertmanagerConfig
+  admissions time out. The object is still admitted; nothing is rejected or lost.
+- Confirm still benign: the bursts coincide with a prometheus-operator restart or
+  rollout (recent `startedAt` / Unhealthy event on
+  `-n prometheus -l app.kubernetes.io/name=prometheus-operator`) and stopped once it
+  went Ready; PrometheusRules still reconcile. A real fault instead keeps erroring
+  while the operator is stable and Ready (Service/NetworkPolicy/serving-cert problem),
+  CrashLoops the operator, or leaves rules never reaching Prometheus.
+
 ### Transient readiness/liveness probe failures during a rollout
 - Pattern: `Readiness probe failed: ... context deadline exceeded` or
   `Liveness/Readiness probe failed: ... connect: connection refused`, clustered
@@ -111,6 +129,24 @@ false alarms on patterns that look like failures but are normal in this cluster.
   answer normally). A real fault instead shows client-facing 5xx/timeouts,
   `panic`, rejected writes (`too many outstanding requests`), or the pod
   CrashLooping.
+
+### Loki results-cache "SERVER_ERROR out of memory storing object"
+- Pattern: `caller=background.go:202 msg="backgroundCache writeBackLoop Cache.Store fail"
+  err="server=<ip>:11211: memcache: unexpected response line from \"set\":
+  \"SERVER_ERROR out of memory storing object\""`, **warn**-level, from `loki-0`
+  (loki namespace), a few hundred lines per day, arriving in short bursts roughly
+  hourly rather than continuously.
+- Why benign: `loki-results-cache` is a deliberately fixed-size memcached (`-m 256`
+  in a 307Mi pod, max item size `-I 5m`). When the matching slab class holds nothing
+  evictable, memcached refuses the `set`. This is the asynchronous write-back path —
+  the query result has already been returned to the client, so a refused store only
+  means the next identical query is a cache miss served from the object store.
+  Nothing fails and nothing is lost.
+- Confirm still benign: the lines are warn-level and on the write-back path
+  (`background.go` / `Cache.Store fail`), `loki-0` and `loki-results-cache-0` are
+  Running with no restarts or OOMKills, and queries still return normally. A real
+  fault instead shows the memcached pod OOMKilled/CrashLooping, cache errors on the
+  read path or at error level, or client-facing query 5xx/timeouts.
 
 ## Synthesize findings
 


### PR DESCRIPTION
## Context

The nightly `log-anomaly` check flagged four patterns. Three were non-incidents, two of which are not yet in the `known-log-noise` catalog and cost the check real effort every night. This adds them.

(The fourth, a `crowdsec-agent` Go map-race panic, is deliberately **not** cataloged — it is a genuine upstream bug, [crowdsecurity/crowdsec#4459](https://github.com/crowdsecurity/crowdsec/issues/4459), still open and reproduced on our v1.7.8.)

## Entries

**kube-apiserver → prometheus-operator admission webhook**
All three `prometheus-admission` webhooks are `failurePolicy: Ignore`, verified in-cluster, and the apiserver states the outcome itself: `Failed calling webhook, failing open`. It then echoes each W-level line as an E-level `"Unhandled Error"`, which is what makes it look like a failure. Bursts only span a restart of the single-replica prometheus-operator; the object is admitted either way.

**Loki results-cache `SERVER_ERROR out of memory storing object`**
Warn-level, from the asynchronous write-back path (`background.go:202`, `backgroundCache writeBackLoop Cache.Store fail`). `loki-results-cache` is a deliberately fixed-size memcached (`-m 256` in a 307Mi pod, `-I 5m`); when the matching slab class holds nothing evictable, memcached refuses the `set`. The query result was already returned — a refused store only costs the next identical query a cache miss.

## Verification

Both patterns were taken from live cluster state, not reconstructed from the check's summary:

- webhook `failurePolicy` and Service target read from the live `ValidatingWebhookConfiguration`/`MutatingWebhookConfiguration`
- Loki line and rate queried against the Loki API: **485 occurrences / 24h**, hourly bursts, `loki-0` and `loki-results-cache-0` both `Running` with 0 restarts

Each entry carries a **Confirm** check in the established style, so a coinciding real fault (operator CrashLooping with the errors persisting; memcached OOMKilled or read-path errors) still escalates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)