### PR TITLE
feat(prometheus): alert on a spent Dyson filter and an unreachable device

### DIFF
--- a/kubernetes/applications/prometheus/base/prometheus-rule.yaml
+++ b/kubernetes/applications/prometheus/base/prometheus-rule.yaml
@@ -223,3 +223,25 @@ spec:
           annotations:
             summary: "Container {{ $labels.namespace }}/{{ $labels.pod }} OOMKilled"
             description: "Container {{ $labels.container }} was OOMKilled and restarted in the last 10m."
+
+    - name: dyson-alerts
+      rules:
+        # Slow-moving: a filter loses a few percent a month, so a long `for`
+        # costs nothing and keeps a flapping scrape from paging.
+        - alert: DysonFilterLow
+          expr: dyson_filter_life_percent < 10
+          for: 6h
+          labels:
+            severity: warning
+          annotations:
+            summary: "Dyson {{ $labels.device }} filter almost spent"
+            description: "HEPA filter at {{ $value | humanize }}% — order a replacement before it runs out."
+
+        - alert: DysonDeviceDisconnected
+          expr: dyson_connected == 0
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Dyson {{ $labels.device }} unreachable"
+            description: "The bridge has not held a connection for 30m — device unplugged, moved, or off the WLAN."


### PR DESCRIPTION
## Two gaps

**`DysonFilterLow`** — `dyson_filter_life_percent < 10`, `for: 6h`.

The filter is the one value in this stack that moves slowly and eventually needs someone to act. A filter loses a few percent a month, so a long `for` costs nothing in warning time and keeps a flapping scrape from paging.

**`DysonDeviceDisconnected`** — `dyson_connected == 0`, `for: 30m`.

Liveness deliberately excludes the device connection, so an unplugged fan surfaces as a metric instead of restart-looping the pod. That was the right call, but it also meant *nothing* noticed a permanently absent device. 30m tolerates a reboot or a brief WLAN outage.

## Dependency

`dyson_filter_life_percent` arrives with dyson-nats-bridge **0.7.0** (dyson-nats-bridge#26). Until that is deployed the filter rule simply has no series to match — harmless, and Renovate now auto-merges first-party image bumps once #1458 lands.

## Verified

- YAML parses, 10 groups, the new group renders as expected
- `kustomize build --enable-helm overlays/prod` renders both rules with the intended expressions and `for` durations

`promtool` is not installed locally, so the expressions were not machine-checked against the PromQL parser — they are simple comparisons on gauges that already exist in the registry (`dyson_connected`) or are added by #26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)