### PR TITLE
fix(ingress): close edge-hygiene gaps and remove dead identity headers

### DIFF
--- a/kubernetes/applications/authentik/base/ingress-route.yaml
+++ b/kubernetes/applications/authentik/base/ingress-route.yaml
@@ -44,6 +44,9 @@ spec:
     - kind: Rule
       match: Host(`PLACEHOLDER`)
       priority: 10
+      middlewares:
+        - name: chain-standard
+          namespace: ingress-controller
       services:
         - kind: Service
           name: authentik-server
@@ -52,6 +55,9 @@ spec:
     - kind: Rule
       match: Host(`PLACEHOLDER`) && PathPrefix(`/_gatus`) && HeaderRegexp(`Cf-Access-Jwt-Assertion`, `.+`)
       priority: 20
+      middlewares:
+        - name: chain-standard
+          namespace: ingress-controller
       services:
         - kind: Service
           name: authentik-server

--- a/kubernetes/applications/external-services/base/ingress-route.yaml
+++ b/kubernetes/applications/external-services/base/ingress-route.yaml
@@ -43,6 +43,9 @@ spec:
     - kind: Rule
       match: Host(`PLACEHOLDER`) && PathPrefix(`/_gatus`) && HeaderRegexp(`Cf-Access-Jwt-Assertion`, `.+`)
       priority: 20
+      middlewares:
+        - name: chain-standard
+          namespace: ingress-controller
       services:
         - kind: Service
           name: proxmox
@@ -94,6 +97,9 @@ spec:
     - kind: Rule
       match: Host(`PLACEHOLDER`) && PathPrefix(`/_gatus`) && HeaderRegexp(`Cf-Access-Jwt-Assertion`, `.+`)
       priority: 20
+      middlewares:
+        - name: chain-standard
+          namespace: ingress-controller
       services:
         - name: backup
           port: 8007
@@ -145,6 +151,9 @@ spec:
     - kind: Rule
       match: Host(`PLACEHOLDER`) && PathPrefix(`/_gatus`) && HeaderRegexp(`Cf-Access-Jwt-Assertion`, `.+`)
       priority: 20
+      middlewares:
+        - name: chain-standard
+          namespace: ingress-controller
       services:
         - name: omni
           port: 443
@@ -368,6 +377,9 @@ spec:
     - kind: Rule
       match: Host(`PLACEHOLDER`) && PathPrefix(`/_gatus`) && HeaderRegexp(`Cf-Access-Jwt-Assertion`, `.+`)
       priority: 20
+      middlewares:
+        - name: chain-standard
+          namespace: ingress-controller
       services:
         - name: ems-esp
           port: 80
@@ -419,6 +431,9 @@ spec:
     - kind: Rule
       match: Host(`PLACEHOLDER`) && PathPrefix(`/_gatus`) && HeaderRegexp(`Cf-Access-Jwt-Assertion`, `.+`)
       priority: 20
+      middlewares:
+        - name: chain-standard
+          namespace: ingress-controller
       services:
         - name: fritzbox
           port: 80
@@ -470,6 +485,9 @@ spec:
     - kind: Rule
       match: Host(`PLACEHOLDER`) && PathPrefix(`/_gatus`) && HeaderRegexp(`Cf-Access-Jwt-Assertion`, `.+`)
       priority: 20
+      middlewares:
+        - name: chain-standard
+          namespace: ingress-controller
       services:
         - name: knx-ip
           port: 8080

--- a/kubernetes/applications/grafana/base/ingress-route.yaml
+++ b/kubernetes/applications/grafana/base/ingress-route.yaml
@@ -56,6 +56,9 @@ spec:
     - kind: Rule
       match: Host(`PLACEHOLDER`) && PathPrefix(`/_gatus`) && HeaderRegexp(`Cf-Access-Jwt-Assertion`, `.+`)
       priority: 20
+      middlewares:
+        - name: chain-standard
+          namespace: ingress-controller
       services:
         - kind: Service
           name: grafana

--- a/kubernetes/applications/homepage/base/ingress-route.yaml
+++ b/kubernetes/applications/homepage/base/ingress-route.yaml
@@ -50,6 +50,9 @@ spec:
     - kind: Rule
       match: Host(`PLACEHOLDER`) && PathPrefix(`/_gatus`) && HeaderRegexp(`Cf-Access-Jwt-Assertion`, `.+`)
       priority: 20
+      middlewares:
+        - name: chain-standard
+          namespace: ingress-controller
       services:
         - kind: Service
           name: homepage

--- a/kubernetes/applications/wiki-js/base/ingress-route.yaml
+++ b/kubernetes/applications/wiki-js/base/ingress-route.yaml
@@ -41,7 +41,7 @@ spec:
       match: Host(`PLACEHOLDER`)
       priority: 10
       middlewares:
