### PR TITLE
refactor(homepage): group Remote Desktop with ArgoCD under GitOps & Operations

### DIFF
--- a/kubernetes/applications/devolutions-gateway/base/ingress-route.yaml
+++ b/kubernetes/applications/devolutions-gateway/base/ingress-route.yaml
@@ -10,17 +10,17 @@ metadata:
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
     # Homepage Service Discovery
     gethomepage.dev/enabled: "true"
-    gethomepage.dev/group: "Infrastructure"
+    gethomepage.dev/group: "GitOps & Operations"
     gethomepage.dev/name: "Remote Desktop"
     gethomepage.dev/icon: "rustdesk.png"
-    gethomepage.dev/weight: "3"
+    gethomepage.dev/weight: "2"
     gethomepage.dev/href: "https://PLACEHOLDER"
     gethomepage.dev/pod-selector: "app.kubernetes.io/name=devolutions-gateway"
     # Gatus — automated status page discovery (probes the unauthenticated health endpoint)
     gatus.home-operations.com/enabled: "true"
     gatus.home-operations.com/endpoint: |
       name: Remote Desktop
-      group: Infrastructure
+      group: GitOps & Operations
       url: https://PLACEHOLDER/jet/health
       interval: 60s
       conditions:

--- a/kubernetes/applications/homepage/base/config/settings.yaml
+++ b/kubernetes/applications/homepage/base/config/settings.yaml
@@ -27,7 +27,7 @@ layout:
 
   Observability:
     icon: mdi-chart-bar-stacked-#FFFFFF
-  GitOps:
+  GitOps & Operations:
     icon: mdi-all-inclusive-#FFFFFF
   Security & Identity:
     icon: mdi-shield-lock-#FFFFFF

--- a/kubernetes/components/gitops-controller/base/ingress-route.yaml
+++ b/kubernetes/components/gitops-controller/base/ingress-route.yaml
@@ -10,7 +10,7 @@ metadata:
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
     # Homepage Service Discovery
     gethomepage.dev/enabled: "true"
-    gethomepage.dev/group: "GitOps"
+    gethomepage.dev/group: "GitOps & Operations"
     gethomepage.dev/name: "ArgoCD"
     gethomepage.dev/icon: "argo-cd.png"
     gethomepage.dev/weight: "1"
@@ -22,7 +22,7 @@ metadata:
     gatus.home-operations.com/enabled: "true"
     gatus.home-operations.com/endpoint: |
       name: ArgoCD
-      group: GitOps
+      group: GitOps & Operations
       url: https://PLACEHOLDER/_gatus
       interval: 60s
       client:


### PR DESCRIPTION
## Why

The Devolutions Gateway tile ("Remote Desktop") sat in **Infrastructure**, next to Proxmox, the Backup Server and the UPS. Those are pieces of hardware/platform; the gateway is a tool you *operate the platform with* — the same category as Argo CD.

Moving it into the **GitOps** group made that group's name inaccurate, since it would no longer hold only the GitOps controller. Renamed to **GitOps & Operations**, matching the existing `Data & AI` / `Security & Identity` style.

## What changed

| File | Change |
| --- | --- |
| `kubernetes/applications/devolutions-gateway/base/ingress-route.yaml` | Homepage + Gatus group `Infrastructure` → `GitOps & Operations`; weight `3` → `2` |
| `kubernetes/components/gitops-controller/base/ingress-route.yaml` | Homepage + Gatus group `GitOps` → `GitOps & Operations` |
| `kubernetes/applications/homepage/base/config/settings.yaml` | Layout key renamed so the group keeps its position and icon |

Both the Homepage discovery annotation and the Gatus endpoint annotation were updated on each route, so the dashboard and the status page group identically.

Ordering inside the group: Argo CD (weight 1) first, Remote Desktop (weight 2) second.

## Notes

- The layout key in `settings.yaml` must match the annotation exactly — otherwise the group renders unstyled at the bottom of the page.
- No other references to the dashboard group name exist in the repo (remaining `GitOps` hits are README badges, a label description and unrelated comments).

## Verification

- [x] All three files parse; layout keys and both group values confirmed via `yaml.safe_load`
- [x] pre-commit hooks pass
- [ ] Visual check on the dashboard after Argo CD syncs

🤖 Generated with [Claude Code](https://claude.com/claude-code)