### PR TITLE
feat(knx): follow the OG group address renumbering, wire up the new Luftreiniger points

### DIFF
--- a/kubernetes/applications/knx-nats-bridge/base/config/ga-catalog.yaml
+++ b/kubernetes/applications/knx-nats-bridge/base/config/ga-catalog.yaml
@@ -9085,208 +9085,238 @@
 6/3/100:
   dpt: '1.003'
   function: Raumklima
+  name: Raumklima.OG.Schlafzimmer-Luis.FBH.Sperren
+  room: Schlafzimmer Luis
+6/3/101:
+  dpt: '5.001'
+  function: Raumklima
+  name: Raumklima.OG.Schlafzimmer-Luis.FBH.Stellwert-Status
+  room: Schlafzimmer Luis
+6/3/102:
+  dpt: '9.001'
+  function: Raumklima
+  name: Raumklima.OG.Schlafzimmer-Luis.FBH.Soll-Temperatur
+  room: Schlafzimmer Luis
+6/3/103:
+  dpt: '9.001'
+  function: Raumklima
+  name: Raumklima.OG.Schlafzimmer-Luis.FBH.Soll-Temperatur-Status
+  room: Schlafzimmer Luis
+6/3/104:
+  dpt: '9.002'
+  function: Raumklima
+  name: Raumklima.OG.Schlafzimmer-Luis.FBH.Sollwertverschiebung
+  room: Schlafzimmer Luis
+6/3/105:
+  dpt: '20.102'
+  function: Raumklima
+  name: Raumklima.OG.Schlafzimmer-Luis.FBH.HVAC
+  room: Schlafzimmer Luis
+6/3/106:
+  dpt: '20.102'
+  function: Raumklima
+  name: Raumklima.OG.Schlafzimmer-Luis.FBH.HVAC-Status
+  room: Schlafzimmer Luis
+6/3/107:
+  dpt: '1.011'
+  function: Raumklima
+  name: Raumklima.OG.Schlafzimmer-Luis.FBH.Aktiv
+  room: Schlafzimmer Luis
+6/3/108:
+  dpt: '5.010'
+  function: Raumklima
+  name: Raumklima.OG.Schlafzimmer-Luis.FBH.Aktiv-Anomalie
+  room: Schlafzimmer Luis
+6/3/109:
+  dpt: '5.010'
+  function: Raumklima
+  name: Raumklima.OG.Schlafzimmer-Luis.FBH.Aktiv-Fenster-Auf-Anomalie
+  room: Schlafzimmer Luis
+6/3/110:
+  dpt: '16.000'
+  function: Raumklima
+  name: Raumklima.OG.Schlafzimmer-Luis.FBH.Diagnose
+  room: Schlafzimmer Luis
+6/3/140:
+  dpt: '1.003'
+  function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.FBH.Sperren
   room: Schlafzimmer Eltern
-6/3/101:
+6/3/141:
   dpt: '5.001'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.FBH.Stellwert-Status
   room: Schlafzimmer Eltern
-6/3/102:
+6/3/142:
   dpt: '9.001'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.FBH.Soll-Temperatur
   room: Schlafzimmer Eltern
-6/3/103:
+6/3/143:
   dpt: '9.001'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.FBH.Soll-Temperatur-Status
   room: Schlafzimmer Eltern
-6/3/104:
+6/3/144:
   dpt: '9.002'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.FBH.Sollwertverschiebung
   room: Schlafzimmer Eltern
-6/3/105:
+6/3/145:
   dpt: '20.102'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.FBH.HVAC
   room: Schlafzimmer Eltern
-6/3/106:
+6/3/146:
   dpt: '20.102'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.FBH.HVAC-Status
   room: Schlafzimmer Eltern
-6/3/107:
+6/3/147:
   dpt: '1.011'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.FBH.Aktiv
   room: Schlafzimmer Eltern
-6/3/108:
+6/3/148:
   dpt: '5.010'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.FBH.Aktiv-Anomalie
   room: Schlafzimmer Eltern
-6/3/109:
+6/3/149:
   dpt: '5.010'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.FBH.Aktiv-Fenster-Auf-Anomalie
   room: Schlafzimmer Eltern
