### PR TITLE
fix(rustfs): disable object data cache to stop beta.9 memory regression

### DIFF
--- a/kubernetes/applications/rustfs/base/values.yaml
+++ b/kubernetes/applications/rustfs/base/values.yaml
@@ -62,3 +62,7 @@ extraEnv:
   # ratchets into the memory limit. Upstream's run.sh enables it, the image does not.
   - name: RUSTFS_ALLOCATOR_RECLAIM_ENABLED
     value: "true"
+  # Object data cache budgets itself from host RAM, not the cgroup limit, and holds
+  # ~300 MiB that no allocator reclaim can return. Off until upstream bounds it.
+  - name: RUSTFS_OBJECT_DATA_CACHE_ENABLE
+    value: "false"


### PR DESCRIPTION
## Regression, not under-provisioning

`1.0.0-beta.8` ran six weeks flat at 270–350 MiB against the same 1Gi limit. The `beta.11` rollout pushed it to 662 MiB within hours and produced daily OOMKills; `beta.12` behaves identically.

| Image | Period | Memory |
|---|---|---|
| `1.0.0-beta.8` | 2026-06-12 → 07-25 20:10Z | 270–350 MiB, flat |
| `1.0.0-beta.11` | 07-25 20:10Z → 07-30 | jumps to 662 MiB, then ratchets |
| `1.0.0-beta.12` | since 07-30 | unchanged |

Dated from `kube_pod_container_info` plus the ReplicaSet history. This matches open upstream issue [rustfs#4917](https://github.com/rustfs/rustfs/issues/4917) ("load increasing after upgrading to beta9/beta10"), reported 2026-07-16.

## Mechanism

The beta.9 release notes introduce the object data cache ("bounded memory admission"). It budgets itself via `RUSTFS_OBJECT_DATA_CACHE_MAX_MEMORY_PERCENT` of **host RAM** (9.7 GiB node), not the 1Gi cgroup limit — `rustfs_memory_total_bytes` reports 9.7 GiB, so the process believes it has ample headroom.

Last night's OOM shows the fingerprint. Tiny S3 bursts produce enormous heap growth:

```
                 00:55  01:00  01:05  01:10   ...   02:00  02:05  02:10  02:15
anon MiB           290    340    452    541          493    756    944    969 → OOM
net TX KiB/s        23      4    413     20            4     13     23      4
http reqs/s          1      1     16      1            1      1      1      1
```

- 01:00–01:01Z `nats-archive-compaction` (69s, ~400 KiB/s) → **+200 MiB**
- 02:00–02:16Z authentik CNPG backup (15s, ~72 KiB/s) → **+400 MiB**, straight into the kill

Meanwhile the timescaledb backup at 03:00Z — 6.8 MiB/s for eight minutes, orders of magnitude more data — moves memory not at all. That is what a per-entry cache ceiling looks like: small objects are admitted and retained, large backup blobs bypass the cache. The step persists for 18h and `mi_collect` cannot return it, because it is live memory rather than allocator residue.

## Change

`RUSTFS_OBJECT_DATA_CACHE_ENABLE=false` — an upstream-provided switch, fully reversible.

The memory limit deliberately stays at 1Gi. It was demonstrably sufficient for six weeks on beta.8, so raising it would mask a version regression rather than fix it.

This builds on #1392 (mimalloc reclaim), which removed a separate defect — the continuous ~150 MiB/day ratchet — but not this one.

## Verification

- `rustfs_object_data_cache_invalidations_total` must stop rising
- `max(rustfs_memory_cgroup_anon_bytes)` across 01:00–02:30 UTC must stay at the 250–420 MiB baseline instead of stepping to ~700–950

If the step persists, the remaining beta.9 candidate is the io_uring read path, and the fallback is a rollback to beta.8 — on-disk format compatibility for that downgrade is not yet verified.

Measurements will be added to rustfs#4917 either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)