### PR TITLE
fix(devolutions-gateway): drop the commented-out WebSocket fallback route

### DIFF
--- a/kubernetes/applications/devolutions-gateway/base/ingress-route.yaml
+++ b/kubernetes/applications/devolutions-gateway/base/ingress-route.yaml
@@ -56,19 +56,5 @@ spec:
         - kind: Service
           name: devolutions-gateway
           port: 7171
-    # Fallback if Authentik forwardAuth breaks the WebSocket upgrade: move the
-    # RDP session stream out of the auth chain. Safe because /jet/rdp requires a
-    # gateway-signed JWT that only the web app hands out. Scoped to /jet/rdp so
-    # /jet/config and /jet/sessions stay behind Authentik.
-    # - kind: Rule
-    #   match: Host(`PLACEHOLDER`) && Path(`/jet/rdp`)
-    #   priority: 20
-    #   middlewares:
-    #     - name: chain-standard
-    #       namespace: ingress-controller
-    #   services:
-    #     - kind: Service
-    #       name: devolutions-gateway
-    #       port: 7171
   tls:
     secretName: devolutions-gateway-tls-cert


### PR DESCRIPTION
## Why

#1419 shipped a commented-out fallback route, in case Authentik forwardAuth broke the WebSocket upgrade for the RDP session stream. That was the one open risk that could not be checked without the cluster.

**It has now been verified in production: forwardAuth does not break the upgrade.** `/jet/rdp` completes the WebSocket handshake through `chain-mfa-auth`, and a full RDP session to the ETS VM works with Authentik authentication and MFA enforced in front of it.

The block is therefore dead weight and is removed. The IngressRoute is left with the two routes actually in use: the web app behind `chain-mfa-auth`, and `/jet/health` behind `chain-standard` for Gatus.

## Also confirmed during the rollout

- DNS resolution of `.eu.com` from the pod works — the session target can be given as `windows-01.zimmermann.eu.com`
- Pod egress reaches the VM on `:3389`; nodes and VM share `192.168.1.0/24`, so no inter-VLAN hop is involved
- The VM's RDP security layer needed no change
- CredSSP forwards the credentials correctly

The only login friction was Windows-side and unrelated to this deployment: a Microsoft-account user has a truncated local name, so the session username is `windows-11\\alexa` rather than the email address.

## Verification

Both overlays render cleanly, no placeholders left, two routes each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)