### PR TITLE
feat(knx): wire the dehumidifiers to KNX

### DIFF
--- a/kubernetes/applications/knx-nats-bridge/base/config/ga-catalog.yaml
+++ b/kubernetes/applications/knx-nats-bridge/base/config/ga-catalog.yaml
@@ -2613,7 +2613,7 @@
   name: Versorgungstechnik.Wallbox.Energie.Geladen-Aktuell
   room: Garage
 15/6/15:
-  dpt: '13.000'
+  dpt: '13.010'
   function: Versorgungstechnik
   name: Versorgungstechnik.Wallbox.Energie.Zählerstand-Aktuell
   room: Garage
@@ -8737,6 +8737,136 @@
   function: Raumklima
   name: Raumklima.Zentral.Gebäude.KWL.Lüftermodi-Status
   room: 1 - Gebäude
+6/1/100:
+  dpt: '1.003'
+  function: Raumklima
+  name: Raumklima.KG.Hauswirtschaftsraum.Entfeuchter.Sperren
+  room: Hauswirtschaftsraum
+6/1/101:
+  dpt: '1.011'
+  function: Raumklima
+  name: Raumklima.KG.Hauswirtschaftsraum.Entfeuchter.Sperren-Status
+  room: Hauswirtschaftsraum
+6/1/102:
+  dpt: '1.001'
+  function: Raumklima
+  name: Raumklima.KG.Hauswirtschaftsraum.Entfeuchter.Ein/Aus
+  room: Hauswirtschaftsraum
+6/1/103:
+  dpt: '1.011'
+  function: Raumklima
+  name: Raumklima.KG.Hauswirtschaftsraum.Entfeuchter.Ein/Aus-Status
+  room: Hauswirtschaftsraum
+6/1/104:
+  dpt: '5.010'
+  function: Raumklima
+  name: Raumklima.KG.Hauswirtschaftsraum.Entfeuchter.Modus
+  room: Hauswirtschaftsraum
+6/1/105:
+  dpt: '5.010'
+  function: Raumklima
+  name: Raumklima.KG.Hauswirtschaftsraum.Entfeuchter.Modus-Status
+  room: Hauswirtschaftsraum
+6/1/106:
+  dpt: '5.010'
+  function: Raumklima
+  name: Raumklima.KG.Hauswirtschaftsraum.Entfeuchter.Lüfterstufe
+  room: Hauswirtschaftsraum
+6/1/107:
+  dpt: '5.010'
+  function: Raumklima
+  name: Raumklima.KG.Hauswirtschaftsraum.Entfeuchter.Lüfterstufe-Status
+  room: Hauswirtschaftsraum
+6/1/108:
+  dpt: '5.001'
+  function: Raumklima
+  name: Raumklima.KG.Hauswirtschaftsraum.Entfeuchter.Soll-Luftfeuchte
+  room: Hauswirtschaftsraum
+6/1/109:
+  dpt: '5.001'
+  function: Raumklima
+  name: Raumklima.KG.Hauswirtschaftsraum.Entfeuchter.Soll-Luftfeuchte-Status
+  room: Hauswirtschaftsraum
+6/1/110:
+  dpt: '1.005'
+  function: Raumklima
+  name: Raumklima.KG.Hauswirtschaftsraum.Entfeuchter.Tank-Voll-Status
+  room: Hauswirtschaftsraum
+6/1/111:
+  dpt: '9.007'
+  function: Raumklima
+  name: Raumklima.KG.Hauswirtschaftsraum.Entfeuchter.Luftfeuchte
+  room: Hauswirtschaftsraum
+6/1/112:
+  dpt: '9.001'
+  function: Raumklima
+  name: Raumklima.KG.Hauswirtschaftsraum.Entfeuchter.Temperatur
+  room: Hauswirtschaftsraum
+6/1/60:
+  dpt: '1.003'
+  function: Raumklima
+  name: Raumklima.KG.Vorratsraum.Entfeuchter.Sperren
+  room: Vorratsraum
+6/1/61:
+  dpt: '1.011'
+  function: Raumklima
+  name: Raumklima.KG.Vorratsraum.Entfeuchter.Sperren-Status
+  room: Vorratsraum
+6/1/62:
+  dpt: '1.001'
+  function: Raumklima
+  name: Raumklima.KG.Vorratsraum.Entfeuchter.Ein/Aus
+  room: Vorratsraum
+6/1/63:
+  dpt: '1.011'
+  function: Raumklima
+  name: Raumklima.KG.Vorratsraum.Entfeuchter.Ein/Aus-Status
+  room: Vorratsraum
+6/1/64:
+  dpt: '5.010'
+  function: Raumklima
+  name: Raumklima.KG.Vorratsraum.Entfeuchter.Modus
+  room: Vorratsraum
+6/1/65:
+  dpt: '5.010'
+  function: Raumklima
+  name: Raumklima.KG.Vorratsraum.Entfeuchter.Modus-Status
+  room: Vorratsraum
+6/1/66:
+  dpt: '5.010'
+  function: Raumklima
+  name: Raumklima.KG.Vorratsraum.Entfeuchter.Lüfterstufe
+  room: Vorratsraum
+6/1/67:
+  dpt: '5.010'
+  function: Raumklima
+  name: Raumklima.KG.Vorratsraum.Entfeuchter.Lüfterstufe-Status
+  room: Vorratsraum
+6/1/68:
+  dpt: '5.001'
+  function: Raumklima
+  name: Raumklima.KG.Vorratsraum.Entfeuchter.Soll-Luftfeuchte
+  room: Vorratsraum
+6/1/69:
+  dpt: '5.001'
+  function: Raumklima
+  name: Raumklima.KG.Vorratsraum.Entfeuchter.Soll-Luftfeuchte-Status
+  room: Vorratsraum
+6/1/70:
+  dpt: '1.005'
+  function: Raumklima
+  name: Raumklima.KG.Vorratsraum.Entfeuchter.Tank-Voll-Status
+  room: Vorratsraum
+6/1/71:
+  dpt: '9.007'
+  function: Raumklima
+  name: Raumklima.KG.Vorratsraum.Entfeuchter.Luftfeuchte
+  room: Vorratsraum
+6/1/72:
+  dpt: '9.001'
+  function: Raumklima
+  name: Raumklima.KG.Vorratsraum.Entfeuchter.Temperatur
+  room: Vorratsraum
 6/2/0:
   dpt: '1.003'
   function: Raumklima

