### PR TITLE
chore(rustfs): drop the object data cache override

### DIFF
--- a/kubernetes/applications/rustfs/base/values.yaml
+++ b/kubernetes/applications/rustfs/base/values.yaml
@@ -62,10 +62,6 @@ extraEnv:
   # ratchets into the memory limit. Upstream's run.sh enables it, the image does not.
   - name: RUSTFS_ALLOCATOR_RECLAIM_ENABLED
     value: "true"
-  # Object data cache budgets itself from host RAM, not the cgroup limit, and holds
-  # ~300 MiB that no allocator reclaim can return. Off until upstream bounds it.
-  - name: RUSTFS_OBJECT_DATA_CACHE_ENABLE
-    value: "false"
   # Console SSO via Authentik — replaces typing the admin access/secret key.
   # Host URLs are injected per environment via overlay replacements.
   - name: RUSTFS_BROWSER_REDIRECT_URL


### PR DESCRIPTION
## Why now

The override was set as a hypothesis while chasing daily OOMKills on `1.0.0-beta.12`, and it was disproven there — disabling the cache was verified effective (absence of the info-level startup line across 106k lines of `/logs/rustfs.log` starting at container start), and the memory step was unchanged.

The underlying regression is gone across the rc line:

| Build | Observed | `cgroup_anon` | OOMKills |
|---|---|---|---|
| `beta.12` | — | 600–920 MiB, 18h+ plateau | daily |
| `rc.1` | 6 days | 285–633 MiB | none |
| `rc.2` | 5 days | 142–485 MiB | none |
| `rc.3` | 76 hours | 229–446 MiB | none |

Same 1Gi limit throughout. Keeping a non-default override whose rationale no longer holds only keeps us off stock configuration — and I offered upstream a stock-config data point twice, which this makes good on.

Upstream issue [rustfs#5803](https://github.com/rustfs/rustfs/issues/5803) is closed as a result.

## What stays

`RUSTFS_ALLOCATOR_RECLAIM_ENABLED=true` stays. Its upstream default is still `false` and the published image never sources `scripts/run.sh`, so without it mimalloc never returns freed pages and RSS ratchets ~150 MiB/day into the limit. Filed separately as [rustfs#6539](https://github.com/rustfs/rustfs/issues/6539).

## Verification after sync

The env var change rolls the pod on its own (`extraEnv` renders literal `env:`, unlike anything under `config.rustfs.*`). Then watch `max(rustfs_memory_cgroup_anon_bytes)` across the 00:00–04:00 UTC window — the compaction job and the authentik backup are what used to trigger the step. Expected to stay in the 229–446 MiB band; a return to a non-recovering plateau means reopening #5803.

🤖 Generated with [Claude Code](https://claude.com/claude-code)