### PR TITLE
feat(tsdb): archive appliance control state, not just sensors

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/kustomization.yaml
+++ b/kubernetes/applications/redpanda-connect/base/kustomization.yaml
@@ -39,6 +39,9 @@ configMapGenerator:
       - streams/warp_mode_flags.yaml
       - streams/dyson_from_knx.yaml
       - streams/dyson_environment.yaml
+      - streams/dyson_state.yaml
+      - streams/midea_environment.yaml
+      - streams/midea_state.yaml
       - streams/bordbar_from_knx.yaml
 
 patches:

--- a/kubernetes/applications/redpanda-connect/base/streams/dyson_state.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/dyson_state.yaml
@@ -1,0 +1,95 @@
+# Dyson Luftreiniger control state -> TimescaleDB + parquet cold archive.
+#
+#   dyson.<device>.state -> dyson_state
+#
+# The bridge publishes only on change, so rows are sparse by design. Fields the
+# model does not report are omitted upstream rather than sent as null -> typed
+# columns stay NULL.
+input:
+  nats_jetstream:
+    urls: ["nats://nats.nats.svc:4222"]
+    auth:
+      user: redpanda-connect
+      password: ${NATS_PASSWORD}
+    stream: DYSON
+    subject: dyson.*.state
+    durable: redpanda-connect-dyson-state
+    deliver: all
+    ack_wait: 20m
+    max_ack_pending: 5000
+
+pipeline:
+  processors:
+    - mapping: |
+        root = {
+          "time":             meta("nats_timestamp").or(now().ts_format("2006-01-02T15:04:05.999999Z")),
+          "device":           meta("nats_subject").split(".").index(1),
+          "power":            this.power | null,
+          "auto":             this.auto | null,
+          "speed":            this.speed | null,
+          "oscillation":      this.oscillation | null,
+          "oscillation_mode": this.oscillation_mode | null,
+          "night":            this.night | null,
+          "fan_running":      this.fan_running | null,
+          "filter_life":      this.filter_life | null,
+          "locked":           this.locked | null,
+          "raw":              this,
+        }
+
+output:
+  broker:
+    pattern: fan_out
+    outputs:
+      - sql_raw:
+          driver: pgx
+          max_in_flight: 16
+          dsn: postgres://${PGUSER}:${PGPASSWORD}@timescaledb-db-pooler.timescaledb.svc.cluster.local:5432/homelab?sslmode=disable
+          init_statement: |
+            SET timezone = 'UTC';
+          query: |
+            INSERT INTO dyson_state (
+              time, device, power, auto, speed, oscillation, oscillation_mode,
+              night, fan_running, filter_life, locked
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+            ON CONFLICT (time, device) DO NOTHING
+          args_mapping: |
+            root = [
+              this.time,
+              this.device,
+              this.power,
+              this.auto,
+              this.speed,
+              this.oscillation,
+              this.oscillation_mode,
+              this.night,
+              this.fan_running,
+              this.filter_life,
+              this.locked,
+            ]
+      - aws_s3:
+          bucket: nats-archive
+          object_canned_acl: private
+          region: us-east-1
+          endpoint: http://rustfs-svc.rustfs.svc.cluster.local:9000
+          force_path_style_urls: true
+          credentials:
+            id: ${RUSTFS_ACCESS_KEY}
+            secret: ${RUSTFS_SECRET_KEY}
+          path: dyson-state/${!now().ts_format("2006/01/02/15")}/${!uuid_v4()}.parquet
+          batching:
+            count: 2000
+            period: 15m
+            processors:
+              - mapping: |
+                  root = {
+                    "time":    this.time,
+                    "subject": meta("nats_subject"),
+                    "payload": this.raw.format_json(),
+                  }
+              - parquet_encode:
+                  default_compression: zstd
+                  schema:
+                    - { name: time,    type: UTF8 }
+                    - { name: subject, type: UTF8 }
+                    - { name: payload, type: UTF8 }

--- a/kubernetes/applications/redpanda-connect/base/streams/midea_environment.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/midea_environment.yaml
@@ -1,0 +1,80 @@
+# Comfee/Midea Entfeuchter sensor telemetry -> TimescaleDB + parquet cold archive.
+#
+#   midea.<device>.environment -> midea_environment
+#
+# tank_level only appears on models advertising the water_level capability; the
+# bridge omits it otherwise rather than reporting a constant 0 that would look
+# like an empty tank -> the column stays NULL.
+input:
+  nats_jetstream:
+    urls: ["nats://nats.nats.svc:4222"]
+    auth:
+      user: redpanda-connect
+      password: ${NATS_PASSWORD}
+    stream: MIDEA
+    subject: midea.*.environment
+    durable: redpanda-connect-midea-environment
+    deliver: all
+    ack_wait: 20m
+    max_ack_pending: 5000
+
+pipeline:
+  processors:
+    - mapping: |
+        root = {
+          "time":          meta("nats_timestamp").or(now().ts_format("2006-01-02T15:04:05.999999Z")),
+          "device":        meta("nats_subject").split(".").index(1),
+          "humidity":      this.humidity | null,
+          "temperature_c": this.temperature_c | null,
+          "tank_level":    this.tank_level | null,
+          "raw":           this,
+        }
+
+output:
+  broker:
+    pattern: fan_out
+    outputs:
+      - sql_raw:
+          driver: pgx
+          max_in_flight: 16
+          dsn: postgres://${PGUSER}:${PGPASSWORD}@timescaledb-db-pooler.timescaledb.svc.cluster.local:5432/homelab?sslmode=disable
+          init_statement: |
+            SET timezone = 'UTC';
+          query: |
+            INSERT INTO midea_environment (time, device, humidity, temperature_c, tank_level)
+            VALUES ($1, $2, $3, $4, $5)
+            ON CONFLICT (time, device) DO NOTHING
+          args_mapping: |
+            root = [
+              this.time,
+              this.device,
+              this.humidity,
+              this.temperature_c,
+              this.tank_level,
+            ]
+      - aws_s3:
+          bucket: nats-archive
+          object_canned_acl: private
+          region: us-east-1
+          endpoint: http://rustfs-svc.rustfs.svc.cluster.local:9000
+          force_path_style_urls: true
+          credentials:
+            id: ${RUSTFS_ACCESS_KEY}
+            secret: ${RUSTFS_SECRET_KEY}
+          path: midea/${!now().ts_format("2006/01/02/15")}/${!uuid_v4()}.parquet
+          batching:
+            count: 2000
+            period: 15m
+            processors:
+              - mapping: |
+                  root = {
+                    "time":    this.time,
+                    "subject": meta("nats_subject"),
+                    "payload": this.raw.format_json(),
+                  }
+              - parquet_encode:
+                  default_compression: zstd
+                  schema:
+                    - { name: time,    type: UTF8 }
+                    - { name: subject, type: UTF8 }
+                    - { name: payload, type: UTF8 }

--- a/kubernetes/applications/redpanda-connect/base/streams/midea_state.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/midea_state.yaml
@@ -1,0 +1,102 @@
+# Comfee/Midea Entfeuchter control state -> TimescaleDB + parquet cold archive.
+#
+#   midea.<device>.state -> midea_state
+#
+# `mode` and `fan_speed` are the appliance's own integers, deliberately
+# untranslated — the value sets are pinned from this history rather than
+# guessed. ion/pump/filter_indicator only appear on models advertising the
+# capability -> the columns stay NULL otherwise.
+input:
+  nats_jetstream:
+    urls: ["nats://nats.nats.svc:4222"]
+    auth:
+      user: redpanda-connect
+      password: ${NATS_PASSWORD}
+    stream: MIDEA
+    subject: midea.*.state
+    durable: redpanda-connect-midea-state
+    deliver: all
+    ack_wait: 20m
+    max_ack_pending: 5000
+
+pipeline:
+  processors:
+    - mapping: |
+        root = {
+          "time":             meta("nats_timestamp").or(now().ts_format("2006-01-02T15:04:05.999999Z")),
+          "device":           meta("nats_subject").split(".").index(1),
+          "power":            this.power | null,
+          "mode":             this.mode | null,
+          "fan_speed":        this.fan_speed | null,
+          "target_humidity":  this.target_humidity | null,
+          "tank_full":        this.tank_full | null,
+          "sleep":            this.sleep | null,
+          "defrosting":       this.defrosting | null,
+          "ion":              this.ion | null,
+          "pump":             this.pump | null,
+          "filter_indicator": this.filter_indicator | null,
+          "error_code":       this.error_code | null,
+          "locked":           this.locked | null,
+          "raw":              this,
+        }
+
+output:
+  broker:
+    pattern: fan_out
+    outputs:
+      - sql_raw:
+          driver: pgx
+          max_in_flight: 16
+          dsn: postgres://${PGUSER}:${PGPASSWORD}@timescaledb-db-pooler.timescaledb.svc.cluster.local:5432/homelab?sslmode=disable
+          init_statement: |
+            SET timezone = 'UTC';
+          query: |
+            INSERT INTO midea_state (
+              time, device, power, mode, fan_speed, target_humidity, tank_full,
+              sleep, defrosting, ion, pump, filter_indicator, error_code, locked
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+            ON CONFLICT (time, device) DO NOTHING
+          args_mapping: |
+            root = [
+              this.time,
+              this.device,
+              this.power,
+              this.mode,
+              this.fan_speed,
+              this.target_humidity,
+              this.tank_full,
+              this.sleep,
+              this.defrosting,
+              this.ion,
+              this.pump,
+              this.filter_indicator,
+              this.error_code,
+              this.locked,
+            ]
+      - aws_s3:
+          bucket: nats-archive
+          object_canned_acl: private
+          region: us-east-1
+          endpoint: http://rustfs-svc.rustfs.svc.cluster.local:9000
+          force_path_style_urls: true
+          credentials:
+            id: ${RUSTFS_ACCESS_KEY}
+            secret: ${RUSTFS_SECRET_KEY}
+          path: midea-state/${!now().ts_format("2006/01/02/15")}/${!uuid_v4()}.parquet
+          batching:
+            count: 2000
+            period: 15m
+            processors:
+              - mapping: |
+                  root = {
+                    "time":    this.time,
+                    "subject": meta("nats_subject"),
+                    "payload": this.raw.format_json(),
+                  }
+              - parquet_encode:
+                  default_compression: zstd
+                  schema:
+                    - { name: time,    type: UTF8 }
+                    - { name: subject, type: UTF8 }
+                    - { name: payload, type: UTF8 }

--- a/kubernetes/applications/timescaledb/base/scripts/bootstrap.sql
+++ b/kubernetes/applications/timescaledb/base/scripts/bootstrap.sql
@@ -420,6 +420,71 @@ SELECT create_hypertable('dyson_environment', 'time', chunk_time_interval => INT
 CREATE INDEX ON dyson_environment (device, time DESC);
 
 -- =========================================================
+-- Dyson Luftreiniger control state (dyson-nats-bridge → dyson.<device>.state)
+-- `power` is the commanded state, `fan_running` whether the fan actually
+-- turns — they differ in auto mode. `speed` 0 encodes auto; oscillation_mode
+-- 0=off, 1..4 = 45/90/180/350 degrees. `locked` is a bridge-side flag with no
+-- counterpart on the device. Fields the model does not report stay NULL.
+-- =========================================================
+CREATE TABLE dyson_state (
+    time             TIMESTAMPTZ NOT NULL,
+    device           TEXT        NOT NULL,
+    power            BOOLEAN,
+    auto             BOOLEAN,
+    speed            SMALLINT,
+    oscillation      BOOLEAN,
+    oscillation_mode SMALLINT,
+    night            BOOLEAN,
+    fan_running      BOOLEAN,
+    filter_life      SMALLINT,
+    locked           BOOLEAN,
+    PRIMARY KEY (time, device)
+);
+SELECT create_hypertable('dyson_state', 'time', chunk_time_interval => INTERVAL '1 day');
+CREATE INDEX ON dyson_state (device, time DESC);
+
+-- =========================================================
+-- Comfee/Midea Entfeuchter (midea-nats-bridge → midea.<device>.environment)
+-- =========================================================
+CREATE TABLE midea_environment (
+    time          TIMESTAMPTZ NOT NULL,
+    device        TEXT        NOT NULL,
+    humidity      SMALLINT,
+    temperature_c REAL,
+    tank_level    SMALLINT,
+    PRIMARY KEY (time, device)
+);
+SELECT create_hypertable('midea_environment', 'time', chunk_time_interval => INTERVAL '1 day');
+CREATE INDEX ON midea_environment (device, time DESC);
+
+-- =========================================================
+-- Comfee/Midea Entfeuchter control state (→ midea.<device>.state)
+-- `mode` and `fan_speed` are the appliance's own integers, deliberately
+-- untranslated — the library's 0-15 / 0-127 are library bounds, not device
+-- capabilities. ion/pump/filter_indicator stay NULL on models that do not
+-- advertise the capability; the bridge omits them rather than reporting false.
+-- =========================================================
+CREATE TABLE midea_state (
+    time             TIMESTAMPTZ NOT NULL,
+    device           TEXT        NOT NULL,
+    power            BOOLEAN,
+    mode             SMALLINT,
+    fan_speed        SMALLINT,
+    target_humidity  SMALLINT,
+    tank_full        BOOLEAN,
+    sleep            BOOLEAN,
+    defrosting       BOOLEAN,
+    ion              BOOLEAN,
+    pump             BOOLEAN,
+    filter_indicator BOOLEAN,
+    error_code       SMALLINT,
+    locked           BOOLEAN,
+    PRIMARY KEY (time, device)
+);
+SELECT create_hypertable('midea_state', 'time', chunk_time_interval => INTERVAL '1 day');
+CREATE INDEX ON midea_state (device, time DESC);
+
+-- =========================================================
 -- Continuous Aggregate Refresh Policies
 -- =========================================================
 SELECT add_continuous_aggregate_policy('knx_1h',
@@ -488,6 +553,15 @@ ALTER TABLE warp_meter SET (timescaledb.compress,
 ALTER TABLE dyson_environment SET (timescaledb.compress,
     timescaledb.compress_segmentby = 'device',
     timescaledb.compress_orderby = 'time DESC');
+ALTER TABLE dyson_state SET (timescaledb.compress,
+    timescaledb.compress_segmentby = 'device',
+    timescaledb.compress_orderby = 'time DESC');
+ALTER TABLE midea_environment SET (timescaledb.compress,
+    timescaledb.compress_segmentby = 'device',
+    timescaledb.compress_orderby = 'time DESC');
+ALTER TABLE midea_state SET (timescaledb.compress,
+    timescaledb.compress_segmentby = 'device',
+    timescaledb.compress_orderby = 'time DESC');
 ALTER TABLE unifi_events SET (timescaledb.compress,
     timescaledb.compress_segmentby = 'camera',
     timescaledb.compress_orderby = 'time DESC');
@@ -503,6 +577,9 @@ SELECT add_compression_policy('warp_charge_manager', INTERVAL '2 days');
 SELECT add_compression_policy('warp_charge_tracker', INTERVAL '2 days');
 SELECT add_compression_policy('warp_meter',          INTERVAL '2 days');
 SELECT add_compression_policy('dyson_environment',   INTERVAL '2 days');
+SELECT add_compression_policy('dyson_state',         INTERVAL '2 days');
+SELECT add_compression_policy('midea_environment',   INTERVAL '2 days');
+SELECT add_compression_policy('midea_state',         INTERVAL '2 days');
 SELECT add_compression_policy('unifi_events',        INTERVAL '7 days');
 
 -- =========================================================
@@ -521,6 +598,9 @@ SELECT add_retention_policy('warp_charge_manager', INTERVAL '365 days');
 SELECT add_retention_policy('warp_charge_tracker', INTERVAL '365 days');
 SELECT add_retention_policy('warp_meter',          INTERVAL '365 days');
 SELECT add_retention_policy('dyson_environment',   INTERVAL '365 days');
+SELECT add_retention_policy('dyson_state',         INTERVAL '365 days');
+SELECT add_retention_policy('midea_environment',   INTERVAL '365 days');
+SELECT add_retention_policy('midea_state',         INTERVAL '365 days');
 
 -- =========================================================
 -- GA catalog — GA → name/room/function/description lookup,


### PR DESCRIPTION
## The gap

`dyson_environment` stored `pm25`/`pm10` and nothing else. Everything the bridge publishes on `.state` — power, speed, oscillation, night, and since 0.7.0 `fan_running`, `filter_life`, `locked` — was thrown away on arrival. The dehumidifiers had no tables at all.

## Added

| Table | Source |
| --- | --- |
| `dyson_state` | `dyson.<device>.state` |
| `midea_environment` | `midea.<device>.environment` |
| `midea_state` | `midea.<device>.state` |

All follow the existing shape: 1-day chunks, index on `(device, time DESC)`, compression segmentby `device` after 2 days, 365-day retention, plus the parquet cold archive every other stream has.

## Two deliberate choices

**`mode` and `fan_speed` stay raw integers.** This history is *how* their value sets get pinned. Only `mode` 1/3 and `fan_speed` 60/80 have been observed on a real appliance so far; inventing the rest would put wrong labels on a KNX group address with nothing to contradict them. After a few weeks: `SELECT DISTINCT mode, fan_speed FROM midea_state`.

**Capability-gated columns stay NULL.** `ion`, `pump`, `filter_indicator`, `tank_level` are absent from the payload on models that do not advertise the capability, because the bridge omits them rather than reporting a `false` or `0` that would read as a measurement. NULL preserves that distinction.

## Verified against the real appliances

- all four streams (including the existing `dyson_environment`) lint clean in `redpandadata/connect:4.104.0`
- both mappings run through `blobl` with **live payloads** captured from the devices

The mapping check mattered: missing fields become `null` while falsy ones survive. `power: false`, `oscillation_mode: 0` and `tank_full: false` all carry through rather than being swallowed by the `|` coalesce — the classic trap with that operator.

```
in:  {"power": false, "auto": false, "night": true, "speed": 3, "filter_life": 96, "oscillation_mode": 0, ...}
out: {"power":false,"auto":false,"night":true,"speed":3,"filter_life":96,"oscillation_mode":0,...}
```

## Applying it

`bootstrap.sql` is the canonical target for a fresh cluster. The running cluster needs the DDL applied manually via psql as role `homelab` — the three `CREATE TABLE` blocks plus their `create_hypertable`, index, compression and retention statements.

Until that is done the new streams will error on insert; they retry, so nothing is lost, but merge and apply close together.

## Not included

The `dyson_environment` device rename (`ventilator-1` → `ventilator-og7`). It is only ~7900 rows across 33 chunks and 6 MB, so it is entirely feasible — but it belongs with the slug change in #1471, not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)