### PR TITLE
Revert "feat(argocd): put the UI behind forward-auth via split routing"

### DIFF
--- a/kubernetes/components/gitops-controller/base/ingress-route.yaml
+++ b/kubernetes/components/gitops-controller/base/ingress-route.yaml
@@ -39,20 +39,18 @@ spec:
   entryPoints:
     - websecure
   routes:
-    # Browser UI. Machine paths below match at higher priority and skip forward-auth.
     - kind: Rule
       match: Host(`PLACEHOLDER`)
       priority: 10
       middlewares:
-        - name: chain-mfa-auth
+        - name: chain-standard
           namespace: ingress-controller
       services:
         - kind: Service
           name: argocd-server
           port: 80
-    # argocd CLI. Regex covers application/grpc, +proto and the grpc-web variants.
     - kind: Rule
-      match: Host(`PLACEHOLDER`) && HeaderRegexp(`Content-Type`, `application/grpc.*`)
+      match: Host(`PLACEHOLDER`) && Header(`Content-Type`, `application/grpc`)
       priority: 11
       middlewares:
         - name: chain-standard
@@ -66,17 +64,6 @@ spec:
     - kind: Rule
       match: Host(`PLACEHOLDER`) && PathPrefix(`/_gatus`) && HeaderRegexp(`Cf-Access-Jwt-Assertion`, `.+`)
       priority: 20
-      middlewares:
-        - name: chain-standard
-          namespace: ingress-controller
-      services:
-        - kind: Service
-          name: argocd-server
-          port: 80
-    # GitHub push webhook — authenticated by its own HMAC signature, not by Authentik.
-    - kind: Rule
-      match: Host(`PLACEHOLDER`) && PathPrefix(`/api/webhook`) && Method(`POST`)
-      priority: 15
       middlewares:
         - name: chain-standard
           namespace: ingress-controller

--- a/kubernetes/components/gitops-controller/overlays/dev/kustomization.yaml
+++ b/kubernetes/components/gitops-controller/overlays/dev/kustomization.yaml
@@ -16,7 +16,6 @@ replacements:
           - spec.routes.0.match
           - spec.routes.1.match
           - spec.routes.2.match
-          - spec.routes.3.match
         options:
           delimiter: "`"
           index: 1

--- a/kubernetes/components/gitops-controller/overlays/prod/kustomization.yaml
+++ b/kubernetes/components/gitops-controller/overlays/prod/kustomization.yaml
@@ -16,7 +16,6 @@ replacements:
           - spec.routes.0.match
           - spec.routes.1.match
           - spec.routes.2.match
-          - spec.routes.3.match
         options:
           delimiter: "`"
           index: 1


### PR DESCRIPTION
**Reverts #1501.** The `argocd` CLI can no longer authenticate:

```
argocd login argocd.zimmermann.sh --sso
rpc error: code = PermissionDenied desc = unexpected HTTP status code received
from server: 403 (Forbidden); transport: received unexpected content-type "text/html"
```

Restores `chain-standard` on the main route, so the CLI works again regardless of which route its requests land on. Merge this before doing anything else.

## What is and is not known

**The 403 did not come from authentik.** Nothing reached it at the time of the failed login, so forward-auth is not the component that refused. That rules out the most obvious explanation — that the CLI fell through to the browser route and was bounced by the outpost.

What remains is the surrounding chain (`cloudflare`, `crowdsec`, `rate-limit`) or Cloudflare's edge itself. `text/html` on a 403 fits an error page from either. Distinguishing them needs Traefik access logs, which this cluster does not currently emit to stdout.

Browser login and the GitHub webhook both worked under the split — the webhook even refreshed `gitops-controller-prod` through the new bypass route — so the regression is specific to the CLI's transport, not to the split routing as such.

## What I got wrong

The PR listed the CLI test as step 2 of 4 and I let steps 1 and 3 stand in for it. Browser login and webhook delivery say nothing about a gRPC client, and the `Header` → `HeaderRegexp` change existed precisely because that path was fragile. The change should not have been merged before that test ran.

## Next time, before retrying

1. Enable Traefik access logs to stdout, at least temporarily. Every hypothesis about this failure is currently untestable, which is the actual blocker.
2. Reproduce with `argocd login --grpc-web` as well, since it sends a different content type and may route differently.
3. Check whether gRPC is enabled for the zone in Cloudflare's network settings — a Cloudflare-side 403 on HTTP/2 gRPC would explain an error that never reaches the cluster, and would mean the split needs a different shape entirely.

Only then is it worth re-proposing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)