### PR TITLE
fix(knx): follow the Luftfeuchtigkeit rename in ETS

### DIFF
--- a/kubernetes/applications/knx-nats-bridge/base/config/ga-catalog.yaml
+++ b/kubernetes/applications/knx-nats-bridge/base/config/ga-catalog.yaml
@@ -8780,12 +8780,12 @@
 6/1/108:
   dpt: '5.001'
   function: Raumklima
-  name: Raumklima.KG.Hauswirtschaftsraum.Entfeuchter.Soll-Luftfeuchte
+  name: Raumklima.KG.Hauswirtschaftsraum.Entfeuchter.Soll-Luftfeuchtigkeit
   room: Hauswirtschaftsraum
 6/1/109:
   dpt: '5.001'
   function: Raumklima
-  name: Raumklima.KG.Hauswirtschaftsraum.Entfeuchter.Soll-Luftfeuchte-Status
+  name: Raumklima.KG.Hauswirtschaftsraum.Entfeuchter.Soll-Luftfeuchtigkeit-Status
   room: Hauswirtschaftsraum
 6/1/110:
   dpt: '1.005'
@@ -8795,7 +8795,7 @@
 6/1/111:
   dpt: '9.007'
   function: Raumklima
-  name: Raumklima.KG.Hauswirtschaftsraum.Entfeuchter.Luftfeuchte
+  name: Raumklima.KG.Hauswirtschaftsraum.Entfeuchter.Luftfeuchtigkeit
   room: Hauswirtschaftsraum
 6/1/112:
   dpt: '9.001'
@@ -8845,12 +8845,12 @@
 6/1/68:
   dpt: '5.001'
   function: Raumklima
-  name: Raumklima.KG.Vorratsraum.Entfeuchter.Soll-Luftfeuchte
+  name: Raumklima.KG.Vorratsraum.Entfeuchter.Soll-Luftfeuchtigkeit
   room: Vorratsraum
 6/1/69:
   dpt: '5.001'
   function: Raumklima
-  name: Raumklima.KG.Vorratsraum.Entfeuchter.Soll-Luftfeuchte-Status
+  name: Raumklima.KG.Vorratsraum.Entfeuchter.Soll-Luftfeuchtigkeit-Status
   room: Vorratsraum
 6/1/70:
   dpt: '1.005'
@@ -8860,7 +8860,7 @@
 6/1/71:
   dpt: '9.007'
   function: Raumklima
-  name: Raumklima.KG.Vorratsraum.Entfeuchter.Luftfeuchte
+  name: Raumklima.KG.Vorratsraum.Entfeuchter.Luftfeuchtigkeit
   room: Vorratsraum
 6/1/72:
   dpt: '9.001'

--- a/kubernetes/applications/knx-nats-bridge/base/config/writer-rules.yaml
+++ b/kubernetes/applications/knx-nats-bridge/base/config/writer-rules.yaml
@@ -1491,7 +1491,7 @@ mappings:
     ga: "6/1/69"
     dpt: "5.001"
     payload_path: "$.target_humidity"
-    description: "Raumklima.KG.Vorratsraum.Entfeuchter.Soll-Luftfeuchte-Status"
+    description: "Raumklima.KG.Vorratsraum.Entfeuchter.Soll-Luftfeuchtigkeit-Status"
     min_delta: 0  # setpoint: only moves when set
     seed_on_start: true
   - subject: "midea.entfeuchter-kg4.state"
@@ -1505,7 +1505,7 @@ mappings:
     ga: "6/1/71"
     dpt: "9.007"
     payload_path: "$.humidity"
-    description: "Raumklima.KG.Vorratsraum.Entfeuchter.Luftfeuchte"
+    description: "Raumklima.KG.Vorratsraum.Entfeuchter.Luftfeuchtigkeit"
     min_delta: 1  # %RH
     seed_on_start: true
   - subject: "midea.entfeuchter-kg4.environment"
@@ -1552,7 +1552,7 @@ mappings:
     ga: "6/1/109"
     dpt: "5.001"
     payload_path: "$.target_humidity"
-    description: "Raumklima.KG.Hauswirtschaftsraum.Entfeuchter.Soll-Luftfeuchte-Status"
+    description: "Raumklima.KG.Hauswirtschaftsraum.Entfeuchter.Soll-Luftfeuchtigkeit-Status"
     min_delta: 0  # setpoint: only moves when set
     seed_on_start: true
   - subject: "midea.entfeuchter-kg5.state"
@@ -1566,7 +1566,7 @@ mappings:
     ga: "6/1/111"
     dpt: "9.007"
     payload_path: "$.humidity"
