### PR TITLE
chore(rustfs): drop the temporary OIDC debug logging

### DIFF
--- a/kubernetes/applications/rustfs/base/values.yaml
+++ b/kubernetes/applications/rustfs/base/values.yaml
@@ -89,11 +89,7 @@ extraEnv:
     value: "off"
   - name: RUSTFS_IDENTITY_OPENID_DISPLAY_NAME
     value: Authentik
-  # Grant one fixed policy instead of deriving policy names from the groups claim.
-  # authentik's built-in profile scope emits the user's real group names into the
-  # same claim, and RustFS requires every value to resolve to a policy — which
-  # names containing a space can never do. Who may log in is decided by the
-  # policy binding on the authentik application, not here.
+  # Fixed policy: the profile scope also emits real group names, which never resolve.
   - name: RUSTFS_IDENTITY_OPENID_ROLE_POLICY
     value: consoleAdmin
   - name: RUSTFS_IDENTITY_OPENID_GROUPS_CLAIM

--- a/kubernetes/applications/rustfs/base/values.yaml
+++ b/kubernetes/applications/rustfs/base/values.yaml
@@ -102,10 +102,3 @@ extraEnv:
     value: preferred_username
   - name: RUSTFS_IDENTITY_OPENID_EMAIL_CLAIM
     value: email
-  # TEMPORARY — remove once the Console SSO policy mapping is diagnosed.
-  # RUST_LOG takes precedence over config.rustfs.log_level and accepts full
-  # EnvFilter syntax, so DEBUG stays scoped to the OIDC path. rustfs_iam::oidc
-  # carries the claims_policy_mapped diagnostic; it only fires on login, and the
-  # data path keeps logging at error, which is what the log_level comment protects.
-  - name: RUST_LOG
-    value: "error,rustfs::admin=debug,rustfs_iam::oidc=debug"


### PR DESCRIPTION
Console SSO works — login goes through Authentik without an access key, and `role_policy` delivers `consoleAdmin` on its own. The diagnostics have served their purpose.

## Two commits

**Removes the `RUST_LOG` override** added in #1507 and widened in #1508. Logging returns to `config.rustfs.log_level`, which stays at `error` for the reason its own comment gives — rustfs at `info` already floods the Loki PVC.

**Shortens the `role_policy` comment** from five lines to one. The rationale is written out in full in #1509's commit and description, which is where it belongs; repeating it in `values.yaml` is noise.

## Worth remembering

If OIDC ever needs diagnosing again, the useful log line is `claims_policy_mapped` in `rustfs_iam::oidc` — not `log_oidc_policy_diagnostics` in `rustfs::admin`. The latter sits behind the early return in `bind()` and only ever reports *successful* bindings, which is why the first attempt at debug logging produced nothing useful.

```
RUST_LOG=error,rustfs_iam::oidc=debug
```

That single directive would have been enough. It prints the decoded ID token, every claim key in it, the lookup state of each configured claim name, and the resulting policy and group lists.

## After sync

Console login keeps working, and the rustfs pod logs at `error` again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)