### PR TITLE
fix(authentik): close open enrollment and bind the forward-auth gate

### DIFF
--- a/kubernetes/applications/authentik/base/blueprints/argocd.yaml
+++ b/kubernetes/applications/authentik/base/blueprints/argocd.yaml
@@ -36,3 +36,13 @@ entries:
       slug: argocd
       provider: !Find [authentik_providers_oauth2.oauth2provider, [name, ArgoCD]]
       policy_engine_mode: any
+
+  # Restrict ArgoCD access to platform-admins
+  - model: authentik_policies.policybinding
+    state: present
+    identifiers:
+      target: !Find [authentik_core.application, [slug, argocd]]
+      group: !Find [authentik_core.group, [name, platform-admins]]
+      order: 0
+    attrs:
+      enabled: true

--- a/kubernetes/applications/authentik/base/blueprints/forward-auth.yaml
+++ b/kubernetes/applications/authentik/base/blueprints/forward-auth.yaml
@@ -40,3 +40,14 @@ entries:
       _config:
         authentik_host: !Env AUTHENTIK_HOST
         authentik_host_browser: !Env AUTHENTIK_HOST
+
+  # Restrict the shared forward-auth gate to platform-admins. Without this binding
+  # every account authentik knows passes the edge for all apps behind it.
+  - model: authentik_policies.policybinding
+    state: present
+    identifiers:
+      target: !Find [authentik_core.application, [slug, forward-auth-proxy]]
+      group: !Find [authentik_core.group, [name, platform-admins]]
+      order: 0
+    attrs:
+      enabled: true

--- a/kubernetes/applications/authentik/base/blueprints/iot-mcp-bridge.yaml
+++ b/kubernetes/applications/authentik/base/blueprints/iot-mcp-bridge.yaml
@@ -39,3 +39,13 @@ entries:
       slug: iot-mcp-bridge
       provider: !Find [authentik_providers_oauth2.oauth2provider, [name, iot-mcp-bridge]]
       policy_engine_mode: any
+
+  # Restrict token issuance for this audience to platform-admins
+  - model: authentik_policies.policybinding
+    state: present
+    identifiers:
+      target: !Find [authentik_core.application, [slug, iot-mcp-bridge]]
+      group: !Find [authentik_core.group, [name, platform-admins]]
+      order: 0
+    attrs:
+      enabled: true

--- a/kubernetes/applications/authentik/base/blueprints/sources.yaml
+++ b/kubernetes/applications/authentik/base/blueprints/sources.yaml
@@ -16,7 +16,9 @@ entries:
       consumer_key: !Env AUTHENTIK_GITHUB_CLIENT_ID
       consumer_secret: !Env AUTHENTIK_GITHUB_CLIENT_SECRET
       authentication_flow: !Find [authentik_flows.flow, [slug, default-source-authentication]]
-      enrollment_flow: !Find [authentik_flows.flow, [slug, default-source-enrollment]]
+      # No enrollment flow: GitHub signs in existing accounts, it does not create them.
+      # Explicitly null rather than omitted — blueprints leave unlisted attrs untouched.
+      enrollment_flow: null
       enabled: true
 
   # Expression Policy: denies login if the GitHub account does not have 2FA enabled


### PR DESCRIPTION
Implements A6, which turned out to be more than the bookkeeping item it looked like.

## The chain

Three applications carried **no policy binding at all**, and the GitHub source allowed **self-enrollment**. Together those formed a chain:

> Any GitHub account with 2FA enabled → registers itself via `default-source-enrollment` → lands in authentik with no group → passes `forward-auth-proxy`, which has no binding → reaches every application behind it.

`forward-auth-proxy` is the one that matters. It gates prometheus, alloy, gatus, hubble, longhorn, homepage, the rustfs console, devolutions-gateway and the device UIs for EMS-ESP, KNX-IP, DALI and the wallbox. Several of those have no second authentication layer of their own — Devolutions runs with Authentication "None" by design, on the assumption that forward-auth is the gate.

The hostnames are discoverable through certificate transparency logs, so obscurity was not protection.

## Verified, not assumed

Queried against the running cluster:

| Application | Binding |
|---|---|
| grafana, node-red, rustfs, wikijs | ✅ platform-admins |
| **argocd** | ❌ none |
| **iot-mcp-bridge** | ❌ none |
| **forward-auth-proxy** | ❌ none |

The application list needs `superuser_full_list=true` — without it the endpoint returns only what the caller may access, which silently hides the bound applications and inverts the picture.

**Nothing was exploited.** The user list holds three accounts: `akadmin`, `alexander-zimmermann`, and the outpost service account. No unexpected enrollments.

Exposure window: `enrollment_flow` entered the repo on 2026-03-27 in `5353d22b`, so roughly five months.

## Two independent changes

Either one breaks the chain; both are cheap.

**Policy bindings** to `platform-admins` on the three unbound applications, matching what grafana and the others already do. This is where authorisation belongs.

**`enrollment_flow: null`** on the GitHub source, so it signs in existing accounts instead of creating new ones. Set explicitly rather than omitted — blueprints leave unlisted attributes untouched, so dropping the line would have changed nothing.

The `github-require-2fa` policy is bound to the *source*, not the enrollment flow, so sign-in for existing accounts is unaffected.

## One consequence to be aware of

`akadmin` belongs to `authentik Admins` but **not** to `platform-admins`, so it will no longer pass forward-auth. It keeps direct access to authentik itself, whose route carries no forward-auth — which is what a break-glass account needs. If you would rather it kept broad access, add it to `platform-admins`.

## After sync

1. Your own login still works everywhere — you are in `platform-admins`.
2. *Applications → forward-auth-proxy → Policy Bindings* shows the binding.
3. *Directory → Federation and Social login → GitHub* shows no enrollment flow.
4. Signing in with GitHub still works for your existing account.

If the blueprint does not take effect, the discovery task has stalled before: `kubectl -n authentik rollout restart deploy/authentik-worker`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)