### PR TITLE
chore(renovate): auto-merge the remaining first-party bridge images

### DIFF
--- a/.renovate/autoMerge.json5
+++ b/.renovate/autoMerge.json5
@@ -33,7 +33,9 @@
         // Tiny built-in components
         "/metrics-server/",
         // First-party images (we own the build + CI)
-        "/knx-nats-bridge/"
+        "/knx-nats-bridge/",
+        "/dyson-nats-bridge/",
+        "/midea-nats-bridge/"
       ],
       "ignoreTests": false
     },


### PR DESCRIPTION
## Why

Only `knx-nats-bridge` was on the first-party auto-merge list, so `dyson-nats-bridge` image bumps sat waiting for a manual merge — #1454 and #1457 both did — even though we own the build and the CI that produced them.

`midea-nats-bridge` is listed ahead of the repo existing. The rule simply does not match until it does, and it saves a follow-up when the dehumidifier bridge lands.

## Note

Auto-merge here still requires green CI (`ignoreTests: false`), unlike the GitHub Actions rules further down the file. The `minimumReleaseAge: 3 days` in this file applies to `matchManagers: ["github-actions"]` only and never gated these images.

## Verified

`renovate-config-validator .renovate/autoMerge.json5` → config validated successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)