### PR TITLE
fix(rustfs): grant consoleAdmin via role_policy instead of the groups claim

### DIFF
--- a/kubernetes/applications/authentik/base/blueprints/rustfs.yaml
+++ b/kubernetes/applications/authentik/base/blueprints/rustfs.yaml
@@ -4,19 +4,12 @@ metadata:
   labels:
     blueprints.goauthentik.io/instantiate: "true"
 entries:
-  # RustFS resolves each groups value against a policy of the same name, so the
-  # claim carries RustFS' built-in policy names rather than Authentik group names.
+  # Superseded by RUSTFS_IDENTITY_OPENID_ROLE_POLICY. The built-in profile scope
+  # emits its own groups claim, so a second mapping could never control the result.
   - model: authentik_providers_oauth2.scopemapping
-    state: present
+    state: absent
     identifiers:
       managed: custom.homelab/scope-rustfs-policies
-    attrs:
-      name: "OAuth Mapping: RustFS policies"
-      scope_name: groups
-      description: "Maps platform-admins to the RustFS consoleAdmin policy"
-      expression: |
-        groups = [group.name for group in request.user.ak_groups.all()]
-        return {"groups": ["consoleAdmin"] if "platform-admins" in groups else []}
 
   # OAuth2/OIDC Provider for the RustFS Console
   - model: authentik_providers_oauth2.oauth2provider
@@ -43,7 +36,7 @@ entries:
         - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-openid]]
         - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-email]]
         - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-profile]]
-        - !Find [authentik_providers_oauth2.scopemapping, [managed, custom.homelab/scope-rustfs-policies]]
+        - !Find [authentik_providers_oauth2.scopemapping, [managed, custom.homelab/scope-groups]]
 
   # Application entry in Authentik's app library
   - model: authentik_core.application

--- a/kubernetes/applications/rustfs/base/values.yaml
+++ b/kubernetes/applications/rustfs/base/values.yaml
@@ -89,7 +89,13 @@ extraEnv:
     value: "off"
   - name: RUSTFS_IDENTITY_OPENID_DISPLAY_NAME
     value: Authentik
-  # Claim values must match RustFS policy names — see initialize-rustfs-users.sh.
+  # Grant one fixed policy instead of deriving policy names from the groups claim.
+  # authentik's built-in profile scope emits the user's real group names into the
+  # same claim, and RustFS requires every value to resolve to a policy — which
+  # names containing a space can never do. Who may log in is decided by the
+  # policy binding on the authentik application, not here.
+  - name: RUSTFS_IDENTITY_OPENID_ROLE_POLICY
+    value: consoleAdmin
   - name: RUSTFS_IDENTITY_OPENID_GROUPS_CLAIM
     value: groups
   - name: RUSTFS_IDENTITY_OPENID_USERNAME_CLAIM


### PR DESCRIPTION
The debug logging from #1507/#1508 answered it. This is the actual fix.

## What the log showed

```
result              = claims_policy_mapped
policies            = ["authentik Admins", "consoleAdmin", "platform-admins"]
groups              = ["authentik Admins", "consoleAdmin", "platform-admins"]
policy_count        = 3
groups_claim_lookup = found
```

`selected_policy_names` was never empty, which is what I had assumed. It held **three** entries, and the binding requires every one of them to resolve:

```rust
selected_policy_names.iter().all(|name|
    is_safe_claim_policy_name(name) && resolved_policy_names.contains(name))
```

`consoleAdmin` resolves. The other two do not.

## Where the extra values come from

authentik's **built-in `profile` scope mapping** emits a groups claim of its own:

```python
return {
    "name": request.user.name,
    ...
    "groups": [group.name for group in request.user.groups.all()],
}
```

RustFS requests `openid profile email groups`, so authentik merges that with the dedicated mapping and delivers all three values in one claim. `map_claims_to_policies` then turns each into a policy name.

**This arrangement could never have worked.** `authentik Admins` contains a space, and `is_safe_claim_policy_name` permits only alphanumerics plus `_ - : .` — so it fails validation whether or not a matching policy exists. Adding a second groups mapping (#1495) could not fix it either, because the profile scope keeps contributing to the same claim.

## The fix

`role_policy` is the mechanism RustFS provides for exactly this case:

```rust
let has_role_policy = !config.role_policy.trim().is_empty();
if has_role_policy { /* policies come from config */ }
for group in &claims.groups {
    groups.push(group.clone());
    if !has_role_policy { policies.push(...) }   // skipped
}
```

With `RUSTFS_IDENTITY_OPENID_ROLE_POLICY=consoleAdmin` the policy list comes from configuration and group values stay purely contextual.

Authorisation moves entirely to the policy binding on the authentik application, which already restricts it to `platform-admins`. authentik decides who may sign in; RustFS grants `consoleAdmin` to whoever gets through. That is the same division of labour the rest of the estate uses.

The dedicated scope mapping is now pointless: set to `absent` so it is removed rather than left orphaned, and the provider returns to the shared `custom.homelab/scope-groups`, which gives more useful context than a hardcoded policy name.

## Trail of wrong turns, for the record

| Attempt | Assumption | Reality |
|---|---|---|
| #1488 | Claim carries the authentik group name; create a matching policy | The job failed and the name could never validate |
| #1495 | Emit `consoleAdmin` instead | The profile scope still adds the real group names |
| #1497 | `consoleAdmin` is missing, create it | It is a seeded built-in |
| this | Read the log first | Three values, two unresolvable |

Every wrong turn rested on documentation or inference. The one that worked came from the log.

## After sync

1. Console login at `rustfs-console.zimmermann.sh` via the Authentik button — buckets and the IAM view reachable.
2. `claims_policy_mapped` should now show `policies = ["consoleAdmin"]` with `policy_count = 1`, while `groups` still lists all three.
3. Once confirmed, revert the debug logging (#1507 and #1508 together).

🤖 Generated with [Claude Code](https://claude.com/claude-code)