### PR TITLE
chore(rustfs): scope DEBUG logging to the admin handlers for OIDC diagnosis

### DIFF
--- a/kubernetes/applications/rustfs/base/values.yaml
+++ b/kubernetes/applications/rustfs/base/values.yaml
@@ -96,3 +96,9 @@ extraEnv:
     value: preferred_username
   - name: RUSTFS_IDENTITY_OPENID_EMAIL_CLAIM
     value: email
+  # TEMPORARY — remove once the Console SSO policy mapping is diagnosed.
+  # RUST_LOG takes precedence over config.rustfs.log_level and accepts full
+  # EnvFilter syntax, so DEBUG stays scoped to the admin handlers. The data
+  # path keeps logging at error, which is what the log_level comment protects.
+  - name: RUST_LOG
+    value: "error,rustfs::admin=debug"


### PR DESCRIPTION
**Temporary diagnostic. Revert once the claim question is answered.**

## Why

Console SSO now completes the whole OIDC flow — authorize, token exchange, claims, group mapping — and fails only at the final binding:

```
InvalidRequest: OIDC policy mapping did not resolve to current policies
```

The condition in `rustfs/src/admin/service/federated_identity.rs` has two halves:

```rust
!selected_policy_names.is_empty()
    && selected_policy_names.iter().all(|name|
           is_safe_claim_policy_name(name) && resolved_policy_names.contains(name))
```

`consoleAdmin` is one of the eight built-ins that `crates/iam/src/store/object.rs` seeds into the IAM cache on every load, and it is a valid claim policy name. So it resolves, and the failing half must be the first one: **`selected_policy_names` is empty**. The claim is producing no policy names at all.

Rather than guessing a fourth time, this reads it. RustFS already logs precisely those two lists — but only at DEBUG:

```rust
if tracing::enabled!(tracing::Level::DEBUG) {
    log_oidc_policy_diagnostics(&iam_store, ...);
}
```

## Why not just raise log_level

`config.rustfs.log_level` stays at `error`. The comment on it is a warning worth heeding:

```yaml
# Keep at error: rustfs at info floods the Loki PVC.
log_level: "error"
```

`debug` globally would be considerably worse than `info`. Instead this uses `RUST_LOG`, which `crates/obs/src/telemetry/filter.rs` gives precedence over the config value and passes to `EnvFilter::new()`, so full directive syntax works:

```
RUST_LOG=error,rustfs::admin=debug
```

The data path — the part that floods — stays at `error`. `rustfs::admin` only sees traffic on admin API calls, so a login produces a handful of extra lines rather than a stream.

## Reading the output

Verified that no kustomize replacement collides with the new variable: `RUST_LOG` is not a prefix of any `RUSTFS_*` name, and the rendered Deployment shows it intact alongside all twelve OIDC variables.

The Deployment mounts `/logs`, so rustfs writes to a file as well as stdout. ERROR lines were readable via `kubectl logs` during yesterday's diagnosis, but if the DEBUG lines do not appear there:

```
kubectl -n rustfs logs -l app.kubernetes.io/name=rustfs --tail=200 | grep -i "policy\|claim"
kubectl -n rustfs exec deploy/rustfs -- sh -c 'ls -t /logs | head'
```

## Procedure

1. Merge, wait for the rollout — the env change restarts the pod.
2. Attempt a Console login; it will still fail.
3. Read the log. `log_oidc_policy_diagnostics` prints which policy names were selected and which resolved.
4. Fix follows from that, then revert this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)