### PR TITLE
feat(midea): add disconnect alert and document the bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,15 +140,17 @@ flowchart TB
         pv[solaredge2mqtt]
         warp[WARP Wallbox]
         fan[Dyson PC1] <-- local MQTT --> dysonb[dyson-nats-bridge]
+        dehum[Comfee dehumidifiers] <-- LAN :6444 --> mideab[midea-nats-bridge]
     end
 
-    nats[(NATS JetStream<br/>+ MQTT gateway<br/><br/>KNX · EMS_ESP · DYSON<br/>WARP · SOLAREDGE · UNIFI)]
+    nats[(NATS JetStream<br/>+ MQTT gateway<br/><br/>KNX · EMS_ESP · DYSON · MIDEA<br/>WARP · SOLAREDGE · UNIFI)]
 
     webhook -- pub unifi.> --> nats
     ems  -- MQTT --> nats
     pv   -- MQTT --> nats
     warp -- MQTT pub --> nats
     dysonb <-- pub/sub dyson.> --> nats
+    mideab <-- pub/sub midea.> --> nats
 
     subgraph KX[KNX]
         direction TB

--- a/kubernetes/applications/prometheus/base/prometheus-rule.yaml
+++ b/kubernetes/applications/prometheus/base/prometheus-rule.yaml
@@ -245,3 +245,16 @@ spec:
           annotations:
             summary: "Dyson {{ $labels.device }} unreachable"
             description: "The bridge has not held a connection for 30m — device unplugged, moved, or off the WLAN."
+
+    - name: midea-alerts
+      rules:
+        # The appliances are permanently powered and answer even while switched
+        # off, so unreachable means unreachable. Reconnect backoff caps at 5m.
+        - alert: MideaDeviceDisconnected
+          expr: midea_connected == 0
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Dehumidifier {{ $labels.device }} unreachable"
+            description: "The bridge has not held a connection for 30m — device unplugged, moved, or off the WLAN."


### PR DESCRIPTION
Closes the two remaining gaps from the dehumidifier integration.

## MideaDeviceDisconnected

Mirrors `DysonDeviceDisconnected`. The threshold was deliberately left open while the appliances hung on a switched KNX socket — there, being powerless was a legitimate state and any alert would have fired during normal operation.

That is now resolved: the socket is bypassed and the dehumidifiers are switched directly, so they are permanently powered. Verified that an appliance answers the LAN protocol even while switched off (`power: false`, `online: True`), so `midea_connected == 0` unambiguously means unreachable rather than "switched off". `for: 30m` clears the bridge's 5m reconnect backoff several times over.

`MideaTankFull` is deliberately absent — that notification is built in Basalte.

## README

The architecture diagram gains the dehumidifiers and the `MIDEA` stream, alongside the Dyson bridge it was modelled on.

Rendered check:

```
- alert: MideaDeviceDisconnected
  expr: midea_connected == 0
  for: 30m
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)