### PR TITLE
docs(holmesgpt): catalog rustfs deleted-objects GC ESTALE/ENOENT noise

### DIFF
--- a/kubernetes/applications/holmesgpt/base/skills/known-log-noise/SKILL.md
+++ b/kubernetes/applications/holmesgpt/base/skills/known-log-noise/SKILL.md
@@ -148,6 +148,30 @@ false alarms on patterns that look like failures but are normal in this cluster.
   fault instead shows the memcached pod OOMKilled/CrashLooping, cache errors on the
   read path or at error level, or client-facing query 5xx/timeouts.
 
+### rustfs `disk_local_background_cleanup` ESTALE / NotFound on `deleted_objects`
+- Pattern: `{"level":"ERROR","message":"Disk local background cleanup failed",
+  "event":"disk_local_background_cleanup","subsystem":"disk_local",
+  "task":"deleted_objects","error":"Io(Os { code: 116, kind: StaleNetworkFileHandle`
+  — and the same line with `code: 2, kind: NotFound` — from the single `rustfs`
+  pod, a handful of lines per day on a roughly hourly GC pass.
+- Why benign: the deleted-objects GC races other paths (scanner, heal, an earlier
+  GC pass) that already removed the entry. On the NFS-backed PVC a handle to a
+  file the server has already unlinked returns ESTALE; when the lookup instead
+  happens after the dentry is gone, the same race returns ENOENT. Two errno values
+  alternating on one task is that race — a genuinely stale mount fails
+  consistently, not a subset of passes. The removal is idempotent, so nothing is
+  left behind.
+- Confirm still benign: the mount is usable — `kubectl exec -n rustfs
+  deploy/rustfs -c rustfs -- stat -f /data` reports type nfs with free blocks, and
+  touch/rm under `/data` succeed — drive health is intact
+  (`rustfs_cluster_health_drives_offline_count` 0,
+  `rustfs_cluster_erasure_set_{read,write}_health` 1), and the nightly CNPG
+  backups complete. Restarts on this pod are OOMKills from the tracked memory
+  regression, so check `lastState.terminated.reason` before reading them as
+  storage trouble. A real fault instead shows drives going offline/FaultyDisk,
+  `InsufficientWriteQuorum` or 5xx on the S3 path, ESTALE on the read/write paths
+  rather than only the GC task, or errors on every pass.
+
 ## Synthesize findings
 
 - Matched + Confirm passes → report the pattern as expected steady-state noise;


### PR DESCRIPTION
## Why

A scheduled log-anomaly check (`log-anomaly-20260806-000200-d18bef`) failed on rustfs, reporting a *"persistent storage fault"* from `disk_local_background_cleanup` occurring *"on every periodic run"*. Neither holds up.

| Claim in the check | Measurement |
|---|---|
| "on every periodic run" | 7 lines in 24h on a roughly hourly GC pass — a minority of runs |
| "mount is no longer valid" | `stat -f /data` → type nfs, 7.0M blocks free; `touch` + `rm` under `/data` succeed |
| "2 restarts confirm the fault persists" | Both are `exitCode: 137` OOMKills from the tracked beta.9 memory regression |

Those 7 lines are also the *entire* log output of the pod in that window.

## What it actually is

Two errno values alternate on the same task — 4× `StaleNetworkFileHandle` (116) and 3× `NotFound` (2). That combination is a delete race, not a dead mount: the deleted-objects GC touches an entry another path (scanner, heal, an earlier GC pass) already removed. On NFS a handle to an already-unlinked file returns ESTALE; when the lookup instead happens after the dentry is gone, the same race returns ENOENT. A genuinely stale mount fails consistently, on every path, not on a subset of GC passes. The removal is idempotent, so nothing is left behind.

Supporting state: `rustfs_cluster_health_drives_offline_count` 0, `rustfs_cluster_erasure_set_{read,write}_health` 1, and the nightly CNPG backups complete.

## Change

New catalog entry with the usual Pattern / Why benign / Confirm structure. The Confirm bullet also tells the check to read `lastState.terminated.reason` before treating restarts on this pod as storage trouble — that was the specific misattribution here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)