### PR TITLE
fix(rustfs): create the consoleAdmin policy the OIDC binding needs

### DIFF
--- a/kubernetes/applications/rustfs/base/scripts/initialize-rustfs-users.sh
+++ b/kubernetes/applications/rustfs/base/scripts/initialize-rustfs-users.sh
@@ -45,5 +45,17 @@ provision timescaledb         timescaledb-backups   readwrite "$TIMESCALEDB_RUST
 provision redpanda-connect    nats-archive          writeonly "$REDPANDA_RUSTFS_ACCESS_KEY"    "$REDPANDA_RUSTFS_SECRET_KEY"
 provision iot-insights-engine iot-mcp-bridge-models readwrite "$IOTENGINE_RUSTFS_ACCESS_KEY"   "$IOTENGINE_RUSTFS_SECRET_KEY"
 
+# Console SSO policy. RustFS documents consoleAdmin as built-in, but the OIDC
+# binding resolves claim values against the IAM store, where it does not exist.
+# No user is attached — the Console mints temporary credentials from it on login.
+# Runs last so a failure here cannot block the machine users above.
+echo ">>> policy='consoleAdmin' (OIDC console access)"
+cat > /tmp/policy.json <<'EOF'
+{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["s3:*","admin:*"],"Resource":["arn:aws:s3:::*"]}]}
+EOF
+rc admin policy create admin consoleAdmin /tmp/policy.json
+
 echo ">>> done; current users:"
 rc admin user ls admin
+echo ">>> current policies:"
+rc admin policy ls admin


### PR DESCRIPTION
Third and hopefully last step for RustFS Console SSO. The OIDC flow now completes — authorize, token exchange, claims, group mapping — and fails only on the final binding:

```
InvalidRequest: OIDC policy mapping did not resolve to current policies
```

## Why

RustFS documents `consoleAdmin` as a built-in policy. The federated session binding in `rustfs/src/admin/service/federated_identity.rs` special-cases nothing:

```rust
!selected_policy_names.is_empty()
    && selected_policy_names.iter().all(|name|
           is_safe_claim_policy_name(name) && resolved_policy_names.contains(name))
```

`resolved_policy_names` comes from `iam_store.current_policies(...)` — the policy must genuinely exist. This instance holds only what the provisioning job creates (`authentik-scoped`, `wiki-js-scoped`, …), so the claim resolved to nothing both times: first as `platform-admins` (#1488), now as `consoleAdmin` (#1495).

So the policy gets created explicitly.

## On the earlier job failure

#1488's policy creation made `initialize-rustfs-users` fail, and I assumed the `admin:*` action was to blame. That was wrong — `crates/policy/src/policy/action.rs:538` defines `AllAdminActions` with exactly that serialization:

```rust
#[strum(serialize = "admin:*")]
AllAdminActions,
```

The real cause is still unknown; the job's pod was gone before I looked. Two changes follow from that:

- The call now sits **after** the five `provision()` calls. If it fails again, the machine users are already provisioned and the job's failure stays contained.
- `rc admin policy ls` runs at the end, so the job log shows the resulting policy set instead of leaving it to be guessed.

## After sync

1. `initialize-rustfs-users` green, and its log lists `consoleAdmin` among the policies.
2. Console login via the Authentik button, with buckets and the IAM view reachable.
3. The five machine keys keep working — CNPG backups and the NATS archive compactor.

If the job fails again, its log now contains the actual error, and step 2 stays blocked without anything else regressing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)