### PR TITLE
fix(renovate): add miele-nats-bridge to the first-party auto-merge list

### DIFF
--- a/.renovate/autoMerge.json5
+++ b/.renovate/autoMerge.json5
@@ -35,6 +35,7 @@
         // First-party images (we own the build + CI)
         "/knx-nats-bridge/",
         "/dyson-nats-bridge/",
+        "/miele-nats-bridge/",
         "/midea-nats-bridge/"
       ],
       "ignoreTests": false


### PR DESCRIPTION
## What

`miele-nats-bridge` was missing from the first-party auto-merge list, even though it is deployed (`kubernetes/applications/miele-nats-bridge/`) and we own its build and CI. Its image bumps therefore waited for a manual merge, exactly as dyson's did before #1458.

This adds it; nothing is removed.

## Why it was missing

#1458 was meant to add it. I read "miele" as a typo for the planned **midea** dehumidifier bridge and wrote that name instead — so the list gained a package that does not exist yet and kept missing the one that does.

Both belong on the list: `miele-nats-bridge` exists today, `midea-nats-bridge` is the planned dehumidifier bridge from the approved plan, pre-listed so its first bump does not need a follow-up.

`bordbar-nats-bridge` deliberately stays off: it is PlatformIO firmware for an ESP32 and publishes no container image, so a `matchDatasources: ["docker"]` rule would never match it.

## Verified

`renovate-config-validator .renovate/autoMerge.json5` → config validated successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)