--- a/kubernetes/applications/knx-nats-bridge/base/config/writer-rules.yaml
+++ b/kubernetes/applications/knx-nats-bridge/base/config/writer-rules.yaml
@@ -519,7 +519,7 @@ mappings:
     ga: "15/6/21"
     dpt: "1.001"
     payload_path: "$.on"  # derived in warp_charging_status from WARP Slot 4 release
-    description: "Versorgungstechnik.Wallbox.Freigabe-Status"
+    description: "Versorgungstechnik.Wallbox.Ein-Freigabe-Status"
     min_delta: 0  # bool state: write only on change
     seed_on_start: true
   # Per-mode status bits for Basalte (radio: exactly one set, all 0 when Aus).
@@ -1453,6 +1453,128 @@ mappings:
     payload_path: "$.pm10"
     description: "Raumklima.OG.Schlafzimmer-Eltern.Luftreiniger.Feinstaub-PM10"
     min_delta: 1  # µg/m³
+    seed_on_start: true
+
+  # Entfeuchter Vorratsraum status feedback (KNX<-NATS). The command GAs
+  # (60/62/64/66/68) are driven KNX->device by the
+  # redpanda-connect midea_from_knx stream. Modus 1=kein Modus 2=Wäschetrocknen
+  # 3=Kontinuierlich 4=Smart; Lüfterstufe 40/60/80 = niedrig/mittel/hoch.
+  - subject: "midea.entfeuchter-kg4.state"
+    ga: "6/1/61"
+    dpt: "1.011"
+    payload_path: "$.locked"
+    description: "Raumklima.KG.Vorratsraum.Entfeuchter.Sperren-Status"
+    min_delta: 0  # bool state: write only on change
+    seed_on_start: true
+  - subject: "midea.entfeuchter-kg4.state"
+    ga: "6/1/63"
+    dpt: "1.011"
+    payload_path: "$.power"
+    description: "Raumklima.KG.Vorratsraum.Entfeuchter.Ein/Aus-Status"
+    min_delta: 0  # bool state: write only on change
+    seed_on_start: true
+  - subject: "midea.entfeuchter-kg4.state"
+    ga: "6/1/65"
+    dpt: "5.010"
+    payload_path: "$.mode"
+    description: "Raumklima.KG.Vorratsraum.Entfeuchter.Modus-Status"
+    min_delta: 0  # enum state: write only on change
+    seed_on_start: true
+  - subject: "midea.entfeuchter-kg4.state"
+    ga: "6/1/67"
+    dpt: "5.010"
+    payload_path: "$.fan_speed"
+    description: "Raumklima.KG.Vorratsraum.Entfeuchter.Lüfterstufe-Status"
+    min_delta: 0  # enum state: write only on change
+    seed_on_start: true
+  - subject: "midea.entfeuchter-kg4.state"
+    ga: "6/1/69"
+    dpt: "5.001"
+    payload_path: "$.target_humidity"
+    description: "Raumklima.KG.Vorratsraum.Entfeuchter.Soll-Luftfeuchte-Status"
+    min_delta: 0  # setpoint: only moves when set
+    seed_on_start: true
+  - subject: "midea.entfeuchter-kg4.state"
+    ga: "6/1/70"
+    dpt: "1.005"
+    payload_path: "$.tank_full"
+    description: "Raumklima.KG.Vorratsraum.Entfeuchter.Tank-Voll-Status"
+    min_delta: 0  # bool state: write only on change
+    seed_on_start: true
+  - subject: "midea.entfeuchter-kg4.environment"
+    ga: "6/1/71"
+    dpt: "9.007"
+    payload_path: "$.humidity"
+    description: "Raumklima.KG.Vorratsraum.Entfeuchter.Luftfeuchte"
+    min_delta: 1  # %RH
+    seed_on_start: true
+  - subject: "midea.entfeuchter-kg4.environment"
+    ga: "6/1/72"
+    dpt: "9.001"
+    payload_path: "$.temperature_c"
+    description: "Raumklima.KG.Vorratsraum.Entfeuchter.Temperatur"
+    min_delta: 0.5  # °C
+    seed_on_start: true
+
+  # Entfeuchter Hauswirtschaftsraum status feedback (KNX<-NATS). The command GAs
+  # (100/102/104/106/108) are driven KNX->device by the
+  # redpanda-connect midea_from_knx stream. Modus 1=kein Modus 2=Wäschetrocknen
+  # 3=Kontinuierlich 4=Smart; Lüfterstufe 40/60/80 = niedrig/mittel/hoch.
+  - subject: "midea.entfeuchter-kg5.state"
+    ga: "6/1/101"
+    dpt: "1.011"
+    payload_path: "$.locked"
+    description: "Raumklima.KG.Hauswirtschaftsraum.Entfeuchter.Sperren-Status"
+    min_delta: 0  # bool state: write only on change
+    seed_on_start: true
+  - subject: "midea.entfeuchter-kg5.state"
+    ga: "6/1/103"
+    dpt: "1.011"
+    payload_path: "$.power"
+    description: "Raumklima.KG.Hauswirtschaftsraum.Entfeuchter.Ein/Aus-Status"
+    min_delta: 0  # bool state: write only on change
+    seed_on_start: true
+  - subject: "midea.entfeuchter-kg5.state"
+    ga: "6/1/105"
+    dpt: "5.010"
+    payload_path: "$.mode"
+    description: "Raumklima.KG.Hauswirtschaftsraum.Entfeuchter.Modus-Status"
+    min_delta: 0  # enum state: write only on change
+    seed_on_start: true
+  - subject: "midea.entfeuchter-kg5.state"
+    ga: "6/1/107"
+    dpt: "5.010"
+    payload_path: "$.fan_speed"
+    description: "Raumklima.KG.Hauswirtschaftsraum.Entfeuchter.Lüfterstufe-Status"
+    min_delta: 0  # enum state: write only on change
+    seed_on_start: true
+  - subject: "midea.entfeuchter-kg5.state"
+    ga: "6/1/109"
+    dpt: "5.001"
+    payload_path: "$.target_humidity"
+    description: "Raumklima.KG.Hauswirtschaftsraum.Entfeuchter.Soll-Luftfeuchte-Status"
+    min_delta: 0  # setpoint: only moves when set
+    seed_on_start: true
+  - subject: "midea.entfeuchter-kg5.state"
+    ga: "6/1/110"
+    dpt: "1.005"
+    payload_path: "$.tank_full"
+    description: "Raumklima.KG.Hauswirtschaftsraum.Entfeuchter.Tank-Voll-Status"
+    min_delta: 0  # bool state: write only on change
+    seed_on_start: true
+  - subject: "midea.entfeuchter-kg5.environment"
+    ga: "6/1/111"
+    dpt: "9.007"
+    payload_path: "$.humidity"
+    description: "Raumklima.KG.Hauswirtschaftsraum.Entfeuchter.Luftfeuchte"
+    min_delta: 1  # %RH
+    seed_on_start: true
+  - subject: "midea.entfeuchter-kg5.environment"
+    ga: "6/1/112"
+    dpt: "9.001"
+    payload_path: "$.temperature_c"
+    description: "Raumklima.KG.Hauswirtschaftsraum.Entfeuchter.Temperatur"
+    min_delta: 0.5  # °C
     seed_on_start: true
 
   # Bordbar LED status feedback (KNX<-NATS). The command GAs (4/2/61/63-67) are