-6/3/110:
+6/3/150:
   dpt: '16.000'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.FBH.Diagnose
   room: Schlafzimmer Eltern
-6/3/111:
+6/3/160:
+  dpt: '1.003'
+  function: Raumklima
+  name: Raumklima.OG.Schlafzimmer-Eltern.Luftreiniger.Sperren
+  room: Schlafzimmer Eltern
+6/3/161:
+  dpt: '1.011'
+  function: Raumklima
+  name: Raumklima.OG.Schlafzimmer-Eltern.Luftreiniger.Sperren-Status
+  room: Schlafzimmer Eltern
+6/3/162:
   dpt: '1.001'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.Luftreiniger.Ein/Aus
   room: Schlafzimmer Eltern
-6/3/112:
+6/3/163:
   dpt: '1.011'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.Luftreiniger.Ein/Aus-Status
   room: Schlafzimmer Eltern
-6/3/113:
+6/3/164:
   dpt: '5.010'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.Luftreiniger.Lüfterstufe
   room: Schlafzimmer Eltern
-6/3/114:
+6/3/165:
   dpt: '5.010'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.Luftreiniger.Lüfterstufe-Status
   room: Schlafzimmer Eltern
-6/3/115:
+6/3/166:
   dpt: '5.010'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.Luftreiniger.Drehmodus
   room: Schlafzimmer Eltern
-6/3/116:
+6/3/167:
   dpt: '5.010'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.Luftreiniger.Drehmodus-Status
   room: Schlafzimmer Eltern
-6/3/117:
+6/3/168:
   dpt: '1.001'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.Luftreiniger.Nachtmodus
   room: Schlafzimmer Eltern
-6/3/118:
+6/3/169:
   dpt: '1.011'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.Luftreiniger.Nachtmodus-Status
   room: Schlafzimmer Eltern
-6/3/120:
+6/3/170:
+  dpt: '9.030'
+  function: Raumklima
+  name: Raumklima.OG.Schlafzimmer-Eltern.Luftreiniger.Feinstaub-PM25
+  room: Schlafzimmer Eltern
+6/3/171:
+  dpt: '9.030'
+  function: Raumklima
+  name: Raumklima.OG.Schlafzimmer-Eltern.Luftreiniger.Feinstaub-PM10
+  room: Schlafzimmer Eltern
+6/3/172:
+  dpt: '5.001'
+  function: Raumklima
+  name: Raumklima.OG.Schlafzimmer-Eltern.Luftreiniger.Filter-Lebensdauer
+  room: Schlafzimmer Eltern
+6/3/173:
+  dpt: '1.011'
+  function: Raumklima
+  name: Raumklima.OG.Schlafzimmer-Eltern.Luftreiniger.Lüfter-Läuft-Status
+  room: Schlafzimmer Eltern
+6/3/180:
   dpt: '1.003'
   function: Raumklima
   name: Raumklima.OG.Begehbarer-Schrank.FBH.Sperren
   room: Begehbarer Schrank
-6/3/121:
+6/3/181:
   dpt: '5.001'
   function: Raumklima
   name: Raumklima.OG.Begehbarer-Schrank.FBH.Stellwert-Status
   room: Begehbarer Schrank
-6/3/122:
+6/3/182:
   dpt: '9.001'
   function: Raumklima
   name: Raumklima.OG.Begehbarer-Schrank.FBH.Soll-Temperatur
   room: Begehbarer Schrank
-6/3/123:
+6/3/183:
   dpt: '9.001'
   function: Raumklima
   name: Raumklima.OG.Begehbarer-Schrank.FBH.Soll-Temperatur-Status
   room: Begehbarer Schrank
-6/3/124:
+6/3/184:
   dpt: '9.002'
   function: Raumklima
   name: Raumklima.OG.Begehbarer-Schrank.FBH.Sollwertverschiebung
   room: Begehbarer Schrank
-6/3/125:
+6/3/185:
   dpt: '20.102'
   function: Raumklima
   name: Raumklima.OG.Begehbarer-Schrank.FBH.HVAC
   room: Begehbarer Schrank
