### PR TITLE
fix(dyson): follow the appliance rename to ventilator-og7

### DIFF
--- a/kubernetes/applications/dyson-nats-bridge/base/config/devices.yaml
+++ b/kubernetes/applications/dyson-nats-bridge/base/config/devices.yaml
@@ -3,6 +3,6 @@
 # dyson-nats-bridge-device-credentials Secret.
 devices:
   - name: ventilator-1
-    host: ventilator-1.zimmermann.eu.com
+    host: ventilator-og7.zimmermann.eu.com
     serial: 9HC-EU-VEA7652A
     product_type: "438M" # Purifier Cool PC1


### PR DESCRIPTION
## Why this is urgent

`ventilator-1.zimmermann.eu.com` no longer resolves — the purifier was renamed to `ventilator-og7`:

```
ventilator-og7   192.168.1.232
ventilator-1     NXDOMAIN
```

The running bridge still reports `dyson_connected{device="ventilator-1"} 1` and is applying commands normally, because **DNS is only consulted when the MQTT connection is established**. The existing TCP session keeps working.

The next pod restart, node drain or network blip would leave it unable to find the device at all — and it would then retry against a name that cannot resolve, backing off to 300 s forever.

## Change

One line: the `host` in `config/devices.yaml`.

The subject slug stays `ventilator-1`. It is deliberately decoupled from the hostname, and renaming it would ripple into the writer rules, the `dyson_from_knx` mapping and the `device` column of `dyson_environment` history — for no operational gain.

## Verified

`kustomize build --enable-helm overlays/prod` renders the ConfigMap with the new host; the content hash changes, so ArgoCD rolls the pod and the bridge reconnects by the new name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)