--- a/kubernetes/applications/nats/base/consumers/kustomization.yaml
+++ b/kubernetes/applications/nats/base/consumers/kustomization.yaml
@@ -9,4 +9,5 @@ resources:
   - warp_charge_mode_from_knx.yaml
   - warp_mode_buttons_from_knx.yaml
   - dyson_from_knx.yaml
+  - midea_from_knx.yaml
   - bordbar_from_knx.yaml

--- a/kubernetes/applications/nats/base/consumers/midea_from_knx.yaml
+++ b/kubernetes/applications/nats/base/consumers/midea_from_knx.yaml
@@ -1,0 +1,41 @@
+# Durable consumer for the redpanda-connect midea_from_knx pipeline.
+#
+#   knx.6.1.60     Sperren           (1.003) -> midea.entfeuchter-kg4.command.lock
+#   knx.6.1.62     Ein/Aus           (1.001) -> midea.entfeuchter-kg4.command.power
+#   knx.6.1.64     Modus             (5.010) -> midea.entfeuchter-kg4.command.mode
+#   knx.6.1.66     Lüfterstufe       (5.010) -> midea.entfeuchter-kg4.command.fan_speed
+#   knx.6.1.68     Soll-Luftfeuchte  (5.001) -> midea.entfeuchter-kg4.command.target_humidity
+#   knx.6.1.100    Sperren           (1.003) -> midea.entfeuchter-kg5.command.lock
+#   knx.6.1.102    Ein/Aus           (1.001) -> midea.entfeuchter-kg5.command.power
+#   knx.6.1.104    Modus             (5.010) -> midea.entfeuchter-kg5.command.mode
+#   knx.6.1.106    Lüfterstufe       (5.010) -> midea.entfeuchter-kg5.command.fan_speed
+#   knx.6.1.108    Soll-Luftfeuchte  (5.001) -> midea.entfeuchter-kg5.command.target_humidity
+#
+# The Entfeuchter command GAs, written by Basalte.
+apiVersion: jetstream.nats.io/v1beta2
+kind: Consumer
+metadata:
+  name: redpanda-connect-midea-from-knx
+  namespace: nats
+spec:
+  streamName: KNX
+  durableName: redpanda-connect-midea-from-knx
+  filterSubjects:
+    - knx.6.1.60
+    - knx.6.1.62
+    - knx.6.1.64
+    - knx.6.1.66
+    - knx.6.1.68
+    - knx.6.1.100
+    - knx.6.1.102
+    - knx.6.1.104
+    - knx.6.1.106
+    - knx.6.1.108
+  deliverPolicy: new
+  ackPolicy: explicit
+  # nats-operator default surfaces as 1ns, which causes immediate re-delivery
+  # of any message slower-than-instant to ack. 15s covers the core republish
+  # comfortably without leaving wedged messages locked long.
+  ackWait: 15s
+  # Drop after 5 attempts so a permanently-failing message can't loop forever.
+  maxDeliver: 5

