### PR TITLE
chore(rustfs): raise log level to info to verify object-data-cache mode

### DIFF
--- a/kubernetes/applications/rustfs/base/values.yaml
+++ b/kubernetes/applications/rustfs/base/values.yaml
@@ -15,8 +15,9 @@ config:
   rustfs:
     # Service DNS used for internal access.
     server_domains: rustfs-svc.rustfs.svc.cluster.local
-    # Set log level to error to suppress verbose tracing warnings
-    log_level: "error"
+    # Temporarily raised from error: the resolved object-data-cache mode is only
+    # reported by an info-level line at startup. Revert once captured.
+    log_level: "info"
     # OTLP push to Alloy. metrics.endpoint must be set explicitly — the chart
     # does not derive it from base_endpoint.
     obs_endpoint:


### PR DESCRIPTION
## Where we are

#1409 disabled the object data cache. It did not change the memory behaviour:

```
08-03 14:00 → 08-04 02:00    239–410 MiB    ← 12h clean after rollout
08-04 03:00                     722 MiB     ← step
08-04 → 08-06 14:00          690–775 MiB    ← plateau, still holding
```

Two OOMKills followed on 08-05 at 01:30Z and 02:45Z. Since then it has run 60h without a kill, but parked at ~750 of 1024 MiB with no headroom.

## Why this PR

Whether that falsifies the object-data-cache hypothesis or the switch never took effect is currently undecidable from telemetry.

`rustfs_object_data_cache_invalidations_total` keeps rising, but that proves nothing either way — the engine-level `invalidate_object` / `invalidate_prefix` / `invalidate_bucket` calls fire on the write path regardless of the cache mode. (I initially misread that counter as evidence the switch had failed; it is not.)

The code path itself reads unambiguously — `get_env_opt_bool` accepts `false`, and `Some(false)` sets `mode = ObjectDataCacheMode::Disabled` — and `RUSTFS_OBJECT_DATA_CACHE_ENABLE=false` is confirmed present in the pod. But the only *direct* signal is an info-level line emitted at startup:

```rust
tracing::info!(source, ?mode, "object data cache enabled");   // only when NOT disabled
```

and `log_level: error` swallows it.

## Change

`log_level: error → info`, **temporary**. After the rollout:

```bash
kubectl logs -n rustfs deploy/rustfs -c rustfs | grep -i "object data cache"
```

- Line present with a `mode` → the switch was ineffective, hypothesis untested.
- Line absent → the cache really is disabled and is ruled out as the cause.

Then revert to `error`.

Worth one restart because the next step is expensive: the remaining beta.9 candidate is the io_uring read path, and after that a rollback to beta.8 — a downgrade across four beta releases on the store holding our CNPG backups, whose on-disk format compatibility is still unverified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)