-    description: "Raumklima.KG.Hauswirtschaftsraum.Entfeuchter.Luftfeuchte"
+    description: "Raumklima.KG.Hauswirtschaftsraum.Entfeuchter.Luftfeuchtigkeit"
     min_delta: 1  # %RH
     seed_on_start: true
   - subject: "midea.entfeuchter-kg5.environment"

--- a/kubernetes/applications/nats/base/consumers/midea_from_knx.yaml
+++ b/kubernetes/applications/nats/base/consumers/midea_from_knx.yaml
@@ -4,12 +4,12 @@
 #   knx.6.1.62     Ein/Aus           (1.001) -> midea.entfeuchter-kg4.command.power
 #   knx.6.1.64     Modus             (5.010) -> midea.entfeuchter-kg4.command.mode
 #   knx.6.1.66     Lüfterstufe       (5.010) -> midea.entfeuchter-kg4.command.fan_speed
-#   knx.6.1.68     Soll-Luftfeuchte  (5.001) -> midea.entfeuchter-kg4.command.target_humidity
+#   knx.6.1.68     Soll-Luftfeuchtigkeit  (5.001) -> midea.entfeuchter-kg4.command.target_humidity
 #   knx.6.1.100    Sperren           (1.003) -> midea.entfeuchter-kg5.command.lock
 #   knx.6.1.102    Ein/Aus           (1.001) -> midea.entfeuchter-kg5.command.power
 #   knx.6.1.104    Modus             (5.010) -> midea.entfeuchter-kg5.command.mode
 #   knx.6.1.106    Lüfterstufe       (5.010) -> midea.entfeuchter-kg5.command.fan_speed
-#   knx.6.1.108    Soll-Luftfeuchte  (5.001) -> midea.entfeuchter-kg5.command.target_humidity
+#   knx.6.1.108    Soll-Luftfeuchtigkeit  (5.001) -> midea.entfeuchter-kg5.command.target_humidity
 #
 # The Entfeuchter command GAs, written by Basalte.
 apiVersion: jetstream.nats.io/v1beta2

--- a/kubernetes/applications/redpanda-connect/base/streams/midea_from_knx.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/midea_from_knx.yaml
@@ -4,12 +4,12 @@
 #   knx.6.1.62     Ein/Aus           (1.001) -> midea.entfeuchter-kg4.command.power
 #   knx.6.1.64     Modus             (5.010) -> midea.entfeuchter-kg4.command.mode
 #   knx.6.1.66     Lüfterstufe       (5.010) -> midea.entfeuchter-kg4.command.fan_speed
-#   knx.6.1.68     Soll-Luftfeuchte  (5.001) -> midea.entfeuchter-kg4.command.target_humidity
+#   knx.6.1.68     Soll-Luftfeuchtigkeit  (5.001) -> midea.entfeuchter-kg4.command.target_humidity
 #   knx.6.1.100    Sperren           (1.003) -> midea.entfeuchter-kg5.command.lock
 #   knx.6.1.102    Ein/Aus           (1.001) -> midea.entfeuchter-kg5.command.power
 #   knx.6.1.104    Modus             (5.010) -> midea.entfeuchter-kg5.command.mode
 #   knx.6.1.106    Lüfterstufe       (5.010) -> midea.entfeuchter-kg5.command.fan_speed
-#   knx.6.1.108    Soll-Luftfeuchte  (5.001) -> midea.entfeuchter-kg5.command.target_humidity
+#   knx.6.1.108    Soll-Luftfeuchtigkeit  (5.001) -> midea.entfeuchter-kg5.command.target_humidity
 #
 # Sperren is 1 = gesperrt, matching the bridge's lock semantics, so nothing is
 # inverted here. While locked the bridge swallows the other four commands.


### PR DESCRIPTION
## What

Six group addresses were renamed in ETS — `Luftfeuchte` → `Luftfeuchtigkeit`, and the same for the `Soll-` variants, across both dehumidifiers.

Addresses and DPTs are unchanged, so nothing functional moves. What was left behind were the `description` fields in four writer rules and the comment blocks in the consumer and the command stream, all pointing at names that no longer exist.

## Why it is worth a PR at all

The descriptions are documentation — the writer keys off `ga` and `payload_path`, so a stale name changes no behaviour. But they are also what the catalog cross-check compares against, and that check is the thing that has caught real problems in this repo twice: a rule pointing at the wrong wallbox GA name, and a DPT that disagreed with ETS.

A check that is allowed to drift stops being trusted, so it gets kept at zero.

## Verified

231 rules against 2559 catalog entries — address, name and DPT — with no exceptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)