--- a/kubernetes/applications/redpanda-connect/base/kustomization.yaml
+++ b/kubernetes/applications/redpanda-connect/base/kustomization.yaml
@@ -42,6 +42,7 @@ configMapGenerator:
       - streams/dyson_state.yaml
       - streams/midea_environment.yaml
       - streams/midea_state.yaml
+      - streams/midea_from_knx.yaml
       - streams/bordbar_from_knx.yaml
 
 patches:

--- a/kubernetes/applications/redpanda-connect/base/streams/midea_from_knx.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/midea_from_knx.yaml
@@ -1,0 +1,62 @@
+# Entfeuchter control: Basalte command GAs -> midea-nats-bridge.
+#
+#   knx.6.1.60     Sperren           (1.003) -> midea.entfeuchter-kg4.command.lock
+#   knx.6.1.62     Ein/Aus           (1.001) -> midea.entfeuchter-kg4.command.power
+#   knx.6.1.64     Modus             (5.010) -> midea.entfeuchter-kg4.command.mode
+#   knx.6.1.66     Lüfterstufe       (5.010) -> midea.entfeuchter-kg4.command.fan_speed
+#   knx.6.1.68     Soll-Luftfeuchte  (5.001) -> midea.entfeuchter-kg4.command.target_humidity
+#   knx.6.1.100    Sperren           (1.003) -> midea.entfeuchter-kg5.command.lock
+#   knx.6.1.102    Ein/Aus           (1.001) -> midea.entfeuchter-kg5.command.power
+#   knx.6.1.104    Modus             (5.010) -> midea.entfeuchter-kg5.command.mode
+#   knx.6.1.106    Lüfterstufe       (5.010) -> midea.entfeuchter-kg5.command.fan_speed
+#   knx.6.1.108    Soll-Luftfeuchte  (5.001) -> midea.entfeuchter-kg5.command.target_humidity
+#
+# Sperren is 1 = gesperrt, matching the bridge's lock semantics, so nothing is
+# inverted here. While locked the bridge swallows the other four commands.
+#
+# Modus 1=kein Modus 2=Wäschetrocknen 3=Kontinuierlich 4=Smart; Lüfterstufe
+# 40/60/80 = niedrig/mittel/hoch. Raw appliance values, deliberately not
+# remapped — the bridge passes them straight through.
+#
+# Core NATS only; the bridge subscribes core and nothing archives commands.
+input:
+  # Consumer (filterSubjects on the ten GAs) is declared as a CRD in
+  # nats/base/consumers/midea_from_knx.yaml.
+  nats_jetstream:
+    urls: ["nats://nats.nats.svc:4222"]
+    auth:
+      user: redpanda-connect
+      password: ${NATS_PASSWORD}
+    stream: KNX
+    durable: redpanda-connect-midea-from-knx
+    bind: true
+
+pipeline:
+  processors:
+    - mapping: |
+        let subj = meta("nats_subject")
+        root = if $subj == "knx.6.1.64" || $subj == "knx.6.1.66" || $subj == "knx.6.1.68" || $subj == "knx.6.1.104" || $subj == "knx.6.1.106" || $subj == "knx.6.1.108" {
+          {"value": this.value.number()}
+        } else {
+          {"value": this.value == true || this.value == 1}
+        }
+        meta midea_subject = (
+          if $subj == "knx.6.1.60" { "midea.entfeuchter-kg4.command.lock" }
+          else if $subj == "knx.6.1.62" { "midea.entfeuchter-kg4.command.power" }
+          else if $subj == "knx.6.1.64" { "midea.entfeuchter-kg4.command.mode" }
+          else if $subj == "knx.6.1.66" { "midea.entfeuchter-kg4.command.fan_speed" }
+          else if $subj == "knx.6.1.68" { "midea.entfeuchter-kg4.command.target_humidity" }
+          else if $subj == "knx.6.1.100" { "midea.entfeuchter-kg5.command.lock" }
+          else if $subj == "knx.6.1.102" { "midea.entfeuchter-kg5.command.power" }
+          else if $subj == "knx.6.1.104" { "midea.entfeuchter-kg5.command.mode" }
+          else if $subj == "knx.6.1.106" { "midea.entfeuchter-kg5.command.fan_speed" }
+          else { "midea.entfeuchter-kg5.command.target_humidity" }
+        )
+
+output:
+  nats:
+    urls: ["nats://nats.nats.svc:4222"]
+    auth:
+      user: redpanda-connect
+      password: ${NATS_PASSWORD}
+    subject: ${! meta("midea_subject") }


