### PR TITLE
fix(crowdsec): stop pruning the homepage watcher machine

### DIFF
--- a/kubernetes/applications/crowdsec/base/ensure-watcher-job.yaml
+++ b/kubernetes/applications/crowdsec/base/ensure-watcher-job.yaml
@@ -1,0 +1,68 @@
+# Post-sync Job that registers the homepage widget as a LAPI watcher. Watcher
+# accounts live only in the CrowdSec database, so without this they are lost on
+# every database rebuild and the widget fails with 401.
+apiVersion: batch/v1
+kind: Job
+
+metadata:
+  name: crowdsec-ensure-watcher
+  namespace: crowdsec
+  annotations:
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
+
+spec:
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 3600
+  template:
+    spec:
+      serviceAccountName: crowdsec-machines
+      restartPolicy: OnFailure
+      imagePullSecrets:
+        - name: dhi-registry-secret
+      containers:
+        - name: ensure
+          # `:1-dev` includes busybox/coreutils so the script can use /bin/sh and awk.
+          image: dhi.io/kubectl:1-dev
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
+          command: ["/bin/sh", "/scripts/ensure-watcher.sh"]
+          env:
+            - name: NAMESPACE
+              value: "crowdsec"
+            - name: SELECTOR
+              value: "type=lapi,k8s-app=crowdsec" # gitleaks:allow
+            - name: WATCHER_NAME
+              value: "homepage"
+            - name: WATCHER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: crowdsec-homepage-lapi-key
+                  key: crowdsec_homepage_lapi_key
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          volumeMounts:
+            - name: scripts
+              mountPath: /scripts
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: scripts
+          configMap:
+            name: crowdsec-ensure-watcher-script
+            defaultMode: 0555
+        - name: tmp
+          emptyDir: {}

--- a/kubernetes/applications/crowdsec/base/kustomization.yaml
+++ b/kubernetes/applications/crowdsec/base/kustomization.yaml
@@ -7,9 +7,15 @@ resources:
   - ./sealed-secret.yaml
   - ./database.yaml
   - ./rbac.yaml
+  - ./ensure-watcher-job.yaml
   - ./machines-prune-cronjob.yaml
 
 configMapGenerator:
+  - name: crowdsec-ensure-watcher-script
+    options:
+      disableNameSuffixHash: true
+    files:
+      - scripts/ensure-watcher.sh
   - name: crowdsec-machines-prune-script
     options:
       disableNameSuffixHash: true

--- a/kubernetes/applications/crowdsec/base/machines-prune-cronjob.yaml
+++ b/kubernetes/applications/crowdsec/base/machines-prune-cronjob.yaml
@@ -1,7 +1,6 @@
-# Daily prune of stale log processors. LAPI pods do not unregister on shutdown,
-# so old replicas accumulate after rollouts and surface in the console as
-# inactive log processors. The chart's agents_autodelete flush does not clear
-# them reliably; cscli machines prune does.
+# Daily prune of stale log processors. Agent and LAPI pods do not unregister on
+# shutdown, so old replicas accumulate after rollouts and surface in the console
+# as inactive log processors. Only registrations whose pod is gone are deleted.
 apiVersion: batch/v1
 kind: CronJob
 
@@ -22,7 +21,7 @@ spec:
       ttlSecondsAfterFinished: 86400
       template:
         spec:
-          serviceAccountName: crowdsec-machines-prune
+          serviceAccountName: crowdsec-machines
           restartPolicy: OnFailure
           imagePullSecrets:
             - name: dhi-registry-secret
@@ -46,8 +45,9 @@ spec:
                   value: "crowdsec"
                 - name: SELECTOR
                   value: "type=lapi,k8s-app=crowdsec" # gitleaks:allow
-                - name: DURATION
-                  value: "48h"
+                # Log processors register under their pod name; watchers never do.
+                - name: MACHINE_PATTERN
+                  value: "^crowdsec-"
               resources:
                 requests:
                   cpu: 10m

--- a/kubernetes/applications/crowdsec/base/rbac.yaml
+++ b/kubernetes/applications/crowdsec/base/rbac.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 
 metadata:
-  name: crowdsec-machines-prune
+  name: crowdsec-machines
   namespace: crowdsec
 
 ---
@@ -10,7 +10,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 
 metadata:
-  name: crowdsec-machines-prune
+  name: crowdsec-machines
   namespace: crowdsec
 
 rules:
@@ -26,15 +26,15 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 
 metadata:
-  name: crowdsec-machines-prune
+  name: crowdsec-machines
   namespace: crowdsec
 
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: crowdsec-machines-prune
+  name: crowdsec-machines
 
 subjects:
   - kind: ServiceAccount
-    name: crowdsec-machines-prune
+    name: crowdsec-machines
     namespace: crowdsec