-6/3/126:
+6/3/186:
   dpt: '20.102'
   function: Raumklima
   name: Raumklima.OG.Begehbarer-Schrank.FBH.HVAC-Status
   room: Begehbarer Schrank
-6/3/127:
+6/3/187:
   dpt: '1.011'
   function: Raumklima
   name: Raumklima.OG.Begehbarer-Schrank.FBH.Aktiv
   room: Begehbarer Schrank
-6/3/128:
+6/3/188:
   dpt: '5.010'
   function: Raumklima
   name: Raumklima.OG.Begehbarer-Schrank.FBH.Aktiv-Anomalie
   room: Begehbarer Schrank
-6/3/129:
+6/3/189:
   dpt: '5.010'
   function: Raumklima
   name: Raumklima.OG.Begehbarer-Schrank.FBH.Aktiv-Fenster-Auf-Anomalie
   room: Begehbarer Schrank
-6/3/130:
+6/3/190:
   dpt: '16.000'
   function: Raumklima
   name: Raumklima.OG.Begehbarer-Schrank.FBH.Diagnose
   room: Begehbarer Schrank
-6/3/140:
-  dpt: '1.003'
-  function: Raumklima
-  name: Raumklima.OG.Badezimmer-Eltern.FBH.Sperren
-  room: Badezimmer Eltern
-6/3/141:
-  dpt: '5.001'
-  function: Raumklima
-  name: Raumklima.OG.Badezimmer-Eltern.FBH.Stellwert-Status
-  room: Badezimmer Eltern
-6/3/142:
-  dpt: '9.001'
-  function: Raumklima
-  name: Raumklima.OG.Badezimmer-Eltern.FBH.Soll-Temperatur
-  room: Badezimmer Eltern
-6/3/143:
-  dpt: '9.001'
-  function: Raumklima
-  name: Raumklima.OG.Badezimmer-Eltern.FBH.Soll-Temperatur-Status
-  room: Badezimmer Eltern
-6/3/144:
-  dpt: '9.002'
-  function: Raumklima
-  name: Raumklima.OG.Badezimmer-Eltern.FBH.Sollwertverschiebung
-  room: Badezimmer Eltern
-6/3/145:
-  dpt: '20.102'
-  function: Raumklima
-  name: Raumklima.OG.Badezimmer-Eltern.FBH.HVAC
-  room: Badezimmer Eltern
-6/3/146:
-  dpt: '20.102'
-  function: Raumklima
-  name: Raumklima.OG.Badezimmer-Eltern.FBH.HVAC-Status
-  room: Badezimmer Eltern
-6/3/147:
-  dpt: '1.011'
-  function: Raumklima
-  name: Raumklima.OG.Badezimmer-Eltern.FBH.Aktiv
-  room: Badezimmer Eltern
-6/3/148:
-  dpt: '5.010'
-  function: Raumklima
-  name: Raumklima.OG.Badezimmer-Eltern.FBH.Aktiv-Anomalie
-  room: Badezimmer Eltern
-6/3/149:
-  dpt: '5.010'
-  function: Raumklima
-  name: Raumklima.OG.Badezimmer-Eltern.FBH.Aktiv-Fenster-Auf-Anomalie
-  room: Badezimmer Eltern
-6/3/150:
-  dpt: '16.000'
-  function: Raumklima
-  name: Raumklima.OG.Badezimmer-Eltern.FBH.Diagnose
-  room: Badezimmer Eltern
 6/3/2:
   dpt: '9.001'
   function: Raumklima
@@ -9297,11 +9327,66 @@
   function: Raumklima
   name: Raumklima.OG.Abstellraum.FBH.Sperren
   room: Abstellraum
