### PR TITLE
feat(miele): mirror appliance state onto 17/1 and archive it

### DIFF
--- a/kubernetes/applications/knx-nats-bridge/base/config/writer-rules.yaml
+++ b/kubernetes/applications/knx-nats-bridge/base/config/writer-rules.yaml
@@ -1596,3 +1596,345 @@ mappings:
     description: "Beleuchtung.EG.Wohnzimmer.Bordbar.Verbindung-Status"
     min_delta: 0  # bool state: write only on change
     seed_on_start: true
+
+  # ---------------------------------------------------------------------------
+  # Miele kitchen appliances (KNX<-NATS), read-only status from the cloud bridge.
+  # Programm and Programm-Phase carry the bridge's DPT-5.010-compacted codes, not
+  # the raw Miele ids; the ovens report phase 255 (OTHER) until a real run reveals
+  # where their phase block starts. Fernsteuerung is the reason a command would be
+  # rejected, so it is on the bus before the command direction exists.
+  # ---------------------------------------------------------------------------
+
+  # Miele Geschirrspüler status feedback (KNX<-NATS). Ein/Aus, Programm-Start
+  # and Startzeit are command GAs and stay unwritten here. Salz- and
+  # Klarspüler-Füllstand are not part of the cloud state model at all.
+  - subject: "miele.geschirrspueler.state"
+    ga: "17/1/3"
+    dpt: "5.010"
+    payload_path: "$.status"
+    description: "Haushaltstechnik.Geschirrspüler.Status"
+    min_delta: 0  # enum state: write only on change
+    seed_on_start: true
+  - subject: "miele.geschirrspueler.state"
+    ga: "17/1/4"
+    dpt: "1.005"
+    payload_path: "$.failure"
+    description: "Haushaltstechnik.Geschirrspüler.Störung"
+    min_delta: 0  # bool state: write only on change
+    seed_on_start: true
+  - subject: "miele.geschirrspueler.state"
+    ga: "17/1/5"
+    dpt: "5.010"
+    payload_path: "$.program"
+    description: "Haushaltstechnik.Geschirrspüler.Programm"
+    min_delta: 0  # enum state: write only on change
+    seed_on_start: true
+  - subject: "miele.geschirrspueler.state"
+    ga: "17/1/6"
+    dpt: "5.010"
+    payload_path: "$.phase"
+    description: "Haushaltstechnik.Geschirrspüler.Programm-Phase"
+    min_delta: 0  # enum state: write only on change
+    seed_on_start: true
+  - subject: "miele.geschirrspueler.state"
+    ga: "17/1/7"
+    dpt: "7.006"
+    payload_path: "$.remaining_minutes"
+    description: "Haushaltstechnik.Geschirrspüler.Restzeit"
+    min_delta: 1  # minutes
+    seed_on_start: true
+  - subject: "miele.geschirrspueler.state"
+    ga: "17/1/9"
+    dpt: "1.005"
+    payload_path: "$.info"
+    description: "Haushaltstechnik.Geschirrspüler.Hinweis-Fertig"
+    min_delta: 0  # bool state: write only on change
+    seed_on_start: true
+  - subject: "miele.geschirrspueler.state"
+    ga: "17/1/12"
+    dpt: "1.003"
+    payload_path: "$.remote_control"
+    description: "Haushaltstechnik.Geschirrspüler.Fernsteuerung"
+    min_delta: 0  # bool state: write only on change
+    seed_on_start: true
+
+  # Miele Backofen status feedback (KNX<-NATS). Kern-Ist-Temperatur only
+  # reports while a food probe is attached; the bridge drops Miele's -32768
+  # sentinel, so the GA keeps its last value instead of seeing -327.68 °C.
+  - subject: "miele.backofen.state"
+    ga: "17/1/64"
+    dpt: "5.010"
+    payload_path: "$.status"
+    description: "Haushaltstechnik.Backofen.Status"
+    min_delta: 0  # enum state: write only on change
+    seed_on_start: true
+  - subject: "miele.backofen.state"
+    ga: "17/1/65"
+    dpt: "1.005"
+    payload_path: "$.failure"
+    description: "Haushaltstechnik.Backofen.Störung"
+    min_delta: 0  # bool state: write only on change
+    seed_on_start: true
+  - subject: "miele.backofen.state"
+    ga: "17/1/66"
+    dpt: "1.019"
+    payload_path: "$.door_open"
+    description: "Haushaltstechnik.Backofen.Tür-Offen"
+    min_delta: 0  # bool state: write only on change
+    seed_on_start: true
+  - subject: "miele.backofen.state"
+    ga: "17/1/67"
+    dpt: "5.010"
+    payload_path: "$.program"
+    description: "Haushaltstechnik.Backofen.Programm"
+    min_delta: 0  # enum state: write only on change
+    seed_on_start: true
+  - subject: "miele.backofen.state"
+    ga: "17/1/68"
+    dpt: "5.010"
+    payload_path: "$.phase"
+    description: "Haushaltstechnik.Backofen.Programm-Phase"
+    min_delta: 0  # enum state: write only on change
+    seed_on_start: true
+  - subject: "miele.backofen.state"
+    ga: "17/1/69"
+    dpt: "7.006"
+    payload_path: "$.remaining_minutes"
+    description: "Haushaltstechnik.Backofen.Restzeit"
+    min_delta: 1  # minutes
+    seed_on_start: true
+  - subject: "miele.backofen.state"
+    ga: "17/1/71"
+    dpt: "9.001"
+    payload_path: "$.temperature_c"
+    description: "Haushaltstechnik.Backofen.Ist-Temperatur"
+    min_delta: 0.5  # °C
+    seed_on_start: true
+  - subject: "miele.backofen.state"
+    ga: "17/1/73"
+    dpt: "9.001"
+    payload_path: "$.core_temperature_c"
+    description: "Haushaltstechnik.Backofen.Kern-Ist-Temperatur"
+    min_delta: 0.5  # °C
+    seed_on_start: true
+  - subject: "miele.backofen.state"
+    ga: "17/1/75"
+    dpt: "1.005"
+    payload_path: "$.info"
+    description: "Haushaltstechnik.Backofen.Hinweis-Fertig"
+    min_delta: 0  # bool state: write only on change
+    seed_on_start: true
+  - subject: "miele.backofen.state"
+    ga: "17/1/76"
+    dpt: "1.003"
+    payload_path: "$.remote_control"
+    description: "Haushaltstechnik.Backofen.Fernsteuerung"
+    min_delta: 0  # bool state: write only on change
+    seed_on_start: true
+
+  # Miele Tellerwärmer status feedback (KNX<-NATS). The appliance has no
+  # programs at all, which is why its block carries no Programm GA.
+  - subject: "miele.tellerwaermer.state"
+    ga: "17/1/82"
+    dpt: "5.010"
+    payload_path: "$.status"
+    description: "Haushaltstechnik.Tellerwärmer.Status"
+    min_delta: 0  # enum state: write only on change
+    seed_on_start: true
+  - subject: "miele.tellerwaermer.state"
+    ga: "17/1/83"
+    dpt: "1.005"
+    payload_path: "$.failure"
+    description: "Haushaltstechnik.Tellerwärmer.Störung"
+    min_delta: 0  # bool state: write only on change
+    seed_on_start: true
+  - subject: "miele.tellerwaermer.state"
+    ga: "17/1/84"
+    dpt: "9.001"
+    payload_path: "$.temperature_c"
+    description: "Haushaltstechnik.Tellerwärmer.Ist-Temperatur"
+    min_delta: 0.5  # °C
+    seed_on_start: true
+  - subject: "miele.tellerwaermer.state"
+    ga: "17/1/86"
+    dpt: "1.003"
+    payload_path: "$.remote_control"
+    description: "Haushaltstechnik.Tellerwärmer.Fernsteuerung"
+    min_delta: 0  # bool state: write only on change
+    seed_on_start: true
+
+  # Miele Mikrowelle status feedback (KNX<-NATS).
+  - subject: "miele.mikrowelle.state"
+    ga: "17/1/104"
+    dpt: "5.010"
+    payload_path: "$.status"
+    description: "Haushaltstechnik.Mikrowelle.Status"
+    min_delta: 0  # enum state: write only on change
+    seed_on_start: true
+  - subject: "miele.mikrowelle.state"
+    ga: "17/1/105"
+    dpt: "1.005"
+    payload_path: "$.failure"
+    description: "Haushaltstechnik.Mikrowelle.Störung"
+    min_delta: 0  # bool state: write only on change
+    seed_on_start: true
+  - subject: "miele.mikrowelle.state"
+    ga: "17/1/106"
+    dpt: "1.019"
+    payload_path: "$.door_open"
+    description: "Haushaltstechnik.Mikrowelle.Tür-Offen"
+    min_delta: 0  # bool state: write only on change
+    seed_on_start: true
+  - subject: "miele.mikrowelle.state"
+    ga: "17/1/107"
+    dpt: "5.010"
+    payload_path: "$.program"
+    description: "Haushaltstechnik.Mikrowelle.Programm"
+    min_delta: 0  # enum state: write only on change
+    seed_on_start: true
+  - subject: "miele.mikrowelle.state"
+    ga: "17/1/108"
+    dpt: "5.010"
+    payload_path: "$.phase"
+    description: "Haushaltstechnik.Mikrowelle.Programm-Phase"
+    min_delta: 0  # enum state: write only on change
+    seed_on_start: true
+  - subject: "miele.mikrowelle.state"
+    ga: "17/1/109"
+    dpt: "7.006"
+    payload_path: "$.remaining_minutes"
+    description: "Haushaltstechnik.Mikrowelle.Restzeit"
+    min_delta: 1  # minutes
+    seed_on_start: true
+  - subject: "miele.mikrowelle.state"
+    ga: "17/1/111"
+    dpt: "9.001"
+    payload_path: "$.temperature_c"
+    description: "Haushaltstechnik.Mikrowelle.Ist-Temperatur"
+    min_delta: 0.5  # °C
+    seed_on_start: true
+  - subject: "miele.mikrowelle.state"
+    ga: "17/1/113"
+    dpt: "1.005"
+    payload_path: "$.info"
+    description: "Haushaltstechnik.Mikrowelle.Hinweis"
+    min_delta: 0  # bool state: write only on change
+    seed_on_start: true
+  - subject: "miele.mikrowelle.state"
+    ga: "17/1/114"
+    dpt: "1.003"
+    payload_path: "$.remote_control"
+    description: "Haushaltstechnik.Mikrowelle.Fernsteuerung"
+    min_delta: 0  # bool state: write only on change
+    seed_on_start: true
+
+  # Miele Kaffeemaschine status feedback (KNX<-NATS). Entkalken/Reinigen/
+  # Milchsystem are not in the cloud state model; the coarse Hinweis is the
+  # only consumable signal. Restzeit is not reported for beverages.
+  - subject: "miele.kaffeemaschine.state"
+    ga: "17/1/123"
+    dpt: "5.010"
+    payload_path: "$.status"
+    description: "Haushaltstechnik.Kaffeemaschine.Status"
+    min_delta: 0  # enum state: write only on change
+    seed_on_start: true
+  - subject: "miele.kaffeemaschine.state"
+    ga: "17/1/124"
+    dpt: "1.005"
+    payload_path: "$.failure"
+    description: "Haushaltstechnik.Kaffeemaschine.Störung"
+    min_delta: 0  # bool state: write only on change
+    seed_on_start: true
+  - subject: "miele.kaffeemaschine.state"
+    ga: "17/1/125"
+    dpt: "5.010"
+    payload_path: "$.program"
+    description: "Haushaltstechnik.Kaffeemaschine.Programm"
+    min_delta: 0  # enum state: write only on change
+    seed_on_start: true
+  - subject: "miele.kaffeemaschine.state"
+    ga: "17/1/126"
+    dpt: "5.010"
+    payload_path: "$.phase"
+    description: "Haushaltstechnik.Kaffeemaschine.Programm-Phase"
+    min_delta: 0  # enum state: write only on change
+    seed_on_start: true
+  - subject: "miele.kaffeemaschine.state"
+    ga: "17/1/127"
+    dpt: "1.005"
+    payload_path: "$.info"
+    description: "Haushaltstechnik.Kaffeemaschine.Hinweis"
+    min_delta: 0  # bool state: write only on change
+    seed_on_start: true
+  - subject: "miele.kaffeemaschine.state"
+    ga: "17/1/131"
+    dpt: "1.003"
+    payload_path: "$.remote_control"
+    description: "Haushaltstechnik.Kaffeemaschine.Fernsteuerung"
+    min_delta: 0  # bool state: write only on change
+    seed_on_start: true
+
+  # Miele Dampfgarer status feedback (KNX<-NATS).
+  - subject: "miele.dampfgarer.state"
+    ga: "17/1/144"
+    dpt: "5.010"
+    payload_path: "$.status"
+    description: "Haushaltstechnik.Dampfgarer.Status"
+    min_delta: 0  # enum state: write only on change
+    seed_on_start: true
+  - subject: "miele.dampfgarer.state"
+    ga: "17/1/145"
+    dpt: "1.005"
+    payload_path: "$.failure"
+    description: "Haushaltstechnik.Dampfgarer.Störung"
+    min_delta: 0  # bool state: write only on change
+    seed_on_start: true
+  - subject: "miele.dampfgarer.state"
+    ga: "17/1/146"
+    dpt: "1.019"
+    payload_path: "$.door_open"
+    description: "Haushaltstechnik.Dampfgarer.Tür-Offen"
+    min_delta: 0  # bool state: write only on change
+    seed_on_start: true
+  - subject: "miele.dampfgarer.state"
+    ga: "17/1/147"
+    dpt: "5.010"
+    payload_path: "$.program"
+    description: "Haushaltstechnik.Dampfgarer.Programm"
+    min_delta: 0  # enum state: write only on change
+    seed_on_start: true
+  - subject: "miele.dampfgarer.state"
+    ga: "17/1/148"
+    dpt: "5.010"
+    payload_path: "$.phase"
+    description: "Haushaltstechnik.Dampfgarer.Programm-Phase"
+    min_delta: 0  # enum state: write only on change
+    seed_on_start: true
+  - subject: "miele.dampfgarer.state"
+    ga: "17/1/149"
+    dpt: "7.006"
+    payload_path: "$.remaining_minutes"
+    description: "Haushaltstechnik.Dampfgarer.Restzeit"
+    min_delta: 1  # minutes
+    seed_on_start: true
+  - subject: "miele.dampfgarer.state"
+    ga: "17/1/151"
+    dpt: "9.001"
+    payload_path: "$.temperature_c"
+    description: "Haushaltstechnik.Dampfgarer.Ist-Temperatur"
+    min_delta: 0.5  # °C
+    seed_on_start: true
+  - subject: "miele.dampfgarer.state"
+    ga: "17/1/153"
+    dpt: "1.005"
+    payload_path: "$.info"
+    description: "Haushaltstechnik.Dampfgarer.Hinweis"
+    min_delta: 0  # bool state: write only on change
+    seed_on_start: true
+  - subject: "miele.dampfgarer.state"
+    ga: "17/1/154"
+    dpt: "1.003"
+    payload_path: "$.remote_control"
+    description: "Haushaltstechnik.Dampfgarer.Fernsteuerung"
+    min_delta: 0  # bool state: write only on change
+    seed_on_start: true

