### PR TITLE
feat(prometheus): alert on the Miele cloud bridge

### DIFF
--- a/kubernetes/applications/prometheus/base/prometheus-rule.yaml
+++ b/kubernetes/applications/prometheus/base/prometheus-rule.yaml
@@ -258,3 +258,64 @@ spec:
           annotations:
             summary: "Dehumidifier {{ $labels.device }} unreachable"
             description: "The bridge has not held a connection for 30m — device unplugged, moved, or off the WLAN."
+
+    # The only cloud-dependent bridge in the stack: appliance state goes stale
+    # whenever the WAN link or Miele is down, and the access token is a second
+    # way to lose the stream without the pod noticing. Warning throughout —
+    # nothing safety-relevant hangs off this path, the KNX current detectors do.
+    - name: miele-alerts
+      rules:
+        - alert: MieleCloudDisconnected
+          expr: miele_connected == 0
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Miele cloud event stream down"
+            description: "The bridge has not held the SSE stream for 30m — WAN outage or a Miele-side problem. It reconnects on its own with backoff; the 17/1 GAs keep their last value meanwhile."
+
+        - alert: MieleEventStreamStale
+          # The keep-alive arrives every ~20s and never gapped below 14 per 5min
+          # in measurement, so silence is decisive. Appliance events alone would
+          # not be: they average 30/h with 15min windows of nothing. Guarded
+          # against the 0 a fresh pod reports until its first frame.
+          expr: miele_last_event_received_timestamp > 0 and time() - miele_last_event_received_timestamp > 300
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Miele stream silent while connected"
+            description: "No SSE frame for {{ $value | humanizeDuration }} although miele_connected is 1 — a half-open connection the read timeout has not yet cut. Restart the pod if it persists."
+
+        # No alert on miele_token_expiry_timestamp_seconds: the token is
+        # refreshed lazily, on the next call that needs it, so it sits expired
+        # for hours while a long-lived stream runs perfectly. A broken refresh
+        # shows up as token_* below, or as PodCrashLooping when consent lapsed.
+        - alert: MieleTokenRefreshFailing
+          expr: sum(rate(miele_api_errors_total{reason=~"token_.*"}[30m])) > 0
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Miele token refresh failing"
+            description: "Token refresh has been erroring for 15m. reason=token_rejected means consent lapsed and only a new round via miele-cloud-auth plus a re-sealed secret repairs it; token_http and token_transport are usually transient."
+
+        - alert: MieleApiErrors
+          expr: sum by (reason) (rate(miele_api_errors_total{reason!~"token_.*"}[30m])) > 0
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Miele API errors ({{ $labels.reason }})"
+            description: "The cloud API has returned {{ $labels.reason }} continuously for 30m. Healthy operation produces none of these."
+
+        - alert: MieleMetricsAbsent
+          # `up` covers a failing scrape; this covers the ServiceMonitor being
+          # dropped or relabelled away, which would silence every rule above.
+          expr: absent(miele_connected)
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Miele bridge metrics absent"
+            description: "miele_connected has not been scraped for 15m — check the pod and its ServiceMonitor. Every other Miele alert is blind until this clears."


### PR DESCRIPTION
The bridge has exported `miele_connected`, `miele_api_errors_total` and a liveness timestamp since it was deployed, and its ServiceMonitor has been scraping them into a rule file that has a `dyson-alerts` group and a `midea-alerts` group and nothing for miele. The one integration in the stack that depends on a cloud, a WAN link and a rotating OAuth token was the only one nobody would be told about.

## The rules

| Alert | Fires when | For |
| --- | --- | --- |
| `MieleCloudDisconnected` | `miele_connected == 0` | 30m |
| `MieleEventStreamStale` | no SSE frame for >5min while connected | 10m |
| `MieleTokenRefreshFailing` | `reason=~"token_.*"` errors ongoing | 15m |
| `MieleApiErrors` | any other API error ongoing | 30m |
| `MieleMetricsAbsent` | `absent(miele_connected)` | 15m |

Warning throughout, matching dyson and midea — nothing safety-relevant hangs off this path, the KNX current detectors do.

## Two drafts the live data threw out

I evaluated every expression against the running Prometheus before committing, which was worth doing:

**An alert on `miele_token_expiry_timestamp_seconds` looks obvious and is wrong.** It fired immediately on a perfectly healthy bridge. The token refreshes *lazily* — on the next call that needs one — so during a long-lived SSE stream nothing calls it and the gauge sits hours in the past while the stream runs fine. The connection was authenticated when it opened and Miele does not re-check mid-stream. A genuinely broken refresh surfaces as `reason=token_*` instead, which is why those get their own rule with the consent-round remediation written into the description.

**The staleness threshold was built on the wrong signal.** It started at 15 minutes against appliance events. Measured over three hours on the live pod:

| signal | behaviour |
| --- | --- |
| `devices` frames | ~30/hour, with **15-minute windows of zero** |
| `ping` frames | never below 14 per 5 minutes |

Any threshold tight enough to catch a half-open connection would have paged during a quiet evening. That is what prompted miele-nats-bridge#16's second commit, which advances the liveness clock on every frame including the keep-alive; the rule now watches that at 5 minutes.

## Merge order matters

**This should land only after miele-nats-bridge#16 is released and rolled out.** Against the currently deployed 0.2.0 two of these rules fire correctly-but-unhelpfully:

- `MieleApiErrors{reason="bad_event_json"}` — the ping-parsed-as-JSON bug that #16 fixes, currently ~0.05/s forever
- `MieleEventStreamStale` — on 0.2.0 the timestamp still only tracks appliance events, so it gaps past 5min normally

Both go quiet on the release that carries #16. Verified against live Prometheus: with those two aside, `miele_connected`, the token rule and `absent()` all evaluate clean right now.

## Verify

All five expressions parse and evaluate against the live Prometheus (no local promtool). `kustomize build` passes for the dev and prod overlays.