+6/3/200:
+  dpt: '1.003'
+  function: Raumklima
+  name: Raumklima.OG.Badezimmer-Eltern.FBH.Sperren
+  room: Badezimmer Eltern
+6/3/201:
+  dpt: '5.001'
+  function: Raumklima
+  name: Raumklima.OG.Badezimmer-Eltern.FBH.Stellwert-Status
+  room: Badezimmer Eltern
+6/3/202:
+  dpt: '9.001'
+  function: Raumklima
+  name: Raumklima.OG.Badezimmer-Eltern.FBH.Soll-Temperatur
+  room: Badezimmer Eltern
+6/3/203:
+  dpt: '9.001'
+  function: Raumklima
+  name: Raumklima.OG.Badezimmer-Eltern.FBH.Soll-Temperatur-Status
+  room: Badezimmer Eltern
+6/3/204:
+  dpt: '9.002'
+  function: Raumklima
+  name: Raumklima.OG.Badezimmer-Eltern.FBH.Sollwertverschiebung
+  room: Badezimmer Eltern
+6/3/205:
+  dpt: '20.102'
+  function: Raumklima
+  name: Raumklima.OG.Badezimmer-Eltern.FBH.HVAC
+  room: Badezimmer Eltern
+6/3/206:
+  dpt: '20.102'
+  function: Raumklima
+  name: Raumklima.OG.Badezimmer-Eltern.FBH.HVAC-Status
+  room: Badezimmer Eltern
+6/3/207:
+  dpt: '1.011'
+  function: Raumklima
+  name: Raumklima.OG.Badezimmer-Eltern.FBH.Aktiv
+  room: Badezimmer Eltern
+6/3/208:
+  dpt: '5.010'
+  function: Raumklima
+  name: Raumklima.OG.Badezimmer-Eltern.FBH.Aktiv-Anomalie
+  room: Badezimmer Eltern
+6/3/209:
+  dpt: '5.010'
+  function: Raumklima
+  name: Raumklima.OG.Badezimmer-Eltern.FBH.Aktiv-Fenster-Auf-Anomalie
+  room: Badezimmer Eltern
 6/3/21:
   dpt: '5.001'
   function: Raumklima
   name: Raumklima.OG.Abstellraum.FBH.Stellwert-Status
   room: Abstellraum
+6/3/210:
+  dpt: '16.000'
+  function: Raumklima
+  name: Raumklima.OG.Badezimmer-Eltern.FBH.Diagnose
+  room: Badezimmer Eltern
 6/3/22:
   dpt: '9.001'
   function: Raumklima
@@ -9487,66 +9572,11 @@
   function: Raumklima
   name: Raumklima.OG.Flur.FBH.Aktiv-Anomalie
   room: Flur
-6/3/80:
-  dpt: '1.003'
-  function: Raumklima
-  name: Raumklima.OG.Schlafzimmer-Luis.FBH.Sperren
-  room: Schlafzimmer Luis
-6/3/81:
-  dpt: '5.001'
-  function: Raumklima
-  name: Raumklima.OG.Schlafzimmer-Luis.FBH.Stellwert-Status
-  room: Schlafzimmer Luis
-6/3/82:
-  dpt: '9.001'
-  function: Raumklima
-  name: Raumklima.OG.Schlafzimmer-Luis.FBH.Soll-Temperatur
-  room: Schlafzimmer Luis
-6/3/83:
-  dpt: '9.001'
-  function: Raumklima
-  name: Raumklima.OG.Schlafzimmer-Luis.FBH.Soll-Temperatur-Status
-  room: Schlafzimmer Luis
-6/3/84:
-  dpt: '9.002'
-  function: Raumklima
-  name: Raumklima.OG.Schlafzimmer-Luis.FBH.Sollwertverschiebung
-  room: Schlafzimmer Luis
-6/3/85:
-  dpt: '20.102'
-  function: Raumklima
-  name: Raumklima.OG.Schlafzimmer-Luis.FBH.HVAC
-  room: Schlafzimmer Luis
-6/3/86:
-  dpt: '20.102'
-  function: Raumklima
-  name: Raumklima.OG.Schlafzimmer-Luis.FBH.HVAC-Status
-  room: Schlafzimmer Luis
-6/3/87:
-  dpt: '1.011'
-  function: Raumklima
-  name: Raumklima.OG.Schlafzimmer-Luis.FBH.Aktiv
-  room: Schlafzimmer Luis
-6/3/88:
-  dpt: '5.010'
-  function: Raumklima
-  name: Raumklima.OG.Schlafzimmer-Luis.FBH.Aktiv-Anomalie
-  room: Schlafzimmer Luis
-6/3/89:
-  dpt: '5.010'
-  function: Raumklima
-  name: Raumklima.OG.Schlafzimmer-Luis.FBH.Aktiv-Fenster-Auf-Anomalie
-  room: Schlafzimmer Luis
 6/3/9:
   dpt: '5.010'
   function: Raumklima
   name: Raumklima.OG.Flur.FBH.Aktiv-Fenster-Auf-Anomalie
   room: Flur
