### PR TITLE
feat(authentik): apply chain-pre-auth to the IdP's routes

### DIFF
--- a/kubernetes/applications/authentik/base/ingress-route.yaml
+++ b/kubernetes/applications/authentik/base/ingress-route.yaml
@@ -41,9 +41,14 @@ spec:
   entryPoints:
     - websecure
   routes:
+    # chain-pre-auth, not chain-standard: the post-auth half strips the session
+    # cookies and X-Forwarded-* headers that authentik requires.
     - kind: Rule
       match: Host(`PLACEHOLDER`)
       priority: 10
+      middlewares:
+        - name: chain-pre-auth
+          namespace: ingress-controller
       services:
         - kind: Service
           name: authentik-server
@@ -52,6 +57,9 @@ spec:
     - kind: Rule
       match: Host(`PLACEHOLDER`) && PathPrefix(`/_gatus`) && HeaderRegexp(`Cf-Access-Jwt-Assertion`, `.+`)
       priority: 20
+      middlewares:
+        - name: chain-pre-auth
+          namespace: ingress-controller
       services:
         - kind: Service
           name: authentik-server


### PR DESCRIPTION
Second attempt at A1. **Do not merge while away from the home network, and not before the RustFS claim question is settled** — see "When to merge" below.

## The gap

Authentik is the only application whose routes reference no middleware at all: no Cloudflare CIDR validation, no CrowdSec, no rate limit, no security headers. The most valuable target in the cluster is the one without edge hygiene.

## Why the first attempt failed

#1489 used `chain-standard` and took down every authentik login. That chain ends in `chain-post-auth`, and both of its middlewares are disqualifying for an IdP:

**`strip-cookies`** removes `authentik_session`, `authentik_device` and `authentik_proxy_*`. It exists to keep those cookies away from *backends*. On authentik's own route it takes the IdP's session away from the IdP — the flow executor then fails every API call, which is exactly the `null` / "interceptors did not return an alternative response" error that appeared.

**`strip-headers`** blanks `X-Forwarded-Proto` and `X-Forwarded-For`. Upstream's [reverse proxy documentation](https://github.com/goauthentik/authentik/blob/main/website/docs/install-config/reverse-proxy.md) lists both as **required**, together with `Host` and the WebSocket upgrade pair, because authentik derives its absolute issuer and redirect URLs from them.

## The fix

`chain-pre-auth` is exactly the remaining set:

```
cloudflare → crowdsec → rate-limit → security-headers → compress
```

No new resource needed. The chain has so far only been used as a building block; the IdP route is the case that exception exists for.

**`cloudflare` stays in.** An earlier draft of the concept proposed adding `LOCAL_IPv4` to its trusted CIDRs. That was wrong: `cloudflare` is a single shared middleware on ~20 routes, so changing it weakens origin validation cluster-wide — for Proxmox and the wallbox as much as for the IdP — to remove a risk that is speculative rather than observed. If in-cluster traffic does fail it, the answer is a *second* middleware instance for this chain, not editing the shared one.

The Gatus bypass follows the same rule as every other host: the main route's chain minus the auth step, which here leaves `chain-pre-auth` unchanged.

## Pre-checks done

- **CSP.** Authentik sets its own CSP only for `files/media/` (`default-src 'none'; sandbox`); the main app ships none, so Traefik's is the only one in play. The flow interface is a same-origin SPA — scripts, API calls, fonts and the background image all resolve under `'self'`, and `connect-src 'self'` covers the same-origin WebSocket. One narrow residual: `img-src` has no `blob:`, which could affect TOTP **enrollment** QR rendering, not login.
- **Rate limit.** 100/min average, burst 50, per real client IP (the entrypoint trusts Cloudflare's forwarded headers). Grafana — a far heavier SPA — already runs behind the same limit via `chain-mfa-auth` without trouble, so a login page is not the case that breaks it.

## When to merge

Both conditions, because a failure here locks you out of everything behind authentik:

1. **On the home network**, with kubectl available. The revert is a GitHub merge and works from anywhere, but diagnosing *why* is what needed cluster access last time.
2. **After RustFS is resolved.** Changing the IdP's ingress mid-diagnosis of an OIDC problem makes the result ambiguous — the same reason #1498 (authentik 2026.8.0) is being held.

## Test plan

1. Full login flow through the flow interface.
2. ArgoCD login — Dex talks to authentik server-to-server, so this exercises the `cloudflare` question directly.
3. RustFS console login, if by then it works.
4. `kubectl -n authentik logs deploy/authentik-server` for 403s from the cloudflare plugin or 429s from the rate limit.

If anything breaks: revert, do not patch forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)