--- a/kubernetes/applications/crowdsec/base/scripts/ensure-watcher.sh
+++ b/kubernetes/applications/crowdsec/base/scripts/ensure-watcher.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+set -eu
+
+# Required environment variables:
+#   NAMESPACE        - crowdsec namespace
+#   SELECTOR         - label selector for the LAPI pod
+#   WATCHER_NAME     - watcher machine to register
+#   WATCHER_PASSWORD - LAPI password for that watcher
+
+attempt=0
+
+while [ "$attempt" -lt 60 ]; do
+  LAPI_POD=$(kubectl -n "$NAMESPACE" get pod -l "$SELECTOR" \
+    -o jsonpath='{.items[?(@.status.phase=="Running")].metadata.name}' \
+    | awk '{print $1}') || LAPI_POD=""
+
+  # --force rewrites the password, so re-runs converge on the sealed secret.
+  if [ -n "$LAPI_POD" ] && kubectl -n "$NAMESPACE" exec "$LAPI_POD" -- \
+      cscli machines add "$WATCHER_NAME" --password "$WATCHER_PASSWORD" -f /dev/null --force; then
+    echo "watcher $WATCHER_NAME registered via $LAPI_POD"
+    exit 0
+  fi
+
+  attempt=$((attempt + 1))
+  sleep 5
+done
+
+echo "lapi did not become reachable"
+exit 1

--- a/kubernetes/applications/crowdsec/base/scripts/prune-machines.sh
+++ b/kubernetes/applications/crowdsec/base/scripts/prune-machines.sh
@@ -2,18 +2,41 @@
 set -eu
 
 # Required environment variables:
-#   NAMESPACE   - crowdsec namespace
-#   SELECTOR    - label selector for the LAPI pod
-#   DURATION    - inactivity threshold passed to cscli machines prune
+#   NAMESPACE       - crowdsec namespace
+#   SELECTOR        - label selector for the LAPI pod
+#   MACHINE_PATTERN - machines eligible for pruning; log processors register under their pod name
 
-POD=$(kubectl -n "$NAMESPACE" get pod -l "$SELECTOR" \
+LAPI_POD=$(kubectl -n "$NAMESPACE" get pod -l "$SELECTOR" \
   -o jsonpath='{.items[?(@.status.phase=="Running")].metadata.name}' \
   | awk '{print $1}')
 
-if [ -z "$POD" ]; then
+if [ -z "$LAPI_POD" ]; then
   echo "no running lapi pod found"
   exit 1
 fi
 
-echo "pruning stale machines via $POD"
-kubectl -n "$NAMESPACE" exec "$POD" -- cscli machines prune --duration "$DURATION" --force
+kubectl -n "$NAMESPACE" get pods --no-headers -o custom-columns=":metadata.name" >/tmp/pods
+
+kubectl -n "$NAMESPACE" exec "$LAPI_POD" -- cscli machines list -o raw \
+  | awk -F, 'NR > 1 { print $1 }' >/tmp/machines
+
+pruned=0
+
+while read -r machine; do
+  [ -n "$machine" ] || continue
+
+  # Everything else is a watcher (homepage widget), which never sends a heartbeat.
+  if ! echo "$machine" | grep -qE "$MACHINE_PATTERN"; then
+    continue
+  fi
+
+  if grep -qxF "$machine" /tmp/pods; then
+    continue
+  fi
+
+  echo "pruning $machine: pod is gone"
+  kubectl -n "$NAMESPACE" exec "$LAPI_POD" -- cscli machines delete "$machine"
+  pruned=$((pruned + 1))
+done </tmp/machines
+
+echo "pruned $pruned stale machine(s)"


### PR DESCRIPTION
## Problem

The CrowdSec widget on Homepage showed `API Error Information`. Homepage logged `Failed to login to Crowdsec API, status: 401`, the LAPI logged `Error machine login for homepage : ent: machine not found` — the `homepage` machine had been deleted from the LAPI database.

The daily `crowdsec-machines-prune` CronJob deleted it. `cscli machines prune --duration 48h` does not only remove machines with a stale heartbeat: `QueryMachinesInactiveSince` also matches `last_heartbeat IS NULL AND created_at < cutoff`. Watcher accounts such as the Homepage widget only log in and never send a heartbeat (confirmed in the `machines` table after a successful login and authenticated API calls), so the account was guaranteed to be deleted 48h after it was created.

The prune runs since 2026-08-01 all reported "No machines to prune", so the machine was already gone before then; the earliest evidence in Loki (retention starts 2026-07-29) is a failed login on 2026-08-06 20:37 UTC.

## Changes

- `prune-machines.sh` no longer calls `cscli machines prune`. It reconciles registrations against the pods in the namespace and deletes only machines whose pod no longer exists — which is exactly the leftover-after-rollout case the job was written for. `DURATION` is replaced by `MACHINE_PATTERN` (`^crowdsec-`), so non-pod watchers are never eligible.
- New `crowdsec-ensure-watcher` PostSync Job registers the `homepage` watcher from the sealed LAPI key (`cscli machines add --force`, idempotent). Watcher accounts only live in the CrowdSec database, so without this they are lost on every database rebuild.
- ServiceAccount, Role and RoleBinding renamed `crowdsec-machines-prune` → `crowdsec-machines`, since both jobs use them.

## Verification

- Machine re-registered in the cluster with the existing sealed key; widget verified end-to-end through Homepage's own proxy (`/api/services/proxy?...&endpoint=alerts` → `200` with alert data).
- New prune logic dry-run and for real against the live cluster with a simulated leftover (`crowdsec-agent-deadpod`): only the orphan was deleted, `homepage` and all five live machines were kept.
- `ensure-watcher.sh` smoke-tested against the running LAPI (idempotent re-registration, widget still `200` afterwards).
- `kustomize build --enable-helm` renders cleanly; `shellcheck` clean on both scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)