### PR TITLE
fix(grafana): restore chunk pruning on ventilation dashboard

### DIFF
--- a/kubernetes/applications/grafana/base/dashboards/hvac-ventilation.yaml
+++ b/kubernetes/applications/grafana/base/dashboards/hvac-ventilation.yaml
@@ -120,7 +120,7 @@ spec:
               "editorMode": "code",
               "format": "time_series",
               "rawQuery": true,
-              "rawSql": "SELECT time, value FROM knx WHERE knx_name = 'Versorgungstechnik.KWL.Lüftermodi-Status' ORDER BY time DESC LIMIT 1;",
+              "rawSql": "SELECT time, value FROM knx WHERE time > now() - INTERVAL '30 days' AND knx_name = 'Versorgungstechnik.KWL.Lüftermodi-Status' ORDER BY time DESC LIMIT 1;",
               "refId": "A"
             }
           ],
@@ -182,7 +182,7 @@ spec:
               "editorMode": "code",
               "format": "time_series",
               "rawQuery": true,
-              "rawSql": "SELECT time, value FROM knx WHERE knx_name = 'Versorgungstechnik.KWL.Filter-Betriebsstunden' ORDER BY time DESC LIMIT 1;",
+              "rawSql": "SELECT time, value FROM knx WHERE time > now() - INTERVAL '30 days' AND knx_name = 'Versorgungstechnik.KWL.Filter-Betriebsstunden' ORDER BY time DESC LIMIT 1;",
               "refId": "A"
             }
           ],
@@ -262,7 +262,7 @@ spec:
               "editorMode": "code",
               "format": "time_series",
               "rawQuery": true,
-              "rawSql": "SELECT time, value FROM knx WHERE knx_name = 'Versorgungstechnik.KWL.Filterwechsel-Status' ORDER BY time DESC LIMIT 1;",
+              "rawSql": "SELECT time, value FROM knx WHERE time > now() - INTERVAL '30 days' AND knx_name = 'Versorgungstechnik.KWL.Filterwechsel-Status' ORDER BY time DESC LIMIT 1;",
               "refId": "A"
             }
           ],
@@ -342,7 +342,7 @@ spec:
               "editorMode": "code",
               "format": "time_series",
               "rawQuery": true,
-              "rawSql": "SELECT time, value FROM knx WHERE knx_name = 'Versorgungstechnik.KWL.Wartungsmodus-Status' ORDER BY time DESC LIMIT 1;",
+              "rawSql": "SELECT bucket AS time, last_value AS value FROM knx_1h WHERE knx_name = 'Versorgungstechnik.KWL.Wartungsmodus-Status' ORDER BY bucket DESC LIMIT 1;",
               "refId": "A"
             }
           ],
@@ -422,7 +422,7 @@ spec:
               "editorMode": "code",
               "format": "time_series",
               "rawQuery": true,
-              "rawSql": "SELECT time, value FROM knx WHERE knx_name = 'Versorgungstechnik.KWL.Status' ORDER BY time DESC LIMIT 1;",
+              "rawSql": "SELECT time, value FROM knx WHERE time > now() - INTERVAL '30 days' AND knx_name = 'Versorgungstechnik.KWL.Status' ORDER BY time DESC LIMIT 1;",
               "refId": "A"
             }
           ],
@@ -512,7 +512,7 @@ spec:
               "editorMode": "code",
               "format": "time_series",
               "rawQuery": true,
-              "rawSql": "SELECT time, value FROM knx WHERE knx_name = 'Versorgungstechnik.KWL.ComfoConnect-Status' ORDER BY time DESC LIMIT 1;",
+              "rawSql": "SELECT bucket AS time, last_value AS value FROM knx_1h WHERE knx_name = 'Versorgungstechnik.KWL.ComfoConnect-Status' ORDER BY bucket DESC LIMIT 1;",
               "refId": "A"
             }
           ],


### PR DESCRIPTION
Third and final part of the TimescaleDB OOM cleanup, after #1423 and #1425.

## Why

After fixing the wallbox dashboard I audited all 22 dashboards rather than assuming it was the only one. `hvac-ventilation.yaml` has the same defect on a bigger table: six stat and gauge panels query `knx` with `ORDER BY time DESC LIMIT 1` and no time filter.

`knx` is the largest hypertable in the database — **363 chunks, 360 compressed**, against `warp_evse`'s 309. Each panel expanded to **1086 chunk nodes** at plan time. Opening this dashboard reproduced exactly the relcache bloat that OOM-killed `timescaledb-db-1`.

## Why one window does not fit

The six group addresses split into two very different classes. Measured over 365 days:

| GA | Panel | Values | Largest gap |
|---|---|---|---|
| 15/3/2 | Aktuelle Lüfterstufe | 5030 | 14d |
| 15/3/20 | Fehlerstatus Lüftungsgerät | 2925 | 3d21h |
| 15/3/23 | Filterwechsel | 442 | 3d24h |
| 15/3/24 | Betriebsstunden Filter | 443 | 3d24h |
| 15/3/21 | Fehlertstatus ComfoConnect | **10** | **195d** |
| 15/3/22 | Wartungsmodus | **10** | **195d** |

A single 30-day bound would have silently emptied the last two panels, since their gaps approach the 365-day retention. And leaving just those two unbounded would have been pointless: relcache bloat follows the *union* of chunks a backend opens, so two unbounded panels keep all 363 chunks open and negate the other four fixes. That is the trap #1423 fell into.

## What

**Four frequent GAs** get a 30-day bound on the raw table — more than 2x margin on their worst observed gap, full freshness retained.

**Two rare GAs** move to the `knx_1h` continuous aggregate:

```sql
SELECT bucket AS time, last_value AS value FROM knx_1h
WHERE knx_name = 'Versorgungstechnik.KWL.Wartungsmodus-Status'
ORDER BY bucket DESC LIMIT 1;
```

`knx_1h` holds `last_value` per group address and hour in **44 uncompressed chunks**, and covers 2025-05-22 to 2026-08-15 — more history than the raw table's retention. So these panels keep unlimited lookback without a time bound at all.

The aggregate is `materialized_only` with `end_offset` 1h on an hourly schedule, so it trails by up to roughly 3 hours. At ten changes per year that is irrelevant; it would not be acceptable for the live fan level, which is why only these two moved.

## Measured

| | chunk nodes per panel |
|---|---|
| before | 1086 |
| after | 88–90 |

Distinct chunks the dashboard opens: **363 → ~73** (29 from `knx` at 30 days, 44 from `knx_1h`).

All six panels return identical values before and after, verified against the live database.

## Audit result

All 22 dashboards were re-checked with a corrected script that recognises both `time` and `bucket` as time columns and ignores CTE names. No further unbounded queries remain. Two apparent hits in `energy-inverter.yaml` are `EXTRACT(HOUR FROM bucket)` matching the `FROM` pattern, and the four `energy-meter.yaml` panels are already bounded via `bucket >= ...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)