### PR TITLE
feat(argocd): put the UI behind forward-auth, with grpc-web routed separately

### DIFF
--- a/kubernetes/components/gitops-controller/base/ingress-route.yaml
+++ b/kubernetes/components/gitops-controller/base/ingress-route.yaml
@@ -39,16 +39,18 @@ spec:
   entryPoints:
     - websecure
   routes:
+    # Browser UI. The machine paths below match at higher priority and skip forward-auth.
     - kind: Rule
       match: Host(`PLACEHOLDER`)
       priority: 10
       middlewares:
-        - name: chain-standard
+        - name: chain-mfa-auth
           namespace: ingress-controller
       services:
         - kind: Service
           name: argocd-server
           port: 80
+    # argocd CLI over HTTP/2. Exact match on purpose: grpc-web must not land on h2c.
     - kind: Rule
       match: Host(`PLACEHOLDER`) && Header(`Content-Type`, `application/grpc`)
       priority: 11
@@ -64,6 +66,39 @@ spec:
     - kind: Rule
       match: Host(`PLACEHOLDER`) && PathPrefix(`/_gatus`) && HeaderRegexp(`Cf-Access-Jwt-Assertion`, `.+`)
       priority: 20
+      middlewares:
+        - name: chain-standard
+          namespace: ingress-controller
+      services:
+        - kind: Service
+          name: argocd-server
+          port: 80
+    # argocd CLI after its automatic fallback — HTTP/1.1, so plain HTTP, not h2c.
+    - kind: Rule
+      match: Host(`PLACEHOLDER`) && HeaderRegexp(`Content-Type`, `application/grpc-web.*`)
+      priority: 12
+      middlewares:
+        - name: chain-standard
+          namespace: ingress-controller
+      services:
+        - kind: Service
+          name: argocd-server
+          port: 80
+    # Dex OIDC endpoints — the CLI exchanges its authorization code here without a session.
+    - kind: Rule
+      match: Host(`PLACEHOLDER`) && PathPrefix(`/api/dex`)
+      priority: 13
+      middlewares:
+        - name: chain-standard
+          namespace: ingress-controller
+      services:
+        - kind: Service
+          name: argocd-server
+          port: 80
+    # GitHub push webhook — authenticated by its own HMAC signature, not by Authentik.
+    - kind: Rule
+      match: Host(`PLACEHOLDER`) && PathPrefix(`/api/webhook`) && Method(`POST`)
+      priority: 15
       middlewares:
         - name: chain-standard
           namespace: ingress-controller

--- a/kubernetes/components/gitops-controller/overlays/dev/kustomization.yaml
+++ b/kubernetes/components/gitops-controller/overlays/dev/kustomization.yaml
@@ -16,6 +16,9 @@ replacements:
           - spec.routes.0.match
           - spec.routes.1.match
           - spec.routes.2.match
+          - spec.routes.3.match
+          - spec.routes.4.match
+          - spec.routes.5.match
         options:
           delimiter: "`"
           index: 1

--- a/kubernetes/components/gitops-controller/overlays/prod/kustomization.yaml
+++ b/kubernetes/components/gitops-controller/overlays/prod/kustomization.yaml
@@ -16,6 +16,9 @@ replacements:
           - spec.routes.0.match
           - spec.routes.1.match
           - spec.routes.2.match
+          - spec.routes.3.match
+          - spec.routes.4.match
+          - spec.routes.5.match
         options:
           delimiter: "`"
           index: 1


### PR DESCRIPTION
Second attempt at A4, after #1501 was reverted in #1511. This time the access log explains the failure instead of a theory.

## What broke last time

The failing request matched the gRPC route and got a 502 from the h2c backend:

```
RequestPath     = /version.VersionService/Version
RequestProtocol = HTTP/2.0
RouterName      = gitops-controller-argocd-server-dc474bf676bc6aea4dd4
ServiceURL      = h2c://10.244.5.218:8080
OriginStatus    = 502
```

That 502 is **normal and pre-existing**. Plain HTTP/2 gRPC does not survive the path to this backend, which is exactly why the CLI prints:

```
Failed to invoke grpc call. Use flag --grpc-web in grpc calls.
```

and retries over **grpc-web** — HTTP/1.1 with `Content-Type: application/grpc-web+proto`. That retry is the transport that actually carries the session.

## Why widening the matcher was the mistake

The exact matcher in the original route was deliberate, not an oversight:

| | Matcher | Where grpc-web lands |
|---|---|---|
| before #1501 | `Header(…, 'application/grpc')` exact | no match → falls through to the plain HTTP route → **works** |
| with #1501 | `HeaderRegexp(…, 'application/grpc.*')` | matches → routed to the **h2c** service → HTTP/1.1 against h2c → **fails** |

I broadened it because I expected grpc-web to otherwise hit forward-auth. The actual consequence was pulling it onto a backend scheme it cannot speak. The exact match protects the h2c route from precisely that.

## The corrected shape

| Prio | Match | Chain | Scheme |
|---|---|---|---|
| 20 | `PathPrefix('/_gatus') && HeaderRegexp('Cf-Access-Jwt-Assertion', '.+')` | `chain-standard` | http |
| 15 | `PathPrefix('/api/webhook') && Method('POST')` | `chain-standard` | http |
| 13 | `PathPrefix('/api/dex')` | `chain-standard` | http |
| 12 | `HeaderRegexp('Content-Type', 'application/grpc-web.*')` | `chain-standard` | http |
| 11 | `Header('Content-Type', 'application/grpc')` **exact** | `chain-standard` | **h2c** |
| 10 | `Host(…)` | `chain-mfa-auth` | http |

`h2c` now appears on exactly one route, and that route matches exactly one content type.

**`/api/dex` is new.** The CLI exchanges its authorization code there without an Authentik session, so forward-auth would reject it. Those endpoints are an OIDC surface and public by design — the same reasoning as the webhook bypass.

The overlays address routes by index and now carry all six; without that the new routes would keep the literal `PLACEHOLDER` as their host.

## Test plan — CLI first this time

Last round I let browser login and webhook delivery stand in for the CLI test and merged on that basis. They say nothing about a gRPC client. So:

1. **`argocd login argocd.zimmermann.sh --sso` and `argocd app list`.** Nothing else counts as verified until this passes. Expect the "Failed to invoke grpc call" warning — that is the normal fallback, not a failure.
2. Browser login and the application list.
3. Push a commit; ArgoCD should refresh immediately and GitHub's delivery log should show 200.
4. Homepage's ArgoCD widget still reports numbers.

If step 1 fails, revert. The diagnosis is now a one-liner:

```
kubectl -n ingress-controller logs -l app.kubernetes.io/name=traefik --since-time=<t> \
  | jq 'select(.RequestHost | startswith("argocd"))'
```

`RouterName` and `ServiceURL` say which route matched and which scheme was used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)