### PR TITLE
fix(holmesgpt): drop holmes-operator image pin

### DIFF
--- a/kubernetes/applications/holmesgpt/base/values.yaml
+++ b/kubernetes/applications/holmesgpt/base/values.yaml
@@ -75,10 +75,6 @@ toolsets:
 # Phase 2: operator runs ScheduledHealthChecks against the holmes server (read-only)
 operator:
   enabled: true
-  # Pinned back: the 0.37.0/0.38.0 images lack the holmes package their entrypoint imports (CrashLoop).
-  # Registry split off the image so the repository path stays resolvable for dependency lookups.
-  registry: docker.io
-  image: robustadev/holmes-operator:0.38.2
 
 # Custom skills as real .md files (kustomize ConfigMap) — a reusable registry of known-benign
 # log noise so investigations (esp. log-anomaly) don't escalate steady-state patterns.


### PR DESCRIPTION
## Why

The `holmes-operator` image was pinned in `values.yaml` because the 0.37.0/0.38.0 images shipped without the `holmes` package their entrypoint imports (`ModuleNotFoundError` → CrashLoopBackOff, upstream [holmesgpt#2326](https://github.com/HolmesGPT/holmesgpt/issues/2326)). The server kept following the chart version, so the operator had to be bumped by hand — which is also why Renovate opens two PRs for every holmes release: one for the chart, one for the pinned image.

Upstream fixed the operator build ([holmesgpt#2330](https://github.com/HolmesGPT/holmesgpt/pull/2330)). Verified on the new image:

```
docker run --platform linux/amd64 --entrypoint python \
  robustadev/holmes-operator:0.39.0 -c "import holmes_operator.operator"
→ IMPORT OK
```

## What

Removes the `operator.registry` / `operator.image` override so the operator follows the chart version again, like the server does.

## Verification

`kustomize build --enable-helm kubernetes/applications/holmesgpt/overlays/prod` renders unchanged on chart 0.38.2:

```
image: robustadev/holmes:0.38.2
image: robustadev/holmes-operator:0.38.2
```

(now from the chart default `registry: robustadev` + `image: holmes-operator:<chart-version>`)

## Follow-up

Makes the image-only Renovate PR #1441 obsolete — Renovate should auto-close it once this lands. #1442 (chart 0.38.2 → 0.39.0) then bumps server and operator together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)