### PR TITLE
fix(longhorn): let Prometheus through the new manager NetworkPolicy

### DIFF
--- a/kubernetes/components/csi-block-storage-controller/base/kustomization.yaml
+++ b/kubernetes/components/csi-block-storage-controller/base/kustomization.yaml
@@ -31,6 +31,23 @@ replacements:
         fieldPaths:
           - 'data.storageclass\.yaml.parameters.staleReplicaTimeout'
 
+patches:
+  # The chart's NetworkPolicy only admits Longhorn's own pods, which blocks
+  # Prometheus from scraping longhorn-manager metrics on :9500
+  - target:
+      kind: NetworkPolicy
+      name: longhorn-manager
+    patch: |-
+      - op: add
+        path: /spec/ingress/0/from/-
+        value:
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: prometheus
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+
 labels:
   - includeSelectors: false
     pairs:


### PR DESCRIPTION
## Problem

Three `InstanceDown` criticals fired for `longhorn-manager` shortly after the 1.12.0 → 1.12.1 chart bump (#1468) rolled out. Storage was never affected — all 24 volumes stayed `attached / healthy` and all three managers `2/2 Running`. What broke was the scrape.

Chart 1.12.1 changed the gate on its `network-policies/*` templates:

| Chart | Gate | Default |
| --- | --- | --- |
| 1.12.0 | `if .Values.networkPolicies.enabled` | `false` → no policies |
| 1.12.1 | `if .Values.networkPolicies.restrictInternalTraffic` | **`true`** → 6 policies |

`restrictInternalTraffic` is a new value defaulting to true, so a patch bump deployed six NetworkPolicies that were never in `values.yaml`. The `longhorn-manager` policy admits only Longhorn's own pods in the namespace, so Cilium dropped Prometheus' scrapes of `:9500` — `context deadline exceeded`, `up == 0`, three criticals plus a pending `TargetDown`.

## Fix

The policy's `from`-list is hardcoded in the template — `.Values` appears only in the `if` gate — so the chart has no native knob for admitting a monitoring namespace. The only supported alternative would be `restrictInternalTraffic: false`, which drops the policies entirely.

Kept them instead and appended the Prometheus selector via kustomize: `manager:9500` is an unauthenticated API that can create and delete volumes, and before 1.12.1 it was reachable from every pod in the cluster. The new policy closes that; this PR just carves out the scrape.

## Verification

- `kustomize build --enable-helm overlays/prod` renders all six policies, with the Prometheus `namespaceSelector` + `podSelector` appended to `longhorn-manager`'s `ingress[0].from`
- Ruled out as causes: the manager does listen on `:9500` (bound to the pod IP, so a localhost port-forward is refused — expected), and the `longhorn-webhook` policy has no `from` restriction, so apiserver admission calls and kubelet probes were never affected

Post-merge the three alerts should resolve within a scrape interval once Argo syncs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)