### PR TITLE
feat(monitoring): alert on per-inverter SolarEdge data staleness

### DIFF
--- a/kubernetes/applications/prometheus/base/prometheus-rule.yaml
+++ b/kubernetes/applications/prometheus/base/prometheus-rule.yaml
@@ -142,6 +142,32 @@ spec:
             summary: "UniFi arm-sync metric stale/absent"
             description: "unifi_arm_sync_ok has not been reported for >15m (expected every ~5min via the KNX status heartbeat). The redpanda-connect stream, its JetStream consumer binding, or the scrape is stuck — drift detection is blind."
 
+    - name: solaredge-alerts
+      rules:
+        - alert: SolarEdgeInverterDataStale
+          # solaredge_inverter_last_reading_timestamp_seconds is emitted by the
+          # redpanda-connect solaredge_inverter stream on every reading (~1/5s, 24/7).
+          expr: time() - max by (inverter) (solaredge_inverter_last_reading_timestamp_seconds) > 600
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "SolarEdge inverter {{ $labels.inverter }} delivering no data"
+            description: "No modbus reading from inverter {{ $labels.inverter }} (pod solaredge2mqtt-{{ $labels.inverter }}) for {{ $value | humanizeDuration }}. Readings arrive every 5s around the clock, so a gap this long means the inverter or its modbus interface is dead — the pod stays Running 1/1 and silently publishes nothing. Reboot the inverter; restarting the pod does not clear it."
+
+        - alert: SolarEdgeInverterDataAbsent
+          # The staleness rule needs an existing series — an inverter that never
+          # reported since the connect stream started has none.
+          expr: |
+            absent(solaredge_inverter_last_reading_timestamp_seconds{inverter="1"})
+            or absent(solaredge_inverter_last_reading_timestamp_seconds{inverter="2"})
+          for: 15m
+          labels:
+            severity: critical
+          annotations:
+            summary: "SolarEdge inverter {{ $labels.inverter }} never reported"
+            description: "Inverter {{ $labels.inverter }} has not delivered a single reading since the redpanda-connect solaredge_inverter stream last started — check the solaredge2mqtt pod, the SOLAREDGE JetStream consumer and the inverter itself."
+
     - name: argocd-alerts
       rules:
         - alert: ArgoCDAppOutOfSync

--- a/kubernetes/applications/redpanda-connect/base/streams/solaredge_inverter.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/solaredge_inverter.yaml
@@ -21,6 +21,7 @@ pipeline:
         # Subject is "solaredge-N.modbus.inverter"; pull N for inverter_id.
         let subj = meta("nats_subject")
         let inv_id = $subj.split(".").index(0).split("-").index(1).number()
+        meta inverter = $inv_id.string()
         root = {
           "time":               $evt.timestamp,
           "inverter_id":        $inv_id,
@@ -44,6 +45,14 @@ pipeline:
           "ac_power_reactive":  $evt.ac.power.reactive.or(null),
           "raw":                $evt,
         }
+
+    # Per-inverter liveness: a dead inverter leaves the pod Running and silent.
+    - metric:
+        type: gauge
+        name: solaredge_inverter_last_reading_timestamp_seconds
+        value: ${! now().ts_unix() }
+        labels:
+          inverter: ${! meta("inverter") }
 
 output:
   broker:


### PR DESCRIPTION
## Why

Inverter 2 (SE4000H) crashed and stopped serving modbus register block 40071 on **every** poll from 2026-08-06 00:00 Berlin until it was rebooted ~40 hours later. Throughout, `solaredge2mqtt-2` stayed `Running 1/1` and logged `Invalid modbus data, skipping this loop` every 5s — publishing nothing. **No alert fired.** The outage only became visible because an unrelated image bump restarted the pod, which then crash-looped (`PodCrashLooping` did fire, 9 restarts) — the crash was a symptom, not the cause.

Loki, errors per hour on inverter 2:

| Window (UTC) | Rate |
|---|---|
| until 08-05 21Z | 1–2/h |
| **08-05 22Z → 08-07 13Z** | **~720/h = every single poll** |

## Why a new metric was needed

No existing signal has per-inverter granularity:

- `nats_stream_last_seq{stream_name="SOLAREDGE"}` — one stream covers `solaredge-1.>` and `solaredge-2.>`. Inverter 1 kept publishing, so the sequence kept advancing.
- redpanda-connect `input_received` / `output_sent` — per stream, not per subject. Same blind spot.
- solaredge2mqtt exposes no metrics of its own (`service.enabled: false`, no port).

So the `solaredge_inverter` stream now emits a per-inverter timestamp gauge, following the existing `unifi_arm_sync_ok` precedent in `unifi_arm_alarm.yaml`. The staleness rule mirrors `PbsBackupStale`.

## Changes

- **redpanda-connect** — tag each reading with the inverter id (`meta inverter`) and emit `solaredge_inverter_last_reading_timestamp_seconds{inverter}`.
- **prometheus** — new `solaredge-alerts` group:
  - `SolarEdgeInverterDataStale` — no reading for >10m, `for: 5m`. At a 5s interval that is ~180 missed readings, well clear of the known ~1min nightly modbus dropout and of a connect pod restart.
  - `SolarEdgeInverterDataAbsent` — covers the case the staleness rule structurally cannot: an inverter that never reported since the connect stream last started has no series to compare against. A bare `absent()` would not fire either, because the sibling inverter keeps the metric alive, hence the explicit per-inverter matchers.

The stale alert's description carries today's lesson: **reboot the inverter — restarting the pod does not clear it.**

Data flows 24/7 (~717 readings/h even at 03:00 Berlin, verified via Loki), so the staleness rule does not false-positive at night. The crash-loop itself stays covered by the existing `PodCrashLooping`.

## Verification

- Bloblang mapping and metric processor **executed** against `connect:4.104.0` locally (not just linted — all streams share one pod, so a broken processor takes the whole deployment down). Result: `solaredge_inverter_last_reading_timestamp_seconds{inverter="2"} 1.786118643e+09`, correct label derived from the subject, no errors.
- `connect lint` on the modified stream: clean.
- `promtool check rules`: SUCCESS, 20 rules.
- Both PromQL expressions run against the live Prometheus; `absent()` returns the `inverter` label, so the annotations render.

## Note

The streams ConfigMap is hash-named, so the connect pod rolls on sync — briefly *all* streams, not just solaredge. With `deliver: all` plus durable consumers they catch up.

## Follow-up

Upstream bug filed separately: DerOetzi/solaredge2mqtt#421 — a single failed modbus read during startup detection raises an uncaught `KeyError: 'c_manufacturer'` and kills the process, while the identical failure is tolerated at runtime. Not fixable from this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
