### PR TITLE
chore(rustfs): restore log level to error after cache-mode check

### DIFF
--- a/kubernetes/applications/rustfs/base/values.yaml
+++ b/kubernetes/applications/rustfs/base/values.yaml
@@ -15,9 +15,8 @@ config:
   rustfs:
     # Service DNS used for internal access.
     server_domains: rustfs-svc.rustfs.svc.cluster.local
-    # Temporarily raised from error: the resolved object-data-cache mode is only
-    # reported by an info-level line at startup. Revert once captured.
-    log_level: "info"
+    # Keep at error: rustfs at info floods the Loki PVC.
+    log_level: "error"
     # OTLP push to Alloy. metrics.endpoint must be set explicitly — the chart
     # does not derive it from base_endpoint.
     obs_endpoint:


### PR DESCRIPTION
Closes the temporary info-level window opened by #1422.

rustfs at `info` produces enough log volume to fill the 5Gi Loki PVC — that has happened before, so the level is not one to leave in place. The comment now states that instead of describing the one-off diagnostic.

**Merge as soon as the startup line has been read.** Loki baseline at the start of the window: 1.39 GiB used, 3.43 GiB free (28.8%).

Verification the window exists for:

```bash
kubectl logs -n rustfs deploy/rustfs -c rustfs | grep -i "object data cache"
```

- Line present with a `mode` → `RUSTFS_OBJECT_DATA_CACHE_ENABLE=false` was ineffective and the hypothesis is still untested.
- Line absent → the cache is genuinely disabled and is ruled out as the cause of the memory step, leaving the io_uring read path as the last beta.9 candidate before a rollback to beta.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)