### PR TITLE
Revert "fix(rustfs): create the consoleAdmin policy the OIDC binding needs"

### DIFF
--- a/kubernetes/applications/rustfs/base/scripts/initialize-rustfs-users.sh
+++ b/kubernetes/applications/rustfs/base/scripts/initialize-rustfs-users.sh
@@ -45,17 +45,5 @@ provision timescaledb         timescaledb-backups   readwrite "$TIMESCALEDB_RUST
 provision redpanda-connect    nats-archive          writeonly "$REDPANDA_RUSTFS_ACCESS_KEY"    "$REDPANDA_RUSTFS_SECRET_KEY"
 provision iot-insights-engine iot-mcp-bridge-models readwrite "$IOTENGINE_RUSTFS_ACCESS_KEY"   "$IOTENGINE_RUSTFS_SECRET_KEY"
 
-# Console SSO policy. RustFS documents consoleAdmin as built-in, but the OIDC
-# binding resolves claim values against the IAM store, where it does not exist.
-# No user is attached — the Console mints temporary credentials from it on login.
-# Runs last so a failure here cannot block the machine users above.
-echo ">>> policy='consoleAdmin' (OIDC console access)"
-cat > /tmp/policy.json <<'EOF'
-{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["s3:*","admin:*"],"Resource":["arn:aws:s3:::*"]}]}
-EOF
-rc admin policy create admin consoleAdmin /tmp/policy.json
-
 echo ">>> done; current users:"
 rc admin user ls admin
-echo ">>> current policies:"
-rc admin policy ls admin


### PR DESCRIPTION
**Reverts #1497.** `initialize-rustfs-users` hit its backoff limit again and the app went Degraded.

## The policy was never missing

RustFS seeds its eight built-in policies into the IAM cache on every load — `crates/iam/src/store/object.rs`:

```rust
let mut policy_docs_cache = CacheEntity::new(get_default_policies());
```

`DEFAULT_POLICIES` contains `readwrite`, `readonly`, `writeonly`, `diagnostics`, **`consoleAdmin`** and three KMS roles. `delete_policy` guards the same set with *"system policy can not be deleted"*.

So `rc admin policy create admin consoleAdmin` was trying to create a system policy that already exists. That is both unnecessary and the likely reason the job failed.

The machine users were not affected: the call sat **after** the five `provision()` calls precisely so a failure there could not reach them. That safeguard did its job.

## What this leaves open

The binding condition is:

```rust
!selected_policy_names.is_empty()
    && selected_policy_names.iter().all(|name|
           is_safe_claim_policy_name(name) && resolved_policy_names.contains(name))
```

`consoleAdmin` is a valid name and it resolves. So the failing half must be the first one — **`selected_policy_names` is empty**. The claim is not being turned into policy names at all, which is a different problem from the one #1497 tried to solve.

Diagnosing that needs evidence rather than another guess. RustFS already logs it:

```rust
if tracing::enabled!(tracing::Level::DEBUG) {
    log_oidc_policy_diagnostics(&iam_store, ...);
}
```

At DEBUG level the rustfs pod logs which policy names were selected and which resolved. That log is in the long-running rustfs pod, not the job — so it survives, unlike the job pod logs which vanish on completion.

## After sync

`initialize-rustfs-users` green, app Healthy. Console SSO stays broken until the claim question is answered; nothing else regresses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)