### PR TITLE
fix(rustfs): map platform-admins to the built-in consoleAdmin policy

### DIFF
--- a/kubernetes/applications/authentik/base/blueprints/rustfs.yaml
+++ b/kubernetes/applications/authentik/base/blueprints/rustfs.yaml
@@ -4,6 +4,20 @@ metadata:
   labels:
     blueprints.goauthentik.io/instantiate: "true"
 entries:
+  # RustFS resolves each groups value against a policy of the same name, so the
+  # claim carries RustFS' built-in policy names rather than Authentik group names.
+  - model: authentik_providers_oauth2.scopemapping
+    state: present
+    identifiers:
+      managed: custom.homelab/scope-rustfs-policies
+    attrs:
+      name: "OAuth Mapping: RustFS policies"
+      scope_name: groups
+      description: "Maps platform-admins to the RustFS consoleAdmin policy"
+      expression: |
+        groups = [group.name for group in request.user.ak_groups.all()]
+        return {"groups": ["consoleAdmin"] if "platform-admins" in groups else []}
+
   # OAuth2/OIDC Provider for the RustFS Console
   - model: authentik_providers_oauth2.oauth2provider
     state: present
@@ -29,7 +43,7 @@ entries:
         - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-openid]]
         - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-email]]
         - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-profile]]
-        - !Find [authentik_providers_oauth2.scopemapping, [managed, custom.homelab/scope-groups]]
+        - !Find [authentik_providers_oauth2.scopemapping, [managed, custom.homelab/scope-rustfs-policies]]
 
   # Application entry in Authentik's app library
   - model: authentik_core.application

--- a/kubernetes/applications/rustfs/base/scripts/initialize-rustfs-users.sh
+++ b/kubernetes/applications/rustfs/base/scripts/initialize-rustfs-users.sh
@@ -39,15 +39,6 @@ EOF
   rc admin policy attach admin "${slug}-scoped" --user "$ak"
 }
 
-# Console SSO: the OIDC groups claim carries Authentik group names, and RustFS
-# resolves each value against a policy of the same name. No user is created —
-# the Console mints temporary credentials from this policy on login.
-echo ">>> policy='platform-admins' (OIDC console admins)"
-cat > /tmp/policy.json <<'EOF'
-{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["s3:*","admin:*"],"Resource":["arn:aws:s3:::*"]}]}
-EOF
-rc admin policy create admin platform-admins /tmp/policy.json
-
 provision authentik           authentik-backups     readwrite "$AUTHENTIK_RUSTFS_ACCESS_KEY"   "$AUTHENTIK_RUSTFS_SECRET_KEY"
 provision wiki-js             wiki-js-backups       readwrite "$WIKIJS_RUSTFS_ACCESS_KEY"      "$WIKIJS_RUSTFS_SECRET_KEY"
 provision timescaledb         timescaledb-backups   readwrite "$TIMESCALEDB_RUSTFS_ACCESS_KEY" "$TIMESCALEDB_RUSTFS_SECRET_KEY"


### PR DESCRIPTION
Follow-up to #1488 and #1490. The Console login now runs the **full** OIDC flow — authorize, token exchange, claims — and fails only at the last step:

```
<Error>
  <Code>InvalidRequest</Code>
  <Message>OIDC policy mapping did not resolve to current policies</Message>
</Error>
```

## What was wrong

#1488 had it backwards. It taught RustFS to expect a policy named after the Authentik group (`platform-admins`) and created that policy in the provisioning job.

RustFS ships built-in policies and its documentation states the intended direction plainly:

| Policy | Purpose |
| --- | --- |
| `consoleAdmin` | Full Console, admin, KMS and S3 access |
| `readwrite` / `readonly` / `writeonly` | S3 access |
| `diagnostics` | Diagnostic admin access |

> Keep group values equal to RustFS policy names.

The IdP emits the policy name. Nothing needs creating.

## The silent breakage

The custom policy never existed anyway — RustFS rejected the `admin:*` action and the job died on it. ArgoCD has been reporting it ever since:

```
hook: Job initialize-rustfs-users   Synced   Failed   Job has reached the specified backoff limit
```

That call sat **above** the five `provision()` calls, so since #1488 the job has aborted under `set -eu` before reaching the machine users. Their IAM state lives on the data PVC and survived, which is why backups kept working and nothing looked broken from the outside.

## The fix

- **Blueprint:** a RustFS-specific scope mapping replaces the shared `custom.homelab/scope-groups` on this provider. It emits `["consoleAdmin"]` for `platform-admins` members and `[]` for everyone else, so the claim carries a policy name RustFS already knows.
- **Provisioning script:** the policy block is removed. The file returns to exactly its pre-#1488 content, which also restores the machine-user provisioning.

The shared `custom.homelab/scope-groups` mapping is untouched and still used by Grafana, Node-RED, Wiki.js and ArgoCD, which do want real group names.

## After sync

1. `initialize-rustfs-users` should go green again — this is the check that the machine users are being provisioned once more.
2. Console login at `rustfs-console.zimmermann.sh` via the Authentik button, with buckets and the IAM view reachable. That proves the claim mapping end to end.
3. The five machine keys keep working: CNPG backups for authentik, wiki-js and timescaledb, plus the NATS archive compactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)