### PR TITLE
fix(grafana): restore chunk pruning on wallbox fault-status panel

### DIFF
--- a/kubernetes/applications/grafana/base/dashboards/energy-wallbox.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/energy-wallbox.yaml
@@ -135,7 +135,7 @@ spec:
               "editorMode": "code",
               "format": "time_series",
               "rawQuery": true,
-              "rawSql": "SELECT time, charger_state AS \"Ladecontroller\" FROM warp_evse WHERE time > now() - INTERVAL '30 days' AND charger_state IS NOT NULL ORDER BY time DESC LIMIT 1;",
+              "rawSql": "SELECT time, charger_state AS \"Ladecontroller\" FROM warp_evse WHERE time > now() - INTERVAL '30 days' AND sub_topic = 'evse.state' AND charger_state IS NOT NULL ORDER BY time DESC LIMIT 1;",
               "refId": "A"
             }
           ],
@@ -230,7 +230,7 @@ spec:
               "editorMode": "code",
               "format": "time_series",
               "rawQuery": true,
-              "rawSql": "SELECT time, error_state AS \"Fehlerzustand\" FROM warp_evse WHERE time > now() - INTERVAL '30 days' AND error_state IS NOT NULL ORDER BY time DESC LIMIT 1;",
+              "rawSql": "SELECT time, error_state AS \"Fehlerzustand\" FROM warp_evse WHERE time > now() - INTERVAL '30 days' AND sub_topic = 'evse.state' AND error_state IS NOT NULL ORDER BY time DESC LIMIT 1;",
               "refId": "A"
             }
           ],
@@ -495,7 +495,7 @@ spec:
               "editorMode": "code",
               "format": "time_series",
               "rawQuery": true,
-              "rawSql": "WITH bucketed AS (SELECT time_bucket_gapfill('1 hour', time, date_trunc('hour', now()) - INTERVAL '12 hours', date_trunc('hour', now())) AS b, last(error_state, time) FILTER (WHERE error_state IS NOT NULL) AS es, last(contactor_error, time) FILTER (WHERE contactor_error IS NOT NULL) AS ce, last(dc_fault_current_state, time) FILTER (WHERE dc_fault_current_state IS NOT NULL) AS dc FROM warp_evse WHERE time >= date_trunc('hour', now()) - INTERVAL '12 hours' AND time < date_trunc('hour', now()) GROUP BY 1), grouped AS (SELECT b, es, ce, dc, count(es) OVER (ORDER BY b) AS es_grp, count(ce) OVER (ORDER BY b) AS ce_grp, count(dc) OVER (ORDER BY b) AS dc_grp FROM bucketed) SELECT b AS time, coalesce(first_value(es) OVER (PARTITION BY es_grp ORDER BY b), (SELECT error_state FROM warp_evse WHERE error_state IS NOT NULL AND time < date_trunc('hour', now()) - INTERVAL '12 hours' ORDER BY time DESC LIMIT 1)) AS error_state, coalesce(first_value(ce) OVER (PARTITION BY ce_grp ORDER BY b), (SELECT contactor_error FROM warp_evse WHERE contactor_error IS NOT NULL AND time < date_trunc('hour', now()) - INTERVAL '12 hours' ORDER BY time DESC LIMIT 1)) AS contactor_error, coalesce(first_value(dc) OVER (PARTITION BY dc_grp ORDER BY b), (SELECT dc_fault_current_state FROM warp_evse WHERE dc_fault_current_state IS NOT NULL AND time < date_trunc('hour', now()) - INTERVAL '12 hours' ORDER BY time DESC LIMIT 1)) AS dc_fault_current_state FROM grouped ORDER BY b;",
+              "rawSql": "WITH bucketed AS (SELECT time_bucket_gapfill('1 hour', time, date_trunc('hour', now()) - INTERVAL '12 hours', date_trunc('hour', now())) AS b, last(error_state, time) FILTER (WHERE error_state IS NOT NULL) AS es, last(contactor_error, time) FILTER (WHERE contactor_error IS NOT NULL) AS ce, last(dc_fault_current_state, time) FILTER (WHERE dc_fault_current_state IS NOT NULL) AS dc FROM warp_evse WHERE sub_topic = 'evse.state' AND time >= date_trunc('hour', now()) - INTERVAL '12 hours' AND time < date_trunc('hour', now()) GROUP BY 1), grouped AS (SELECT b, es, ce, dc, count(es) OVER (ORDER BY b) AS es_grp, count(ce) OVER (ORDER BY b) AS ce_grp, count(dc) OVER (ORDER BY b) AS dc_grp FROM bucketed) SELECT b AS time, coalesce(first_value(es) OVER (PARTITION BY es_grp ORDER BY b), (SELECT error_state FROM warp_evse WHERE sub_topic = 'evse.state' AND error_state IS NOT NULL AND time >= now() - INTERVAL '30 days' AND time < date_trunc('hour', now()) - INTERVAL '12 hours' ORDER BY time DESC LIMIT 1)) AS error_state, coalesce(first_value(ce) OVER (PARTITION BY ce_grp ORDER BY b), (SELECT contactor_error FROM warp_evse WHERE sub_topic = 'evse.state' AND contactor_error IS NOT NULL AND time >= now() - INTERVAL '30 days' AND time < date_trunc('hour', now()) - INTERVAL '12 hours' ORDER BY time DESC LIMIT 1)) AS contactor_error, coalesce(first_value(dc) OVER (PARTITION BY dc_grp ORDER BY b), (SELECT dc_fault_current_state FROM warp_evse WHERE sub_topic = 'evse.state' AND dc_fault_current_state IS NOT NULL AND time >= now() - INTERVAL '30 days' AND time < date_trunc('hour', now()) - INTERVAL '12 hours' ORDER BY time DESC LIMIT 1)) AS dc_fault_current_state FROM grouped ORDER BY b;",
               "refId": "A"
             }
           ],