### PR DESCRIPTION
## What

Both Comfee units get a group address block and a full command path, so Basalte can drive them and see their state.

| Device | Block |
| --- | --- |
| Vorratsraum (`entfeuchter-kg4`) | `6/1/60-72` |
| Hauswirtschaftsraum (`entfeuchter-kg5`) | `6/1/100-112` |

16 writer rules carry state and sensor values back to KNX; a consumer plus the `midea_from_knx` stream carry the five command GAs per device the other way.

**The rules were generated from the catalog, not typed.** A group address here can only be wrong if ETS is.

## Values on the bus

```
Modus         1 = kein Modus   2 = Wäschetrocknen   3 = Kontinuierlich   4 = Smart
Lüfterstufe  40 = niedrig     60 = mittel          80 = hoch
```

The appliance's own integers, unmapped. Each was established by pressing that button and reading the result back — including one correction along the way, when a press that changed nothing was briefly misread as "already in that mode".

`Sperren` is `1 = gesperrt` on both sides, so nothing is inverted anywhere. While locked the bridge swallows the other four commands and unlocking always gets through.

## Bus load

Sensor values are throttled — 1 %RH, 0.5 °C — so the 60 s poll does not drive the bus. States write only on change.

## Two deliberate absences

**No Tankfüllstand GA.** This model does not advertise the `water_level` capability, so the value never arrives; the address would sit there meaning nothing. Only `Tank-Voll` is real.

