### PR TITLE
Revert "fix(authentik): apply chain-standard to the IdP's own routes"

### DIFF
--- a/kubernetes/applications/authentik/base/ingress-route.yaml
+++ b/kubernetes/applications/authentik/base/ingress-route.yaml
@@ -44,9 +44,6 @@ spec:
     - kind: Rule
       match: Host(`PLACEHOLDER`)
       priority: 10
-      middlewares:
-        - name: chain-standard
-          namespace: ingress-controller
       services:
         - kind: Service
           name: authentik-server
@@ -55,9 +52,6 @@ spec:
     - kind: Rule
       match: Host(`PLACEHOLDER`) && PathPrefix(`/_gatus`) && HeaderRegexp(`Cf-Access-Jwt-Assertion`, `.+`)
       priority: 20
-      middlewares:
-        - name: chain-standard
-          namespace: ingress-controller
       services:
         - kind: Service
           name: authentik-server


### PR DESCRIPTION
**Reverts A1 from #1489.** ArgoCD login is broken:

> The request failed and the interceptors did not return an alternative response

Dex can no longer complete the OIDC flow against Authentik.

## Why chain-standard is wrong for an IdP

Two independent causes, either of which alone breaks it:

**`strip-headers`** (via `chain-post-auth`) blanks `X-Forwarded-Proto`, `-Host` and `-For`. Ordinary backends do not care — they are reached over plain HTTP from Traefik and never build absolute URLs. An identity provider does exactly that: Authentik derives its issuer, authorize and token URLs from those headers. Stripped, it believes it is serving plain HTTP and emits URLs no client can validate.

**`cloudflare`** validates the source IP against Cloudflare CIDRs. Unlike `crowdsec`, it never receives `LOCAL_IPv4` — see the replacements in `components/ingress-controller/base/kustomization.yaml`, where `LOCAL_IPv4` targets only `bouncer.clientTrustedIPs`. Every in-cluster and LAN client talking to Authentik through Traefik is therefore rejected outright.

## What I got wrong

I treated `chain-standard` as universally safe because it contains no auth step. It does not follow that it is side-effect free: it also rewrites headers and filters source IPs, and an IdP is exactly the workload that depends on both. The PR flagged the rate limit as the thing to watch and missed these two entirely.

## The gap is still real

Authentik remains the only application with no CrowdSec, no rate limiting and no security headers. Reintroducing that needs a chain built for this case rather than the generic one:

- `chain-pre-auth` **without** `cloudflare` (or with `LOCAL_IPv4` added to its trusted CIDRs)
- **no** `chain-post-auth` — `strip-cookies` is equally suspect for the IdP that owns those cookies

That is a new middleware chain plus a test of the full login flow, not a one-line change. Not in scope here; this PR only restores service.

Unaffected and staying in place: A2 (Gatus bypasses), A3 (Wiki.js forward-auth), A5 (dead identity headers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)