@@ -601,7 +601,7 @@ spec:
               "editorMode": "code",
               "format": "time_series",
               "rawQuery": true,
-              "rawSql": "SELECT time, dc_fault_current_state AS \"DC-Fehler\" FROM warp_evse WHERE time > now() - INTERVAL '30 days' AND dc_fault_current_state IS NOT NULL ORDER BY time DESC LIMIT 1;",
+              "rawSql": "SELECT time, dc_fault_current_state AS \"DC-Fehler\" FROM warp_evse WHERE time > now() - INTERVAL '30 days' AND sub_topic = 'evse.state' AND dc_fault_current_state IS NOT NULL ORDER BY time DESC LIMIT 1;",
               "refId": "A"
             }
           ],
@@ -740,7 +740,7 @@ spec:
               "editorMode": "code",
               "format": "time_series",
               "rawQuery": true,
-              "rawSql": "SELECT time, contactor_error AS \"Schützfehler\" FROM warp_evse WHERE time > now() - INTERVAL '30 days' AND contactor_error IS NOT NULL ORDER BY time DESC LIMIT 1;",
+              "rawSql": "SELECT time, contactor_error AS \"Schützfehler\" FROM warp_evse WHERE time > now() - INTERVAL '30 days' AND sub_topic = 'evse.state' AND contactor_error IS NOT NULL ORDER BY time DESC LIMIT 1;",
               "refId": "A"
             }
           ],


### PR DESCRIPTION
Follow-up to #1423.

## Why this is needed

#1423 did not actually fix the OOM. I scoped it to the five stat panels and listed the "Fehlerstatus über Zeit" panel under *not in scope*; measuring afterwards showed that panel was the larger offender by a wide margin.

Its three fallback subqueries carry an upper time bound but no lower one:

```sql
(SELECT error_state FROM warp_evse
 WHERE error_state IS NOT NULL
   AND time < date_trunc('hour', now()) - INTERVAL '12 hours'
 ORDER BY time DESC LIMIT 1)
```

Constraint exclusion cannot prune on an open-ended lower bound, so the planner expanded every `warp_evse` chunk on each dashboard load. Since relcache bloat is driven by the *union* of chunks a backend touches, `warp_evse` stayed fully expanded after #1423:

| Table | before #1423 | after #1423 | after this PR |
|---|---|---|---|
| `warp_charge_tracker` | 282 chunks | 28 | 28 |
| `warp_evse` | 309 chunks | **309** | **28** |

## What

1. Bounds the three fallback subqueries to 30 days, consistent with the stat panels.
2. Filters every `warp_evse` query on `sub_topic = 'evse.state'`.

On (2): the four state columns are populated exclusively by that sub_topic, verified across 365 days — `charger_state`, `error_state`, `contactor_error` and `dc_fault_current_state` each have exactly 171034 non-null rows, all from `evse.state`, with no other sub_topic contributing. Meanwhile `evse.low_level_state` floods the table with rows where all four are NULL, at roughly 290:1. The filter therefore discards nothing and removes the bulk of the backward scan.

## Measured

Fault-status panel, against the live database:

| | chunk nodes planned | runtime |
|---|---|---|
| before | 2773 | 2399 ms |
| after | 241 | 524 ms |

## Correctness

Output of the fault-status panel is **byte-identical** before and after (12 rows, diffed). The four stat panels return identical values as well. The embedded dashboard JSON parses and all 22 panels are intact.

An audit of the file confirms no `warp_evse` query is left without both a lower time bound and the sub_topic filter. The nine `warp_meter` panels use Grafana's `$__timeFilter(time)` macro, which is bounded on both sides.

## Still not in scope

Datasource pool tuning (`maxIdleConns: 5`, `connMaxLifetime: 14400`), raising the 1Gi memory limit, and enabling `log_min_duration_statement` / `log_temp_files` — both logging knobs are `-1`, which is why none of these queries ever appeared in the PostgreSQL log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)