### PR TITLE
fix(connect): read the JetStream message timestamp that actually exists

### DIFF
--- a/kubernetes/applications/redpanda-connect/base/streams/dyson_environment.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/dyson_environment.yaml
@@ -22,7 +22,7 @@ pipeline:
   processors:
     - mapping: |
         root = {
-          "time":   meta("nats_timestamp").or(now().ts_format("2006-01-02T15:04:05.999999Z")),
+          "time":   (meta("nats_timestamp_unix_nano").number() / 1000000000).ts_format("2006-01-02T15:04:05.999999Z").catch(now().ts_format("2006-01-02T15:04:05.999999Z")),
           "device": meta("nats_subject").split(".").index(1),
           "pm25":   this.pm25 | null,
           "pm10":   this.pm10 | null,

--- a/kubernetes/applications/redpanda-connect/base/streams/dyson_state.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/dyson_state.yaml
@@ -22,7 +22,7 @@ pipeline:
   processors:
     - mapping: |
         root = {
-          "time":             meta("nats_timestamp").or(now().ts_format("2006-01-02T15:04:05.999999Z")),
+          "time":             (meta("nats_timestamp_unix_nano").number() / 1000000000).ts_format("2006-01-02T15:04:05.999999Z").catch(now().ts_format("2006-01-02T15:04:05.999999Z")),
           "device":           meta("nats_subject").split(".").index(1),
           "power":            this.power | null,
           "auto":             this.auto | null,

--- a/kubernetes/applications/redpanda-connect/base/streams/ems_esp.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/ems_esp.yaml
@@ -30,7 +30,7 @@ pipeline:
         let topic = meta("nats_subject").split(".").index(1)
         # ems-esp payloads carry no timestamp field — use the JetStream-server
         # receive time, falling back to now() if metadata is missing.
-        let ts = meta("nats_timestamp").or(now().ts_format("2006-01-02T15:04:05.999999Z"))
+        let ts = (meta("nats_timestamp_unix_nano").number() / 1000000000).ts_format("2006-01-02T15:04:05.999999Z").catch(now().ts_format("2006-01-02T15:04:05.999999Z"))
         root = {
           "time":              $ts,
           "topic":             $topic,

--- a/kubernetes/applications/redpanda-connect/base/streams/midea_environment.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/midea_environment.yaml
@@ -22,7 +22,7 @@ pipeline:
   processors:
     - mapping: |
         root = {
-          "time":          meta("nats_timestamp").or(now().ts_format("2006-01-02T15:04:05.999999Z")),
+          "time":          (meta("nats_timestamp_unix_nano").number() / 1000000000).ts_format("2006-01-02T15:04:05.999999Z").catch(now().ts_format("2006-01-02T15:04:05.999999Z")),
           "device":        meta("nats_subject").split(".").index(1),
           "humidity":      this.humidity | null,
           "temperature_c": this.temperature_c | null,

--- a/kubernetes/applications/redpanda-connect/base/streams/midea_state.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/midea_state.yaml
@@ -23,7 +23,7 @@ pipeline:
   processors:
     - mapping: |
         root = {
-          "time":             meta("nats_timestamp").or(now().ts_format("2006-01-02T15:04:05.999999Z")),
+          "time":             (meta("nats_timestamp_unix_nano").number() / 1000000000).ts_format("2006-01-02T15:04:05.999999Z").catch(now().ts_format("2006-01-02T15:04:05.999999Z")),
           "device":           meta("nats_subject").split(".").index(1),
           "power":            this.power | null,
           "mode":             this.mode | null,

--- a/kubernetes/applications/redpanda-connect/base/streams/unifi_events.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/unifi_events.yaml
@@ -27,7 +27,7 @@ pipeline:
         # read from the payload rather than parsing the subject.
         # Use JetStream server-receive time as the canonical row time;
         # the original UniFi trigger.timestamp (ms epoch) stays in `raw`.
-        let ts = meta("nats_timestamp").or(now().ts_format("2006-01-02T15:04:05.999999Z"))
+        let ts = (meta("nats_timestamp_unix_nano").number() / 1000000000).ts_format("2006-01-02T15:04:05.999999Z").catch(now().ts_format("2006-01-02T15:04:05.999999Z"))
         root = {
           "time":           $ts,
           "camera":         $evt.camera,

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_charge_manager.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_charge_manager.yaml
@@ -20,7 +20,7 @@ pipeline:
         let evt = this
         let parts = meta("nats_subject").split(".")
         root = {
-          "time":      meta("nats_timestamp").or(now().ts_format("2006-01-02T15:04:05.999999Z")),
+          "time":      (meta("nats_timestamp_unix_nano").number() / 1000000000).ts_format("2006-01-02T15:04:05.999999Z").catch(now().ts_format("2006-01-02T15:04:05.999999Z")),
           "sub_topic": $parts.slice(1).join("."),
           "raw":       $evt,
         }

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_charge_tracker.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_charge_tracker.yaml
@@ -29,7 +29,7 @@ pipeline:
         let evt = this
         let parts = meta("nats_subject").split(".")
         root = {
-          "time":                   meta("nats_timestamp").or(now().ts_format("2006-01-02T15:04:05.999999Z")),
+          "time":                   (meta("nats_timestamp_unix_nano").number() / 1000000000).ts_format("2006-01-02T15:04:05.999999Z").catch(now().ts_format("2006-01-02T15:04:05.999999Z")),
           "sub_topic":              $parts.slice(1).join("."),
           "user_id":                $evt.user_id.or(null),
           "charge_duration":        $evt.charge_duration.or(null),

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_evse.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_evse.yaml
@@ -20,7 +20,7 @@ pipeline:
         let evt = this
         let parts = meta("nats_subject").split(".")
         root = {
-          "time":                     meta("nats_timestamp").or(now().ts_format("2006-01-02T15:04:05.999999Z")),
+          "time":                     (meta("nats_timestamp_unix_nano").number() / 1000000000).ts_format("2006-01-02T15:04:05.999999Z").catch(now().ts_format("2006-01-02T15:04:05.999999Z")),
           "sub_topic":                $parts.slice(1).join("."),
           "charger_state":            $evt.charger_state.or(null),
           "error_state":              $evt.error_state.or(null),

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_meter.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_meter.yaml
@@ -32,7 +32,7 @@ pipeline:
         let is_indexed_values = $parts.length() == 4 && $parts.index(3) == "values"
         let is_full_array = $is_indexed_values && $evt.type() == "array" && $evt.length() >= 9
         root = {
-          "time":       meta("nats_timestamp").or(now().ts_format("2006-01-02T15:04:05.999999Z")),
+          "time":       (meta("nats_timestamp_unix_nano").number() / 1000000000).ts_format("2006-01-02T15:04:05.999999Z").catch(now().ts_format("2006-01-02T15:04:05.999999Z")),
           "sub_topic":  $parts.slice(1).join("."),
           "meter_id":   $parts.index(2).number(),
           "voltage_l1": if $is_full_array { $evt.index(0) } else { null },

--- a/kubernetes/applications/redpanda-connect/base/streams/warp_system.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/warp_system.yaml
@@ -46,7 +46,7 @@ pipeline:
         let evt = this
         let parts = meta("nats_subject").split(".")
         root = {
-          "time":      meta("nats_timestamp").or(now().ts_format("2006-01-02T15:04:05.999999Z")),
+          "time":      (meta("nats_timestamp_unix_nano").number() / 1000000000).ts_format("2006-01-02T15:04:05.999999Z").catch(now().ts_format("2006-01-02T15:04:05.999999Z")),
           "sub_topic": $parts.slice(1).join("."),
           "raw":       $evt,
         }


### PR DESCRIPTION
## The bug

Every stream took its event time from `meta("nats_timestamp")`. **That key does not exist.** The `nats_jetstream` input publishes `nats_timestamp_unix_nano`:

```
nats_subject, nats_sequence_stream, nats_sequence_consumer,
nats_num_delivered, nats_num_pending, nats_domain, nats_timestamp_unix_nano
```

The lookup failed on every message and the `.or(now())` fallback silently supplied the *ingestion* time instead. It never errored, never logged — it just quietly wrote a different number than intended.

## Why it stayed hidden

Live, ingestion follows the event by milliseconds, so the wrong value looks right. It only bites when a **new consumer reads an existing backlog**.

Adding `dyson_state` made that concrete. 22166 rows covering 168h of history landed inside two minutes:

```
13:39  18036 rows
13:38   4098 rows
```

A month of `dyson_environment` looks fine for the same reason — its consumer has always been live.

## The fix

```
(meta("nats_timestamp_unix_nano").number() / 1000000000)
    .ts_format("2006-01-02T15:04:05.999999Z")
```

Verified with `blobl` against the real image:

| Attempt | Result |
| --- | --- |
| `ns.ts_format(...)` — raw nanoseconds | `56614468411-07-02T06:13:20Z` |
| `(ns / 1e9).floor().ts_format(...)` | `2026-08-13T00:15:23Z` — drops sub-second |
| `(ns / 1e9).ts_format(...)` | `2026-08-13T00:15:23.456789Z` ✅ |

Flooring would have been tempting and wrong: the `(time, device)` primary keys rely on sub-second precision to avoid collisions that `ON CONFLICT DO NOTHING` would swallow.

## Scope

All **11** streams, not only the three new ones. Leaving the broken pattern in place is exactly how it reached the new streams — they were copied from `dyson_environment`.

Existing rows are unaffected; their timestamps were already close to the event time.

## Follow-up, not in this PR

`dyson_state` needs its 22k backfilled rows dropped and the durable consumer recreated, so the history is read again with real timestamps:

```sql
TRUNCATE dyson_state;
```
```sh
nats consumer rm DYSON redpanda-connect-dyson-state
kubectl rollout restart deploy/redpanda-connect -n redpanda-connect
```

`deliver: all` then replays the full 168h with correct timestamps.

## Verified

All 11 streams lint clean in `redpandadata/connect:4.104.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)