-6/3/90:
-  dpt: '16.000'
-  function: Raumklima
-  name: Raumklima.OG.Schlafzimmer-Luis.FBH.Diagnose
-  room: Schlafzimmer Luis
 7/0/200:
   description: 1 - Innen Bedienelemente
   dpt: '1.001'

--- a/kubernetes/applications/knx-nats-bridge/base/config/writer-rules.yaml
+++ b/kubernetes/applications/knx-nats-bridge/base/config/writer-rules.yaml
@@ -1245,56 +1245,56 @@ mappings:
     min_delta: 0
     seed_on_start: true
   - subject: "anomaly.fbh_cold.og-schlafzimmer-luis"
-    ga: "6/3/88"
+    ga: "6/3/108"
     dpt: "5.010"
     payload_path: "$.severity_level"
     description: "Raumklima.OG.Schlafzimmer-Luis.FBH.Aktiv-Anomalie"
     min_delta: 0
     seed_on_start: true
   - subject: "anomaly.window_while_heating.og-schlafzimmer-luis"
-    ga: "6/3/89"
+    ga: "6/3/109"
     dpt: "5.010"
     payload_path: "$.severity_level"
     description: "Raumklima.OG.Schlafzimmer-Luis.FBH.Aktiv-Fenster-Auf-Anomalie"
     min_delta: 0
     seed_on_start: true
   - subject: "anomaly.fbh_cold.og-schlafzimmer-eltern"
-    ga: "6/3/108"
+    ga: "6/3/148"
     dpt: "5.010"
     payload_path: "$.severity_level"
     description: "Raumklima.OG.Schlafzimmer-Eltern.FBH.Aktiv-Anomalie"
     min_delta: 0
     seed_on_start: true
   - subject: "anomaly.window_while_heating.og-schlafzimmer-eltern"
-    ga: "6/3/109"
+    ga: "6/3/149"
     dpt: "5.010"
     payload_path: "$.severity_level"
     description: "Raumklima.OG.Schlafzimmer-Eltern.FBH.Aktiv-Fenster-Auf-Anomalie"
     min_delta: 0
     seed_on_start: true
   - subject: "anomaly.fbh_cold.og-begehbarer-schrank"
-    ga: "6/3/128"
+    ga: "6/3/188"
     dpt: "5.010"
     payload_path: "$.severity_level"
     description: "Raumklima.OG.Begehbarer-Schrank.FBH.Aktiv-Anomalie"
     min_delta: 0
     seed_on_start: true
   - subject: "anomaly.window_while_heating.og-begehbarer-schrank"
-    ga: "6/3/129"
+    ga: "6/3/189"
     dpt: "5.010"
     payload_path: "$.severity_level"
     description: "Raumklima.OG.Begehbarer-Schrank.FBH.Aktiv-Fenster-Auf-Anomalie"
     min_delta: 0
     seed_on_start: true
   - subject: "anomaly.fbh_cold.og-badezimmer-eltern"
-    ga: "6/3/148"
+    ga: "6/3/208"
     dpt: "5.010"
     payload_path: "$.severity_level"
     description: "Raumklima.OG.Badezimmer-Eltern.FBH.Aktiv-Anomalie"
     min_delta: 0
     seed_on_start: true
   - subject: "anomaly.window_while_heating.og-badezimmer-eltern"
-    ga: "6/3/149"
+    ga: "6/3/209"
     dpt: "5.010"
     payload_path: "$.severity_level"
     description: "Raumklima.OG.Badezimmer-Eltern.FBH.Aktiv-Fenster-Auf-Anomalie"
