### PR TITLE
feat(rustfs): upgrade chart to 1.0.0-rc.1, track pre-releases in Renovate

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -32,6 +32,12 @@
   },
   "packageRules": [
     {
+      // rustfs chart mirrors the app version and ships only pre-releases since 1.0.0
+      "matchDatasources": ["helm"],
+      "matchPackageNames": ["rustfs"],
+      "ignoreUnstable": false
+    },
+    {
       "matchFileNames": ["infrastructure/manifest/20-image/image.yaml"],
       "postUpgradeTasks": {
         "commands": [

--- a/kubernetes/applications/rustfs/base/kustomization.yaml
+++ b/kubernetes/applications/rustfs/base/kustomization.yaml
@@ -15,7 +15,7 @@ helmCharts:
   - name: rustfs
     repo: https://rustfs.github.io/helm
     releaseName: rustfs
-    version: 0.12.0
+    version: 1.0.0-rc.1
     valuesFile: values.yaml
     namespace: rustfs
 


### PR DESCRIPTION
## Why

Renovate has silently stopped offering rustfs updates. It pins the **chart**, not the image — the container tag comes from the chart `appVersion` since `image.rustfs.tag` is unset in our values.

rustfs changed its chart versioning scheme on 2026-08-08: the chart version now mirrors the app version, so every published chart is a semver **pre-release**.

| Chart | appVersion |
| --- | --- |
| 0.12.0 | 1.0.0-beta.12 (current) |
| 1.0.0-beta.10-preview.1 … beta.12-preview.1 | mirrored |
| 1.0.0-rc.1 | 1.0.0-rc.1 |

Renovate's default `ignoreUnstable: true` (via `config:recommended`) never proposes a pre-release when the current version is stable. `0.12.0` is stable, so `1.0.0-rc.1` was filtered out — no PR, no dashboard entry. The manager itself works fine; it bumped this chart from 0.3.0 through 0.12.0.

## What

- Pin the chart to `1.0.0-rc.1`.
- Add a `packageRule` for `helm`/`rustfs` with `ignoreUnstable: false`, so the chart is tracked across pre-releases again. Without it this bump is a one-off and we freeze again — including at 1.0.0 GA.

## Verification

Chart tarballs 0.12.0 vs 1.0.0-rc.1 compared directly: identical file set, identical `values.yaml`. The only template change is in `cert-manager-mtls/04-server-cert.yaml` (ingress hosts removed from the cert SANs), which does not render — `mtls.enabled` is `false` by default and we do not override it.

`kustomize build --enable-helm` on the prod overlay, complete diff:

```
app.kubernetes.io/version: 1.0.0-beta.12 → 1.0.0-rc.1
helm.sh/chart:      rustfs-0.12.0 → rustfs-1.0.0-rc.1
image:  rustfs/rustfs:1.0.0-beta.12 → rustfs/rustfs:1.0.0-rc.1
```

Nothing structural. `RUSTFS_DRIVE_*_TIMEOUT_SECS` and `fsGroupChangePolicy` are untouched.

## Risk

The chart step is a no-op; all risk is in the 306 app commits between beta.12 and rc.1. Worth watching after rollout:

- **RSS / OOM** — the mimalloc reclaim behaviour depends on the image entrypoint, and `fix(observability): fallback mimalloc requested memory stats` landed in rc.1.
- **FaultyDisk on the NFS-backed PVC** — the drive timeout envs stay set, but scanner internals were reworked (`fix(scanner): bound corrupt metadata traversal`, `fix(scanner): publish bounded observational usage`).
- **The actual motivation** — whether Alloy's `duplicate sample for timestamp` on `rustfs_scanner_objects_scanned_total` returns. It only fires in bursts during active scanner cycles, so this needs a few days of observation before it can be called fixed. Companion PR adds it to the known-log-noise catalog in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)