### PR TITLE
feat(renovate): detect CloudNativePG cluster images

### DIFF
--- a/.renovate/customManagers.json5
+++ b/.renovate/customManagers.json5
@@ -19,6 +19,14 @@
     },
     {
       "customType": "regex",
+      // CNPG Cluster CRD uses spec.imageName, which the kubernetes manager ignores
+      "description": "Process CloudNativePG cluster images",
+      "managerFilePatterns": ["/\\.yaml$/"],
+      "matchStrings": ["imageName: (?<depName>[^:\\s]+):(?<currentValue>\\S+)"],
+      "datasourceTemplate": "docker"
+    },
+    {
+      "customType": "regex",
       "description": "Process shell config file versions",
       "managerFilePatterns": ["\\.conf\\.tftpl$"],
       "matchStrings": [

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -38,6 +38,14 @@
       "ignoreUnstable": false
     },
     {
+      // Own build; bumping it rolls the TimescaleDB cluster, so gate it behind the dashboard
+      "matchDatasources": ["docker"],
+      "matchPackageNames": [
+        "ghcr.io/alexander-zimmermann/cnpg-postgres-timescaledb"
+      ],
+      "dependencyDashboardApproval": true
+    },
+    {
       "matchFileNames": ["infrastructure/manifest/20-image/image.yaml"],
       "postUpgradeTasks": {
         "commands": [


### PR DESCRIPTION
## Problem

Renovate never proposed updates for any CloudNativePG database image. The CNPG `Cluster` CRD declares its image as `spec.imageName:`, but Renovate's built-in `kubernetes` manager only reads the PodSpec `image:` key, and none of the existing custom managers matched it either:

- *annotated dependencies* needs a `# renovate: datasource=… depName=…` comment (absent), and its regex expects the version to start with `v` or a digit after the last space — `imageName: ghcr.io/…:18.3` starts with `g`
- *OCI dependencies* requires an `oci://` prefix
- the remaining two are scoped to `.conf.tftpl` and the Talos image manifest

Evidence: the Dependency Dashboard's detected-dependency list contains `apply-grants-job.yaml` (a plain `image:` key) but not a single `database.yaml`. And `git log -S"imageName: ghcr.io/cloudnative-pg/postgresql"` returns only hand-written commits — no Renovate commit has ever touched those lines.

Consequence: four databases (authentik, crowdsec, gatus, wiki-js) sit on `postgresql:18.3` while 18.6 is current, and the TimescaleDB cluster runs `18.3-ts2.26-tk` although `18.4-ts2.26-tk` has been available since 2026-06-29.

## Change

- **Custom manager** for `imageName:` (`datasourceTemplate: docker`). Because it emits the `docker` datasource, it inherits the existing `renovate/container` label and the `container` semantic-commit scope automatically — no changes needed in `labels.json5` or `semanticCommits.json5`.
- **Dashboard gate** for the self-built `cnpg-postgres-timescaledb` image via `dependencyDashboardApproval: true`. A bump there rolls the TimescaleDB cluster, so the update stays visible on the dashboard but only becomes a PR once the checkbox is ticked. Preferred over `ignoreDeps`, which would hide the pending 18.4 entirely.

Default `docker` versioning parses `18.3-ts2.26-tk` as version `18.3` plus compatibility `ts2.26-tk` and compares only within the same compatibility, so no custom `versioning` is required.

## Verification

- Regex checked against all five manifests; `depName`/`currentValue` extract correctly in every case, and a repo-wide grep for `imageName` returns exactly those five lines — no false positives possible.
- `renovate-config-validator` passes on both files with 44.29.1 (the version that opened #1466). Note that a bare `npx renovate` resolves to 37.440.7, which rejects `managerFilePatterns` on *all* custom managers including the four pre-existing ones — that is a stale validator, not a config error.

## Expected effect after merge

The push triggers the Renovate workflow (it watches these exact paths). Expect four `18.3 → 18.6` PRs for authentik/crowdsec/gatus/wiki-js, plus a dashboard entry awaiting approval for TimescaleDB. None of them automerge — these packages are not in the `autoMerge.json5` allowlist. Each merge rolls the respective CNPG cluster, so they are worth merging one at a time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)