--- a/kubernetes/applications/redpanda-connect/base/kustomization.yaml
+++ b/kubernetes/applications/redpanda-connect/base/kustomization.yaml
@@ -44,6 +44,8 @@ configMapGenerator:
       - streams/midea_state.yaml
       - streams/midea_from_knx.yaml
       - streams/bordbar_from_knx.yaml
+      - streams/miele_state.yaml
+      - streams/miele_eco.yaml
 
 patches:
   # Expose redpanda-connect service via Cilium/BGP-announced LoadBalancer so

--- a/kubernetes/applications/redpanda-connect/base/streams/miele_eco.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/miele_eco.yaml
@@ -1,0 +1,91 @@
+# Miele ecoFeedback (energy/water per programme run) -> TimescaleDB + parquet.
+#
+#   miele.<appliance>.eco -> miele_eco
+#
+# The bridge publishes this subject only while a programme runs or has just
+# finished — the API reports null otherwise, which is a normal idle state.
+# The consumption counters are cumulative within a run, so the last row before
+# the next run is that run's total. The forecasts are Miele's own 0..1
+# relative estimate, not an absolute prediction.
+input:
+  nats_jetstream:
+    urls: ["nats://nats.nats.svc:4222"]
+    auth:
+      user: redpanda-connect
+      password: ${NATS_PASSWORD}
+    stream: MIELE
+    subject: miele.*.eco
+    durable: redpanda-connect-miele-eco
+    deliver: all
+    ack_wait: 20m
+    max_ack_pending: 5000
+
+pipeline:
+  processors:
+    - mapping: |
+        root = {
+          "time":            (meta("nats_timestamp_unix_nano").number() / 1000000000).ts_format("2006-01-02T15:04:05.999999Z").catch(now().ts_format("2006-01-02T15:04:05.999999Z")),
+          "device":          meta("nats_subject").split(".").index(1),
+          "energy_kwh":      this.energy_kwh | null,
+          "energy_unit":     this.energy_kwh_unit | null,
+          "water_l":         this.water_l | null,
+          "water_unit":      this.water_l_unit | null,
+          "energy_forecast": this.energy_forecast | null,
+          "water_forecast":  this.water_forecast | null,
+          "raw":             this,
+        }
+
+output:
+  broker:
+    pattern: fan_out
+    outputs:
+      - sql_raw:
+          driver: pgx
+          max_in_flight: 16
+          dsn: postgres://${PGUSER}:${PGPASSWORD}@timescaledb-db-pooler.timescaledb.svc.cluster.local:5432/homelab?sslmode=disable
+          init_statement: |
+            SET timezone = 'UTC';
+          query: |
+            INSERT INTO miele_eco (
+              time, device, energy_kwh, energy_unit, water_l, water_unit,
+              energy_forecast, water_forecast
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+            ON CONFLICT (time, device) DO NOTHING
+          args_mapping: |
+            root = [
+              this.time,
+              this.device,
+              this.energy_kwh,
+              this.energy_unit,
+              this.water_l,
+              this.water_unit,
+              this.energy_forecast,
+              this.water_forecast,
+            ]
+      - aws_s3:
+          bucket: nats-archive
+          object_canned_acl: private
+          region: us-east-1
+          endpoint: http://rustfs-svc.rustfs.svc.cluster.local:9000
+          force_path_style_urls: true
+          credentials:
+            id: ${RUSTFS_ACCESS_KEY}
+            secret: ${RUSTFS_SECRET_KEY}
+          path: miele-eco/${!now().ts_format("2006/01/02/15")}/${!uuid_v4()}.parquet
+          batching:
+            count: 2000
+            period: 15m
+            processors:
+              - mapping: |
+                  root = {
+                    "time":    this.time,
+                    "subject": meta("nats_subject"),
+                    "payload": this.raw.format_json(),
+                  }
+              - parquet_encode:
+                  default_compression: zstd
+                  schema:
+                    - { name: time,    type: UTF8 }
+                    - { name: subject, type: UTF8 }
+                    - { name: payload, type: UTF8 }

--- a/kubernetes/applications/redpanda-connect/base/streams/miele_state.yaml
+++ b/kubernetes/applications/redpanda-connect/base/streams/miele_state.yaml
@@ -1,0 +1,126 @@
+# Miele kitchen appliance state -> TimescaleDB + parquet cold archive.
+#
+#   miele.<appliance>.state -> miele_state
+#
+# The bridge omits fields an appliance does not report rather than sending
+# null, so a row is a partial snapshot and untouched columns stay NULL.
+# `program`/`phase` are the DPT-5.010-compacted codes that go on the bus;
+# `program_id`/`phase_id` keep Miele's raw ids, which is what analysis needs.
+# `*_name` is only present where the API supplies a plain-text name — some
+# runtime codes have none.
+input:
+  nats_jetstream:
+    urls: ["nats://nats.nats.svc:4222"]
+    auth:
+      user: redpanda-connect
+      password: ${NATS_PASSWORD}
+    stream: MIELE
+    subject: miele.*.state
+    durable: redpanda-connect-miele-state
+    deliver: all
+    ack_wait: 20m
+    max_ack_pending: 5000
+
+pipeline:
+  processors:
+    - mapping: |
+        root = {
+          "time":                      (meta("nats_timestamp_unix_nano").number() / 1000000000).ts_format("2006-01-02T15:04:05.999999Z").catch(now().ts_format("2006-01-02T15:04:05.999999Z")),
+          "device":                    meta("nats_subject").split(".").index(1),
+          "status":                    this.status | null,
+          "status_name":               this.status_name | null,
+          "program_id":                this.program_id | null,
+          "program":                   this.program | null,
+          "program_name":              this.program_name | null,
+          "phase_id":                  this.phase_id | null,
+          "phase":                     this.phase | null,
+          "phase_name":                this.phase_name | null,
+          "remaining_minutes":         this.remaining_minutes | null,
+          "start_minutes":             this.start_minutes | null,
+          "elapsed_minutes":           this.elapsed_minutes | null,
+          "temperature_c":             this.temperature_c | null,
+          "target_temperature_c":      this.target_temperature_c | null,
+          "core_temperature_c":        this.core_temperature_c | null,
+          "core_target_temperature_c": this.core_target_temperature_c | null,
+          "failure":                   this.failure | null,
+          "info":                      this.info | null,
+          "door_open":                 this.door_open | null,
+          "remote_control":            this.remote_control | null,
+          "mobile_start":              this.mobile_start | null,
+          "light":                     this.light | null,
+          "raw":                       this,
+        }
+
+output:
+  broker:
+    pattern: fan_out
+    outputs:
+      - sql_raw:
+          driver: pgx
+          max_in_flight: 16
+          dsn: postgres://${PGUSER}:${PGPASSWORD}@timescaledb-db-pooler.timescaledb.svc.cluster.local:5432/homelab?sslmode=disable
+          init_statement: |
+            SET timezone = 'UTC';
+          query: |
+            INSERT INTO miele_state (
+              time, device, status, status_name, program_id, program, program_name,
+              phase_id, phase, phase_name, remaining_minutes, start_minutes,
+              elapsed_minutes, temperature_c, target_temperature_c, core_temperature_c,
+              core_target_temperature_c, failure, info, door_open, remote_control,
+              mobile_start, light
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15,
+                    $16, $17, $18, $19, $20, $21, $22, $23)
+            ON CONFLICT (time, device) DO NOTHING
+          args_mapping: |
+            root = [
+              this.time,
+              this.device,
+              this.status,
+              this.status_name,
+              this.program_id,
+              this.program,
+              this.program_name,
+              this.phase_id,
+              this.phase,
+              this.phase_name,
+              this.remaining_minutes,
+              this.start_minutes,
+              this.elapsed_minutes,
+              this.temperature_c,
+              this.target_temperature_c,
+              this.core_temperature_c,
+              this.core_target_temperature_c,
+              this.failure,
+              this.info,
+              this.door_open,
+              this.remote_control,
+              this.mobile_start,
+              this.light,
+            ]
+      - aws_s3:
+          bucket: nats-archive
+          object_canned_acl: private
+          region: us-east-1
+          endpoint: http://rustfs-svc.rustfs.svc.cluster.local:9000
+          force_path_style_urls: true
+          credentials:
+            id: ${RUSTFS_ACCESS_KEY}
+            secret: ${RUSTFS_SECRET_KEY}
+          path: miele-state/${!now().ts_format("2006/01/02/15")}/${!uuid_v4()}.parquet
+          batching:
+            count: 2000
+            period: 15m
+            processors:
+              - mapping: |
+                  root = {
+                    "time":    this.time,
+                    "subject": meta("nats_subject"),
+                    "payload": this.raw.format_json(),
+                  }
+              - parquet_encode:
+                  default_compression: zstd
+                  schema:
+                    - { name: time,    type: UTF8 }
+                    - { name: subject, type: UTF8 }
+                    - { name: payload, type: UTF8 }

--- a/kubernetes/applications/timescaledb/base/scripts/bootstrap.sql
+++ b/kubernetes/applications/timescaledb/base/scripts/bootstrap.sql
@@ -485,6 +485,63 @@ SELECT create_hypertable('midea_state', 'time', chunk_time_interval => INTERVAL 
 CREATE INDEX ON midea_state (device, time DESC);
 
 -- =========================================================
+-- Miele kitchen appliances (miele-nats-bridge → miele.<device>.state)
+-- The bridge omits fields an appliance does not report, so a row is a partial
+-- snapshot and untouched columns stay NULL. `program`/`phase` are the codes
+-- compacted into DPT 5.010 for the bus; `program_id`/`phase_id` keep Miele's
+-- raw ids, which the selectable-program list and the runtime state number
+-- differently. `*_name` is NULL wherever the API supplies no plain-text name.
+-- =========================================================
+CREATE TABLE miele_state (
+    time                      TIMESTAMPTZ NOT NULL,
+    device                    TEXT        NOT NULL,
+    status                    SMALLINT,
+    status_name               TEXT,
+    program_id                INTEGER,
+    program                   SMALLINT,
+    program_name              TEXT,
+    phase_id                  INTEGER,
+    phase                     SMALLINT,
+    phase_name                TEXT,
+    remaining_minutes         INTEGER,
+    start_minutes             INTEGER,
+    elapsed_minutes           INTEGER,
+    temperature_c             REAL,
+    target_temperature_c      REAL,
+    core_temperature_c        REAL,
+    core_target_temperature_c REAL,
+    failure                   BOOLEAN,
+    info                      BOOLEAN,
+    door_open                 BOOLEAN,
+    remote_control            BOOLEAN,
+    mobile_start              BOOLEAN,
+    light                     BOOLEAN,
+    PRIMARY KEY (time, device)
+);
+SELECT create_hypertable('miele_state', 'time', chunk_time_interval => INTERVAL '1 day');
+CREATE INDEX ON miele_state (device, time DESC);
+
+-- =========================================================
+-- Miele ecoFeedback per programme run (→ miele.<device>.eco)
+-- Only present while a programme runs or has just finished. The consumption
+-- counters are cumulative within a run; the forecasts are Miele's own 0..1
+-- relative estimate rather than an absolute prediction.
+-- =========================================================
+CREATE TABLE miele_eco (
+    time            TIMESTAMPTZ NOT NULL,
+    device          TEXT        NOT NULL,
+    energy_kwh      REAL,
+    energy_unit     TEXT,
+    water_l         REAL,
+    water_unit      TEXT,
+    energy_forecast REAL,
+    water_forecast  REAL,
+    PRIMARY KEY (time, device)
+);
+SELECT create_hypertable('miele_eco', 'time', chunk_time_interval => INTERVAL '1 day');
+CREATE INDEX ON miele_eco (device, time DESC);
+
+-- =========================================================
 -- Continuous Aggregate Refresh Policies
 -- =========================================================
 SELECT add_continuous_aggregate_policy('knx_1h',
@@ -562,6 +619,12 @@ ALTER TABLE midea_environment SET (timescaledb.compress,
 ALTER TABLE midea_state SET (timescaledb.compress,
     timescaledb.compress_segmentby = 'device',
     timescaledb.compress_orderby = 'time DESC');
+ALTER TABLE miele_state SET (timescaledb.compress,
+    timescaledb.compress_segmentby = 'device',
+    timescaledb.compress_orderby = 'time DESC');
+ALTER TABLE miele_eco SET (timescaledb.compress,
+    timescaledb.compress_segmentby = 'device',
+    timescaledb.compress_orderby = 'time DESC');
 ALTER TABLE unifi_events SET (timescaledb.compress,
     timescaledb.compress_segmentby = 'camera',
     timescaledb.compress_orderby = 'time DESC');
@@ -580,6 +643,8 @@ SELECT add_compression_policy('dyson_environment',   INTERVAL '2 days');
 SELECT add_compression_policy('dyson_state',         INTERVAL '2 days');
 SELECT add_compression_policy('midea_environment',   INTERVAL '2 days');
 SELECT add_compression_policy('midea_state',         INTERVAL '2 days');
+SELECT add_compression_policy('miele_state',         INTERVAL '2 days');
+SELECT add_compression_policy('miele_eco',           INTERVAL '2 days');
 SELECT add_compression_policy('unifi_events',        INTERVAL '7 days');
 
 -- =========================================================
@@ -601,6 +666,8 @@ SELECT add_retention_policy('dyson_environment',   INTERVAL '365 days');
 SELECT add_retention_policy('dyson_state',         INTERVAL '365 days');
 SELECT add_retention_policy('midea_environment',   INTERVAL '365 days');
 SELECT add_retention_policy('midea_state',         INTERVAL '365 days');
+SELECT add_retention_policy('miele_state',         INTERVAL '365 days');
+SELECT add_retention_policy('miele_eco',           INTERVAL '365 days');
 
 -- =========================================================
 -- GA catalog — GA → name/room/function/description lookup,


### PR DESCRIPTION
Closes the read-only half of #1447. The bridge itself is already deployed and has been publishing `miele.<appliance>.state|eco` for a week — until now nothing consumed those subjects.

## What lands here

**45 writer rules** (`knx-nats-bridge/base/config/writer-rules.yaml`) put the six appliances on their `17/1` status GAs. Every rule carries `seed_on_start: true`, so Basalte is populated after a bridge or broker restart instead of showing blanks until the appliance next changes state — the `MIELE` stream is file-backed precisely for this.

| Appliance | GAs | Rules |
| --- | --- | --- |
| Geschirrspüler | 17/1/3–12 | 7 |
| Backofen | 17/1/64–76 | 10 |
| Tellerwärmer | 17/1/82–86 | 4 |
| Mikrowelle | 17/1/104–114 | 9 |
| Kaffeemaschine | 17/1/123–131 | 6 |
| Dampfgarer | 17/1/144–154 | 9 |

Every `ga`/`dpt`/`description` triple was checked against `ga-catalog.yaml`, and the file validates against the bridge's `writer-rules.schema.json`.

**Two redpanda-connect streams** — `miele_state` and `miele_eco` — fan out to TimescaleDB and the parquet cold archive, matching the midea/dyson shape (`driver: pgx` behind the pooler).

**`bootstrap.sql`** gains `miele_state` and `miele_eco` as hypertables with the usual 2d compression and 365d retention. `grants.sql` needs no change: it runs as `homelab` and the existing `ALTER DEFAULT PRIVILEGES` already grants `connect` INSERT on new tables.

## Decisions worth reviewing

- **Programm / Programm-Phase carry the bridge's compacted codes, not raw Miele ids.** Five of six appliances pass through unchanged (dishwasher 1–44, ovens 6–75); only the coffee system's 24000+ is shifted. The three ovens report `255` (OTHER) on Programm-Phase until a real cooking run shows where their phase block begins — inventing a base would be worse than reporting unknown. TimescaleDB keeps `program_id`/`phase_id` unshifted alongside, so analysis is unaffected.
- **Fernsteuerung is on the bus in this phase already.** It is the reason a Phase-2 command would be rejected, which makes it worth showing before commands exist.
- **The five consumable GAs stay unwritten** (Salz-, Klarspüler-Füllstand, Entkalken-, Reinigen-Fällig, Milchsystem-Reinigen) — they are not part of the cloud state model at all, so scope is 45 GAs rather than the 50 the issue first assumed.
- **`start_minutes` is archived but not written to KNX.** Startzeit (17/1/8/70/110/150) is a delayed-start setting and belongs to the command direction in #1449.
- **`miele_eco` is its own table, not columns on `miele_state`.** It only exists while a programme runs, and its counters are cumulative *within* a run, so the last row before the next run is that run's total.

## Manual step after merge

The DDL is applied by hand as the `homelab` role (`miele_state`, `miele_eco`, hypertables, compression, retention). Until then the two connect streams will fail their inserts.

## Verify

- state changes propagate Miele → NATS → `17/1` and show up in Basalte
- a bridge restart re-seeds the GAs from the `MIELE` stream
- `miele_state` rows land in TimescaleDB; a dishwasher cycle produces plausible `miele_eco` energy/water values
