### PR TITLE
fix(devolutions-gateway): fold the config seeding into the main container

### DIFF
--- a/kubernetes/applications/devolutions-gateway/base/values.yaml
+++ b/kubernetes/applications/devolutions-gateway/base/values.yaml
@@ -18,38 +18,19 @@ deployment:
 
   # Bypass the image's pwsh entrypoint: it only generates a config and
   # provisioner keys — both supplied here — and then stays resident at ~58 MiB.
+  #
+  # gateway.json is copied into the writable data directory first: the gateway
+  # writes jrl.json, boot.stacktrace and the libsql databases next to it, and a
+  # ConfigMap mounted there directly would be shadowed by the emptyDir.
   command:
-    - /opt/devolutions/gateway/devolutions-gateway
-  args:
-    - --config-path
-    - /var/lib/devolutions-gateway
+    - sh
+    - -c
+    - cp /config/gateway.json /var/lib/devolutions-gateway/gateway.json && exec /opt/devolutions/gateway/devolutions-gateway --config-path /var/lib/devolutions-gateway
 
   env:
     # Keep logs/timestamps consistent with local timezone.
     TZ:
       value: "Europe/Berlin"
-
-  # The gateway needs gateway.json inside its own writable data directory — it
-  # writes jrl.json, boot.stacktrace and the libsql databases next to it. A
-  # ConfigMap mounted there directly would be shadowed by the emptyDir, so the
-  # config is seeded into it instead.
-  initContainers:
-    seed-config:
-      image: docker.io/devolutions/devolutions-gateway:2026.2.4
-      imagePullPolicy: IfNotPresent
-      command:
-        - sh
-        - -c
-        - cp /config/gateway.json /var/lib/devolutions-gateway/gateway.json
-      securityContext:
-        runAsUser: 1000
-        runAsGroup: 1000
-      volumeMounts:
-        - name: devolutions-gateway-config
-          mountPath: /config
-          readOnly: true
-        - name: devolutions-gateway-data
-          mountPath: /var/lib/devolutions-gateway
 
   volumes:
     # Writable data directory: gateway.json plus jrl.json and the libsql
@@ -68,6 +49,9 @@ deployment:
   volumeMounts:
     devolutions-gateway-data:
       mountPath: /var/lib/devolutions-gateway
+    devolutions-gateway-config:
+      mountPath: /config
+      readOnly: true
     devolutions-gateway-keys:
       mountPath: /etc/devolutions-gateway/keys
       readOnly: true


### PR DESCRIPTION
## Why

The image was referenced twice in `values.yaml`, in two different shapes:

| | shape | Renovate |
|---|---|---|
| main container | `repository:` + `tag:` | tracked |
| initContainer | `image: repo:tag` | **not tracked** |

The combined `repo:tag` string matches neither Renovate's built-in helm-values manager nor the annotated-dependency custom manager, which expects a bare version value. The next bump would have moved `deployment.image.tag` while leaving the initContainer pinned — the two drifting apart silently, plus a pointless second image pull.

## What

Copying `gateway.json` into the writable data directory now happens in the main container's command instead of a dedicated initContainer. That removes the second image reference entirely, and a container with it.

The mount layout stays flat — `/config`, `/var/lib/devolutions-gateway` and `/etc/devolutions-gateway/keys` are siblings — so the mount-shadowing problem the initContainer originally solved does not come back.

## Verification

Rendered and then run locally against the real config and provisioner keys, with `--read-only` and UID 1000:

- **one process**: `devolutions-gateway` at 10 MiB RSS, no lingering `sh` — `exec` replaces the shell, so the gateway stays PID 1 and keeps receiving signals directly
- no `Generating provisioner keys...` and no `TlsVerifyStrict` warning, i.e. config and keys are picked up
- `Listening on http://0.0.0.0:7171`, `/jet/health` → 200
- rendered manifest contains exactly one image reference and no initContainer

🤖 Generated with [Claude Code](https://claude.com/claude-code)