@@ -1382,37 +1382,77 @@ mappings:
     seed_on_start: true
 
   # Luftreiniger (Dyson PC1) status feedback (KNX<-NATS). The command GAs
-  # (6/3/111/113/115/117) are driven KNX->device by the redpanda-connect
+  # (6/3/160/162/164/166/168) are driven KNX->device by the redpanda-connect
   # dyson_from_knx stream; these rules report the actual device state back
   # so Basalte reflects reality. Lüfterstufe 0 = Automatik; Drehmodus enum
   # 0=Aus 1=45° 2=90° 3=180° 4=350°.
   - subject: "dyson.ventilator-1.state"
-    ga: "6/3/112"
+    ga: "6/3/161"
+    dpt: "1.011"
+    payload_path: "$.locked"
+    description: "Raumklima.OG.Schlafzimmer-Eltern.Luftreiniger.Sperren-Status"
+    min_delta: 0  # bool state: write only on change
+    seed_on_start: true
+  - subject: "dyson.ventilator-1.state"
+    ga: "6/3/163"
     dpt: "1.011"
     payload_path: "$.power"
     description: "Raumklima.OG.Schlafzimmer-Eltern.Luftreiniger.Ein/Aus-Status"
     min_delta: 0  # bool state: write only on change
     seed_on_start: true
   - subject: "dyson.ventilator-1.state"
-    ga: "6/3/114"
+    ga: "6/3/165"
     dpt: "5.010"
     payload_path: "$.speed"
     description: "Raumklima.OG.Schlafzimmer-Eltern.Luftreiniger.Lüfterstufe-Status"
     min_delta: 0  # enum state: write only on change
     seed_on_start: true
   - subject: "dyson.ventilator-1.state"
-    ga: "6/3/116"
+    ga: "6/3/167"
     dpt: "5.010"
     payload_path: "$.oscillation_mode"
     description: "Raumklima.OG.Schlafzimmer-Eltern.Luftreiniger.Drehmodus-Status"
     min_delta: 0  # enum state: write only on change
     seed_on_start: true
   - subject: "dyson.ventilator-1.state"
-    ga: "6/3/118"
+    ga: "6/3/169"
     dpt: "1.011"
     payload_path: "$.night"
     description: "Raumklima.OG.Schlafzimmer-Eltern.Luftreiniger.Nachtmodus-Status"
     min_delta: 0  # bool state: write only on change
+    seed_on_start: true
+  # `power` is the commanded state, `fan_running` whether the fan actually
+  # turns — in Automatik with clean air the device is on while the fan idles.
+  - subject: "dyson.ventilator-1.state"
+    ga: "6/3/173"
+    dpt: "1.011"
+    payload_path: "$.fan_running"
+    description: "Raumklima.OG.Schlafzimmer-Eltern.Luftreiniger.Lüfter-Läuft-Status"
+    min_delta: 0  # bool state: write only on change
+    seed_on_start: true
+  - subject: "dyson.ventilator-1.state"
+    ga: "6/3/172"
+    dpt: "5.001"
+    payload_path: "$.filter_life"
+    description: "Raumklima.OG.Schlafzimmer-Eltern.Luftreiniger.Filter-Lebensdauer"
+    min_delta: 1  # percent
+    seed_on_start: true
+
+  # Luftreiniger particulate sensor (KNX<-NATS). Only the PM sensor exists on
+  # this model; min_delta keeps the poll interval off the bus.
+  - subject: "dyson.ventilator-1.environment"
+    ga: "6/3/170"
+    dpt: "9.030"
+    payload_path: "$.pm25"
+    description: "Raumklima.OG.Schlafzimmer-Eltern.Luftreiniger.Feinstaub-PM25"
+    min_delta: 1  # µg/m³
+    seed_on_start: true
+  - subject: "dyson.ventilator-1.environment"
+    ga: "6/3/171"
+    dpt: "9.030"
+    payload_path: "$.pm10"
+    description: "Raumklima.OG.Schlafzimmer-Eltern.Luftreiniger.Feinstaub-PM10"
+    min_delta: 1  # µg/m³
     seed_on_start: true
 
   # Bordbar LED status feedback (KNX<-NATS). The command GAs (4/2/61/63-67) are

