### PR TITLE
chore(rustfs): extend OIDC debug logging to the IAM crate

### DIFF
--- a/kubernetes/applications/rustfs/base/values.yaml
+++ b/kubernetes/applications/rustfs/base/values.yaml
@@ -98,7 +98,8 @@ extraEnv:
     value: email
   # TEMPORARY — remove once the Console SSO policy mapping is diagnosed.
   # RUST_LOG takes precedence over config.rustfs.log_level and accepts full
-  # EnvFilter syntax, so DEBUG stays scoped to the admin handlers. The data
-  # path keeps logging at error, which is what the log_level comment protects.
+  # EnvFilter syntax, so DEBUG stays scoped to the OIDC path. rustfs_iam::oidc
+  # carries the claims_policy_mapped diagnostic; it only fires on login, and the
+  # data path keeps logging at error, which is what the log_level comment protects.
   - name: RUST_LOG
-    value: "error,rustfs::admin=debug"
+    value: "error,rustfs::admin=debug,rustfs_iam::oidc=debug"


### PR DESCRIPTION
Follow-up to #1507. Still temporary; revert together with it.

## What the first filter showed

`rustfs::admin=debug` produced exactly one useful line — the authorize redirect — and then the same error:

```
18:18:26 DEBUG admin_oidc_state  state=authorize_redirect
18:18:27 ERROR OIDC policy mapping did not resolve to current policies
```

No claim information at all. Two reasons, and the first one was my mistake:

**`log_oidc_policy_diagnostics` cannot fire on this path.** In `federated_identity.rs` it sits *after* `issue_credentials`, so the early return on an unresolved mapping skips it entirely:

```rust
if !all_oidc_policies_resolved(&selected_policy_names, &resolved_policy_mapping) {
    return Err(...);                      // ← taken
}
let credentials = issue_credentials(...)?;
if tracing::enabled!(tracing::Level::DEBUG) {
    log_oidc_policy_diagnostics(...);     // ← never reached
}
```

It only ever reports *successful* bindings. #1507 was built on the assumption that it would report failures.

**The diagnostic that does fire lives in another crate.** At the end of `map_claims_to_policies` in `crates/iam/src/oidc.rs`:

```rust
debug!(event = EVENT_OIDC_DIAGNOSTICS, result = "claims_policy_mapped",
       policies = ?policies, groups = ?groups,
       raw_claim_keys = ?raw_claim_keys, raw_claims = ?claims.raw,
       claim_name_lookup = %claim_name_lookup, groups_claim_lookup = %groups_claim_lookup, ...)
```

That logs the decoded ID token, every claim key present in it, the lookup state of each configured claim name, and the resulting policy and group lists.

## Why that is the right place

`policies` is derived from `claims.groups` — one policy name per group value:

```rust
for group in &claims.groups {
    groups.push(group.clone());
    if !has_role_policy {
        policies.push(/* claim_prefix + */ group.clone());
    }
}
```

`consoleAdmin` is a seeded built-in and resolves, so the binding must be failing on `selected_policy_names.is_empty()`. That means `claims.groups` came back empty, and this log says why: whether the `groups` claim was `found`, `missing` or `ambiguous`, and what the token actually contained.

## Scope

The crate's package is `rustfs-iam`, so the log target is `rustfs_iam::oidc`. Scoped to the module rather than the whole crate deliberately: IAM authorises every S3 request, while the OIDC module is only entered on login. The data path stays at `error`.

```
RUST_LOG=error,rustfs::admin=debug,rustfs_iam::oidc=debug
```

## Procedure

1. Merge and wait for the rollout.
2. Attempt a Console login.
3. `kubectl -n rustfs logs -l app.kubernetes.io/name=rustfs --tail=200 | grep claims_policy_mapped`

The `raw_claims` field will contain the ID token as decoded. Note it holds the full token payload, so treat the output as sensitive — do not paste it anywhere public without trimming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)