**No tank-full alert rule.** That lives in Basalte by your decision, so `midea_tank_full` stays a metric without a Prometheus rule attached.

## Two pre-existing fixes picked up

- `15/6/21`: the writer rule's description said `Freigabe-Status`; ETS has always said `Ein-Freigabe-Status`. The rule was wrong, not ETS.
- `15/6/15`: catalog now carries DPT `13.010` instead of `13.000` — a counter of watt-hours is active energy, not counter pulses. Both DPTs are 4-byte signed on the wire, which is why nothing ever broke.

With both resolved, **all 231 rules validate against the catalog for address, name and DPT with no exceptions left** — the first fully clean run.

## Verified

- writer rules valid against the JSON schema, 231 rules
- `kustomize build --enable-helm` green for knx-nats-bridge, nats, redpanda-connect and midea-nats-bridge
- `midea_from_knx` lints in `redpandadata/connect:4.104.0`
- command mapping run through `blobl` for all six shapes:

```
knx.6.1.62  {"value":1}      → kg4 power            value true    (1 coerced)
knx.6.1.60  {"value":false}  → kg4 lock             value false   (survives)
knx.6.1.104 {"value":2}      → kg5 mode             value 2       (stays numeric)
knx.6.1.108 {"value":45}     → kg5 target_humidity  value 45
```

That last check matters: a coalesce that swallowed `false` would leave an unlock command looking like a lock.

## Deploy note

The consumer is new, so nothing needs deleting — but it only starts delivering once redpanda-connect picks up the stream. Both appliances are currently asleep; the writer rules will seed their status GAs as soon as the devices report again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)