--- a/kubernetes/applications/nats/base/consumers/dyson_from_knx.yaml
+++ b/kubernetes/applications/nats/base/consumers/dyson_from_knx.yaml
@@ -1,9 +1,10 @@
 # Durable consumer for the redpanda-connect dyson_from_knx pipeline.
 #
-#   knx.6.3.111 Ein/Aus     (1.001)
-#   knx.6.3.113 Lüfterstufe (5.010, 0 = Automatik, 1..10 manual)
-#   knx.6.3.115 Drehmodus   (5.010 enum: 0=Aus, 1=45°, 2=90°, 3=180°, 4=350°)
-#   knx.6.3.117 Nachtmodus  (1.001)
+#   knx.6.3.160 Sperren     (1.003, 1 = gesperrt)
+#   knx.6.3.162 Ein/Aus     (1.001)
+#   knx.6.3.164 Lüfterstufe (5.010, 0 = Automatik, 1..10 manual)
+#   knx.6.3.166 Drehmodus   (5.010 enum: 0=Aus, 1=45°, 2=90°, 3=180°, 4=350°)
+#   knx.6.3.168 Nachtmodus  (1.001)
 #
 # The Luftreiniger command GAs, written by Basalte.
 apiVersion: jetstream.nats.io/v1beta2
@@ -15,10 +16,11 @@ spec:
   streamName: KNX
   durableName: redpanda-connect-dyson-from-knx
   filterSubjects:
-    - knx.6.3.111
-    - knx.6.3.113
-    - knx.6.3.115
-    - knx.6.3.117
+    - knx.6.3.160
+    - knx.6.3.162
+    - knx.6.3.164
+    - knx.6.3.166
+    - knx.6.3.168
   deliverPolicy: new
   ackPolicy: explicit
   # nats-operator default surfaces as 1ns, which causes immediate re-delivery

--- a/kubernetes/applications/redpanda-connect/base/streams/dyson_from_knx.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/dyson_from_knx.yaml
@@ -1,13 +1,17 @@
 # Luftreiniger control: Basalte command GAs -> dyson-nats-bridge.
 #
-#   knx.6.3.111 Ein/Aus     -> dyson.ventilator-1.command.power       {"value": bool}
-#   knx.6.3.113 Lüfterstufe -> dyson.ventilator-1.command.speed       {"value": 0..10, 0 = auto}
-#   knx.6.3.115 Drehmodus   -> dyson.ventilator-1.command.oscillation {"value": 0..4}
-#   knx.6.3.117 Nachtmodus  -> dyson.ventilator-1.command.night       {"value": bool}
+#   knx.6.3.160 Sperren     -> dyson.ventilator-1.command.lock        {"value": bool}
+#   knx.6.3.162 Ein/Aus     -> dyson.ventilator-1.command.power       {"value": bool}
+#   knx.6.3.164 Lüfterstufe -> dyson.ventilator-1.command.speed       {"value": 0..10, 0 = auto}
+#   knx.6.3.166 Drehmodus   -> dyson.ventilator-1.command.oscillation {"value": 0..4}
+#   knx.6.3.168 Nachtmodus  -> dyson.ventilator-1.command.night       {"value": bool}
+#
+# Sperren is 1 = gesperrt, matching the bridge's lock semantics, so nothing is
+# inverted here. While locked the bridge swallows the other four commands.
 #
 # Core NATS only; the bridge subscribes core and nothing archives commands.
 input:
-  # Consumer (filterSubjects on the four GAs) is declared as a CRD in
+  # Consumer (filterSubjects on the five GAs) is declared as a CRD in
   # nats/base/consumers/dyson_from_knx.yaml.
   nats_jetstream:
     urls: ["nats://nats.nats.svc:4222"]
@@ -22,15 +26,16 @@ pipeline:
   processors:
     - mapping: |
         let subj = meta("nats_subject")