-        - name: chain-standard
+        - name: chain-mfa-auth
           namespace: ingress-controller
       services:
         - kind: Service
@@ -51,6 +51,9 @@ spec:
     - kind: Rule
       match: Host(`PLACEHOLDER`) && PathPrefix(`/_gatus`) && HeaderRegexp(`Cf-Access-Jwt-Assertion`, `.+`)
       priority: 20
+      middlewares:
+        - name: chain-standard
+          namespace: ingress-controller
       services:
         - kind: Service
           name: wiki-js

--- a/kubernetes/components/gitops-controller/base/ingress-route.yaml
+++ b/kubernetes/components/gitops-controller/base/ingress-route.yaml
@@ -64,6 +64,9 @@ spec:
     - kind: Rule
       match: Host(`PLACEHOLDER`) && PathPrefix(`/_gatus`) && HeaderRegexp(`Cf-Access-Jwt-Assertion`, `.+`)
       priority: 20
+      middlewares:
+        - name: chain-standard
+          namespace: ingress-controller
       services:
         - kind: Service
           name: argocd-server

--- a/kubernetes/components/ingress-controller/base/middlewares.yaml
+++ b/kubernetes/components/ingress-controller/base/middlewares.yaml
@@ -165,11 +165,6 @@ spec:
     trustForwardHeader: true
     # Bound auth-server response body; silences Traefik's unlimited-body DoS warning.
     maxResponseBodySize: 1048576
-    authResponseHeaders:
-      - "Remote-User"
-      - "Remote-Groups"
-      - "Remote-Name"
-      - "Remote-Email"
 
 ---
 # Basic Auth: Simple htpasswd-based authentication for emergency or technical access


### PR DESCRIPTION
Implements A1, A2, A3 and A5 from the auth topology review. Four independent commits, each revertible on its own.

## A1 — The Authentik route had no chain at all

Both routes referenced no middleware whatsoever. The identity provider — the most valuable target in the cluster — was the only application reaching Traefik without Cloudflare CIDR validation, CrowdSec, rate limiting or security headers. `chain-mfa-auth` is impossible here (chicken-and-egg), `chain-standard` is not.

## A2 — Ten Gatus bypass routes had no chain

These routes deliberately skip forward-auth so probes reach the backend, but they also skipped everything else, because they referenced no middleware at all. They match on the mere presence of a `Cf-Access-Jwt-Assertion` header, which is trivially forged from the LAN.

The Devolutions health route (`/jet/health` + `chain-standard`) already showed the correct shape: bypass the auth step, keep the edge chain.

Covers homepage, grafana, wiki-js, argocd, authentik and five external-services hosts.

## A3 — Wiki.js was the only unexplained browser UI on chain-standard

The introducing commit `bb9906eb` gives no reason, and the copied Gatus bypass was inert precisely because there was no forward-auth to bypass. Now on `chain-mfa-auth`, which also makes its bypass meaningful.

**Assumption:** the GraphQL API is only called same-origin from the browser, which carries the Authentik session cookie. If an external tool talks to `/graphql` directly, it needs its own bypass route.

## A5 — Four dead identity headers

The `authentik` middleware forwarded `Remote-User`, `Remote-Groups`, `Remote-Name` and `Remote-Email` to every upstream. A repo-wide search finds no consumer — Grafana uses `generic_oauth`, Node-RED `passport-openidconnect`, ArgoCD Dex. Removed; re-add deliberately if an app ever adopts header-based auth.

## Verification

All 20 external-services routes now carry a chain, and no bypass route anywhere is left without one:

```
proxmox      haupt   chain-mfa-auth      proxmox   bypass  chain-standard
backup       haupt   chain-mfa-auth      backup    bypass  chain-standard
omni         haupt   chain-standard      omni      bypass  chain-standard
ems-esp      haupt   chain-mfa-auth      ems-esp   bypass  chain-standard
fritzbox     haupt   chain-mfa-auth      fritzbox  bypass  chain-standard
knx-ip       haupt   chain-mfa-auth      knx-ip    bypass  chain-standard
dali-1/2     haupt   chain-mfa-auth,retry-transient
verso, warp  haupt   chain-mfa-auth
ai-pro-1..4  haupt   chain-basic-auth
```

Seven overlays build clean: authentik, homepage, grafana, wiki-js, external-services, gitops-controller, ingress-controller.

## What to watch after sync

- **Authentik login flows against the rate limit** (100 req/min avg, burst 50) — the new chain applies to the IdP's own endpoints, including the embedded outpost's forward-auth callbacks.
- **Wiki.js** — confirm the wiki still loads and search works, in case anything calls the API cross-origin.

Not in scope: A4 (ArgoCD forward-auth, needs a test plan), A6 (policy bindings, blocked on cluster state), A7 (Node-RED break-glass, docs), A8 (PVE/PBS OpenID).

🤖 Generated with [Claude Code](https://claude.com/claude-code)