### PR TITLE
feat(midea): poll every 20s so manual changes surface sooner

### DIFF
--- a/kubernetes/applications/midea-nats-bridge/base/values.yaml
+++ b/kubernetes/applications/midea-nats-bridge/base/values.yaml
@@ -23,6 +23,10 @@ deployment:
     # NKey seed mounted as a file from the synced Secret (Kyverno clones from `nats` namespace)
     NATS_NKEY_SEED_FILE:
       value: /etc/midea-nats-bridge/nkey-seed
+    # Bounds how long a change made at the appliance itself stays invisible:
+    # only commands are confirmed by a re-read, a manual press is not.
+    POLL_INTERVAL:
+      value: "20"
     LOG_FORMAT:
       value: json
     METRICS_PORT:


### PR DESCRIPTION
## Why

v0.4.0 confirms every command with a re-read, so a commanded change reaches the status group address in about a second — measured today: command at 16:51:39, `6/1/63 = 1` at 16:51:40.

A change made at the appliance itself is not a command, so there is nothing to confirm. The bridge only learns of it on the next scheduled poll. At `POLL_INTERVAL: 60` that meant a switch pressed on the unit stayed invisible for up to a minute — long enough to conclude the status was stuck and intervene, which is exactly what happened during testing.

Both cases showed up in the same minute today:

| | trigger | status on the bus |
| --- | --- | --- |
| 12:34:06 | switched on at the appliance | poll grid, up to 60 s |
| 12:34:11 -> 12:34:12 | command on `6/1/102` | 1 s |

## What

`POLL_INTERVAL: 20`. Manual changes are now bounded at 20 s.

Three LAN reads per minute per appliance instead of one is negligible traffic. It does raise the number of chances to hit the occasional read timeout the appliances throw, but those already self-heal — the handle is dropped and the supervisor reconnects within a second, as seen at 13:08 today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)