-        root = if $subj == "knx.6.3.113" || $subj == "knx.6.3.115" {
+        root = if $subj == "knx.6.3.164" || $subj == "knx.6.3.166" {
           {"value": this.value.number()}
         } else {
           {"value": this.value == true || this.value == 1}
         }
         meta dyson_subject = "dyson.ventilator-1.command." + (
-          if $subj == "knx.6.3.111" { "power" }
-          else if $subj == "knx.6.3.113" { "speed" }
-          else if $subj == "knx.6.3.115" { "oscillation" }
+          if $subj == "knx.6.3.160" { "lock" }
+          else if $subj == "knx.6.3.162" { "power" }
+          else if $subj == "knx.6.3.164" { "speed" }
+          else if $subj == "knx.6.3.166" { "oscillation" }
           else { "night" }
         )
 


### PR DESCRIPTION
## What happened in ETS

The whole OG moved onto one 20-address block per device. Every FBH block shifted, and the Luftreiniger left the Schlafzimmer-Eltern FBH block for its own at `6/3/160-179`, gaining Sperren, particulate, filter life and fan state.

## The trap

52 addresses moved, **22 of them in collision chains**:

```
Schlafzimmer-Luis    88/89   ->  108/109
Schlafzimmer-Eltern 108/109  ->  148/149     <- Luis' new = Eltern's old
Badezimmer-Eltern   148/149  ->  208/209     <- Eltern's new = Bad's old
```

A find-and-replace over addresses would have silently mapped Luis' anomalies onto Eltern's group addresses — heating anomalies landing in the wrong room, with nothing failing loudly. Rules were therefore rematched by the **GA name in `description`**, and the result verified against the catalog for both address and DPT.

That is also how the Schlafzimmer-Luis pair surfaced at all: it was not on the list of expected moves.

## Address corrections (12)

| Room | Old | New |
| --- | --- | --- |
| Schlafzimmer-Luis FBH anomalies | 88/89 | 108/109 |
| Schlafzimmer-Eltern FBH anomalies | 108/109 | 148/149 |
| Begehbarer-Schrank FBH anomalies | 128/129 | 188/189 |
| Badezimmer-Eltern FBH anomalies | 148/149 | 208/209 |
| Luftreiniger status | 112/114/116/118 | 163/165/167/169 |

## New writer rules (5)

| GA | Source | DPT | Throttle |
| --- | --- | --- | --- |
| `6/3/161` Sperren-Status | `state.locked` | 1.011 | on change |
| `6/3/170` Feinstaub-PM25 | `environment.pm25` | 9.030 | 1 µg/m³ |
| `6/3/171` Feinstaub-PM10 | `environment.pm10` | 9.030 | 1 µg/m³ |
| `6/3/172` Filter-Lebensdauer | `state.filter_life` | 5.001 | 1 % |
| `6/3/173` Lüfter-Läuft-Status | `state.fan_running` | 1.011 | on change |

`min_delta` on the sensor values keeps the 60 s poll interval off the bus.

## Command path

Gains the lock as a fifth function. Sperren is `1 = gesperrt`, matching the bridge's semantics, so nothing is inverted — which matters because writer rules have no transform step.

## Verified

- 215 rules validated against the writer-rules JSON schema
- every rule's GA cross-checked against the catalog for address **and** DPT
- `kustomize build` green for knx-nats-bridge, nats and redpanda-connect
- rendered consumer carries `knx.6.3.160/162/164/166/168`

## Deploy order

1. Merge — ArgoCD syncs, the ConfigMap hash rolls the knx-nats-bridge pod, `seed_on_start` writes the status GAs to their new addresses
2. **The consumer is immutable**: delete and reapply, then `kubectl rollout restart deploy/redpanda-connect -n redpanda-connect`
3. The PostSync job reimports the catalog into `ga_catalog`

Requires dyson-nats-bridge **0.6.0** for `state.locked`, `filter_life` and `fan_running`. Renovate will offer that bump separately.

## Two pre-existing findings, not touched here

- `15/6/15` writer rule declares DPT `13.010`, the catalog says `13.000`. Same wire format, so it works, but the semantics disagree.
- `Versorgungstechnik.Wallbox.Freigabe-Status` in a rule description does not exist in the catalog — the GA is named `Ein-Freigabe-Status`. Matches the ETS rename you already have open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)