### PR TITLE
fix(grafana): bound wallbox stat-panel queries to 30 days

### DIFF
--- a/kubernetes/applications/grafana/base/dashboards/energy-wallbox.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/energy-wallbox.yaml
@@ -135,7 +135,7 @@ spec:
               "editorMode": "code",
               "format": "time_series",
               "rawQuery": true,
-              "rawSql": "SELECT time, charger_state AS \"Ladecontroller\" FROM warp_evse WHERE charger_state IS NOT NULL ORDER BY time DESC LIMIT 1;",
+              "rawSql": "SELECT time, charger_state AS \"Ladecontroller\" FROM warp_evse WHERE time > now() - INTERVAL '30 days' AND charger_state IS NOT NULL ORDER BY time DESC LIMIT 1;",
               "refId": "A"
             }
           ],
@@ -230,7 +230,7 @@ spec:
               "editorMode": "code",
               "format": "time_series",
               "rawQuery": true,
-              "rawSql": "SELECT time, error_state AS \"Fehlerzustand\" FROM warp_evse WHERE error_state IS NOT NULL ORDER BY time DESC LIMIT 1;",
+              "rawSql": "SELECT time, error_state AS \"Fehlerzustand\" FROM warp_evse WHERE time > now() - INTERVAL '30 days' AND error_state IS NOT NULL ORDER BY time DESC LIMIT 1;",
               "refId": "A"
             }
           ],
@@ -601,7 +601,7 @@ spec:
               "editorMode": "code",
               "format": "time_series",
               "rawQuery": true,
-              "rawSql": "SELECT time, dc_fault_current_state AS \"DC-Fehler\" FROM warp_evse WHERE dc_fault_current_state IS NOT NULL ORDER BY time DESC LIMIT 1;",
+              "rawSql": "SELECT time, dc_fault_current_state AS \"DC-Fehler\" FROM warp_evse WHERE time > now() - INTERVAL '30 days' AND dc_fault_current_state IS NOT NULL ORDER BY time DESC LIMIT 1;",
               "refId": "A"
             }
           ],
@@ -740,7 +740,7 @@ spec:
               "editorMode": "code",
               "format": "time_series",
               "rawQuery": true,
-              "rawSql": "SELECT time, contactor_error AS \"Schützfehler\" FROM warp_evse WHERE contactor_error IS NOT NULL ORDER BY time DESC LIMIT 1;",
+              "rawSql": "SELECT time, contactor_error AS \"Schützfehler\" FROM warp_evse WHERE time > now() - INTERVAL '30 days' AND contactor_error IS NOT NULL ORDER BY time DESC LIMIT 1;",
               "refId": "A"
             }
           ],
@@ -817,7 +817,7 @@ spec:
               "editorMode": "code",
               "format": "time_series",
               "rawQuery": true,
-              "rawSql": "SELECT time, tracked_charges AS \"Ladevorgänge Gesamt\" FROM warp_charge_tracker WHERE tracked_charges IS NOT NULL ORDER BY time DESC LIMIT 1;",
+              "rawSql": "SELECT time, tracked_charges AS \"Ladevorgänge Gesamt\" FROM warp_charge_tracker WHERE time > now() - INTERVAL '30 days' AND tracked_charges IS NOT NULL ORDER BY time DESC LIMIT 1;",
               "refId": "A"
             }
           ],


### PR DESCRIPTION
## Why

`timescaledb-db-1` was OOMKilled (exit 137) on 2026-08-06 20:45:07 UTC against its 1Gi limit. The cause was not load or a leak, but per-backend relcache bloat driven by this dashboard.

Five stat panels queried `warp_evse` and `warp_charge_tracker` with `ORDER BY time DESC LIMIT 1` and **no time filter**. Both hypertables are fully compressed columnstore (309 and 282 chunks). Without a bound on the partitioning column, constraint exclusion cannot prune anything, so the planner opens every chunk relation on every dashboard load. That relcache lives in `CacheMemoryContext` and is only released when the connection closes — and the Grafana datasource keeps `maxIdleConns: 5` with `connMaxLifetime: 14400`, so five idle backends held it for up to 4 hours.

Timeline from the incident:

| Time (UTC) | Event | Container RSS |
|---|---|---|
| until 20:39 | idle | 48 MiB |
| 20:39:53 | wallbox dashboard opened | |
| 20:40:00 | panel queries, wave 1 | 48 → 435 MiB |
| 20:41:30 | panel queries, wave 2 | 435 → 651 MiB |
| 20:41–20:44 | 5 idle `grafana_ro` backends, memory never released | 651 MiB |
| 20:45:00 | hourly CAgg refreshes + three `*/15` insights-engine cronjobs | |
| 20:45:07 | **OOM kill** | |

`container_memory_rss` rose while `container_memory_cache` was reclaimed (745 → 338 MiB), confirming a real anonymous allocation rather than page cache.

## What

Adds `time > now() - INTERVAL '30 days'` to the five unbounded stat-panel queries. This restores chunk pruning: **309 chunks planned → 28**.

## Window sizing, and what it changes

These panels use the "last known non-null value" idiom. The four `warp_evse` columns are populated only by `sub_topic = 'evse.state'`, which is roughly 290x rarer than the `evse.low_level_state` rows that dominate the table, so the lookback can legitimately reach back a long way.

A bound therefore changes semantics: if the wallbox produces no state for longer than the window, these panels go empty instead of showing an old value.

30 days was chosen deliberately:

- The largest gap in non-null `warp_evse` readings over the last 180 days was **8d22h** (p99: 3 minutes).
- That gap class is caused by the wallbox physically losing power (a tripped breaker caused a multi-day gap in early August), so it is not bounded by anything in the data pipeline and could in principle exceed 30 days.
- Blanking is the better failure mode here: four of the five panels are fault indicators (`Fehlerzustand`, `DC-Fehler`, `Schützfehler`). Rendering a stale "no fault" from six weeks ago while the wallbox is dead would be actively misleading, whereas an empty panel is a signal.

## Verification

All five rewritten queries were run against the live database and return a row, in 5–250 ms. The embedded dashboard JSON parses and all 22 panels are intact.

## Not in scope

- Adding `sub_topic = 'evse.state'` to the four `warp_evse` panels would cut the rows scanned at execution time by ~290x. It is orthogonal to this fix (it does not affect chunk pruning, which is what caused the OOM) and is left for a follow-up.
- The "Fehlerstatus über Zeit" panel still has three fallback subqueries with an upper bound but no lower bound (`time < now() - INTERVAL '12 hours' ORDER BY time DESC LIMIT 1`); they defeat pruning by the same mechanism.
- Datasource pool tuning (`maxIdleConns`, `connMaxLifetime`), raising the 1Gi limit, and enabling `log_min_duration_statement` / `log_temp_files` were deliberately left out — both logging knobs are currently `-1`, which is why nothing about these queries appears in the PostgreSQL log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)