### PR TITLE
fix(rustfs): declare grant_types on the OIDC provider

### DIFF
--- a/kubernetes/applications/authentik/base/blueprints/rustfs.yaml
+++ b/kubernetes/applications/authentik/base/blueprints/rustfs.yaml
@@ -14,6 +14,11 @@ entries:
       authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
       invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
       client_type: confidential
+      # Providers created after authentik migration 0032 default to an empty list,
+      # which rejects every authorize request as invalid_request.
+      grant_types:
+        - authorization_code
+        - refresh_token
       client_id: rustfs
       client_secret: !Env RUSTFS_OIDC_CLIENT_SECRET
       signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]


### PR DESCRIPTION
Follow-up to #1488. The RustFS Console login fails at the authorize endpoint:

```
<Error>
  <Code>AccessDenied</Code>
  <Message>OIDC authentication failed: invalid_request - The request is otherwise malformed</Message>
</Error>
```

## Root cause

The message comes from **authentik**, not RustFS — the handler in `rustfs/src/admin/handlers/oidc.rs` surfaces the IdP's `error` and `error_description` query parameters verbatim.

In authentik 2026.5.6, exactly two code paths raise `invalid_request` in `authorize.py`: a missing `nonce` (ruled out — the `openidconnect` crate always sends one) and this one:

```python
if self.grant_type not in self.provider.grant_types:
    LOGGER.warning("Invalid grant_type for provider", grant_type=self.grant_type)
    raise AuthorizeError(error="invalid_request", ...)
```

Migration `0032_oauth2provider_grant_types` (2026-02-17) introduced the field. It backfills **existing** providers with all seven grant types, but the model field itself is declared `default=list`:

```python
grant_types = ArrayField(models.TextField(choices=GrantType.choices), default=list)
```

A provider created by blueprint without setting `grant_types` therefore gets an empty list, and every authorize request is rejected. The check runs before scope and redirect-URI validation, which is why the callback was never reached — discovery, PKCE and the policy binding were never at fault.

Grafana, Node-RED, Wiki.js and ArgoCD are unaffected because they predate the migration and were backfilled. RustFS is the first provider added after it.

## Fix

```yaml
grant_types:
  - authorization_code
  - refresh_token
```

Grants only what the Console flow needs rather than mirroring the migration's seven-type backfill.

## After sync

The blueprint file content changes, so the ConfigMap hash changes and the blueprint re-applies to the existing provider — no manual intervention needed. Worth confirming in *Applications → Providers → RustFS* that **Grant types** is no longer empty, then retrying the Console login.

Note: the two remaining unknowns flagged in #1488 (the `admin:*` policy syntax and the issuer-base vs. full-discovery-URL question) are still untested — they sit further along the flow than this failure did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)