### PR TITLE
feat(knx): GA catalog writability from ETS flags

### DIFF
--- a/kubernetes/applications/knx-nats-bridge/base/config/ga-catalog.yaml
+++ b/kubernetes/applications/knx-nats-bridge/base/config/ga-catalog.yaml
@@ -3,12849 +3,15408 @@
   function: Allgemein
   name: Allgemein.Zentral.KG.Szenen
   room: Kellergeschoss
+  writable: true
 0/0/101:
   dpt: '1.003'
   function: Allgemein
   name: Allgemein.Zentral.KG.Alles-Aus
   room: Kellergeschoss
+  writable: true
 0/0/110:
   dpt: '17.001'
   function: Allgemein
   name: Allgemein.Zentral.EG.Szenen
   room: Erdgeschoss
+  writable: true
 0/0/111:
   dpt: '1.001'
   function: Allgemein
   name: Allgemein.Zentral.EG.Alles-Aus
   room: Erdgeschoss
+  writable: true
 0/0/120:
   dpt: '17.001'
   function: Allgemein
   name: Allgemein.Zentral.OG.Szenen
   room: Obergeschoss
+  writable: true
 0/0/121:
   dpt: '1.001'
   function: Allgemein
   name: Allgemein.Zentral.OG.Alles-Aus
   room: Obergeschoss
+  writable: true
 0/0/130:
   dpt: '17.001'
   function: Allgemein
   name: Allgemein.Zentral.DG.Szenen
   room: Dachgeschoss
+  writable: true
 0/0/131:
   dpt: '1.001'
   function: Allgemein
   name: Allgemein.Zentral.DG.Alles-Aus
   room: Dachgeschoss
+  writable: true
 0/0/140:
   dpt: '17.001'
   function: Allgemein
   name: Allgemein.Zentral.A.Szenen
   room: Außenbereich
+  writable: true
 0/0/141:
   dpt: '1.001'
   function: Allgemein
   name: Allgemein.Zentral.A.Alles-Aus
   room: Außenbereich
+  writable: true
 0/0/240:
   dpt: '17.001'
   function: Allgemein
   name: Allgemein.Zentral.Anwesen.Szenen
   room: Anwesen Steinroth 20
+  writable: true
 0/0/241:
   dpt: '1.001'
   function: Allgemein
   name: Allgemein.Zentral.Anwesen.Alles-Aus
   room: Anwesen Steinroth 20
+  writable: true
 0/0/245:
   dpt: '10.001'
   function: Allgemein
   name: Allgemein.Zentral.Anwesen.Uhrzeit
   room: Anwesen Steinroth 20
+  writable: true
 0/0/246:
   dpt: '11.001'
   function: Allgemein
   name: Allgemein.Zentral.Anwesen.Datum
   room: Anwesen Steinroth 20
+  writable: true
 0/0/247:
   dpt: '19.001'
   function: Allgemein
   name: Allgemein.Zentral.Anwesen.Datum-Uhrzeit
   room: Anwesen Steinroth 20
+  writable: true
 0/0/248:
   dpt: '1.002'
   function: Allgemein
   name: Allgemein.Zentral.Anwesen.Sommer/Winter
   room: Anwesen Steinroth 20
+  writable: true
 0/0/251:
   dpt: '1.011'
   function: Allgemein
   name: Allgemein.Zentral.Anwesen.Präsenz.Alexander
   room: Anwesen Steinroth 20
+  writable: false
 0/0/252:
   dpt: '1.011'
   function: Allgemein
   name: Allgemein.Zentral.Anwesen.Präsenz.Vanessa
   room: Anwesen Steinroth 20
+  writable: false
 0/0/253:
   dpt: '1.011'
   function: Allgemein
   name: Allgemein.Zentral.Anwesen.Präsenz.Luis
   room: Anwesen Steinroth 20
+  writable: false
 0/0/254:
   dpt: '1.011'
   function: Allgemein
   name: Allgemein.Zentral.Anwesen.Präsenz.Gregory
   room: Anwesen Steinroth 20
+  writable: false
 0/1/0:
   dpt: '17.001'
   function: Allgemein
   name: Allgemein.KG.Flur.Szenen
   room: Flur
+  writable: true
 0/1/1:
   dpt: '1.001'
   function: Allgemein
   name: Allgemein.KG.Flur.Alles-Aus
   room: Flur
+  writable: true
 0/1/20:
   dpt: '17.001'
   function: Allgemein
   name: Allgemein.KG.Garage.Szenen
   room: Garage
+  writable: true
 0/1/21:
   dpt: '1.001'
   function: Allgemein
   name: Allgemein.KG.Garage.Alles-Aus
   room: Garage
+  writable: true
 0/1/40:
   dpt: '17.001'
   function: Allgemein
   name: Allgemein.KG.Technikraum.Szenen
   room: Technikraum
+  writable: true
 0/1/41:
   dpt: '1.001'
   function: Allgemein
   name: Allgemein.KG.Technikraum.Alles-Aus
   room: Technikraum
+  writable: true
 0/1/60:
   dpt: '17.001'
   function: Allgemein
   name: Allgemein.KG.Vorratsraum.Szenen
   room: Vorratsraum
+  writable: true
 0/1/61:
   dpt: '1.001'
   function: Allgemein
   name: Allgemein.KG.Vorratsraum.Alles-Aus
   room: Vorratsraum
+  writable: true
 0/1/80:
   dpt: '17.001'
   function: Allgemein
   name: Allgemein.KG.Hauswirtschaftsraum.Szenen
   room: Hauswirtschaftsraum
+  writable: true
 0/1/81:
   dpt: '1.001'
   function: Allgemein
   name: Allgemein.KG.Hauswirtschaftsraum.Alles-Aus
   room: Hauswirtschaftsraum
+  writable: true
 0/2/0:
   dpt: '17.001'
   function: Allgemein
   name: Allgemein.EG.Flur.Szenen
   room: Flur
+  writable: true
 0/2/1:
   dpt: '1.001'
   function: Allgemein
   name: Allgemein.EG.Flur.Alles-Aus
   room: Flur
+  writable: true
 0/2/100:
   dpt: '17.001'
   function: Allgemein
   name: Allgemein.EG.Küche.Szenen
   room: Küche
+  writable: true
 0/2/101:
   dpt: '1.001'
   function: Allgemein
   name: Allgemein.EG.Küche.Alles-Aus
   room: Küche
+  writable: true
 0/2/20:
   dpt: '17.001'
   function: Allgemein
   name: Allgemein.EG.Gäste-WC.Szenen
   room: Gäste WC
+  writable: true
 0/2/21:
   dpt: '1.001'
   function: Allgemein
   name: Allgemein.EG.Gäste-WC.Alles-Aus
   room: Gäste WC
+  writable: true
 0/2/40:
   dpt: '17.001'
   function: Allgemein
   name: Allgemein.EG.Büro.Szenen
   room: Büro
+  writable: true
 0/2/41:
   dpt: '1.001'
   function: Allgemein
   name: Allgemein.EG.Büro.Alles-Aus
   room: Büro
+  writable: true
 0/2/42:
   dpt: '1.001'
   function: Allgemein
   name: Allgemein.EG.Büro.Alles-Aus-Trigger
   room: Büro
+  writable: false
 0/2/60:
   dpt: '17.001'
   function: Allgemein
   name: Allgemein.EG.Wohnzimmer.Szenen
   room: Wohnzimmer
+  writable: true
 0/2/61:
   dpt: '1.001'
   function: Allgemein
   name: Allgemein.EG.Wohnzimmer.Alles-Aus
   room: Wohnzimmer
+  writable: true
 0/2/62:
   dpt: '1.001'
   function: Allgemein
   name: Allgemein.EG.Wohnzimmer.Alles-Aus-Trigger
   room: Wohnzimmer
+  writable: false
 0/2/80:
   dpt: '17.001'
   function: Allgemein
   name: Allgemein.EG.Esszimmer.Szenen
   room: Esszimmer
+  writable: true
 0/2/81:
   dpt: '1.001'
   function: Allgemein
   name: Allgemein.EG.Esszimmer.Alles-Aus
   room: Esszimmer
+  writable: true
 0/3/0:
   dpt: '17.001'
   function: Allgemein
   name: Allgemein.OG.Flur.Szenen
   room: Flur
+  writable: true
 0/3/1:
   dpt: '1.001'
   function: Allgemein
   name: Allgemein.OG.Flur.Alles-Aus
   room: Flur
+  writable: true
 0/3/100:
   dpt: '17.001'
   function: Allgemein
   name: Allgemein.OG.Schlafzimmer-Eltern.Szenen
   room: Schlafzimmer Eltern
+  writable: true
 0/3/101:
   dpt: '1.001'
   function: Allgemein
   name: Allgemein.OG.Schlafzimmer-Eltern.Alles-Aus
   room: Schlafzimmer Eltern
+  writable: true
 0/3/102:
   dpt: '1.001'
   function: Allgemein
   name: Allgemein.OG.Schlafzimmer-Eltern.Alles-Aus-Trigger
   room: Schlafzimmer Eltern
+  writable: false
 0/3/120:
   dpt: '17.001'
   function: Allgemein
   name: Allgemein.OG.Begehbarer-Schrank.Szenen
   room: Begehbarer Schrank
+  writable: true
 0/3/121:
   dpt: '1.001'
   function: Allgemein
   name: Allgemein.OG.Begehbarer-Schrank.Alles-Aus
   room: Begehbarer Schrank
+  writable: true
 0/3/140:
   dpt: '17.001'
   function: Allgemein
   name: Allgemein.OG.Badezimmer-Eltern.Szenen
   room: Badezimmer Eltern
+  writable: true
 0/3/141:
   dpt: '1.001'
   function: Allgemein
   name: Allgemein.OG.Badezimmer-Eltern.Alles-Aus
   room: Badezimmer Eltern
+  writable: true
 0/3/142:
   dpt: '1.001'
   function: Allgemein
   name: Allgemein.OG.Badezimmer-Eltern.Alles-Aus-Trigger
   room: Badezimmer Eltern
+  writable: false
 0/3/20:
   dpt: '17.001'
   function: Allgemein
   name: Allgemein.OG.Abstellraum.Szenen
   room: Abstellraum
+  writable: true
 0/3/21:
   dpt: '1.001'
   function: Allgemein
   name: Allgemein.OG.Abstellraum.Alles-Aus
   room: Abstellraum
+  writable: true
 0/3/22:
   dpt: '1.001'
   function: Allgemein
   name: Allgemein.OG.Abstellraum.Alles-Aus-Trigger
   room: Abstellraum
+  writable: false
 0/3/40:
   dpt: '17.001'
   function: Allgemein
   name: Allgemein.OG.Badezimmer-Kinder.Szenen
   room: Badezimmer Kinder
+  writable: true
 0/3/41:
   dpt: '1.001'
   function: Allgemein
   name: Allgemein.OG.Badezimmer-Kinder.Alles-Aus
   room: Badezimmer Kinder
+  writable: true
 0/3/42:
   dpt: '1.001'
   function: Allgemein
   name: Allgemein.OG.Badezimmer-Kinder.Alles-Aus-Trigger
   room: Badezimmer Kinder
+  writable: false
 0/3/60:
   dpt: '17.001'
   function: Allgemein
   name: Allgemein.OG.Schlafzimmer-Gregory.Szenen
   room: Schlafzimmer Gregory
+  writable: true
 0/3/61:
   dpt: '1.001'
   function: Allgemein
   name: Allgemein.OG.Schlafzimmer-Gregory.Alles-Aus
   room: Schlafzimmer Gregory
+  writable: true
 0/3/62:
   dpt: '1.001'
   function: Allgemein
   name: Allgemein.OG.Schlafzimmer-Gregory.Alles-Aus-Trigger
   room: Schlafzimmer Gregory
+  writable: false
 0/3/80:
   dpt: '17.001'
   function: Allgemein
   name: Allgemein.OG.Schlafzimmer-Luis.Szenen
   room: Schlafzimmer Luis
+  writable: true
 0/3/81:
   dpt: '1.001'
   function: Allgemein
   name: Allgemein.OG.Schlafzimmer-Luis.Alles-Aus
   room: Schlafzimmer Luis
+  writable: true
 0/3/82:
   dpt: '1.001'
   function: Allgemein
   name: Allgemein.OG.Schlafzimmer-Luis.Alles-Aus-Trigger
   room: Schlafzimmer Luis
+  writable: false
 0/4/0:
   dpt: '17.001'
   function: Allgemein
   name: Allgemein.DG.Speicher.Szenen
   room: Speicher (S)
+  writable: true
 0/4/1:
   dpt: '1.001'
   function: Allgemein
   name: Allgemein.DG.Speicher.Alles-Aus
   room: Speicher (S)
+  writable: true
 0/5/0:
   dpt: '17.001'
   function: Allgemein
   name: Allgemein.A.Fassade.Szenen
   room: Fassade
+  writable: true
 0/5/1:
   dpt: '1.001'
   function: Allgemein
   name: Allgemein.A.Fassade.Alles-Aus
   room: Fassade
+  writable: true
 0/5/20:
   dpt: '17.001'
   function: Allgemein
   name: Allgemein.A.Terrasse.Szenen
   room: Terrasse
+  writable: true
 0/5/21:
   dpt: '1.001'
   function: Allgemein
   name: Allgemein.A.Terrasse.Alles-Aus
   room: Terrasse
+  writable: true
 0/5/40:
   dpt: '17.001'
   function: Allgemein
   name: Allgemein.A.Balkon.Szenen
   room: Balkon
+  writable: true
 0/5/41:
   dpt: '1.001'
   function: Allgemein
   name: Allgemein.A.Balkon.Alles-Aus
   room: Balkon
+  writable: true
 0/5/60:
   dpt: '17.001'
   function: Allgemein
   name: Allgemein.A.Dach.Szenen
   room: Dach
+  writable: true
 0/5/61:
   dpt: '1.001'
   function: Allgemein
   name: Allgemein.A.Dach.Alles-Aus
   room: Dach
+  writable: false
 0/6/20:
   dpt: '17.001'
   function: Allgemein
   name: Allgemein.G.Eingang.Szenen
   room: Eingang
+  writable: true
 0/6/21:
   dpt: '1.001'
   function: Allgemein
   name: Allgemein.G.Eingang.Alles-Aus
   room: Eingang
+  writable: true
 0/6/40:
   dpt: '17.001'
   function: Allgemein
   name: Allgemein.G.Garten.Szenen
   room: Garten
+  writable: true
 0/6/41:
   dpt: '1.001'
   function: Allgemein
   name: Allgemein.G.Garten.Alles-Aus
   room: Garten
+  writable: true
 10/0/100:
   dpt: '1.011'
   function: Sicherheit
   name: Sicherheit.Zentral.KG.Fenster/Tür.Offen-Status
   room: Kellergeschoss
+  writable: true
 10/0/110:
   dpt: '1.011'
   function: Sicherheit
   name: Sicherheit.Zentral.EG.Fenster/Tür.Offen-Status
   room: Erdgeschoss
+  writable: true
 10/0/120:
   dpt: '1.011'
   function: Sicherheit
   name: Sicherheit.Zentral.OG.Fenster/Tür.Offen-Status
   room: Obergeschoss
+  writable: true
 10/1/1:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.KG.Garage.Fenster.Geöffnet-Status
   room: Garage
+  writable: false
 10/1/11:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.KG.Garage.Garagentor.Geöffnet-Status
   room: Garage
+  writable: false
 10/1/21:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.KG.Technikraum.Fenster.Geöffnet-Status
   room: Technikraum
+  writable: false
 10/1/31:
   dpt: '1.005'
   function: Sicherheit
   name: Sicherheit.KG.Technikraum.Gasmelder.Alarm
   room: Technikraum
+  writable: false
 10/1/41:
   dpt: '1.005'
   function: Sicherheit
   name: Sicherheit.KG.Technikraum.CO-Melder.Alarm
   room: Technikraum
+  writable: false
 10/1/51:
   dpt: '1.005'
   function: Sicherheit
   name: Sicherheit.KG.Technikraum.Wassermelder.Alarm
   room: Technikraum
+  writable: false
 10/1/61:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.KG.Vorratsraum.Fenster.Geöffnet-Status
   room: Vorratsraum
+  writable: false
 10/1/71:
   dpt: '1.005'
   function: Sicherheit
   name: Sicherheit.KG.Vorratsraum.Gasmelder.Alarm
   room: Vorratsraum
+  writable: false
 10/1/81:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.KG.Hauswirtschaftsraum.Fenster.Geöffnet-Status
   room: Hauswirtschaftsraum
+  writable: false
 10/1/91:
   dpt: '1.005'
   function: Sicherheit
   name: Sicherheit.KG.Hauswirtschaftsraum.Wassermelder.Alarm
   room: Hauswirtschaftsraum
+  writable: false
 10/2/1:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Flur.Fenster.Geöffnet-Status
   room: Flur
+  writable: false
 10/2/101:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Küche.Fenster.Links.Geöffnet-Status
   room: Küche
+  writable: false
 10/2/102:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Küche.Fenster.Links.Stellung-Kipp-Status
   room: Küche
+  writable: false
 10/2/103:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Küche.Fenster.Links.Stellung-Geöffnet-Status
   room: Küche
+  writable: false
 10/2/11:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Flur.Tür.Geöffnet-Status
   room: Flur
+  writable: false
 10/2/111:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Küche.Fenster.Mitte-Links.Geöffnet-Status
   room: Küche
+  writable: false
 10/2/112:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Küche.Fenster.Mitte-Links.Stellung-Kipp-Status
   room: Küche
+  writable: false
 10/2/113:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Küche.Fenster.Mitte-Links.Stellung-Geöffnet-Status
   room: Küche
+  writable: false
 10/2/121:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Küche.Fenster.Mitte-Rechts.Geöffnet-Status
   room: Küche
+  writable: false
 10/2/122:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Küche.Fenster.Mitte-Rechts.Stellung-Kipp-Status
   room: Küche
+  writable: false
 10/2/123:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Küche.Fenster.Mitte-Rechts.Stellung-Geöffnet-Status
   room: Küche
+  writable: false
 10/2/131:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Küche.Fenster.Rechts.Geöffnet-Status
   room: Küche
+  writable: false
 10/2/132:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Küche.Fenster.Rechts.Stellung-Kipp-Status
   room: Küche
+  writable: false
 10/2/133:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Küche.Fenster.Rechts.Stellung-Geöffnet-Status
   room: Küche
+  writable: false
 10/2/141:
   dpt: '1.005'
   function: Sicherheit
   name: Sicherheit.EG.Küche.Wassermelder.Küchenzeile.Links.Alarm
   room: Küche
+  writable: false
 10/2/151:
   dpt: '1.005'
   function: Sicherheit
   name: Sicherheit.EG.Küche.Wassermelder.Küchenzeile.Rechts.Alarm
   room: Küche
+  writable: false
 10/2/161:
   dpt: '1.005'
   function: Sicherheit
   name: Sicherheit.EG.Küche.Wassermelder.Kücheninsel.Alarm
   room: Küche
+  writable: false
 10/2/2:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Flur.Fenster.Stellung-Kipp-Status
   room: Flur
+  writable: false
 10/2/21:
   dpt: '1.005'
   function: Sicherheit
   name: Sicherheit.EG.Flur.Wassermelder-Alarm
   room: Flur
+  writable: false
 10/2/3:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Flur.Fenster.Stellung-Geöffnet-Status
   room: Flur
+  writable: false
 10/2/31:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Gäste-WC.Fenster.Geöffnet-Status
   room: Gäste WC
+  writable: false
 10/2/32:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Gäste-WC.Fenster.Stellung-Kipp-Status
   room: Gäste WC
+  writable: false
 10/2/33:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Gäste-WC.Fenster.Stellung-Geöffnet-Status
   room: Gäste WC
+  writable: false
 10/2/41:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Büro.Fenster.Links.Geöffnet-Status
   room: Büro
+  writable: false
 10/2/42:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Büro.Fenster.Links.Stellung-Kipp-Status
   room: Büro
+  writable: false
 10/2/43:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Büro.Fenster.Links.Stellung-Geöffnet-Status
   room: Büro
+  writable: false
 10/2/51:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Büro.Fenster.Mitte.Geöffnet-Status
   room: Büro
+  writable: false
 10/2/52:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Büro.Fenster.Mitte.Stellung-Kipp-Status
   room: Büro
+  writable: false
 10/2/53:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Büro.Fenster.Mitte.Stellung-Geöffnet-Status
   room: Büro
+  writable: false
 10/2/61:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Büro.Fenster.Rechts.Geöffnet-Status
   room: Büro
+  writable: false
 10/2/62:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Büro.Fenster.Rechts.Stellung-Kipp-Status
   room: Büro
+  writable: false
 10/2/63:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Büro.Fenster.Rechts.Stellung-Geöffnet-Status
   room: Büro
+  writable: false
 10/2/71:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Büro.Fenster.Seite.Geöffnet-Status
   room: Büro
+  writable: false
 10/2/72:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Büro.Fenster.Seite.Stellung-Kipp-Status
   room: Büro
+  writable: false
 10/2/73:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Büro.Fenster.Seite.Stellung-Geöffnet-Status
   room: Büro
+  writable: false
 10/2/81:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Wohnzimmer.Fenster.Geöffnet-Status
   room: Wohnzimmer
+  writable: false
 10/2/91:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.EG.Esszimmer.Fenster.Geöffnet-Status
   room: Esszimmer
+  writable: false
 10/3/1:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.OG.Flur.Fenster.Treppe.Geöffnet-Status
   room: Flur
+  writable: false
 10/3/11:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.OG.Flur.Fenster.Galerie.Geöffnet-Status
   room: Flur
+  writable: false
 10/3/12:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.OG.Flur.Fenster.Galerie.Stellung-Kipp-Status
   room: Flur
+  writable: false
 10/3/13:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.OG.Flur.Fenster.Galerie.Stellung-Geöffnet-Status
   room: Flur
+  writable: false
 10/3/2:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.OG.Flur.Fenster.Treppe.Stellung-Kipp-Status
   room: Flur
+  writable: false
 10/3/21:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.OG.Abstellraum.Fenster.Geöffnet-Status
   room: Abstellraum
+  writable: false
 10/3/22:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.OG.Abstellraum.Fenster.Stellung-Kipp-Status
   room: Abstellraum
+  writable: false
 10/3/23:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.OG.Abstellraum.Fenster.Stellung-Geöffnet-Status
   room: Abstellraum
+  writable: false
 10/3/3:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.OG.Flur.Fenster.Treppe.Stellung-Geöffnet-Status
   room: Flur
+  writable: false
 10/3/31:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.OG.Badezimmer-Kinder.Fenster.Geöffnet-Status
   room: Badezimmer Kinder
+  writable: false
 10/3/32:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.OG.Badezimmer-Kinder.Fenster.Stellung-Kipp-Status
   room: Badezimmer Kinder
+  writable: false
 10/3/33:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.OG.Badezimmer-Kinder.Fenster.Stellung-Geöffnet-Status
   room: Badezimmer Kinder
+  writable: false
 10/3/41:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.OG.Schlafzimmer-Gregory.Fenster.Geöffnet-Status
   room: Schlafzimmer Gregory
+  writable: false
 10/3/51:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.OG.Schlafzimmer-Luis.Fenster.Geöffnet-Status
   room: Schlafzimmer Luis
+  writable: false
 10/3/61:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.OG.Schlafzimmer-Eltern.Fenster.Geöffnet-Status
   room: Schlafzimmer Eltern
+  writable: false
 10/3/71:
   dpt: '1.005'
   function: Sicherheit
   name: Sicherheit.OG.Schlafzimmer-Eltern.Wassermelder.Alarm
   room: Schlafzimmer Eltern
+  writable: false
 10/3/81:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.OG.Badezimmer-Eltern.Fenster.Geöffnet-Status
   room: Badezimmer Eltern
+  writable: false
 10/3/82:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.OG.Badezimmer-Eltern.Fenster.Stellung-Kipp-Status
   room: Badezimmer Eltern
+  writable: false
 10/3/83:
   dpt: '1.019'
   function: Sicherheit
   name: Sicherheit.OG.Badezimmer-Eltern.Fenster.Stellung-Geöffnet-Status
   room: Badezimmer Eltern
+  writable: false
 11/1/10:
   dpt: '1.003'
   function: Zutritt
   name: Zutritt.KG.Garage.Garagentor.Sperren
   room: Garage
+  writable: false
 11/1/11:
   dpt: '1.011'
   function: Zutritt
   name: Zutritt.KG.Garage.Garagentor.Sperren-Status
   room: Garage
+  writable: false
 11/1/12:
   dpt: '1.003'
   function: Zutritt
   name: Zutritt.KG.Garage.Garagentor.Automatik-Sperren
   room: Garage
+  writable: false
 11/1/13:
   dpt: '1.011'
   function: Zutritt
   name: Zutritt.KG.Garage.Garagentor.Automatik-Sperren-Status
   room: Garage
+  writable: false
 11/1/14:
   dpt: '1.003'
   function: Zutritt
   name: Zutritt.KG.Garage.Garagentor.Automatik-Bereit
   room: Garage
+  writable: false
 11/1/15:
   dpt: '1.011'
   function: Zutritt
   name: Zutritt.KG.Garage.Garagentor.Automatik-Bereit-Status
   room: Garage
+  writable: false
 11/1/16:
   dpt: '1.017'
   function: Zutritt
   name: Zutritt.KG.Garage.Garagentor.Aktivieren
   room: Garage
+  writable: false
 12/0/200:
   description: Haus Steinroth 20 Entertainment
   dpt: '5.010'
   function: Entertainment
   name: Entertainment.Zentral.Anwesen.Stream.Alexander.Voreinstellung
   room: Anwesen Steinroth 20
+  writable: false
 12/0/201:
   description: Haus Steinroth 20 Entertainment
   dpt: '5.010'
   function: Entertainment
   name: Entertainment.Zentral.Anwesen.Stream.Alexander.Aktion
   room: Anwesen Steinroth 20
+  writable: false
 12/0/202:
   description: Haus Steinroth 20 Entertainment
   dpt: '1.001'
   function: Entertainment
   name: Entertainment.Zentral.Anwesen.Stream.Alexander.Wiederholung
   room: Anwesen Steinroth 20
+  writable: false
 12/0/203:
   description: Haus Steinroth 20 Entertainment
   dpt: '1.011'
   function: Entertainment
   name: Entertainment.Zentral.Anwesen.Stream.Alexander.Wiederholung-Status
   room: Anwesen Steinroth 20
+  writable: false
 12/0/204:
   description: Haus Steinroth 20 Entertainment
   dpt: '1.001'
   function: Entertainment
   name: Entertainment.Zentral.Anwesen.Stream.Alexander.Shuffle
   room: Anwesen Steinroth 20
+  writable: false
 12/0/205:
   description: Haus Steinroth 20 Entertainment
   dpt: '1.011'
   function: Entertainment
   name: Entertainment.Zentral.Anwesen.Stream.Alexander.Shuffle-Status
   room: Anwesen Steinroth 20
+  writable: false
 12/0/210:
   description: Haus Steinroth 20 Entertainment
   dpt: '5.010'
   function: Entertainment
   name: Entertainment.Zentral.Anwesen.Stream.Vanessa.Voreinstellung
   room: Anwesen Steinroth 20
+  writable: false
 12/0/211:
   description: Haus Steinroth 20 Entertainment
   dpt: '5.010'
   function: Entertainment
   name: Entertainment.Zentral.Anwesen.Stream.Vanessa.Aktion
   room: Anwesen Steinroth 20
+  writable: false
 12/0/212:
   description: Haus Steinroth 20 Entertainment
   dpt: '1.001'
   function: Entertainment
   name: Entertainment.Zentral.Anwesen.Stream.Vanessa.Wiederholung
   room: Anwesen Steinroth 20
+  writable: false
 12/0/213:
   description: Haus Steinroth 20 Entertainment
   dpt: '1.011'
   function: Entertainment
   name: Entertainment.Zentral.Anwesen.Stream.Vanessa.Wiederholung-Status
   room: Anwesen Steinroth 20
+  writable: false
 12/0/214:
   description: Haus Steinroth 20 Entertainment
   dpt: '1.001'
   function: Entertainment
   name: Entertainment.Zentral.Anwesen.Stream.Vanessa.Shuffle
   room: Anwesen Steinroth 20
+  writable: false
 12/0/215:
   description: Haus Steinroth 20 Entertainment
   dpt: '1.011'
   function: Entertainment
   name: Entertainment.Zentral.Anwesen.Stream.Vanessa.Shuffle-Status
   room: Anwesen Steinroth 20
+  writable: false
 12/0/220:
   description: Haus Steinroth 20 Entertainment
   dpt: '5.010'
   function: Entertainment
   name: Entertainment.Zentral.Anwesen.Stream.Luis.Voreinstellung
   room: Anwesen Steinroth 20
+  writable: false
 12/0/221:
   description: Haus Steinroth 20 Entertainment
   dpt: '5.010'
   function: Entertainment
   name: Entertainment.Zentral.Anwesen.Stream.Luis.Aktion
   room: Anwesen Steinroth 20
+  writable: false
 12/0/222:
   description: Haus Steinroth 20 Entertainment
   dpt: '1.001'
   function: Entertainment
   name: Entertainment.Zentral.Anwesen.Stream.Luis.Wiederholung
   room: Anwesen Steinroth 20
+  writable: false
 12/0/223:
   description: Haus Steinroth 20 Entertainment
   dpt: '1.011'
   function: Entertainment
   name: Entertainment.Zentral.Anwesen.Stream.Luis.Wiederholung-Status
   room: Anwesen Steinroth 20
+  writable: false
 12/0/224:
   description: Haus Steinroth 20 Entertainment
   dpt: '1.001'
   function: Entertainment
   name: Entertainment.Zentral.Anwesen.Stream.Luis.Shuffle
   room: Anwesen Steinroth 20
+  writable: false
 12/0/225:
   description: Haus Steinroth 20 Entertainment
   dpt: '1.011'
   function: Entertainment
   name: Entertainment.Zentral.Anwesen.Stream.Luis.Shuffle-Status
   room: Anwesen Steinroth 20
+  writable: false
 12/0/230:
   description: Haus Steinroth 20 Entertainment
   dpt: '5.010'
   function: Entertainment
   name: Entertainment.Zentral.Anwesen.Stream.Gregory.Voreinstellung
   room: Anwesen Steinroth 20
+  writable: false
 12/0/231:
   description: Haus Steinroth 20 Entertainment
   dpt: '5.010'
   function: Entertainment
   name: Entertainment.Zentral.Anwesen.Stream.Gregory.Aktion
   room: Anwesen Steinroth 20
+  writable: false
 12/0/232:
   description: Haus Steinroth 20 Entertainment
   dpt: '1.001'
   function: Entertainment
   name: Entertainment.Zentral.Anwesen.Stream.Gregory.Wiederholung
   room: Anwesen Steinroth 20
+  writable: false
 12/0/233:
   description: Haus Steinroth 20 Entertainment
   dpt: '1.011'
   function: Entertainment
   name: Entertainment.Zentral.Anwesen.Stream.Gregory.Wiederholung-Status
   room: Anwesen Steinroth 20
+  writable: false
 12/0/234:
   description: Haus Steinroth 20 Entertainment
   dpt: '1.001'
   function: Entertainment
   name: Entertainment.Zentral.Anwesen.Stream.Gregory.Shuffle
   room: Anwesen Steinroth 20
+  writable: false
 12/0/235:
   description: Haus Steinroth 20 Entertainment
   dpt: '1.011'
   function: Entertainment
   name: Entertainment.Zentral.Anwesen.Stream.Gregory.Shuffle-Status
   room: Anwesen Steinroth 20
+  writable: false
 12/2/101:
   dpt: '1.001'
   function: Entertainment
   name: Entertainment.EG.Wohnzimmer.Sony-TV.Ein/Aus
   room: Wohnzimmer
+  writable: false
 12/2/102:
   dpt: '1.011'
   function: Entertainment
   name: Entertainment.EG.Wohnzimmer.Sony-TV.Ein/Aus-Status
   room: Wohnzimmer
+  writable: true
 12/2/103:
   dpt: '1.001'
   function: Entertainment
   name: Entertainment.EG.Wohnzimmer.Sony-TV.Stummschalten
   room: Wohnzimmer
+  writable: false
 12/2/104:
   dpt: '1.011'
   function: Entertainment
   name: Entertainment.EG.Wohnzimmer.Sony-TV.Stummschalten-Status
   room: Wohnzimmer
+  writable: false
 12/2/105:
   dpt: '5.001'
   function: Entertainment
   name: Entertainment.EG.Wohnzimmer.Sony-TV.Lautstärke
   room: Wohnzimmer
+  writable: false
 12/2/106:
   dpt: '5.001'
   function: Entertainment
   name: Entertainment.EG.Wohnzimmer.Sony-TV.Lautstärke-Status
   room: Wohnzimmer
+  writable: false
 12/2/121:
   dpt: '1.001'
   function: Entertainment
   name: Entertainment.EG.Esszimmer.Shape.Ein/Aus
   room: Esszimmer
+  writable: false
 12/2/122:
   dpt: '1.011'
   function: Entertainment
   name: Entertainment.EG.Esszimmer.Shape.Ein/Aus-Status
   room: Esszimmer
+  writable: false
 12/2/123:
   dpt: '1.001'
   function: Entertainment
   name: Entertainment.EG.Esszimmer.Shape.Stummschalten
   room: Esszimmer
+  writable: false
 12/2/124:
   dpt: '1.011'
   function: Entertainment
   name: Entertainment.EG.Esszimmer.Shape.Stummschalten-Status
   room: Esszimmer
+  writable: false
 12/2/125:
   dpt: '5.001'
   function: Entertainment
   name: Entertainment.EG.Esszimmer.Shape.Lautstärke
   room: Esszimmer
+  writable: false
 12/2/126:
   dpt: '5.001'
   function: Entertainment
   name: Entertainment.EG.Esszimmer.Shape.Lautstärke-Status
   room: Esszimmer
+  writable: false
 12/2/127:
   dpt: '5.010'
   function: Entertainment
   name: Entertainment.EG.Esszimmer.Shape.Quelle
   room: Esszimmer
+  writable: false
 12/2/128:
   dpt: '5.010'
   function: Entertainment
   name: Entertainment.EG.Esszimmer.Shape.Quelle-Status
   room: Esszimmer
+  writable: false
 12/2/141:
   dpt: '1.001'
   function: Entertainment
   name: Entertainment.EG.Küche.Sonos.Ein/Aus
   room: Küche
+  writable: false
 12/2/142:
   dpt: '1.011'
   function: Entertainment
   name: Entertainment.EG.Küche.Sonos.Ein/Aus-Status
   room: Küche
+  writable: false
 12/2/143:
   dpt: '1.001'
   function: Entertainment
   name: Entertainment.EG.Küche.Sonos.Stummschalten
   room: Küche
+  writable: false
 12/2/144:
   dpt: '1.011'
   function: Entertainment
   name: Entertainment.EG.Küche.Sonos.Stummschalten-Status
   room: Küche
+  writable: false
 12/2/145:
   dpt: '5.001'
   function: Entertainment
   name: Entertainment.EG.Küche.Sonos.Lautstärke
   room: Küche
+  writable: false
 12/2/146:
   dpt: '5.001'
   function: Entertainment
   name: Entertainment.EG.Küche.Sonos.Lautstärke-Status
   room: Küche
+  writable: false
 12/2/41:
   dpt: '1.001'
   function: Entertainment
   name: Entertainment.EG.Büro.Sonos.Ein/Aus
   room: Büro
+  writable: false
 12/2/42:
   dpt: '1.011'
   function: Entertainment
   name: Entertainment.EG.Büro.Sonos.Ein/Aus-Status
   room: Büro
+  writable: true
 12/2/43:
   dpt: '1.001'
   function: Entertainment
   name: Entertainment.EG.Büro.Sonos.Stummschalten
   room: Büro
+  writable: false
 12/2/44:
   dpt: '1.011'
   function: Entertainment
   name: Entertainment.EG.Büro.Sonos.Stummschalten-Status
   room: Büro
+  writable: false
 12/2/45:
   dpt: '5.001'
   function: Entertainment
   name: Entertainment.EG.Büro.Sonos.Lautstärke
   room: Büro
+  writable: false
 12/2/46:
   dpt: '5.001'
   function: Entertainment
   name: Entertainment.EG.Büro.Sonos.Lautstärke-Status
   room: Büro
+  writable: false
 12/2/61:
   dpt: '1.001'
   function: Entertainment
   name: Entertainment.EG.Wohnzimmer.Aalto.Ein/Aus
   room: Wohnzimmer
+  writable: false
 12/2/62:
   dpt: '1.011'
   function: Entertainment
   name: Entertainment.EG.Wohnzimmer.Aalto.Ein/Aus-Status
   room: Wohnzimmer
+  writable: true
 12/2/63:
   dpt: '1.001'
   function: Entertainment
   name: Entertainment.EG.Wohnzimmer.Aalto.Stummschalten
   room: Wohnzimmer
+  writable: false
 12/2/64:
   dpt: '1.011'
   function: Entertainment
   name: Entertainment.EG.Wohnzimmer.Aalto.Stummschalten-Status
   room: Wohnzimmer
+  writable: false
 12/2/65:
   dpt: '5.001'
   function: Entertainment
   name: Entertainment.EG.Wohnzimmer.Aalto.Lautstärke
   room: Wohnzimmer
+  writable: false
 12/2/66:
   dpt: '5.001'
   function: Entertainment
   name: Entertainment.EG.Wohnzimmer.Aalto.Lautstärke-Status
   room: Wohnzimmer
+  writable: false
 12/2/67:
   dpt: '5.010'
   function: Entertainment
   name: Entertainment.EG.Wohnzimmer.Aalto.Quelle
   room: Wohnzimmer
+  writable: false
 12/2/68:
   dpt: '5.010'
   function: Entertainment
   name: Entertainment.EG.Wohnzimmer.Aalto.Quelle-Status
   room: Wohnzimmer
+  writable: false
 12/2/81:
   dpt: '1.001'
   function: Entertainment
   name: Entertainment.EG.Wohnzimmer.Asano.Ein/Aus
   room: Wohnzimmer
+  writable: false
 12/2/82:
   dpt: '1.011'
   function: Entertainment
   name: Entertainment.EG.Wohnzimmer.Asano.Ein/Aus-Status
   room: Wohnzimmer
+  writable: true
 12/2/83:
   dpt: '1.001'
   function: Entertainment
   name: Entertainment.EG.Wohnzimmer.Asano.Stummschalten
   room: Wohnzimmer
+  writable: false
 12/2/84:
   dpt: '1.011'
   function: Entertainment
   name: Entertainment.EG.Wohnzimmer.Asano.Stummschalten-Status
   room: Wohnzimmer
+  writable: false
 12/2/85:
   dpt: '5.001'
   function: Entertainment
   name: Entertainment.EG.Wohnzimmer.Asano.Lautstärke
   room: Wohnzimmer
+  writable: false
 12/2/86:
   dpt: '5.001'
   function: Entertainment
   name: Entertainment.EG.Wohnzimmer.Asano.Lautstärke-Status
   room: Wohnzimmer
+  writable: false
 12/2/87:
   dpt: '5.010'
   function: Entertainment
   name: Entertainment.EG.Wohnzimmer.Asano.Quelle
   room: Wohnzimmer
+  writable: false
 12/2/88:
   dpt: '5.010'
   function: Entertainment
   name: Entertainment.EG.Wohnzimmer.Asano.Quelle-Status
   room: Wohnzimmer
+  writable: false
 12/3/101:
   dpt: '1.001'
   function: Entertainment
   name: Entertainment.OG.Schlafzimmer-Eltern.Asano.Ein/Aus
   room: Schlafzimmer Eltern
+  writable: false
 12/3/102:
   dpt: '1.011'
   function: Entertainment
   name: Entertainment.OG.Schlafzimmer-Eltern.Asano.Ein/Aus-Status
   room: Schlafzimmer Eltern
+  writable: true
 12/3/103:
   dpt: '1.001'
   function: Entertainment
   name: Entertainment.OG.Schlafzimmer-Eltern.Asano.Stummschalten
   room: Schlafzimmer Eltern
+  writable: false
 12/3/104:
   dpt: '1.011'
   function: Entertainment
   name: Entertainment.OG.Schlafzimmer-Eltern.Asano.Stummschalten-Status
   room: Schlafzimmer Eltern
+  writable: false
 12/3/105:
   dpt: '5.001'
   function: Entertainment
   name: Entertainment.OG.Schlafzimmer-Eltern.Asano.Lautstärke
   room: Schlafzimmer Eltern
+  writable: false
 12/3/106:
   dpt: '5.001'
   function: Entertainment
   name: Entertainment.OG.Schlafzimmer-Eltern.Asano.Lautstärke-Status
   room: Schlafzimmer Eltern
+  writable: false
 12/3/107:
   dpt: '5.010'
   function: Entertainment
   name: Entertainment.OG.Schlafzimmer-Eltern.Asano.Quelle
   room: Schlafzimmer Eltern
+  writable: false
 12/3/108:
   dpt: '5.010'
   function: Entertainment
   name: Entertainment.OG.Schlafzimmer-Eltern.Asano.Quelle-Status
   room: Schlafzimmer Eltern
+  writable: false
 12/3/121:
   dpt: '1.001'
   function: Entertainment
   name: Entertainment.OG.Schlafzimmer-Eltern.Sony-TV.Ein/Aus
   room: Schlafzimmer Eltern
+  writable: false
 12/3/122:
   dpt: '1.011'
   function: Entertainment
   name: Entertainment.OG.Schlafzimmer-Eltern.Sony-TV.Ein/Aus-Status
   room: Schlafzimmer Eltern
+  writable: true
 12/3/123:
   dpt: '1.001'
   function: Entertainment
   name: Entertainment.OG.Schlafzimmer-Eltern.Sony-TV.Stummschalten
   room: Schlafzimmer Eltern
+  writable: false
 12/3/124:
   dpt: '1.011'
   function: Entertainment
   name: Entertainment.OG.Schlafzimmer-Eltern.Sony-TV.Stummschalten-Status
   room: Schlafzimmer Eltern
+  writable: false
 12/3/125:
   dpt: '5.001'
   function: Entertainment
   name: Entertainment.OG.Schlafzimmer-Eltern.Sony-TV.Lautstärke
   room: Schlafzimmer Eltern
+  writable: false
 12/3/126:
   dpt: '5.001'
   function: Entertainment
   name: Entertainment.OG.Schlafzimmer-Eltern.Sony-TV.Lautstärke-Status
   room: Schlafzimmer Eltern
+  writable: false
 12/3/141:
   dpt: '1.001'
   function: Entertainment
   name: Entertainment.OG.Badezimmer-Eltern.Asano.Ein/Aus
   room: Badezimmer Eltern
+  writable: false
 12/3/142:
   dpt: '1.011'
   function: Entertainment
   name: Entertainment.OG.Badezimmer-Eltern.Asano.Ein/Aus-Status
   room: Badezimmer Eltern
+  writable: true
 12/3/143:
   dpt: '1.001'
   function: Entertainment
   name: Entertainment.OG.Badezimmer-Eltern.Asano.Stummschalten
   room: Badezimmer Eltern
+  writable: false
 12/3/144:
   dpt: '1.011'
   function: Entertainment
   name: Entertainment.OG.Badezimmer-Eltern.Asano.Stummschalten-Status
   room: Badezimmer Eltern
+  writable: false
 12/3/145:
   dpt: '5.001'
   function: Entertainment
   name: Entertainment.OG.Badezimmer-Eltern.Asano.Lautstärke
   room: Badezimmer Eltern
+  writable: false
 12/3/146:
   dpt: '5.001'
   function: Entertainment
   name: Entertainment.OG.Badezimmer-Eltern.Asano.Lautstärke-Status
   room: Badezimmer Eltern
+  writable: false
 12/3/147:
   dpt: '5.010'
   function: Entertainment
   name: Entertainment.OG.Badezimmer-Eltern.Asano.Quelle
   room: Badezimmer Eltern
+  writable: false
 12/3/148:
   dpt: '5.010'
   function: Entertainment
   name: Entertainment.OG.Badezimmer-Eltern.Asano.Quelle-Status
   room: Badezimmer Eltern
+  writable: false
 12/3/61:
   dpt: '1.001'
   function: Entertainment
   name: Entertainment.OG.Schlafzimmer-Gregory.Sonos.Ein/Aus
   room: Schlafzimmer Gregory
+  writable: false
 12/3/62:
   dpt: '1.011'
   function: Entertainment
   name: Entertainment.OG.Schlafzimmer-Gregory.Sonos.Ein/Aus-Status
   room: Schlafzimmer Gregory
+  writable: true
 12/3/63:
   dpt: '1.001'
   function: Entertainment
   name: Entertainment.OG.Schlafzimmer-Gregory.Sonos.Stummschalten
   room: Schlafzimmer Gregory
+  writable: false
 12/3/81:
   dpt: '1.001'
   function: Entertainment
   name: Entertainment.OG.Schlafzimmer-Luis.Sonos.Ein/Aus
   room: Schlafzimmer Luis
+  writable: false
 12/3/82:
   dpt: '1.011'
   function: Entertainment
   name: Entertainment.OG.Schlafzimmer-Luis.Sonos.Ein/Aus-Status
   room: Schlafzimmer Luis
+  writable: true
 12/5/1:
   dpt: '1.001'
   function: Entertainment
   name: Entertainment.A.Terrasse.Asano.Ein/Aus
   room: Terrasse
+  writable: false
 12/5/2:
   dpt: '1.011'
   function: Entertainment
   name: Entertainment.A.Terrasse.Asano.Ein/Aus-Status
   room: Terrasse
+  writable: false
 12/5/3:
   dpt: '1.001'
   function: Entertainment
   name: Entertainment.A.Terrasse.Asano.Stummschalten
   room: Terrasse
+  writable: false
 12/5/4:
   dpt: '1.011'
   function: Entertainment
   name: Entertainment.A.Terrasse.Asano.Stummschalten-Status
   room: Terrasse
+  writable: false
 12/5/5:
   dpt: '5.001'
   function: Entertainment
   name: Entertainment.A.Terrasse.Asano.Lautstärke
   room: Terrasse
+  writable: false
 12/5/6:
   dpt: '5.001'
   function: Entertainment
   name: Entertainment.A.Terrasse.Asano.Lautstärke-Status
   room: Terrasse
+  writable: false
 12/5/7:
   dpt: '5.010'
   function: Entertainment
   name: Entertainment.A.Terrasse.Asano.Quelle
   room: Terrasse
+  writable: false
 12/5/8:
   dpt: '5.010'
   function: Entertainment
   name: Entertainment.A.Terrasse.Asano.Quelle-Status
   room: Terrasse
+  writable: false
 14/1/1:
   dpt: '1.011'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Status
   room: Technikraum
+  writable: false
 14/1/10:
   dpt: '1.011'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Störung.Akku
   room: Technikraum
+  writable: true
 14/1/11:
   dpt: '1.011'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Störung.Übertragungseinrichtung
   room: Technikraum
+  writable: true
 14/1/2:
   dpt: '1.015'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Neustart
   room: Technikraum
+  writable: false
 14/1/20:
   dpt: '1.001'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Sicherungsbereich.Haus.Unscharf
   room: Technikraum
+  writable: false
 14/1/21:
   dpt: '1.011'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Sicherungsbereich.Haus.Unscharf-Status
   room: Technikraum
+  writable: true
 14/1/22:
   dpt: '1.001'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Sicherungsbereich.Haus.Intern-Scharf
   room: Technikraum
+  writable: false
 14/1/23:
   dpt: '1.011'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Sicherungsbereich.Haus.Intern-Scharf-Status
   room: Technikraum
+  writable: true
 14/1/24:
   dpt: '1.011'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Sicherungsbereich.Haus.Intern-Scharf-Bereit
   room: Technikraum
+  writable: true
 14/1/25:
   dpt: '1.001'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Sicherungsbereich.Haus.Extern-Scharf
   room: Technikraum
+  writable: false
 14/1/26:
   dpt: '1.011'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Sicherungsbereich.Haus.Extern-Scharf-Status
   room: Technikraum
+  writable: true
 14/1/27:
   dpt: '1.011'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Sicherungsbereich.Haus.Extern-Scharf-Bereit
   room: Technikraum
+  writable: true
 14/1/28:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Sicherungsbereich.Haus.Alarm
   room: Technikraum
+  writable: false
 14/1/29:
   dpt: '1.015'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Sicherungsbereich.Haus.Alarm-Zurücksetzen
   room: Technikraum
+  writable: false
 14/1/3:
   dpt: '1.007'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Zustände-Lesen
   room: Technikraum
+  writable: false
 14/1/30:
   dpt: '1.011'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Sicherungsbereich.Haus.Störung
   room: Technikraum
+  writable: true
 14/1/4:
   dpt: '1.007'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Zustände-Aktualisieren
   room: Technikraum
+  writable: false
 14/1/40:
   dpt: '1.003'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Meldebereich.Sabotage.Sperren
   room: Technikraum
+  writable: false
 14/1/41:
   dpt: '1.011'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Meldebereich.Sabotage.Sperren-Status
   room: Technikraum
+  writable: false
 14/1/42:
   dpt: '1.011'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Meldebereich.Sabotage.Status
   room: Technikraum
+  writable: false
 14/1/43:
   dpt: '1.003'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Meldebereich.IR-Melder.Sperren
   room: Technikraum
+  writable: false
 14/1/44:
   dpt: '1.011'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Meldebereich.IR-Melder.Sperren-Status
   room: Technikraum
+  writable: false
 14/1/45:
   dpt: '1.011'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Meldebereich.IR-Melder.Status
   room: Technikraum
+  writable: false
 14/1/46:
   dpt: '1.003'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Meldebereich.Fensterkontakt.Sperren
   room: Technikraum
+  writable: false
 14/1/47:
   dpt: '1.011'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Meldebereich.Fensterkontakt.Sperren-Status
   room: Technikraum
+  writable: false
 14/1/48:
   dpt: '1.011'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Meldebereich.Fensterkontakt.Status
   room: Technikraum
+  writable: false
 14/1/49:
   dpt: '1.003'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Meldebereich.Türkontakt.Sperren
   room: Technikraum
+  writable: false
 14/1/5:
   dpt: '1.011'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Sabotage.Deckelkontakt
   room: Technikraum
+  writable: false
 14/1/50:
   dpt: '1.011'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Meldebereich.Türkontakt.Sperren-Status
   room: Technikraum
+  writable: false
 14/1/51:
   dpt: '1.011'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Meldebereich.Türkontakt.Status
   room: Technikraum
+  writable: false
 14/1/6:
   dpt: '1.011'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Sabotage.Signalgeber.Leitungsüberwachung.ASG
   room: Technikraum
+  writable: false
 14/1/60:
   dpt: '1.001'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Relais.R1.Ein/Aus
   room: Technikraum
+  writable: false
 14/1/61:
   dpt: '1.011'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Relais.R1.Ein/Aus-Status
   room: Technikraum
+  writable: false
 14/1/62:
   dpt: '1.001'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Relais.R2.Ein/Aus
   room: Technikraum
+  writable: false
 14/1/63:
   dpt: '1.011'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Relais.R2.Ein/Aus-Status
   room: Technikraum
+  writable: false
 14/1/64:
   dpt: '1.001'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Relais.R3.Ein/Aus
   room: Technikraum
+  writable: false
 14/1/65:
   dpt: '1.011'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Relais.R3.Ein/Aus-Status
   room: Technikraum
+  writable: false
 14/1/7:
   dpt: '1.011'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Sabotage.Signalgeber.Leitungsüberwachung.OSG
   room: Technikraum
+  writable: false
 14/1/8:
   dpt: '1.011'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Sabotage.Signalgeber.Wandabreißkontakt
   room: Technikraum
+  writable: false
 14/1/9:
   dpt: '1.011'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.EMA.Störung.Strom
   room: Technikraum
+  writable: true
 14/3/1:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Fassade.Objekterkennung.Person
   room: Fassade
+  writable: false
 14/3/10:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Fassade.Aktivität.Linienüberschreitung
   room: Fassade
+  writable: false
 14/3/11:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Fassade.Geräusch.Gespräch
   room: Fassade
+  writable: false
 14/3/12:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Fassade.Geräusch.Sirene
   room: Fassade
+  writable: false
 14/3/121:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Esszimmer.Objekterkennung.Person
   room: Terrasse
+  writable: false
 14/3/122:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Esszimmer.Objekterkennung.Fahrzeug
   room: Terrasse
+  writable: false
 14/3/123:
   dpt: '5.010'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Esszimmer.Gesichtserkennung.Gesicht-Bekannt
   room: Terrasse
+  writable: false
 14/3/124:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Esszimmer.Gesichtserkennung.Gesicht-Unbekannt
   room: Terrasse
+  writable: false
 14/3/125:
   dpt: '5.010'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Esszimmer.Gesichtserkennung.Gesicht-Markiert
   room: Terrasse
+  writable: false
 14/3/126:
   dpt: '5.010'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Esszimmer.Nummerschilderkennung.Fahrzeug-Bekannt
   room: Terrasse
+  writable: false
 14/3/127:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Esszimmer.Nummerschilderkennung.Fahrzeug-Unbekannt
   room: Terrasse
+  writable: false
 14/3/128:
   dpt: '5.010'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Esszimmer.Nummerschilderkennung.Fahrzeug-Markiert
   room: Terrasse
+  writable: false
 14/3/129:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Esszimmer.Aktivität.Bewegung
   room: Terrasse
+  writable: false
 14/3/13:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Fassade.Geräusch.Glasbruch
   room: Fassade
+  writable: false
 14/3/130:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Esszimmer.Aktivität.Linienüberschreitung
   room: Terrasse
+  writable: false
 14/3/131:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Esszimmer.Geräusch.Gespräch
   room: Terrasse
+  writable: false
 14/3/132:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Esszimmer.Geräusch.Sirene
   room: Terrasse
+  writable: false
 14/3/133:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Esszimmer.Geräusch.Glasbruch
   room: Terrasse
+  writable: false
 14/3/134:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Esszimmer.Geräusch.Einbruch
   room: Terrasse
+  writable: false
 14/3/14:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Fassade.Geräusch.Einbruch
   room: Fassade
+  writable: false
 14/3/2:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Fassade.Objekterkennung.Fahrzeug
   room: Fassade
+  writable: false
 14/3/200:
   dpt: '1.011'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Abwesend.Scharf-Status
   room: Technikraum
+  writable: false
 14/3/201:
   dpt: '1.011'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Abwesend.Unscharf-Status
   room: Technikraum
+  writable: false
 14/3/3:
   dpt: '5.010'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Fassade.Gesichtserkennung.Gesicht-Bekannt
   room: Fassade
+  writable: false
 14/3/4:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Fassade.Gesichtserkennung.Gesicht-Unbekannt
   room: Fassade
+  writable: false
 14/3/41:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Eingang.Objekterkennung.Person
   room: Eingang
+  writable: false
 14/3/42:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Eingang.Objekterkennung.Fahrzeug
   room: Eingang
+  writable: false
 14/3/43:
   dpt: '5.010'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Eingang.Gesichtserkennung.Gesicht-Bekannt
   room: Eingang
+  writable: false
 14/3/44:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Eingang.Gesichtserkennung.Gesicht-Unbekannt
   room: Eingang
+  writable: false
 14/3/45:
   dpt: '5.010'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Eingang.Gesichtserkennung.Gesicht-Markiert
   room: Eingang
+  writable: false
 14/3/46:
   dpt: '5.010'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Eingang.Nummerschilderkennung.Fahrzeug-Bekannt
   room: Eingang
+  writable: false
 14/3/47:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Eingang.Nummerschilderkennung.Fahrzeug-Unbekannt
   room: Eingang
+  writable: false
 14/3/48:
   dpt: '5.010'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Eingang.Nummerschilderkennung.Fahrzeug-Markiert
   room: Eingang
+  writable: false
 14/3/49:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Eingang.Aktivität.Bewegung
   room: Eingang
+  writable: false
 14/3/5:
   dpt: '5.010'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Fassade.Gesichtserkennung.Gesicht-Markiert
   room: Fassade
+  writable: false
 14/3/50:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Eingang.Aktivität.Linienüberschreitung
   room: Eingang
+  writable: false
 14/3/51:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Eingang.Geräusch.Gespräch
   room: Eingang
+  writable: false
 14/3/52:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Eingang.Geräusch.Sirene
   room: Eingang
+  writable: false
 14/3/53:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Eingang.Geräusch.Glasbruch
   room: Eingang
+  writable: false
 14/3/54:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Eingang.Geräusch.Einbruch
   room: Eingang
+  writable: false
 14/3/6:
   dpt: '5.010'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Fassade.Nummerschilderkennung.Fahrzeug-Bekannt
   room: Fassade
+  writable: false
 14/3/7:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Fassade.Nummerschilderkennung.Fahrzeug-Unbekannt
   room: Fassade
+  writable: false
 14/3/8:
   dpt: '5.010'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Fassade.Nummerschilderkennung.Fahrzeug-Markiert
   room: Fassade
+  writable: false
 14/3/81:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Wohnzimmer.Objekterkennung.Person
   room: Terrasse
+  writable: false
 14/3/82:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Wohnzimmer.Objekterkennung.Fahrzeug
   room: Terrasse
+  writable: false
 14/3/83:
   dpt: '5.010'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Wohnzimmer.Gesichtserkennung.Gesicht-Bekannt
   room: Terrasse
+  writable: false
 14/3/84:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Wohnzimmer.Gesichtserkennung.Gesicht-Unbekannt
   room: Terrasse
+  writable: false
 14/3/85:
   dpt: '5.010'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Wohnzimmer.Gesichtserkennung.Gesicht-Markiert
   room: Terrasse
+  writable: false
 14/3/86:
   dpt: '5.010'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Wohnzimmer.Nummerschilderkennung.Fahrzeug-Bekannt
   room: Terrasse
+  writable: false
 14/3/87:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Wohnzimmer.Nummerschilderkennung.Fahrzeug-Unbekannt
   room: Terrasse
+  writable: false
 14/3/88:
   dpt: '5.010'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Wohnzimmer.Nummerschilderkennung.Fahrzeug-Markiert
   room: Terrasse
+  writable: false
 14/3/89:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Wohnzimmer.Aktivität.Bewegung
   room: Terrasse
+  writable: false
 14/3/9:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Fassade.Aktivität.Bewegung
   room: Fassade
+  writable: false
 14/3/90:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Wohnzimmer.Aktivität.Linienüberschreitung
   room: Terrasse
+  writable: false
 14/3/91:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Wohnzimmer.Geräusch.Gespräch
   room: Terrasse
+  writable: false
 14/3/92:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Wohnzimmer.Geräusch.Sirene
   room: Terrasse
+  writable: false
 14/3/93:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Wohnzimmer.Geräusch.Glasbruch
   room: Terrasse
+  writable: false
 14/3/94:
   dpt: '1.005'
   function: Sicherheitstechnik
   name: Sicherheitstechnik.VÜA.Terrasse.Wohnzimmer.Geräusch.Einbruch
   room: Terrasse
+  writable: false
 15/1/0:
   description: 2 - Garage (K2) Energiezähler
   dpt: '13.013'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Netzbezug.Zählerstand-Gesamt
   room: Garage
+  writable: false
 15/1/1:
   description: 2 - Garage (K2) Energiezähler
   dpt: '13.013'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Netzbezug.Zählerstand-Tagtarif
   room: Garage
+  writable: false
 15/1/10:
   description: 2 - Garage (K2) Energiezähler
   dpt: '13.013'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Einspeisung.Zählerstand-Tagtarif-2
   room: Garage
+  writable: false
 15/1/11:
   description: 2 - Garage (K2) Energiezähler
   dpt: '13.013'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Einspeisung.Zählerstand-Nachttarif-1
   room: Garage
+  writable: false
 15/1/12:
   description: 2 - Garage (K2) Energiezähler
   dpt: '13.013'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Einspeisung.Zählerstand-Nachttarif-2
   room: Garage
+  writable: false
 15/1/13:
   description: 2 - Garage (K2) Energiezähler
   dpt: '14.056'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Einspeisung.Wirkleistung-Gesamt-1
   room: Garage
+  writable: false
 15/1/14:
   description: 2 - Garage (K2) Energiezähler
   dpt: '14.056'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Einspeisung.Wirkleistung-Gesamt-2
   room: Garage
+  writable: false
 15/1/15:
   description: 2 - Garage (K2) Energiezähler
   dpt: '14.056'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Einspeisung.Wirkleistung-L1
   room: Garage
+  writable: false
 15/1/16:
   description: 2 - Garage (K2) Energiezähler
   dpt: '14.056'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Einspeisung.Wirkleistung-L2
   room: Garage
+  writable: false
 15/1/17:
   description: 2 - Garage (K2) Energiezähler
   dpt: '14.056'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Einspeisung.Wirkleistung-L3
   room: Garage
+  writable: false
 15/1/18:
   description: 2 - Garage (K2) Energiezähler
   dpt: '14.019'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Stromstärke-L1
   room: Garage
+  writable: false
 15/1/19:
   description: 2 - Garage (K2) Energiezähler
   dpt: '14.019'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Stromstärke-L2
   room: Garage
+  writable: false
 15/1/2:
   description: 2 - Garage (K2) Energiezähler
   dpt: '13.013'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Netzbezug.Zählerstand-Nachttarif
   room: Garage
+  writable: false
 15/1/20:
   description: 2 - Garage (K2) Energiezähler
   dpt: '14.019'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Stromstärke-L3
   room: Garage
+  writable: false
 15/1/21:
   description: 2 - Garage (K2) Energiezähler
   dpt: '14.027'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Spannung-L1
   room: Garage
+  writable: false
 15/1/22:
   description: 2 - Garage (K2) Energiezähler
   dpt: '14.027'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Spannung-L2
   room: Garage
+  writable: false
 15/1/23:
   description: 2 - Garage (K2) Energiezähler
   dpt: '14.027'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Spannung-L3
   room: Garage
+  writable: false
 15/1/24:
   description: 2 - Garage (K2) Energiezähler
   dpt: '14.056'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Wirkleistung-Gesamt
   room: Garage
+  writable: false
 15/1/3:
   description: 2 - Garage (K2) Energiezähler
   dpt: '14.056'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Netzbezug.Wirkleistung-Gesamt
   room: Garage
+  writable: false
 15/1/4:
   description: 2 - Garage (K2) Energiezähler
   dpt: '14.056'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Netzbezug.Wirkleistung-L1
   room: Garage
+  writable: false
 15/1/40:
   dpt: '14.005'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Wasser.Zählerstand-Skala-1
   room: Vorratsraum
+  writable: false
 15/1/41:
   dpt: '14.005'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Wasser.Zählerstand-Skala-2
   room: Vorratsraum
+  writable: false
 15/1/42:
   dpt: '14.005'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Wasser.Stichwert-Skala-1
   room: Vorratsraum
+  writable: false
 15/1/43:
   dpt: '14.005'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Wasser.Stichwert-Skala-2
   room: Vorratsraum
+  writable: false
 15/1/44:
   dpt: '14.005'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Wasser.Verbrauchswert-Skala-1
   room: Vorratsraum
+  writable: false
 15/1/45:
   dpt: '14.005'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Wasser.Verbrauchswert-Skala-2
   room: Vorratsraum
+  writable: false
 15/1/46:
   dpt: '14.005'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Wasser.Durchfluss-Gesamt
   room: Vorratsraum
+  writable: false
 15/1/47:
   dpt: '14.005'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Wasser.Durchfluss-Skala-1
   room: Vorratsraum
+  writable: false
 15/1/48:
   dpt: '14.005'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Wasser.Durchfluss-Skala-2
   room: Vorratsraum
+  writable: false
 15/1/49:
   dpt: '1.005'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Wasser.Durchfluss-Skala-1-Alarm
   room: Vorratsraum
+  writable: true
 15/1/5:
   description: 2 - Garage (K2) Energiezähler
   dpt: '14.056'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Netzbezug.Wirkleistung-L2
   room: Garage
+  writable: false
 15/1/50:
   dpt: '1.005'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Wasser.Durchfluss-Skala-2-Alarm
   room: Vorratsraum
+  writable: true
 15/1/51:
   dpt: '1.005'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Wasser.Durchfluss-Skala-1-Alarm-Erweitert
   room: Vorratsraum
+  writable: false
 15/1/52:
   dpt: '1.005'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Wasser.Durchfluss-Skala-2-Alarm-Erweitert
   room: Vorratsraum
+  writable: false
 15/1/53:
   dpt: '1.001'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Wasser.Skalenumschaltung
   room: Vorratsraum
+  writable: false
 15/1/54:
   dpt: '11.001'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Wasser.Letztes-Stichdatum
   room: Vorratsraum
+  writable: false
 15/1/55:
   dpt: '11.001'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Wasser.Nächstes-Stichdatum
   room: Vorratsraum
+  writable: true
 15/1/56:
   dpt: '7.001'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Wasser.Reset
   room: Vorratsraum
+  writable: true
 15/1/57:
   dpt: '10.001'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Wasser.Reset-Uhrzeit
   room: Vorratsraum
+  writable: false
 15/1/58:
   dpt: '11.001'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Wasser.Reset-Datum
   room: Vorratsraum
+  writable: false
 15/1/59:
   dpt: '16.000'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Wasser.Seriennummer
   room: Vorratsraum
+  writable: false
 15/1/6:
   description: 2 - Garage (K2) Energiezähler
   dpt: '14.056'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Netzbezug.Wirkleistung-L3
   room: Garage
+  writable: false
 15/1/7:
   description: 2 - Garage (K2) Energiezähler
   dpt: '13.013'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Einspeisung.Zählerstand-Gesamt-1
   room: Garage
+  writable: false
 15/1/8:
   description: 2 - Garage (K2) Energiezähler
   dpt: '13.013'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Einspeisung.Zählerstand-Gesamt-2
   room: Garage
+  writable: false
 15/1/9:
   description: 2 - Garage (K2) Energiezähler
   dpt: '13.013'
   function: Versorgungstechnik
   name: Versorgungstechnik.Energiezähler.Strom.Einspeisung.Zählerstand-Tagtarif-1
   room: Garage
+  writable: false
 15/2/0:
   dpt: '9.006'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Gastherme.System-Druck
   room: Technikraum
+  writable: false
 15/2/1:
   dpt: '5.010'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Gastherme.Anomalie-Gesamt
   room: Technikraum
+  writable: false
 15/2/10:
   dpt: '1.011'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Gastherme.Brenner.Status
   room: Technikraum
+  writable: false
 15/2/11:
   dpt: '5.001'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Gastherme.Brenner.Modulation
   room: Technikraum
+  writable: false
 15/2/12:
   dpt: '5.010'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Gastherme.Brenner.Modulation-Anomalie
   room: Technikraum
+  writable: false
 15/2/20:
   dpt: '1.001'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Gastherme.Heizung.Aktiv
   room: Technikraum
+  writable: false
 15/2/21:
   dpt: '5.010'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Gastherme.Heizung.Aktiv-Anomalie
   room: Technikraum
+  writable: false
 15/2/22:
   dpt: '5.010'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Gastherme.Heizung.Aktiv-Saisonal-Anomalie
   room: Technikraum
+  writable: false
 15/2/23:
   dpt: '9.001'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Gastherme.Heizung.Vorlauf.Ist-Temperatur
   room: Technikraum
+  writable: false
 15/2/24:
   dpt: '5.010'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Gastherme.Heizung.Vorlauf.Ist-Temperatur-Anomalie
   room: Technikraum
+  writable: false
 15/2/25:
   dpt: '9.001'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Gastherme.Heizung.Vorlauf.Soll-Temperatur
   room: Technikraum
+  writable: false
 15/2/26:
   dpt: '9.001'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Gastherme.Heizung.Rücklauf.Ist-Temperatur
   room: Technikraum
+  writable: false
 15/2/27:
   dpt: '5.010'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Gastherme.Heizung.Rücklauf.Ist-Temperatur-Anomalie
   room: Technikraum
+  writable: false
 15/2/28:
   dpt: '1.001'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Gastherme.Heizung.Pumpe-Aktiv
   room: Technikraum
+  writable: false
 15/2/30:
   dpt: '9.001'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Gastherme.Hydraulische-Weiche.Ist-Temperatur
   room: Technikraum
+  writable: false
 15/2/40:
   dpt: '1.001'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Gastherme.Mischer.Pumpe-Aktiv
   room: Technikraum
+  writable: false
 15/2/41:
   dpt: '5.001'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Gastherme.Mischer.Stellung
   room: Technikraum
+  writable: false
 15/2/42:
   dpt: '9.001'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Gastherme.Mischer.Vorlauf.Ist-Temperatur
   room: Technikraum
+  writable: false
 15/2/43:
   dpt: '9.001'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Gastherme.Mischer.Vorlauf.Soll-Temperatur
   room: Technikraum
+  writable: false
 15/2/50:
   dpt: '1.001'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Gastherme.Warmwasser.Bereitung-Aktiv
   room: Technikraum
+  writable: false
 15/2/51:
   dpt: '9.025'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Gastherme.Warmwasser.Durchfluss
   room: Technikraum
+  writable: false
 15/2/52:
   dpt: '5.010'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Gastherme.Warmwasser.Durchfluss-Anomalie
   room: Technikraum
+  writable: false
 15/2/53:
   dpt: '9.001'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Gastherme.Warmwasser.Ist-Temperatur
   room: Technikraum
+  writable: false
 15/2/54:
   dpt: '5.010'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Gastherme.Warmwasser.Ist-Temperatur-Anomalie
   room: Technikraum
+  writable: false
 15/2/55:
   dpt: '9.001'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Gastherme.Warmwasser.Soll-Temperatur
   room: Technikraum
+  writable: false
 15/2/60:
   dpt: '9.001'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Gastherme.Außen-Temperatur
   room: Technikraum
+  writable: false
 15/3/1:
   dpt: '5.010'
   function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Lüftermodi
   room: Vorratsraum
+  writable: true
 15/3/10:
   dpt: '1.011'
   function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Lüftermodus-Mittel-Status
   room: Vorratsraum
+  writable: false
 15/3/11:
   dpt: '1.001'
   function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Lüftermodus-Hoch
   room: Vorratsraum
+  writable: true
 15/3/12:
   dpt: '1.011'
   function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Lüftermodus-Hoch-Status
   room: Vorratsraum
+  writable: false
 15/3/2:
   dpt: '5.010'
   function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Lüftermodi-Status
   room: Vorratsraum
+  writable: false
 15/3/20:
   dpt: '1.002'
   function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Status
   room: Vorratsraum
+  writable: false
 15/3/21:
   dpt: '5.001'
   function: Versorgungstechnik
   name: Versorgungstechnik.KWL.ComfoConnect-Status
   room: Vorratsraum
+  writable: false
 15/3/22:
   dpt: '1.002'
   function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Wartungsmodus-Status
   room: Vorratsraum
+  writable: false
 15/3/23:
   dpt: '1.002'
   function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Filterwechsel-Status
   room: Vorratsraum
+  writable: false
 15/3/24:
   dpt: '7.007'
   function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Filter-Betriebsstunden
   room: Vorratsraum
+  writable: false
 15/3/25:
   dpt: '13.002'
   function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Luftstrom
   room: Vorratsraum
+  writable: false
 15/3/26:
   dpt: '9.001'
   function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Temperatur-Abluft
   room: Vorratsraum
+  writable: false
 15/3/27:
   dpt: '9.001'
   function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Temperatur-Fortluft
   room: Vorratsraum
+  writable: false
 15/3/28:
   dpt: '9.001'
   function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Temperatur-Außenluft
   room: Vorratsraum
+  writable: false
 15/3/29:
   dpt: '9.001'
   function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Temperatur-Zuluft
   room: Vorratsraum
+  writable: false
 15/3/3:
   dpt: '1.001'
   function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Lüftermodus-Auto
   room: Vorratsraum
+  writable: true
 15/3/30:
   dpt: '9.007'
   function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Luftfeuchtigkeit-Abluft
   room: Vorratsraum
+  writable: false
 15/3/31:
   dpt: '9.007'
   function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Luftfeuchtigkeit-Fortluft
   room: Vorratsraum
+  writable: false
 15/3/32:
   dpt: '9.007'
   function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Luftfeuchtigkeit-Außenluft
   room: Vorratsraum
+  writable: false
 15/3/33:
   dpt: '9.007'
   function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Luftfeuchtigkeit-Zuluft
   room: Vorratsraum
+  writable: false
 15/3/4:
   dpt: '1.011'
   function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Lüftermodus-Auto-Status
   room: Vorratsraum
+  writable: false
 15/3/5:
   dpt: '1.001'
   function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Lüftermodus-Away
   room: Vorratsraum
+  writable: true
 15/3/6:
   dpt: '1.011'
   function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Lüftermodus-Away-Status
   room: Vorratsraum
+  writable: false
 15/3/7:
   dpt: '1.001'
   function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Lüftermodus-Niedrig
   room: Vorratsraum
+  writable: true
 15/3/8:
   dpt: '1.011'
   function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Lüftermodus-Niedrig-Status
   room: Vorratsraum
+  writable: false
 15/3/9:
   dpt: '1.001'
   function: Versorgungstechnik
   name: Versorgungstechnik.KWL.Lüftermodus-Mittel
   room: Vorratsraum
+  writable: true
 15/4/0:
   dpt: '14.056'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Photovoltaik.Netz-Leistung
   room: Technikraum
+  writable: false
 15/4/1:
   dpt: '5.010'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Photovoltaik.Netz-Leistung-Anomalie
   room: Technikraum
+  writable: false
 15/4/10:
   dpt: '14.056'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Photovoltaik.Erzeugung-Leistung
   room: Technikraum
+  writable: false
 15/4/11:
   dpt: '5.010'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Photovoltaik.Erzeugung-Leistung-Anomalie
   room: Technikraum
+  writable: false
 15/4/2:
   dpt: '14.056'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Photovoltaik.Netzbezug
   room: Technikraum
+  writable: false
 15/4/20:
   dpt: '5.010'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Photovoltaik.Wechselrichter-1.Anomalie-Gesamt
   room: Technikraum
+  writable: false
 15/4/21:
   dpt: '14.056'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Photovoltaik.Wechselrichter-1.Leistung
   room: Technikraum
+  writable: false
 15/4/22:
   dpt: '5.010'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Photovoltaik.Wechselrichter-1.Leistung-Anomalie
   room: Technikraum
+  writable: false
 15/4/23:
   dpt: '9.001'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Photovoltaik.Wechselrichter-1.Temperatur
   room: Technikraum
+  writable: false
 15/4/24:
   dpt: '5.010'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Photovoltaik.Wechselrichter-1.Temperatur-Anomalie
   room: Technikraum
+  writable: false
 15/4/3:
   dpt: '5.010'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Photovoltaik.Netzbezug-Anomalie
   room: Technikraum
+  writable: false
 15/4/4:
   dpt: '14.056'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Photovoltaik.Netzeinspeisung
   room: Technikraum
+  writable: false
 15/4/40:
   dpt: '5.010'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Photovoltaik.Wechselrichter-2.Anomalie-Gesamt
   room: Technikraum
+  writable: false
 15/4/41:
   dpt: '14.056'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Photovoltaik.Wechselrichter-2.Leistung
   room: Technikraum
+  writable: false
 15/4/42:
   dpt: '5.010'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Photovoltaik.Wechselrichter-2.Leistung-Anomalie
   room: Technikraum
+  writable: false
 15/4/43:
   dpt: '9.001'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Photovoltaik.Wechselrichter-2.Temperatur
   room: Technikraum
+  writable: false
 15/4/44:
   dpt: '5.010'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Photovoltaik.Wechselrichter-2.Temperatur-Anomalie
   room: Technikraum
+  writable: false
 15/4/5:
   dpt: '5.010'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Photovoltaik.Netzeinspeisung-Anomalie
   room: Technikraum
+  writable: false
 15/4/50:
   dpt: '5.010'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Photovoltaik.Batterie.Anomalie-Gesamt
   room: Technikraum
+  writable: false
 15/4/51:
   dpt: '14.056'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Photovoltaik.Batterie.Ladeleistung
   room: Technikraum
+  writable: false
 15/4/52:
   dpt: '5.010'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Photovoltaik.Batterie.Ladeleistung-Anomalie
   room: Technikraum
+  writable: false
 15/4/53:
   dpt: '14.056'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Photovoltaik.Batterie.Entladeleistung
   room: Technikraum
+  writable: false
 15/4/54:
   dpt: '5.010'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Photovoltaik.Batterie.Entladeleistung-Anomalie
   room: Technikraum
+  writable: false
 15/4/55:
   dpt: '5.001'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Photovoltaik.Batterie.Ladestand
   room: Technikraum
+  writable: false
 15/4/56:
   dpt: '5.010'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Photovoltaik.Batterie.Ladestand-Anomalie
   room: Technikraum
+  writable: false
 15/4/6:
   dpt: '14.056'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Photovoltaik.Direktverbrauch
   room: Technikraum
+  writable: false
 15/4/60:
   dpt: '13.013'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Photovoltaik.Erzeugung
   room: Technikraum
+  writable: false
 15/4/61:
   dpt: '13.013'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Photovoltaik.Verbrauch
   room: Technikraum
+  writable: false
 15/4/62:
   dpt: '13.013'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Photovoltaik.Eigenverbrauch
   room: Technikraum
+  writable: false
 15/4/63:
   dpt: '13.013'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Photovoltaik.Eigenversorgung
   room: Technikraum
+  writable: false
 15/4/64:
   dpt: '5.001'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Photovoltaik.Eigenverbrauchsquote
   room: Technikraum
+  writable: false
 15/4/65:
   dpt: '5.001'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Photovoltaik.Eigenversorgungsquote
   room: Technikraum
+  writable: false
 15/4/7:
   dpt: '5.010'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Photovoltaik.Direktverbrauch-Anomalie
   room: Technikraum
+  writable: false
 15/4/70:
   dpt: '13.013'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Photovoltaik.Prognose.Erzeugung-Heute
   room: Technikraum
+  writable: false
 15/4/71:
   dpt: '13.013'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Photovoltaik.Prognose.Erzeugung-Rest-Heute
   room: Technikraum
+  writable: false
 15/4/72:
   dpt: '13.013'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Photovoltaik.Prognose.Erzeugung-Morgen
   room: Technikraum
+  writable: false
 15/4/73:
   dpt: '14.056'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Photovoltaik.Prognose.Leistung-Aktuell
   room: Technikraum
+  writable: false
 15/4/8:
   dpt: '14.056'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Photovoltaik.Verbrauch-Leistung
   room: Technikraum
+  writable: false
 15/4/9:
   dpt: '5.010'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Photovoltaik.Verbrauch-Leistung-Anomalie
   room: Technikraum
+  writable: false
 15/5/102:
   dpt: '1.011'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Bewässerung.Kreislauf-10.Ein/Aus-Status
   room: Technikraum
+  writable: false
 15/5/112:
   dpt: '1.011'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Bewässerung.Kreislauf-11.Ein/Aus-Status
   room: Technikraum
+  writable: false
 15/5/12:
   dpt: '1.011'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Bewässerung.Kreislauf-1.Ein/Aus-Status
   room: Technikraum
+  writable: false
 15/5/122:
   dpt: '1.011'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Bewässerung.Kreislauf-12.Ein/Aus-Status
   room: Technikraum
+  writable: false
 15/5/132:
   dpt: '1.011'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Bewässerung.Kreislauf-13.Ein/Aus-Status
   room: Technikraum
+  writable: false
 15/5/142:
   dpt: '1.011'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Bewässerung.Kreislauf-14.Ein/Aus-Status
   room: Technikraum
+  writable: false
 15/5/2:
   dpt: '1.011'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Bewässerung.Kreislauf-Master.Ein/Aus-Status
   room: Technikraum
+  writable: false
 15/5/22:
   dpt: '1.011'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Bewässerung.Kreislauf-2.Ein/Aus-Status
   room: Technikraum
+  writable: false
 15/5/32:
   dpt: '1.011'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Bewässerung.Kreislauf-3.Ein/Aus-Status
   room: Technikraum
+  writable: false
 15/5/42:
   dpt: '1.011'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Bewässerung.Kreislauf-4.Ein/Aus-Status
   room: Technikraum
+  writable: false
 15/5/52:
   dpt: '1.011'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Bewässerung.Kreislauf-5.Ein/Aus-Status
   room: Technikraum
+  writable: false
 15/5/62:
   dpt: '1.011'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Bewässerung.Kreislauf-6.Ein/Aus-Status
   room: Technikraum
+  writable: false
 15/5/72:
   dpt: '1.011'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Bewässerung.Kreislauf-7.Ein/Aus-Status
   room: Technikraum
+  writable: false
 15/5/82:
   dpt: '1.011'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Bewässerung.Kreislauf-8.Ein/Aus-Status
   room: Technikraum
+  writable: false
 15/5/92:
   dpt: '1.011'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Bewässerung.Kreislauf-9.Ein/Aus-Status
   room: Technikraum
+  writable: false
 15/6/0:
   dpt: '5.010'
   function: Versorgungstechnik
   name: Versorgungstechnik.Wallbox.Fehlerzustand-Status
   room: Garage
+  writable: false
 15/6/1:
   dpt: '16.001'
   function: Versorgungstechnik
   name: Versorgungstechnik.Wallbox.Fehlerzustand-Statustext
   room: Garage
+  writable: false
 15/6/10:
   dpt: '7.012'
   function: Versorgungstechnik
   name: Versorgungstechnik.Wallbox.Ladestrom
   room: Garage
+  writable: false
 15/6/11:
   dpt: '7.012'
   function: Versorgungstechnik
   name: Versorgungstechnik.Wallbox.Ladestrom-Erlaubt
   room: Garage
+  writable: false
 15/6/12:
   dpt: '14.056'
   function: Versorgungstechnik
   name: Versorgungstechnik.Wallbox.Ladeleistung
   room: Garage
+  writable: false
 15/6/13:
   dpt: '5.010'
   function: Versorgungstechnik
   name: Versorgungstechnik.Wallbox.Ladeleistung-Anomalie
   room: Garage
+  writable: false
 15/6/14:
   dpt: '13.013'
   function: Versorgungstechnik
   name: Versorgungstechnik.Wallbox.Energie.Geladen-Aktuell
   room: Garage
+  writable: false
 15/6/15:
   dpt: '13.010'
   function: Versorgungstechnik
   name: Versorgungstechnik.Wallbox.Energie.Zählerstand-Aktuell
   room: Garage
+  writable: false
 15/6/16:
   dpt: '13.010'
   function: Versorgungstechnik
   name: Versorgungstechnik.Wallbox.Energie.Zählerstand-Ladebeginn
   room: Garage
+  writable: false
 15/6/2:
   dpt: '5.010'
   function: Versorgungstechnik
   name: Versorgungstechnik.Wallbox.Ladecontroller-Status
   room: Garage
+  writable: false
 15/6/20:
   dpt: '1.001'
   function: Versorgungstechnik
   name: Versorgungstechnik.Wallbox.Ein-Freigabe
   room: Garage
+  writable: false
 15/6/21:
   dpt: '1.001'
   function: Versorgungstechnik
   name: Versorgungstechnik.Wallbox.Ein-Freigabe-Status
   room: Garage
+  writable: false
 15/6/22:
   dpt: '5.010'
   function: Versorgungstechnik
   name: Versorgungstechnik.Wallbox.Lademodi
   room: Garage
+  writable: false
 15/6/23:
   dpt: '5.010'
   function: Versorgungstechnik
   name: Versorgungstechnik.Wallbox.Lademodi-Status
   room: Garage
+  writable: false
 15/6/24:
   dpt: '16.001'
   function: Versorgungstechnik
   name: Versorgungstechnik.Wallbox.Lademodi-Statustext
   room: Garage
+  writable: false
 15/6/25:
   dpt: '1.001'
   function: Versorgungstechnik
   name: Versorgungstechnik.Wallbox.Lademodus-PV
   room: Garage
+  writable: false
 15/6/26:
   dpt: '1.011'
   function: Versorgungstechnik
   name: Versorgungstechnik.Wallbox.Lademodus-PV-Status
   room: Garage
+  writable: false
 15/6/27:
   dpt: '1.001'
   function: Versorgungstechnik
   name: Versorgungstechnik.Wallbox.Lademodus-PV+Min
   room: Garage
+  writable: false
 15/6/28:
   dpt: '1.011'
   function: Versorgungstechnik
   name: Versorgungstechnik.Wallbox.Lademodus-PV+Min-Status
   room: Garage
+  writable: false
 15/6/29:
   dpt: '1.001'
   function: Versorgungstechnik
   name: Versorgungstechnik.Wallbox.Lademodus-Schnell
   room: Garage
+  writable: false
 15/6/3:
   dpt: '16.001'
   function: Versorgungstechnik
   name: Versorgungstechnik.Wallbox.Ladecontroller-Statustext
   room: Garage
+  writable: false
 15/6/30:
   dpt: '1.011'
   function: Versorgungstechnik
   name: Versorgungstechnik.Wallbox.Lademodus-Schnell-Status
   room: Garage
+  writable: false
 15/6/4:
   dpt: '5.010'
   function: Versorgungstechnik
   name: Versorgungstechnik.Wallbox.IEC61851-Status
   room: Garage
+  writable: false
 15/6/40:
   dpt: '5.010'
   function: Versorgungstechnik
   name: Versorgungstechnik.Wallbox.Anomalie-Gesamt
   room: Garage
+  writable: false
 15/6/5:
   dpt: '16.001'
   function: Versorgungstechnik
   name: Versorgungstechnik.Wallbox.IEC61851-Statustext
   room: Garage
+  writable: false
 15/6/6:
   dpt: '5.010'
   function: Versorgungstechnik
   name: Versorgungstechnik.Wallbox.DC-Fehlerstrom-Status
   room: Garage
+  writable: false
 15/6/7:
   dpt: '16.001'
   function: Versorgungstechnik
   name: Versorgungstechnik.Wallbox.DC-Fehlerstrom-Statustext
   room: Garage
+  writable: false
 15/6/8:
   dpt: '5.010'
   function: Versorgungstechnik
   name: Versorgungstechnik.Wallbox.Schütz-Fehler
   room: Garage
+  writable: false
 15/6/9:
   dpt: '16.001'
   function: Versorgungstechnik
   name: Versorgungstechnik.Wallbox.Schütz-Fehlertext
   room: Garage
+  writable: false
 16/0/240:
   dpt: '1.011'
   name: Informationstechnik.Kubernetes.Alle.Status
+  writable: true
 17/1/0:
   dpt: '1.003'
   function: Haushaltstechnik
   name: Haushaltstechnik.Geschirrspüler.Sperren
   room: Küche
+  writable: false
 17/1/1:
   dpt: '1.001'
   function: Haushaltstechnik
   name: Haushaltstechnik.Geschirrspüler.Ein/Aus
   room: Küche
+  writable: false
 17/1/10:
   dpt: '5.010'
   function: Haushaltstechnik
   name: Haushaltstechnik.Geschirrspüler.Salz-Füllstand
   room: Küche
+  writable: false
 17/1/100:
   dpt: '1.003'
   function: Haushaltstechnik
   name: Haushaltstechnik.Mikrowelle.Sperren
   room: Küche
+  writable: false
 17/1/101:
   dpt: '1.001'
   function: Haushaltstechnik
   name: Haushaltstechnik.Mikrowelle.Ein/Aus
   room: Küche
+  writable: false
 17/1/102:
   dpt: '1.001'
   function: Haushaltstechnik
   name: Haushaltstechnik.Mikrowelle.Programm-Start
   room: Küche
+  writable: false
 17/1/103:
   dpt: '1.001'
   function: Haushaltstechnik
   name: Haushaltstechnik.Mikrowelle.Licht
   room: Küche
+  writable: false
 17/1/104:
   dpt: '5.010'
   function: Haushaltstechnik
   name: Haushaltstechnik.Mikrowelle.Status
   room: Küche
+  writable: false
 17/1/105:
   dpt: '1.005'
   function: Haushaltstechnik
   name: Haushaltstechnik.Mikrowelle.Störung
   room: Küche
+  writable: false
 17/1/106:
   dpt: '1.019'
   function: Haushaltstechnik
   name: Haushaltstechnik.Mikrowelle.Tür-Offen
   room: Küche
+  writable: false
 17/1/107:
   dpt: '5.010'
   function: Haushaltstechnik
   name: Haushaltstechnik.Mikrowelle.Programm
   room: Küche
+  writable: false
 17/1/108:
   dpt: '5.010'
   function: Haushaltstechnik
   name: Haushaltstechnik.Mikrowelle.Programm-Phase
   room: Küche
+  writable: false
 17/1/109:
   dpt: '7.006'
   function: Haushaltstechnik
   name: Haushaltstechnik.Mikrowelle.Restzeit
   room: Küche
+  writable: false
 17/1/11:
   dpt: '5.010'
   function: Haushaltstechnik
   name: Haushaltstechnik.Geschirrspüler.Klarspüler-Füllstand
   room: Küche
+  writable: false
 17/1/110:
   dpt: '7.006'
   function: Haushaltstechnik
   name: Haushaltstechnik.Mikrowelle.Startzeit
   room: Küche
+  writable: false
 17/1/111:
   dpt: '9.001'
   function: Haushaltstechnik
   name: Haushaltstechnik.Mikrowelle.Ist-Temperatur
   room: Küche
+  writable: false
 17/1/112:
   dpt: '9.001'
   function: Haushaltstechnik
   name: Haushaltstechnik.Mikrowelle.Soll-Temperatur
   room: Küche
+  writable: false
 17/1/113:
   dpt: '1.005'
   function: Haushaltstechnik
   name: Haushaltstechnik.Mikrowelle.Hinweis
   room: Küche
+  writable: false
 17/1/114:
   dpt: '1.003'
   function: Haushaltstechnik
   name: Haushaltstechnik.Mikrowelle.Fernsteuerung
   room: Küche
+  writable: false
 17/1/12:
   dpt: '1.003'
   function: Haushaltstechnik
   name: Haushaltstechnik.Geschirrspüler.Fernsteuerung
   room: Küche
+  writable: false
 17/1/120:
   dpt: '1.003'
   function: Haushaltstechnik
   name: Haushaltstechnik.Kaffeemaschine.Sperren
   room: Küche
+  writable: false
 17/1/121:
   dpt: '1.001'
   function: Haushaltstechnik
   name: Haushaltstechnik.Kaffeemaschine.Ein/Aus
   room: Küche
+  writable: false
 17/1/122:
   dpt: '1.001'
   function: Haushaltstechnik
   name: Haushaltstechnik.Kaffeemaschine.Programm-Stop
   room: Küche
+  writable: false
 17/1/123:
   dpt: '5.010'
   function: Haushaltstechnik
   name: Haushaltstechnik.Kaffeemaschine.Status
   room: Küche
+  writable: false
 17/1/124:
   dpt: '1.005'
   function: Haushaltstechnik
   name: Haushaltstechnik.Kaffeemaschine.Störung
   room: Küche
+  writable: false
 17/1/125:
   dpt: '5.010'
   function: Haushaltstechnik
   name: Haushaltstechnik.Kaffeemaschine.Programm
   room: Küche
+  writable: false
 17/1/126:
   dpt: '5.010'
   function: Haushaltstechnik
   name: Haushaltstechnik.Kaffeemaschine.Programm-Phase
   room: Küche
+  writable: false
 17/1/127:
   dpt: '1.005'
   function: Haushaltstechnik
   name: Haushaltstechnik.Kaffeemaschine.Hinweis
   room: Küche
+  writable: false
 17/1/128:
   dpt: '1.005'
   function: Haushaltstechnik
   name: Haushaltstechnik.Kaffeemaschine.Entkalken-Fällig
   room: Küche
+  writable: false
 17/1/129:
   dpt: '1.005'
   function: Haushaltstechnik
   name: Haushaltstechnik.Kaffeemaschine.Reinigen-Fällig
   room: Küche
+  writable: false
 17/1/130:
   dpt: '1.005'
   function: Haushaltstechnik
   name: Haushaltstechnik.Kaffeemaschine.Milchsystem-Reinigen
   room: Küche
+  writable: false
 17/1/131:
   dpt: '1.003'
   function: Haushaltstechnik
   name: Haushaltstechnik.Kaffeemaschine.Fernsteuerung
   room: Küche
+  writable: false
 17/1/140:
   dpt: '1.003'
   function: Haushaltstechnik
   name: Haushaltstechnik.Dampfgarer.Sperren
   room: Küche
+  writable: false
 17/1/141:
   dpt: '1.001'
   function: Haushaltstechnik
   name: Haushaltstechnik.Dampfgarer.Ein/Aus
   room: Küche
+  writable: false
 17/1/142:
   dpt: '1.001'
   function: Haushaltstechnik
   name: Haushaltstechnik.Dampfgarer.Programm-Start
   room: Küche
+  writable: false
 17/1/143:
   dpt: '1.001'
   function: Haushaltstechnik
   name: Haushaltstechnik.Dampfgarer.Licht
   room: Küche
+  writable: false
 17/1/144:
   dpt: '5.010'
   function: Haushaltstechnik
   name: Haushaltstechnik.Dampfgarer.Status
   room: Küche
+  writable: false
 17/1/145:
   dpt: '1.005'
   function: Haushaltstechnik
   name: Haushaltstechnik.Dampfgarer.Störung
   room: Küche
+  writable: false
 17/1/146:
   dpt: '1.019'
   function: Haushaltstechnik
   name: Haushaltstechnik.Dampfgarer.Tür-Offen
   room: Küche
+  writable: false
 17/1/147:
   dpt: '5.010'
   function: Haushaltstechnik
   name: Haushaltstechnik.Dampfgarer.Programm
   room: Küche
+  writable: false
 17/1/148:
   dpt: '5.010'
   function: Haushaltstechnik
   name: Haushaltstechnik.Dampfgarer.Programm-Phase
   room: Küche
+  writable: false
 17/1/149:
   dpt: '7.006'
   function: Haushaltstechnik
   name: Haushaltstechnik.Dampfgarer.Restzeit
   room: Küche
+  writable: false
 17/1/150:
   dpt: '7.006'
   function: Haushaltstechnik
   name: Haushaltstechnik.Dampfgarer.Startzeit
   room: Küche
+  writable: false
 17/1/151:
   dpt: '9.001'
   function: Haushaltstechnik
   name: Haushaltstechnik.Dampfgarer.Ist-Temperatur
   room: Küche
+  writable: false
 17/1/152:
   dpt: '9.001'
   function: Haushaltstechnik
   name: Haushaltstechnik.Dampfgarer.Soll-Temperatur
   room: Küche
+  writable: false
 17/1/153:
   dpt: '1.005'
   function: Haushaltstechnik
   name: Haushaltstechnik.Dampfgarer.Hinweis
   room: Küche
+  writable: false
 17/1/154:
   dpt: '1.003'
   function: Haushaltstechnik
   name: Haushaltstechnik.Dampfgarer.Fernsteuerung
   room: Küche
+  writable: false
 17/1/160:
   dpt: '1.003'
   function: Haushaltstechnik
   name: Haushaltstechnik.Gefrierschrank.Sperren
   room: Küche
+  writable: false
 17/1/161:
   dpt: '1.001'
   function: Haushaltstechnik
   name: Haushaltstechnik.Gefrierschrank.Ein/Aus
   room: Küche
+  writable: false
 17/1/162:
   dpt: '1.001'
   function: Haushaltstechnik
   name: Haushaltstechnik.Gefrierschrank.SuperGefrieren
   room: Küche
+  writable: false
 17/1/163:
   dpt: '5.010'
   function: Haushaltstechnik
   name: Haushaltstechnik.Gefrierschrank.Status
   room: Küche
+  writable: false
 17/1/164:
   dpt: '1.005'
   function: Haushaltstechnik
   name: Haushaltstechnik.Gefrierschrank.Störung
   room: Küche
+  writable: false
 17/1/165:
   dpt: '1.019'
   function: Haushaltstechnik
   name: Haushaltstechnik.Gefrierschrank.Tür-Offen
   room: Küche
+  writable: false
 17/1/166:
   dpt: '9.001'
   function: Haushaltstechnik
   name: Haushaltstechnik.Gefrierschrank.Ist-Temperatur
   room: Küche
+  writable: false
 17/1/167:
   dpt: '9.001'
   function: Haushaltstechnik
   name: Haushaltstechnik.Gefrierschrank.Soll-Temperatur
   room: Küche
+  writable: false
 17/1/168:
   dpt: '1.003'
   function: Haushaltstechnik
   name: Haushaltstechnik.Gefrierschrank.Fernsteuerung
   room: Küche
+  writable: false
 17/1/2:
   dpt: '1.001'
   function: Haushaltstechnik
   name: Haushaltstechnik.Geschirrspüler.Programm-Start
   room: Küche
+  writable: false
 17/1/20:
   dpt: '1.003'
   function: Haushaltstechnik
   name: Haushaltstechnik.Haubenlüfter.Sperren
   room: Küche
+  writable: false
 17/1/21:
   dpt: '1.001'
   function: Haushaltstechnik
   name: Haushaltstechnik.Haubenlüfter.Ein/Aus
   room: Küche
+  writable: false
 17/1/22:
   dpt: '5.001'
   function: Haushaltstechnik
   name: Haushaltstechnik.Haubenlüfter.Lüfterstufe
   room: Küche
+  writable: false
 17/1/23:
   dpt: '1.001'
   function: Haushaltstechnik
   name: Haushaltstechnik.Haubenlüfter.Licht
   room: Küche
+  writable: false
 17/1/24:
   dpt: '5.010'
   function: Haushaltstechnik
   name: Haushaltstechnik.Haubenlüfter.Status
   room: Küche
+  writable: false
 17/1/25:
   dpt: '1.005'
   function: Haushaltstechnik
   name: Haushaltstechnik.Haubenlüfter.Störung
   room: Küche
+  writable: false
 17/1/26:
   dpt: '5.001'
   function: Haushaltstechnik
   name: Haushaltstechnik.Haubenlüfter.Fettfilter
   room: Küche
+  writable: false
 17/1/27:
   dpt: '1.003'
   function: Haushaltstechnik
   name: Haushaltstechnik.Haubenlüfter.Fernsteuerung
   room: Küche
+  writable: false
 17/1/3:
   dpt: '5.010'
   function: Haushaltstechnik
   name: Haushaltstechnik.Geschirrspüler.Status
   room: Küche
+  writable: false
 17/1/4:
   dpt: '1.005'
   function: Haushaltstechnik
   name: Haushaltstechnik.Geschirrspüler.Störung
   room: Küche
+  writable: false
 17/1/40:
   dpt: '1.003'
   function: Haushaltstechnik
   name: Haushaltstechnik.Kühlschrank.Sperren
   room: Küche
+  writable: false
 17/1/41:
   dpt: '1.001'
   function: Haushaltstechnik
   name: Haushaltstechnik.Kühlschrank.Ein/Aus
   room: Küche
+  writable: false
 17/1/42:
   dpt: '1.001'
   function: Haushaltstechnik
   name: Haushaltstechnik.Kühlschrank.SuperKühlen
   room: Küche
+  writable: false
 17/1/43:
   dpt: '5.010'
   function: Haushaltstechnik
   name: Haushaltstechnik.Kühlschrank.Status
   room: Küche
+  writable: false
 17/1/44:
   dpt: '1.005'
   function: Haushaltstechnik
   name: Haushaltstechnik.Kühlschrank.Störung
   room: Küche
+  writable: false
 17/1/45:
   dpt: '1.019'
   function: Haushaltstechnik
   name: Haushaltstechnik.Kühlschrank.Tür-Offen
   room: Küche
+  writable: false
 17/1/46:
   dpt: '9.001'
   function: Haushaltstechnik
   name: Haushaltstechnik.Kühlschrank.Ist-Temperatur
   room: Küche
+  writable: false
 17/1/47:
   dpt: '9.002'
   function: Haushaltstechnik
   name: Haushaltstechnik.Kühlschrank.Soll-Temperatur
   room: Küche
+  writable: false
 17/1/48:
   dpt: '1.003'
   function: Haushaltstechnik
   name: Haushaltstechnik.Kühlschrank.Fernsteuerung
   room: Küche
+  writable: false
 17/1/5:
   dpt: '5.010'
   function: Haushaltstechnik
   name: Haushaltstechnik.Geschirrspüler.Programm
   room: Küche
+  writable: false
 17/1/6:
   dpt: '5.010'
   function: Haushaltstechnik
   name: Haushaltstechnik.Geschirrspüler.Programm-Phase
   room: Küche
+  writable: false
 17/1/60:
   dpt: '1.003'
   function: Haushaltstechnik
   name: Haushaltstechnik.Backofen.Sperren
   room: Küche
+  writable: false
 17/1/61:
   dpt: '1.001'
   function: Haushaltstechnik
   name: Haushaltstechnik.Backofen.Ein/Aus
   room: Küche
+  writable: false
 17/1/62:
   dpt: '1.001'
   function: Haushaltstechnik
   name: Haushaltstechnik.Backofen.Programm-Start
   room: Küche
+  writable: false
 17/1/63:
   dpt: '1.001'
   function: Haushaltstechnik
   name: Haushaltstechnik.Backofen.Licht
   room: Küche
+  writable: false
 17/1/64:
   dpt: '5.010'
   function: Haushaltstechnik
   name: Haushaltstechnik.Backofen.Status
   room: Küche
+  writable: false
 17/1/65:
   dpt: '1.005'
   function: Haushaltstechnik
   name: Haushaltstechnik.Backofen.Störung
   room: Küche
+  writable: false
 17/1/66:
   dpt: '1.019'
   function: Haushaltstechnik
   name: Haushaltstechnik.Backofen.Tür-Offen
   room: Küche
+  writable: false
 17/1/67:
   dpt: '5.010'
   function: Haushaltstechnik
   name: Haushaltstechnik.Backofen.Programm
   room: Küche
+  writable: false
 17/1/68:
   dpt: '5.010'
   function: Haushaltstechnik
   name: Haushaltstechnik.Backofen.Programm-Phase
   room: Küche
+  writable: false
 17/1/69:
   dpt: '7.006'
   function: Haushaltstechnik
   name: Haushaltstechnik.Backofen.Restzeit
   room: Küche
+  writable: false
 17/1/7:
   dpt: '7.006'
   function: Haushaltstechnik
   name: Haushaltstechnik.Geschirrspüler.Restzeit
   room: Küche
+  writable: false
 17/1/70:
   dpt: '7.006'
   function: Haushaltstechnik
   name: Haushaltstechnik.Backofen.Startzeit
   room: Küche
+  writable: false
 17/1/71:
   dpt: '9.001'
   function: Haushaltstechnik
   name: Haushaltstechnik.Backofen.Ist-Temperatur
   room: Küche
+  writable: false
 17/1/72:
   dpt: '9.001'
   function: Haushaltstechnik
   name: Haushaltstechnik.Backofen.Soll-Temperatur
   room: Küche
+  writable: false
 17/1/73:
   dpt: '9.001'
   function: Haushaltstechnik
   name: Haushaltstechnik.Backofen.Kern-Ist-Temperatur
   room: Küche
+  writable: false
 17/1/74:
   dpt: '9.001'
   function: Haushaltstechnik
   name: Haushaltstechnik.Backofen.Kern-Soll-Temperatur
   room: Küche
+  writable: false
 17/1/75:
   dpt: '1.005'
   function: Haushaltstechnik
   name: Haushaltstechnik.Backofen.Hinweis-Fertig
   room: Küche
+  writable: false
 17/1/76:
   dpt: '1.003'
   function: Haushaltstechnik
   name: Haushaltstechnik.Backofen.Fernsteuerung
   room: Küche
+  writable: false
 17/1/8:
   dpt: '7.006'
   function: Haushaltstechnik
   name: Haushaltstechnik.Geschirrspüler.Startzeit
   room: Küche
+  writable: false
 17/1/80:
   dpt: '1.003'
   function: Haushaltstechnik
   name: Haushaltstechnik.Tellerwärmer.Sperren
   room: Küche
+  writable: false
 17/1/81:
   dpt: '1.001'
   function: Haushaltstechnik
   name: Haushaltstechnik.Tellerwärmer.Ein/Aus
   room: Küche
+  writable: false
 17/1/82:
   dpt: '5.010'
   function: Haushaltstechnik
   name: Haushaltstechnik.Tellerwärmer.Status
   room: Küche
+  writable: false
 17/1/83:
   dpt: '1.005'
   function: Haushaltstechnik
   name: Haushaltstechnik.Tellerwärmer.Störung
   room: Küche
+  writable: false
 17/1/84:
   dpt: '9.001'
   function: Haushaltstechnik
   name: Haushaltstechnik.Tellerwärmer.Ist-Temperatur
   room: Küche
+  writable: false
 17/1/85:
   dpt: '9.001'
   function: Haushaltstechnik
   name: Haushaltstechnik.Tellerwärmer.Soll-Temperatur
   room: Küche
+  writable: false
 17/1/86:
   dpt: '1.003'
   function: Haushaltstechnik
   name: Haushaltstechnik.Tellerwärmer.Fernsteuerung
   room: Küche
+  writable: false
 17/1/9:
   dpt: '1.005'
   function: Haushaltstechnik
   name: Haushaltstechnik.Geschirrspüler.Hinweis-Fertig
   room: Küche
+  writable: false
 2/0/240:
   description: 1 - Innen Schalten
   dpt: '1.003'
   function: Schalten
   name: Schalten.Zentral.Anwesen.Kilowattstunde-Löschen
   room: Anwesen Steinroth 20
+  writable: true
 2/1/0:
   dpt: '1.001'
   function: Schalten
   name: Schalten.KG.Flur.K1-L1.Steckdose.Sperren
   room: Flur
+  writable: true
 2/1/1:
   dpt: '1.001'
   function: Schalten
   name: Schalten.KG.Flur.K1-L1.Steckdose.Ein/Aus
   room: Flur
+  writable: true
 2/1/10:
   dpt: '1.001'
   function: Schalten
   name: Schalten.KG.Flur.K1-L2.Heizkörper.Sperren
   room: Flur
+  writable: true
 2/1/100:
   dpt: '1.003'
   function: Schalten
   name: Schalten.KG.Technikraum.Bewässerung.Regen.Sperren
   room: Technikraum
+  writable: true
 2/1/101:
   dpt: '1.001'
   function: Schalten
   name: Schalten.KG.Technikraum.Bewässerung.Regen.Ein/Aus
   room: Technikraum
+  writable: true
 2/1/102:
   dpt: '1.011'
   function: Schalten
   name: Schalten.KG.Technikraum.Bewässerung.Regen.Ein/Aus-Status
   room: Technikraum
+  writable: false
 2/1/11:
   dpt: '1.001'
   function: Schalten
   name: Schalten.KG.Flur.K1-L2.Heizkörper.Ein/Aus
   room: Flur
+  writable: true
 2/1/110:
   dpt: '1.003'
   function: Schalten
   name: Schalten.KG.Vorratsraum.K1-L3.Entfeuchter.Sperren
   room: Vorratsraum
+  writable: true
 2/1/111:
   dpt: '1.001'
   function: Schalten
   name: Schalten.KG.Vorratsraum.K1-L3.Entfeuchter.Ein/Aus
   room: Vorratsraum
+  writable: true
 2/1/112:
   dpt: '1.011'
   function: Schalten
   name: Schalten.KG.Vorratsraum.K1-L3.Entfeuchter.Ein/Aus-Status
   room: Vorratsraum
+  writable: false
 2/1/113:
   dpt: '13.100'
   function: Schalten
   name: Schalten.KG.Vorratsraum.K1-L3.Entfeuchter.Betriebsstunden
   room: Vorratsraum
+  writable: false
 2/1/114:
   dpt: '1.003'
   function: Schalten
   name: Schalten.KG.Vorratsraum.K1-L3.Entfeuchter.Betriebsstunden-Löschen
   room: Vorratsraum
+  writable: true
 2/1/115:
   dpt: '13.013'
   function: Schalten
   name: Schalten.KG.Vorratsraum.K1-L3.Entfeuchter.Kilowattstunde
   room: Vorratsraum
+  writable: false
 2/1/116:
   dpt: '1.003'
   function: Schalten
   name: Schalten.KG.Vorratsraum.K1-L3.Entfeuchter.Kilowattstunde-Löschen
   room: Vorratsraum
+  writable: true
 2/1/117:
   dpt: '7.012'
   function: Schalten
   name: Schalten.KG.Vorratsraum.K1-L3.Entfeuchter.Stromwert
   room: Technikraum
+  writable: false
 2/1/118:
   dpt: '5.010'
   function: Schalten
   name: Schalten.KG.Vorratsraum.K1-L3.Entfeuchter.Stromwert-Standby-Anomalie
   room: Technikraum
+  writable: false
 2/1/119:
   dpt: '5.010'
   function: Schalten
   name: Schalten.KG.Vorratsraum.K1-L3.Entfeuchter.Stromwert-Dauerbetrieb-Anomalie
   room: Technikraum
+  writable: false
 2/1/12:
   dpt: '1.011'
   function: Schalten
   name: Schalten.KG.Flur.K1-L2.Heizkörper.Ein/Aus-Status
   room: Flur
+  writable: false
 2/1/120:
   dpt: '1.001'
   function: Schalten
   name: Schalten.KG.Vorratsraum.K1-L2.Steckdose.Sperren
   room: Vorratsraum
+  writable: true
 2/1/121:
   dpt: '1.001'
   function: Schalten
   name: Schalten.KG.Vorratsraum.K1-L2.Steckdose.Ein/Aus
   room: Vorratsraum
+  writable: true
 2/1/122:
   dpt: '1.011'
   function: Schalten
   name: Schalten.KG.Vorratsraum.K1-L2.Steckdose.Ein/Aus-Status
   room: Vorratsraum
+  writable: false
 2/1/130:
   dpt: '1.001'
   function: Schalten
   name: Schalten.KG.Vorratsraum.K2-L1.Wasserstop.Sperren
   room: Vorratsraum
+  writable: true
 2/1/131:
   dpt: '1.001'
   function: Schalten
   name: Schalten.KG.Vorratsraum.K2-L1.Wasserstop.Ein/Aus
   room: Vorratsraum
+  writable: true
 2/1/132:
   dpt: '1.011'
   function: Schalten
   name: Schalten.KG.Vorratsraum.K2-L1.Wasserstop.Ein/Aus-Status
   room: Vorratsraum
+  writable: false
 2/1/140:
   dpt: '1.003'
   function: Schalten
   name: Schalten.KG.Vorratsraum.K3-L1.Lüftung.Sperren
   room: Vorratsraum
+  writable: true
 2/1/141:
   dpt: '1.001'
   function: Schalten
   name: Schalten.KG.Vorratsraum.K3-L1.Lüftung.Ein/Aus
   room: Vorratsraum
+  writable: true
 2/1/142:
   dpt: '1.011'
   function: Schalten
   name: Schalten.KG.Vorratsraum.K3-L1.Lüftung.Ein/Aus-Status
   room: Vorratsraum
+  writable: false
 2/1/143:
   dpt: '13.100'
   function: Schalten
   name: Schalten.KG.Vorratsraum.K3-L1.Lüftung.Betriebsstunden
   room: Vorratsraum
+  writable: false
 2/1/144:
   dpt: '1.003'
   function: Schalten
   name: Schalten.KG.Vorratsraum.K3-L1.Lüftung.Betriebsstunden-Löschen
   room: Vorratsraum
+  writable: true
 2/1/145:
   dpt: '13.013'
   function: Schalten
   name: Schalten.KG.Vorratsraum.K3-L1.Lüftung.Kilowattstunde
   room: Vorratsraum
+  writable: false
 2/1/146:
   dpt: '1.003'
   function: Schalten
   name: Schalten.KG.Vorratsraum.K3-L1.Lüftung.Kilowattstunde-Löschen
   room: Vorratsraum
+  writable: true
 2/1/147:
   dpt: '7.012'
   function: Schalten
   name: Schalten.KG.Vorratsraum.K3-L1.Lüftung.Stromwert
   room: Technikraum
+  writable: false
 2/1/148:
   dpt: '5.010'
   function: Schalten
   name: Schalten.KG.Vorratsraum.K3-L1.Lüftung.Stromwert-Standby-Anomalie
   room: Technikraum
+  writable: false
 2/1/149:
   dpt: '5.010'
   function: Schalten
   name: Schalten.KG.Vorratsraum.K3-L1.Lüftung.Stromwert-Dauerbetrieb-Anomalie
   room: Technikraum
+  writable: false
 2/1/150:
   dpt: '1.003'
   function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K1-L3.Entfeuchter.Sperren
   room: Hauswirtschaftsraum
+  writable: true
 2/1/151:
   dpt: '1.001'
   function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K1-L3.Entfeuchter.Ein/Aus
   room: Hauswirtschaftsraum
+  writable: true
 2/1/152:
   dpt: '1.011'
   function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K1-L3.Entfeuchter.Ein/Aus-Status
   room: Hauswirtschaftsraum
+  writable: false
 2/1/153:
   dpt: '13.100'
   function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K1-L3.Entfeuchter.Betriebsstunden
   room: Hauswirtschaftsraum
+  writable: false
 2/1/154:
   dpt: '1.001'
   function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K1-L3.Entfeuchter.Betriebsstunden-Löschen
   room: Hauswirtschaftsraum
+  writable: true
 2/1/155:
   dpt: '13.013'
   function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K1-L3.Entfeuchter.Kilowattstunde
   room: Hauswirtschaftsraum
+  writable: true
 2/1/156:
   dpt: '1.010'
   function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K1-L3.Entfeuchter.Kilowattstunde-Löschen
   room: Hauswirtschaftsraum
+  writable: true
 2/1/157:
   dpt: '7.012'
   function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K1-L3.Entfeuchter.Stromwert
   room: Hauswirtschaftsraum
+  writable: false
 2/1/158:
   dpt: '5.010'
   function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K1-L3.Entfeuchter.Stromwert-Standby-Anomalie
   room: Hauswirtschaftsraum
+  writable: false
 2/1/159:
   dpt: '5.010'
   function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K1-L3.Entfeuchter.Stromwert-Dauerbetrieb-Anomalie
   room: Hauswirtschaftsraum
+  writable: false
 2/1/160:
   dpt: '1.001'
   function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K1-L3.Heizkörper.Sperren
   room: Hauswirtschaftsraum
+  writable: true
 2/1/161:
   dpt: '1.001'
   function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K1-L3.Heizkörper.Ein/Aus
   room: Hauswirtschaftsraum
+  writable: true
 2/1/162:
   dpt: '1.011'
   function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K1-L3.Heizkörper.Ein/Aus-Status
   room: Hauswirtschaftsraum
+  writable: false
 2/1/170:
   dpt: '1.001'
   function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K2-L2.Fehrnseh.Sperren
   room: Hauswirtschaftsraum
+  writable: true
 2/1/171:
   dpt: '1.001'
   function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K2-L2.Fehrnseh.Ein/Aus
   room: Hauswirtschaftsraum
+  writable: true
 2/1/172:
   dpt: '1.011'
   function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K2-L2.Fehrnseh.Ein/Aus-Status
   room: Hauswirtschaftsraum
+  writable: false
 2/1/180:
   dpt: '1.003'
   function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K3-L1.Trockner.Sperren
   room: Hauswirtschaftsraum
+  writable: true
 2/1/181:
   dpt: '1.001'
   function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K3-L1.Trockner.Ein/Aus
   room: Hauswirtschaftsraum
+  writable: true
 2/1/182:
   dpt: '1.011'
   function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K3-L1.Trockner.Ein/Aus-Status
   room: Hauswirtschaftsraum
+  writable: false
 2/1/183:
   dpt: '13.100'
   function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K3-L1.Trockner.Betriebsstunden
   room: Hauswirtschaftsraum
+  writable: false
 2/1/184:
   dpt: '1.003'
   function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K3-L1.Trockner.Betriebsstunden-Löschen
   room: Hauswirtschaftsraum
+  writable: true
 2/1/185:
   dpt: '13.013'
   function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K3-L1.Trockner.Kilowattstunde
   room: Hauswirtschaftsraum
+  writable: false
 2/1/186:
   dpt: '1.003'
   function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K3-L1.Trockner.Kilowattstunde-Löschen
   room: Hauswirtschaftsraum
+  writable: true
 2/1/187:
   dpt: '7.012'
   function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K3-L1.Trockner.Stromwert
   room: Hauswirtschaftsraum
+  writable: false
 2/1/188:
   dpt: '5.010'
   function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K3-L1.Trockner.Stromwert-Standby-Anomalie
   room: Hauswirtschaftsraum
+  writable: false
 2/1/189:
   dpt: '5.010'
   function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K3-L1.Trockner.Stromwert-Dauerbetrieb-Anomalie
   room: Hauswirtschaftsraum
+  writable: false
 2/1/190:
   dpt: '1.003'
   function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K4-L1.Waschmaschine.Sperren
   room: Hauswirtschaftsraum
+  writable: true
 2/1/191:
   dpt: '1.001'
   function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K4-L1.Waschmaschine.Ein/Aus
   room: Hauswirtschaftsraum
+  writable: true
 2/1/192:
   dpt: '1.011'
   function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K4-L1.Waschmaschine.Ein/Aus-Status
   room: Hauswirtschaftsraum
+  writable: false
 2/1/193:
   dpt: '13.100'
   function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K4-L1.Waschmaschine.Betriebsstunden
   room: Hauswirtschaftsraum
+  writable: false
 2/1/194:
   dpt: '1.003'
   function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K4-L1.Waschmaschine.Betriebsstunden-Löschen
   room: Hauswirtschaftsraum
+  writable: true
 2/1/195:
   dpt: '13.013'
   function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K4-L1.Waschmaschine.Kilowattstunde
   room: Hauswirtschaftsraum
+  writable: false
 2/1/196:
   dpt: '1.003'
   function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K4-L1.Waschmaschine.Kilowattstunde-Löschen
   room: Hauswirtschaftsraum
+  writable: true
 2/1/197:
   dpt: '7.012'
   function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K4-L1.Waschmaschine.Stromwert
   room: Hauswirtschaftsraum
+  writable: false
 2/1/198:
   dpt: '5.010'
   function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K4-L1.Waschmaschine.Stromwert-Standby-Anomalie
   room: Hauswirtschaftsraum
+  writable: false
 2/1/199:
   dpt: '5.010'
   function: Schalten
   name: Schalten.KG.Hauswirtschaftsraum.K4-L1.Waschmaschine.Stromwert-Dauerbetrieb-Anomalie
   room: Hauswirtschaftsraum
+  writable: false
 2/1/2:
   dpt: '1.011'
   function: Schalten
   name: Schalten.KG.Flur.K1-L1.Steckdose.Ein/Aus-Status
   room: Flur
+  writable: false
 2/1/20:
   dpt: '1.003'
   function: Schalten
   name: Schalten.KG.Garage.K1-L3.Entfeuchter.Sperren
   room: Garage
+  writable: true
 2/1/21:
   dpt: '1.001'
   function: Schalten
   name: Schalten.KG.Garage.K1-L3.Entfeuchter.Ein/Aus
   room: Garage
+  writable: true
 2/1/22:
   dpt: '1.011'
   function: Schalten
   name: Schalten.KG.Garage.K1-L3.Entfeuchter.Ein/Aus-Status
   room: Garage
+  writable: false
 2/1/23:
   dpt: '13.100'
   function: Schalten
   name: Schalten.KG.Garage.K1-L3.Entfeuchter.Betriebsstunden
   room: Garage
+  writable: false
 2/1/24:
   dpt: '1.003'
   function: Schalten
   name: Schalten.KG.Garage.K1-L3.Entfeuchter.Betriebsstunden-Löschen
   room: Garage
+  writable: true
 2/1/25:
   dpt: '13.013'
   function: Schalten
   name: Schalten.KG.Garage.K1-L3.Entfeuchter.Kilowattstunde
   room: Garage
+  writable: false
 2/1/26:
   dpt: '1.003'
   function: Schalten
   name: Schalten.KG.Garage.K1-L3.Entfeuchter.Kilowattstunde-Löschen
   room: Garage
+  writable: true
 2/1/27:
   dpt: '7.012'
   function: Schalten
   name: Schalten.KG.Garage.K1-L3.Entfeuchter.Stromwert
   room: Garage
+  writable: false
 2/1/28:
   dpt: '5.010'
   function: Schalten
   name: Schalten.KG.Garage.K1-L3.Entfeuchter.Stromwert-Standby-Anomalie
   room: Garage
+  writable: false
 2/1/29:
   dpt: '5.010'
   function: Schalten
   name: Schalten.KG.Garage.K1-L3.Entfeuchter.Stromwert-Dauerbetrieb-Anomalie
   room: Garage
+  writable: false
 2/1/30:
   dpt: '1.001'
   function: Schalten
   name: Schalten.KG.Garage.K2-L2.Steckdose.Sperren
   room: Garage
+  writable: true
 2/1/31:
   dpt: '1.001'
   function: Schalten
   name: Schalten.KG.Garage.K2-L2.Steckdose.Ein/Aus
   room: Garage
+  writable: true
 2/1/32:
   dpt: '1.011'
   function: Schalten
   name: Schalten.KG.Garage.K2-L2.Steckdose.Ein/Aus-Status
   room: Garage
+  writable: false
 2/1/40:
   dpt: '1.001'
   function: Schalten
   name: Schalten.KG.Garage.K3-L1.Garagentor.Sperren
   room: Garage
+  writable: true
 2/1/41:
   dpt: '1.001'
   function: Schalten
   name: Schalten.KG.Garage.K3-L1.Garagentor.Ein/Aus
   room: Garage
+  writable: true
 2/1/42:
   dpt: '1.011'
   function: Schalten
   name: Schalten.KG.Garage.K3-L1.Garagentor.Ein/Aus-Status
   room: Garage
+  writable: false
 2/1/50:
   dpt: '1.003'
   function: Schalten
   name: Schalten.KG.Technikraum.K1-L1.Heizung.Sperren
   room: Technikraum
+  writable: true
 2/1/51:
   dpt: '1.001'
   function: Schalten
   name: Schalten.KG.Technikraum.K1-L1.Heizung.Ein/Aus
   room: Technikraum
+  writable: true
 2/1/52:
   dpt: '1.011'
   function: Schalten
   name: Schalten.KG.Technikraum.K1-L1.Heizung.Ein/Aus-Status
   room: Technikraum
+  writable: false
 2/1/53:
   dpt: '13.100'
   function: Schalten
   name: Schalten.KG.Technikraum.K1-L1.Heizung.Betriebsstunden
   room: Technikraum
+  writable: false
 2/1/54:
   dpt: '1.003'
   function: Schalten
   name: Schalten.KG.Technikraum.K1-L1.Heizung.Betriebsstunden-Löschen
   room: Technikraum
+  writable: true
 2/1/55:
   dpt: '13.013'
   function: Schalten
   name: Schalten.KG.Technikraum.K1-L1.Heizung.Kilowattstunde
   room: Technikraum
+  writable: true
 2/1/56:
   dpt: '1.003'
   function: Schalten
   name: Schalten.KG.Technikraum.K1-L1.Heizung.Löschen-Kilowattstunde
   room: Technikraum
+  writable: true
 2/1/57:
   dpt: '7.012'
   function: Schalten
   name: Schalten.KG.Technikraum.K1-L1.Heizung.Stromwert
   room: Technikraum
+  writable: false
 2/1/58:
   dpt: '5.010'
   function: Schalten
   name: Schalten.KG.Technikraum.K1-L1.Heizung.Stromwert-Standby-Anomalie
   room: Technikraum
+  writable: false
 2/1/59:
   dpt: '5.010'
   function: Schalten
   name: Schalten.KG.Technikraum.K1-L1.Heizung.Stromwert-Dauerbetrieb-Anomalie
   room: Technikraum
+  writable: false
 2/1/60:
   dpt: '1.003'
   function: Schalten
   name: Schalten.KG.Technikraum.K1-L2.Heizung.Sperren
   room: Technikraum
+  writable: true
 2/1/61:
   dpt: '1.001'
   function: Schalten
   name: Schalten.KG.Technikraum.K1-L2.Heizung.Ein/Aus
   room: Technikraum
+  writable: true
 2/1/62:
   dpt: '1.011'
   function: Schalten
   name: Schalten.KG.Technikraum.K1-L2.Heizung.Ein/Aus-Status
   room: Technikraum
+  writable: false
 2/1/63:
   dpt: '13.100'
   function: Schalten
   name: Schalten.KG.Technikraum.K1-L2.Heizung.Betriebsstunden
   room: Technikraum
+  writable: false
 2/1/64:
   dpt: '1.003'
   function: Schalten
   name: Schalten.KG.Technikraum.K1-L2.Heizung.Betriebsstunden-Löschen
   room: Technikraum
+  writable: true
 2/1/65:
   dpt: '13.013'
   function: Schalten
   name: Schalten.KG.Technikraum.K1-L2.Heizung.Kilowattstunde
   room: Technikraum
+  writable: true
 2/1/66:
   dpt: '1.003'
   function: Schalten
   name: Schalten.KG.Technikraum.K1-L2.Heizung.Kilowattstunde-Löschen
   room: Technikraum
+  writable: true
 2/1/67:
   dpt: '7.012'
   function: Schalten
   name: Schalten.KG.Technikraum.K1-L2.Heizung.Stromwert
   room: Technikraum
+  writable: false
 2/1/68:
   dpt: '5.010'
   function: Schalten
   name: Schalten.KG.Technikraum.K1-L2.Heizung.Stromwert-Standby-Anomalie
   room: Technikraum
+  writable: false
 2/1/69:
   dpt: '5.010'
   function: Schalten
   name: Schalten.KG.Technikraum.K1-L2.Heizung.Stromwert-Dauerbetrieb-Anomalie
   room: Technikraum
+  writable: false
 2/1/70:
   dpt: '1.003'
   function: Schalten
   name: Schalten.KG.Technikraum.K2-L1.Netzwerkschrank.Sperren
   room: Technikraum
+  writable: true
 2/1/71:
   dpt: '1.001'
   function: Schalten
   name: Schalten.KG.Technikraum.K2-L1.Netzwerkschrank.Ein/Aus
   room: Technikraum
+  writable: true
 2/1/72:
   dpt: '1.011'
   function: Schalten
   name: Schalten.KG.Technikraum.K2-L1.Netzwerkschrank.Ein/Aus-Status
   room: Technikraum
+  writable: false
 2/1/73:
   dpt: '13.100'
   function: Schalten
   name: Schalten.KG.Technikraum.K2-L1.Netzwerkschrank.Betriebsstunden
   room: Technikraum
+  writable: false
 2/1/74:
   dpt: '1.003'
   function: Schalten
   name: Schalten.KG.Technikraum.K2-L1.Netzwerkschrank.Betriebsstunden-Löschen
   room: Technikraum
+  writable: true
 2/1/75:
   dpt: '13.013'
   function: Schalten
   name: Schalten.KG.Technikraum.K2-L1.Netzwerkschrank.Kilowattstunde
   room: Technikraum
+  writable: true
 2/1/76:
   dpt: '1.003'
   function: Schalten
   name: Schalten.KG.Technikraum.K2-L1.Netzwerkschrank.Kilowattstunde-Löschen
   room: Technikraum
+  writable: true
 2/1/77:
   dpt: '7.012'
   function: Schalten
   name: Schalten.KG.Technikraum.K2-L1.Netzwerkschrank.Stromwert
   room: Technikraum
+  writable: false
 2/1/78:
   dpt: '5.010'
   function: Schalten
   name: Schalten.KG.Technikraum.K2-L1.Netzwerkschrank.Stromwert-Standby-Anomalie
   room: Technikraum
+  writable: false
 2/1/79:
   dpt: '5.010'
   function: Schalten
   name: Schalten.KG.Technikraum.K2-L1.Netzwerkschrank.Stromwert-Dauerbetrieb-Anomalie
   room: Technikraum
+  writable: false
 2/1/80:
   dpt: '1.003'
   function: Schalten
   name: Schalten.KG.Technikraum.K2-L2.Netzwerkschrank.Sperren
   room: Technikraum
+  writable: true
 2/1/81:
   dpt: '1.001'
   function: Schalten
   name: Schalten.KG.Technikraum.K2-L2.Netzwerkschrank.Ein/Aus
   room: Technikraum
+  writable: true
 2/1/82:
   dpt: '1.011'
   function: Schalten
   name: Schalten.KG.Technikraum.K2-L2.Netzwerkschrank.Ein/Aus-Status
   room: Technikraum
+  writable: false
 2/1/83:
   dpt: '13.100'
   function: Schalten
   name: Schalten.KG.Technikraum.K2-L2.Netzwerkschrank.Betriebsstunden
   room: Technikraum
+  writable: false
 2/1/84:
   dpt: '1.003'
   function: Schalten
   name: Schalten.KG.Technikraum.K2-L2.Netzwerkschrank.Betriebsstunden-Löschen
   room: Technikraum
+  writable: true
 2/1/85:
   dpt: '13.013'
   function: Schalten
   name: Schalten.KG.Technikraum.K2-L2.Netzwerkschrank.Kilowattstunde
   room: Technikraum
+  writable: true
 2/1/86:
   dpt: '1.003'
   function: Schalten
   name: Schalten.KG.Technikraum.K2-L2.Netzwerkschrank.Kilowattstunde-Löschen
   room: Technikraum
+  writable: true
 2/1/87:
   dpt: '7.012'
   function: Schalten
   name: Schalten.KG.Technikraum.K2-L2.Netzwerkschrank.Stromwert
   room: Technikraum
+  writable: false
 2/1/88:
   dpt: '5.010'
   function: Schalten
   name: Schalten.KG.Technikraum.K2-L2.Netzwerkschrank.Stromwert-Standby-Anomalie
   room: Technikraum
+  writable: false
 2/1/89:
   dpt: '5.010'
   function: Schalten
   name: Schalten.KG.Technikraum.K2-L2.Netzwerkschrank.Stromwert-Dauerbetrieb-Anomalie
   room: Technikraum
+  writable: false
 2/1/90:
   dpt: '1.003'
   function: Schalten
   name: Schalten.KG.Technikraum.K3-L3.Entfeuchter.Sperren
   room: Technikraum
+  writable: true
 2/1/91:
   dpt: '1.001'
   function: Schalten
   name: Schalten.KG.Technikraum.K3-L3.Entfeuchter.Ein/Aus
   room: Technikraum
+  writable: true
 2/1/92:
   dpt: '1.011'
   function: Schalten
   name: Schalten.KG.Technikraum.K3-L3.Entfeuchter.Ein/Aus-Status
   room: Technikraum
+  writable: false
 2/1/93:
   dpt: '13.100'
   function: Schalten
   name: Schalten.KG.Technikraum.K3-L3.Entfeuchter.Betriebsstunden
   room: Technikraum
+  writable: false
 2/1/94:
   dpt: '1.003'
   function: Schalten
   name: Schalten.KG.Technikraum.K3-L3.Entfeuchter.Betriebsstunden-Löschen
   room: Technikraum
+  writable: true
 2/1/95:
   dpt: '13.013'
   function: Schalten
   name: Schalten.KG.Technikraum.K3-L3.Entfeuchter.Kilowattstunde
   room: Technikraum
+  writable: false
 2/1/96:
   dpt: '1.003'
   function: Schalten
   name: Schalten.KG.Technikraum.K3-L3.Entfeuchter.Kilowattstunde-Löschen
   room: Technikraum
+  writable: true
 2/1/97:
   dpt: '7.012'
   function: Schalten
   name: Schalten.KG.Technikraum.K3-L3.Entfeuchter.Stromwert
   room: Technikraum
+  writable: false
 2/1/98:
   dpt: '5.010'
   function: Schalten
   name: Schalten.KG.Technikraum.K3-L3.Entfeuchter.Stromwert-Standby-Anomalie
   room: Technikraum
+  writable: false
 2/1/99:
   dpt: '5.010'
   function: Schalten
   name: Schalten.KG.Technikraum.K3-L3.Entfeuchter.Stromwert-Dauerbetrieb-Anomalie
   room: Technikraum
+  writable: false
 2/2/0:
   dpt: '1.001'
   function: Schalten
   name: Schalten.EG.Büro.K1-L2.Steckdose.Sperren
   room: Büro
+  writable: true
 2/2/1:
   dpt: '1.001'
   function: Schalten
   name: Schalten.EG.Büro.K1-L2.Steckdose.Ein/Aus
   room: Büro
+  writable: true
 2/2/10:
   dpt: '1.001'
   function: Schalten
   name: Schalten.EG.Büro.K2-L2.Schreibtisch.Sperren
   room: Büro
+  writable: true
 2/2/100:
   dpt: '1.001'
   function: Schalten
   name: Schalten.EG.Küche.K1-L3.Steckdose.Sperren
   room: Küche
+  writable: true
 2/2/101:
   dpt: '1.001'
   function: Schalten
   name: Schalten.EG.Küche.K1-L3.Steckdose.Ein/Aus
   room: Küche
+  writable: true
 2/2/102:
   dpt: '1.011'
   function: Schalten
   name: Schalten.EG.Küche.K1-L3.Steckdose.Ein/Aus-Status
   room: Küche
+  writable: false
 2/2/11:
   dpt: '1.001'
   function: Schalten
   name: Schalten.EG.Büro.K2-L2.Schreibtisch.Ein/Aus
   room: Büro
+  writable: true
 2/2/110:
   dpt: '1.001'
   function: Schalten
   name: Schalten.EG.Küche.K2-L1.Steckdose.Sperren
   room: Küche
+  writable: true
 2/2/111:
   dpt: '1.001'
   function: Schalten
   name: Schalten.EG.Küche.K2-L1.Steckdose.Ein/Aus
   room: Küche
+  writable: true
 2/2/112:
   dpt: '1.011'
   function: Schalten
   name: Schalten.EG.Küche.K2-L1.Steckdose.Ein/Aus-Status
   room: Küche
+  writable: false
 2/2/12:
   dpt: '1.011'
   function: Schalten
   name: Schalten.EG.Büro.K2-L2.Schreibtisch.Ein/Aus-Status
   room: Büro
+  writable: false
 2/2/120:
   dpt: '1.001'
   function: Schalten
   name: Schalten.EG.Küche.K2-L2.Steckdose.Sperren
   room: Küche
+  writable: true
 2/2/121:
   dpt: '1.001'
   function: Schalten
   name: Schalten.EG.Küche.K2-L2.Steckdose.Ein/Aus
   room: Küche
+  writable: true
 2/2/122:
   dpt: '1.011'
   function: Schalten
   name: Schalten.EG.Küche.K2-L2.Steckdose.Ein/Aus-Status
   room: Küche
+  writable: false
 2/2/130:
   dpt: '1.001'
   function: Schalten
   name: Schalten.EG.Küche.K3-L3.Kücheninsel.Sperren
   room: Küche
+  writable: true
 2/2/131:
   dpt: '1.001'
   function: Schalten
   name: Schalten.EG.Küche.K3-L3.Kücheninsel.Ein/Aus
   room: Küche
+  writable: true
 2/2/132:
   dpt: '1.011'
   function: Schalten
   name: Schalten.EG.Küche.K3-L3.Kücheninsel.Ein/Aus-Status
   room: Küche
+  writable: false
 2/2/140:
   dpt: '1.003'
   function: Schalten
   name: Schalten.EG.Küche.K4-L1.Geschirrspüler.Sperren
   room: Küche
+  writable: true
 2/2/141:
   dpt: '1.001'
   function: Schalten
   name: Schalten.EG.Küche.K4-L1.Geschirrspüler.Ein/Aus
   room: Küche
+  writable: true
 2/2/142:
   dpt: '1.011'
   function: Schalten
   name: Schalten.EG.Küche.K4-L1.Geschirrspüler.Ein/Aus-Status
   room: Küche
+  writable: false
 2/2/143:
   dpt: '13.100'
   function: Schalten
   name: Schalten.EG.Küche.K4-L1.Geschirrspüler.Betriebsstunden
   room: Küche
+  writable: false
 2/2/144:
   dpt: '1.003'
   function: Schalten
   name: 'Schalten.EG.Küche.K4-L1.Geschirrspüler.Betriebsstunden-Löschen '
   room: Küche
+  writable: true
 2/2/145:
   dpt: '13.013'
   function: Schalten
   name: Schalten.EG.Küche.K4-L1.Geschirrspüler.Kilowattstunde
   room: Küche
+  writable: false
 2/2/146:
   dpt: '1.003'
   function: Schalten
   name: Schalten.EG.Küche.K4-L1.Geschirrspüler.Kilowattstunde-Löschen
   room: Küche
+  writable: true
 2/2/147:
   dpt: '7.012'
   function: Schalten
   name: Schalten.EG.Küche.K4-L1.Geschirrspüler.Stromwert
   room: Küche
+  writable: false
 2/2/148:
   dpt: '5.010'
   function: Schalten
   name: Schalten.EG.Küche.K4-L1.Geschirrspüler.Stromwert-Standby-Anomalie
   room: Küche
+  writable: false
 2/2/149:
   dpt: '5.010'
   function: Schalten
   name: Schalten.EG.Küche.K4-L1.Geschirrspüler.Stromwert-Dauerbetrieb-Anomalie
   room: Küche
+  writable: false
 2/2/150:
   dpt: '1.003'
   function: Schalten
   name: Schalten.EG.Küche.K5-L1.Haubenlüfter.Sperren
   room: Küche
+  writable: true
 2/2/151:
   dpt: '1.001'
   function: Schalten
   name: Schalten.EG.Küche.K5-L1.Haubenlüfter.Ein/Aus
   room: Küche
+  writable: true
 2/2/152:
   dpt: '1.011'
   function: Schalten
   name: Schalten.EG.Küche.K5-L1.Haubenlüfter.Ein/Aus-Status
   room: Küche
+  writable: false
 2/2/153:
   dpt: '13.100'
   function: Schalten
   name: Schalten.EG.Küche.K5-L1.Haubenlüfter.Betriebsstunden
   room: Küche
+  writable: false
 2/2/154:
   dpt: '1.003'
   function: Schalten
   name: Schalten.EG.Küche.K5-L1.Haubenlüfter.Betriebsstunden-Löschen
   room: Küche
+  writable: true
 2/2/155:
   dpt: '13.013'
   function: Schalten
   name: Schalten.EG.Küche.K5-L1.Haubenlüfter.Kilowattstunde
   room: Küche
+  writable: false
 2/2/156:
   dpt: '1.003'
   function: Schalten
   name: Schalten.EG.Küche.K5-L1.Haubenlüfter.Kilowattstunde-Löschen
   room: Küche
+  writable: true
 2/2/157:
   dpt: '7.012'
   function: Schalten
   name: Schalten.EG.Küche.K5-L1.Haubenlüfter.Stromwert
   room: Küche
+  writable: false
 2/2/158:
   dpt: '5.010'
   function: Schalten
   name: Schalten.EG.Küche.K5-L1.Haubenlüfter.Stromwert-Standby-Anomalie
   room: Küche
+  writable: false
 2/2/159:
   dpt: '5.010'
   function: Schalten
   name: Schalten.EG.Küche.K5-L1.Haubenlüfter.Stromwert-Dauerbetrieb-Anomalie
   room: Küche
+  writable: false
 2/2/160:
   dpt: '1.003'
   function: Schalten
   name: Schalten.EG.Küche.K7-L1.Kühlschrank.Sperren
   room: Küche
+  writable: true
 2/2/161:
   dpt: '1.001'
   function: Schalten
   name: Schalten.EG.Küche.K7-L1.Kühlschrank.Ein/Aus
   room: Küche
+  writable: true
 2/2/162:
   dpt: '1.011'
   function: Schalten
   name: Schalten.EG.Küche.K7-L1.Kühlschrank.Ein/Aus-Status
   room: Küche
+  writable: false
 2/2/163:
   dpt: '13.100'
   function: Schalten
   name: Schalten.EG.Küche.K7-L1.Kühlschrank.Betriebsstunden
   room: Küche
+  writable: false
 2/2/164:
   dpt: '1.003'
   function: Schalten
   name: Schalten.EG.Küche.K7-L1.Kühlschrank.Betriebsstunden-Löschen
   room: Küche
+  writable: true
 2/2/165:
   dpt: '13.013'
   function: Schalten
   name: Schalten.EG.Küche.K7-L1.Kühlschrank.Kilowattstunde
   room: Küche
+  writable: true
 2/2/166:
   dpt: '1.003'
   function: Schalten
   name: Schalten.EG.Küche.K7-L1.Kühlschrank.Kilowattstunde-Löschen
   room: Küche
+  writable: true
 2/2/167:
   dpt: '7.012'
   function: Schalten
   name: Schalten.EG.Küche.K7-L1.Kühlschrank.Stromwert
   room: Küche
+  writable: false
 2/2/168:
   dpt: '5.010'
   function: Schalten
   name: Schalten.EG.Küche.K7-L1.Kühlschrank.Stromwert-Standby-Anomalie
   room: Küche
+  writable: false
 2/2/169:
   dpt: '5.010'
   function: Schalten
   name: Schalten.EG.Küche.K7-L1.Kühlschrank.Stromwert-Dauerbetrieb-Anomalie
   room: Küche
+  writable: false
 2/2/170:
   dpt: '1.003'
   function: Schalten
   name: Schalten.EG.Küche.K9-L1.Backofen.Sperren
   room: Küche
+  writable: true
 2/2/171:
   dpt: '1.001'
   function: Schalten
   name: Schalten.EG.Küche.K9-L1.Backofen.Ein/Aus
   room: Küche
+  writable: true
 2/2/172:
   dpt: '1.011'
   function: Schalten
   name: Schalten.EG.Küche.K9-L1.Backofen.Ein/Aus-Status
   room: Küche
+  writable: false
 2/2/173:
   dpt: '13.100'
   function: Schalten
   name: Schalten.EG.Küche.K9-L1.Backofen.Betriebsstunden
   room: Küche
+  writable: false
 2/2/174:
   dpt: '1.003'
   function: Schalten
   name: Schalten.EG.Küche.K9-L1.Backofen.Betriebsstunden-Löschen
   room: Küche
+  writable: true
 2/2/175:
   dpt: '13.013'
   function: Schalten
   name: Schalten.EG.Küche.K9-L1.Backofen.Kilowattstunde
   room: Küche
+  writable: true
 2/2/176:
   dpt: '1.003'
   function: Schalten
   name: Schalten.EG.Küche.K9-L1.Backofen.Kilowattstunde-Löschen
   room: Küche
+  writable: true
 2/2/177:
   dpt: '7.012'
   function: Schalten
   name: Schalten.EG.Küche.K9-L1.Backofen.Stromwert
   room: Küche
+  writable: false
 2/2/178:
   dpt: '5.010'
   function: Schalten
   name: Schalten.EG.Küche.K9-L1.Backofen.Stromwert-Standby-Anomalie
   room: Küche
+  writable: false
 2/2/179:
   dpt: '5.010'
   function: Schalten
   name: Schalten.EG.Küche.K9-L1.Backofen.Stromwert-Dauerbetrieb-Anomalie
   room: Küche
+  writable: false
 2/2/180:
   dpt: '1.003'
   function: Schalten
   name: Schalten.EG.Küche.K10-L1.Tellerwärmer.Sperren
   room: Küche
+  writable: true
 2/2/181:
   dpt: '1.001'
   function: Schalten
   name: Schalten.EG.Küche.K10-L1.Tellerwärmer.Ein/Aus
   room: Küche
+  writable: true
 2/2/182:
   dpt: '1.011'
   function: Schalten
   name: Schalten.EG.Küche.K10-L1.Tellerwärmer.Ein/Aus-Status
   room: Küche
+  writable: false
 2/2/183:
   dpt: '13.100'
   function: Schalten
   name: Schalten.EG.Küche.K10-L1.Tellerwärmer.Betriebsstunden
   room: Küche
+  writable: false
 2/2/184:
   dpt: '1.003'
   function: Schalten
   name: Schalten.EG.Küche.K10-L1.Tellerwärmer.Betriebsstunden-Löschen
   room: Küche
+  writable: true
 2/2/185:
   dpt: '13.013'
   function: Schalten
   name: Schalten.EG.Küche.K10-L1.Tellerwärmer.Kilowattstunde
   room: Küche
+  writable: false
 2/2/186:
   dpt: '1.003'
   function: Schalten
   name: Schalten.EG.Küche.K10-L1.Tellerwärmer.Kilowattstunde-Löschen
   room: Küche
+  writable: true
 2/2/187:
   dpt: '7.012'
   function: Schalten
   name: Schalten.EG.Küche.K10-L1.Tellerwärmer.Stromwert
   room: Küche
+  writable: false
 2/2/188:
   dpt: '5.010'
   function: Schalten
   name: Schalten.EG.Küche.K10-L1.Tellerwärmer.Stromwert-Standby-Anomalie
   room: Küche
+  writable: false
 2/2/189:
   dpt: '5.010'
   function: Schalten
   name: Schalten.EG.Küche.K10-L1.Tellerwärmer.Stromwert-Dauerbetrieb-Anomalie
   room: Küche
+  writable: false
 2/2/190:
   dpt: '1.003'
   function: Schalten
   name: Schalten.EG.Küche.K12-L1.Mikrowelle.Sperren
   room: Küche
+  writable: true
 2/2/191:
   dpt: '1.001'
   function: Schalten
   name: Schalten.EG.Küche.K12-L1.Mikrowelle.Ein/Aus
   room: Küche
+  writable: true
 2/2/192:
   dpt: '1.011'
   function: Schalten
   name: Schalten.EG.Küche.K12-L1.Mikrowelle.Ein/Aus-Status
   room: Küche
+  writable: false
 2/2/193:
   dpt: '13.100'
   function: Schalten
   name: Schalten.EG.Küche.K12-L1.Mikrowelle.Betriebsstunden
   room: Küche
+  writable: false
 2/2/194:
   dpt: '1.003'
   function: Schalten
   name: Schalten.EG.Küche.K12-L1.Mikrowelle.Betriebsstunden-Löschen
   room: Küche
+  writable: true
 2/2/195:
   dpt: '13.013'
   function: Schalten
   name: Schalten.EG.Küche.K12-L1.Mikrowelle.Kilowattstunde
   room: Küche
+  writable: false
 2/2/196:
   dpt: '1.003'
   function: Schalten
   name: Schalten.EG.Küche.K12-L1.Mikrowelle.Kilowattstunde-Löschen
   room: Küche
+  writable: true
 2/2/197:
   dpt: '7.012'
   function: Schalten
   name: Schalten.EG.Küche.K12-L1.Mikrowelle.Stromwert
   room: Küche
+  writable: false
 2/2/198:
   dpt: '5.010'
   function: Schalten
   name: Schalten.EG.Küche.K12-L1.Mikrowelle.Stromwert-Standby-Anomalie
   room: Küche
+  writable: false
 2/2/199:
   dpt: '5.010'
   function: Schalten
   name: Schalten.EG.Küche.K12-L1.Mikrowelle.Stromwert-Dauerbetrieb-Anomalie
   room: Küche
+  writable: false
 2/2/2:
   dpt: '1.011'
   function: Schalten
   name: Schalten.EG.Büro.K1-L2.Steckdose.Ein/Aus-Status
   room: Büro
+  writable: false
 2/2/20:
   dpt: '1.001'
   function: Schalten
   name: Schalten.EG.Büro.K2-L3.Schreibtisch.Sperren
   room: Büro
+  writable: true
 2/2/200:
   dpt: '1.003'
   function: Schalten
   name: Schalten.EG.Küche.K13-L1.Kaffeemaschine.Sperren
   room: Küche
+  writable: true
 2/2/201:
   dpt: '1.001'
   function: Schalten
   name: Schalten.EG.Küche.K13-L1.Kaffeemaschine.Ein/Aus
   room: Küche
+  writable: true
 2/2/202:
   dpt: '1.011'
   function: Schalten
   name: Schalten.EG.Küche.K13-L1.Kaffeemaschine.Ein/Aus-Status
   room: Küche
+  writable: false
 2/2/203:
   dpt: '13.100'
   function: Schalten
   name: Schalten.EG.Küche.K13-L1.Kaffeemaschine.Betriebsstunden
   room: Küche
+  writable: false
 2/2/204:
   dpt: '1.003'
   function: Schalten
   name: Schalten.EG.Küche.K13-L1.Kaffeemaschine.Betriebsstunden-Löschen
   room: Küche
+  writable: true
 2/2/205:
   dpt: '13.013'
   function: Schalten
   name: Schalten.EG.Küche.K13-L1.Kaffeemaschine.Kilowattstunde
   room: Küche
+  writable: false
 2/2/206:
   dpt: '1.003'
   function: Schalten
   name: Schalten.EG.Küche.K13-L1.Kaffeemaschine.Kilowattstunde-Löschen
   room: Küche
+  writable: true
 2/2/207:
   dpt: '7.012'
   function: Schalten
   name: Schalten.EG.Küche.K13-L1.Kaffeemaschine.Stromwert
   room: Küche
+  writable: false
 2/2/208:
   dpt: '5.010'
   function: Schalten
   name: Schalten.EG.Küche.K13-L1.Kaffeemaschine.Stromwert-Standby-Anomalie
   room: Küche
+  writable: false
 2/2/209:
   dpt: '5.010'
   function: Schalten
   name: Schalten.EG.Küche.K13-L1.Kaffeemaschine.Stromwert-Dauerbetrieb-Anomalie
   room: Küche
+  writable: false
 2/2/21:
   dpt: '1.001'
   function: Schalten
   name: Schalten.EG.Büro.K2-L3.Schreibtisch.Ein/Aus
   room: Büro
+  writable: true
 2/2/210:
   dpt: '1.003'
   function: Schalten
   name: Schalten.EG.Küche.K14-L1.Dampfgarer.Sperren
   room: Küche
+  writable: true
 2/2/211:
   dpt: '1.001'
   function: Schalten
   name: Schalten.EG.Küche.K14-L1.Dampfgarer.Ein/Aus
   room: Küche
+  writable: true
 2/2/212:
   dpt: '1.011'
   function: Schalten
   name: Schalten.EG.Küche.K14-L1.Dampfgarer.Ein/Aus-Status
   room: Küche
+  writable: false
 2/2/213:
   dpt: '13.100'
   function: Schalten
   name: Schalten.EG.Küche.K14-L1.Dampfgarer.Betriebsstunden
   room: Küche
+  writable: false
 2/2/214:
   dpt: '1.003'
   function: Schalten
   name: Schalten.EG.Küche.K14-L1.Dampfgarer.Betriebsstunden-Löschen
   room: Küche
+  writable: true
 2/2/215:
   dpt: '13.013'
   function: Schalten
   name: Schalten.EG.Küche.K14-L1.Dampfgarer.Kilowattstunde
   room: Küche
+  writable: true
 2/2/216:
   dpt: '1.003'
   function: Schalten
   name: Schalten.EG.Küche.K14-L1.Dampfgarer.Kilowattstunde-Löschen
   room: Küche
+  writable: true
 2/2/217:
   dpt: '7.012'
   function: Schalten
   name: Schalten.EG.Küche.K14-L1.Dampfgarer.Stromwert
   room: Küche
+  writable: false
 2/2/218:
   dpt: '5.010'
   function: Schalten
   name: Schalten.EG.Küche.K14-L1.Dampfgarer.Stromwert-Standby-Anomalie
   room: Küche
+  writable: false
 2/2/219:
   dpt: '5.010'
   function: Schalten
   name: Schalten.EG.Küche.K14-L1.Dampfgarer.Stromwert-Dauerbetrieb-Anomalie
   room: Küche
+  writable: false
 2/2/22:
   dpt: '1.011'
   function: Schalten
   name: Schalten.EG.Büro.K2-L3.Schreibtisch.Ein/Aus-Status
   room: Büro
+  writable: false
 2/2/220:
   dpt: '1.003'
   function: Schalten
   name: Schalten.EG.Küche.K15-L1.Gefrierschrank.Sperren
   room: Küche
+  writable: true
 2/2/221:
   dpt: '1.001'
   function: Schalten
   name: Schalten.EG.Küche.K15-L1.Gefrierschrank.Ein/Aus
   room: Küche
+  writable: true
 2/2/222:
   dpt: '1.011'
   function: Schalten
   name: Schalten.EG.Küche.K15-L1.Gefrierschrank.Ein/Aus-Status
   room: Küche
+  writable: false
 2/2/223:
   dpt: '13.100'
   function: Schalten
   name: Schalten.EG.Küche.K15-L1.Gefrierschrank.Betriebsstunden
   room: Küche
+  writable: false
 2/2/224:
   dpt: '1.003'
   function: Schalten
   name: Schalten.EG.Küche.K15-L1.Gefrierschrank.Betriebsstunden-Löschen
   room: Küche
+  writable: true
 2/2/225:
   dpt: '13.013'
   function: Schalten
   name: Schalten.EG.Küche.K15-L1.Gefrierschrank.Kilowattstunde
   room: Küche
+  writable: true
 2/2/226:
   dpt: '1.003'
   function: Schalten
   name: Schalten.EG.Küche.K15-L1.Gefrierschrank.Kilowattstunde-Löschen
   room: Küche
+  writable: true
 2/2/227:
   dpt: '7.012'
   function: Schalten
   name: Schalten.EG.Küche.K15-L1.Gefrierschrank.Stromwert
   room: Küche
+  writable: false
 2/2/228:
   dpt: '5.010'
   function: Schalten
   name: Schalten.EG.Küche.K15-L1.Gefrierschrank.Stromwert-Standby-Anomalie
   room: Küche
+  writable: false
 2/2/229:
   dpt: '5.010'
   function: Schalten
   name: Schalten.EG.Küche.K15-L1.Gefrierschrank.Stromwert-Dauerbetrieb-Anomalie
   room: Küche
+  writable: false
 2/2/30:
   dpt: '1.001'
   function: Schalten
   name: Schalten.EG.Wohnzimmer.K1-L2.Steckdose.Sperren
   room: Wohnzimmer
+  writable: true
 2/2/31:
   dpt: '1.001'
   function: Schalten
   name: Schalten.EG.Wohnzimmer.K1-L2.Steckdose.Ein/Aus
   room: Wohnzimmer
+  writable: true
 2/2/32:
   dpt: '1.011'
   function: Schalten
   name: Schalten.EG.Wohnzimmer.K1-L2.Steckdose.Ein/Aus-Status
   room: Wohnzimmer
+  writable: false
 2/2/40:
   dpt: '1.001'
   function: Schalten
   name: Schalten.EG.Wohnzimmer.K2-L2.Steckdose.Sperren
   room: Wohnzimmer
+  writable: true
 2/2/41:
   dpt: '1.001'
   function: Schalten
   name: Schalten.EG.Wohnzimmer.K2-L2.Steckdose.Ein/Aus
   room: Wohnzimmer
+  writable: true
 2/2/42:
   dpt: '1.011'
   function: Schalten
   name: Schalten.EG.Wohnzimmer.K2-L2.Steckdose.Ein/Aus-Status
   room: Wohnzimmer
+  writable: false
 2/2/50:
   dpt: '1.001'
   function: Schalten
   name: Schalten.EG.Wohnzimmer.K3-L1.Fernseh.Sperren
   room: Wohnzimmer
+  writable: true
 2/2/51:
   dpt: '1.001'
   function: Schalten
   name: Schalten.EG.Wohnzimmer.K3-L1.Fernseh.Ein/Aus
   room: Wohnzimmer
+  writable: true
 2/2/52:
   dpt: '1.011'
   function: Schalten
   name: Schalten.EG.Wohnzimmer.K3-L1.Fernseh.Ein/Aus-Status
   room: Wohnzimmer
+  writable: false
 2/2/60:
   dpt: '1.001'
   function: Schalten
   name: Schalten.EG.Wohnzimmer.K3-L2.Fernseh.Sperren
   room: Wohnzimmer
+  writable: true
 2/2/61:
   dpt: '1.001'
   function: Schalten
   name: Schalten.EG.Wohnzimmer.K3-L2.Fernseh.Ein/Aus
   room: Wohnzimmer
+  writable: true
 2/2/62:
   dpt: '1.011'
   function: Schalten
   name: Schalten.EG.Wohnzimmer.K3-L2.Fernseh.Ein/Aus-Status
   room: Wohnzimmer
+  writable: false
 2/2/70:
   dpt: '1.001'
   function: Schalten
   name: Schalten.EG.Wohnzimmer.K3-L3.Fernseh.Sperren
   room: Wohnzimmer
+  writable: true
 2/2/71:
   dpt: '1.001'
   function: Schalten
   name: Schalten.EG.Wohnzimmer.K3-L3.Fernseh.Ein/Aus
   room: Wohnzimmer
+  writable: true
 2/2/72:
   dpt: '1.011'
   function: Schalten
   name: Schalten.EG.Wohnzimmer.K3-L3.Fernseh.Ein/Aus-Status
   room: Wohnzimmer
+  writable: false
 2/2/80:
   dpt: '1.003'
   function: Schalten
   name: Schalten.EG.Wohnzimmer.K4-L1.Ofen.Sperren
   room: Wohnzimmer
+  writable: true
 2/2/81:
   dpt: '1.001'
   function: Schalten
   name: Schalten.EG.Wohnzimmer.K4-L1.Ofen.Ein/Aus
   room: Wohnzimmer
+  writable: true
 2/2/82:
   dpt: '1.011'
   function: Schalten
   name: Schalten.EG.Wohnzimmer.K4-L1.Ofen.Ein/Aus-Status
   room: Wohnzimmer
+  writable: false
 2/2/83:
   dpt: '13.100'
   function: Schalten
   name: Schalten.EG.Wohnzimmer.K4-L1.Ofen.Betriebsstunden
   room: Wohnzimmer
+  writable: false
 2/2/84:
   dpt: '1.003'
   function: Schalten
   name: Schalten.EG.Wohnzimmer.K4-L1.Ofen.Betriebsstunden-Löschen
   room: Wohnzimmer
+  writable: true
 2/2/85:
   dpt: '13.013'
   function: Schalten
   name: Schalten.EG.Wohnzimmer.K4-L1.Ofen.Kilowattstunde
   room: Wohnzimmer
+  writable: false
 2/2/86:
   dpt: '1.003'
   function: Schalten
   name: Schalten.EG.Wohnzimmer.K4-L1.Ofen.Kilowattstunde-Löschen
   room: Wohnzimmer
+  writable: true
 2/2/87:
   dpt: '7.012'
   function: Schalten
   name: Schalten.EG.Wohnzimmer.K4-L1.Ofen.Stromwert
   room: Wohnzimmer
+  writable: false
 2/2/88:
   dpt: '5.010'
   function: Schalten
   name: Schalten.EG.Wohnzimmer.K4-L1.Ofen.Stromwert-Standby-Anomalie
   room: Wohnzimmer
+  writable: false
 2/2/89:
   dpt: '5.010'
   function: Schalten
   name: Schalten.EG.Wohnzimmer.K4-L1.Ofen.Stromwert-Dauerbetrieb-Anomalie
   room: Wohnzimmer
+  writable: false
 2/2/90:
   dpt: '1.001'
   function: Schalten
   name: Schalten.EG.Esszimmer.K2-L3.Steckdose.Sperren
   room: Esszimmer
+  writable: true
 2/2/91:
   dpt: '1.001'
   function: Schalten
   name: Schalten.EG.Esszimmer.K2-L3.Steckdose.Ein/Aus
   room: Esszimmer
+  writable: true
 2/2/92:
   dpt: '1.011'
   function: Schalten
   name: Schalten.EG.Esszimmer.K2-L3.Steckdose.Ein/Aus-Status
   room: Esszimmer
+  writable: false
 2/3/0:
   dpt: '1.001'
   function: Schalten
   name: Schalten.OG.Abstellraum.K1-L1.Steckdose.Sperren
   room: Abstellraum
+  writable: true
 2/3/1:
   dpt: '1.001'
   function: Schalten
   name: Schalten.OG.Abstellraum.K1-L1.Steckdose.Ein/Aus
   room: Abstellraum
+  writable: true
 2/3/10:
   dpt: '1.001'
   function: Schalten
   name: Schalten.OG.Abstellraum.K2-L1.Steckdose.Sperren
   room: Abstellraum
+  writable: true
 2/3/100:
   dpt: '1.001'
   function: Schalten
   name: Schalten.OG.Schlafzimmer-Eltern.K2-L1.Bett.Sperren
   room: Schlafzimmer Eltern
+  writable: true
 2/3/101:
   dpt: '1.001'
   function: Schalten
   name: Schalten.OG.Schlafzimmer-Eltern.K2-L1.Bett.Ein/Aus
   room: Schlafzimmer Eltern
+  writable: true
 2/3/102:
   dpt: '1.011'
   function: Schalten
   name: Schalten.OG.Schlafzimmer-Eltern.K2-L1.Bett.Ein/Aus-Status
   room: Schlafzimmer Eltern
+  writable: false
 2/3/11:
   dpt: '1.001'
   function: Schalten
   name: Schalten.OG.Abstellraum.K2-L1.Steckdose.Ein/Aus
   room: Abstellraum
+  writable: true
 2/3/110:
   dpt: '1.001'
   function: Schalten
   name: Schalten.OG.Schlafzimmer-Eltern.K2-L2.Bett.Sperren
   room: Schlafzimmer Eltern
+  writable: true
 2/3/111:
   dpt: '1.001'
   function: Schalten
   name: Schalten.OG.Schlafzimmer-Eltern.K2-L2.Bett.Ein/Aus
   room: Schlafzimmer Eltern
+  writable: true
 2/3/112:
   dpt: '1.011'
   function: Schalten
   name: Schalten.OG.Schlafzimmer-Eltern.K2-L2.Bett.Ein/Aus-Status
   room: Schlafzimmer Eltern
+  writable: false
 2/3/12:
   dpt: '1.011'
   function: Schalten
   name: Schalten.OG.Abstellraum.K2-L1.Steckdose.Ein/Aus-Status
   room: Abstellraum
+  writable: false
 2/3/120:
   dpt: '1.001'
   function: Schalten
   name: Schalten.OG.Schlafzimmer-Eltern.K2-L3.Bett.Sperren
   room: Schlafzimmer Eltern
+  writable: true
 2/3/121:
   dpt: '1.001'
   function: Schalten
   name: Schalten.OG.Schlafzimmer-Eltern.K2-L3.Bett.Ein/Aus
   room: Schlafzimmer Eltern
+  writable: true
 2/3/122:
   dpt: '1.011'
   function: Schalten
   name: Schalten.OG.Schlafzimmer-Eltern.K2-L3.Bett.Ein/Aus-Status
   room: Schlafzimmer Eltern
+  writable: false
 2/3/130:
   dpt: '1.001'
   function: Schalten
   name: Schalten.OG.Badezimmer-Eltern.K1-L2.Schrank.Sperren
   room: Badezimmer Eltern
+  writable: true
 2/3/131:
   dpt: '1.001'
   function: Schalten
   name: Schalten.OG.Badezimmer-Eltern.K1-L2.Schrank.Ein/Aus
   room: Badezimmer Eltern
+  writable: true
 2/3/132:
   dpt: '1.011'
   function: Schalten
   name: Schalten.OG.Badezimmer-Eltern.K1-L2.Schrank.Ein/Aus-Status
   room: Badezimmer Eltern
+  writable: false
 2/3/140:
   dpt: '1.001'
   function: Schalten
   name: Schalten.OG.Badezimmer-Eltern.K1-L3.Schrank.Sperren
   room: Badezimmer Eltern
+  writable: true
 2/3/141:
   dpt: '1.001'
   function: Schalten
   name: Schalten.OG.Badezimmer-Eltern.K1-L3.Schrank.Ein/Aus
   room: Badezimmer Eltern
+  writable: true
 2/3/142:
   dpt: '1.011'
   function: Schalten
   name: Schalten.OG.Badezimmer-Eltern.K1-L3.Schrank.Ein/Aus-Status
   room: Badezimmer Eltern
+  writable: false
 2/3/150:
   dpt: '1.001'
   function: Schalten
   name: Schalten.OG.Badezimmer-Eltern.K2-L3.Heizkörper.Sperren
   room: Badezimmer Eltern
+  writable: true
 2/3/151:
   dpt: '1.001'
   function: Schalten
   name: Schalten.OG.Badezimmer-Eltern.K2-L3.Heizkörper.Ein/Aus
   room: Badezimmer Eltern
+  writable: true
 2/3/152:
   dpt: '1.011'
   function: Schalten
   name: Schalten.OG.Badezimmer-Eltern.K2-L3.Heizkörper.Ein/Aus-Status
   room: Badezimmer Eltern
+  writable: false
 2/3/2:
   dpt: '1.011'
   function: Schalten
   name: Schalten.OG.Abstellraum.K1-L1.Steckdose.Ein/Aus-Status
   room: Abstellraum
+  writable: false
 2/3/20:
   dpt: '1.001'
   function: Schalten
   name: Schalten.OG.Badezimmer-Kinder.K1-L2.Schrank.Sperren
   room: Badezimmer Kinder
+  writable: true
 2/3/21:
   dpt: '1.001'
   function: Schalten
   name: Schalten.OG.Badezimmer-Kinder.K1-L2.Schrank.Ein/Aus
   room: Badezimmer Kinder
+  writable: true
 2/3/22:
   dpt: '1.011'
   function: Schalten
   name: Schalten.OG.Badezimmer-Kinder.K1-L2.Schrank.Ein/Aus-Status
   room: Badezimmer Kinder
+  writable: false
 2/3/30:
   dpt: '1.001'
   function: Schalten
   name: Schalten.OG.Badezimmer-Kinder.K1-L3.Schrank.Sperren
   room: Badezimmer Kinder
+  writable: true
 2/3/31:
   dpt: '1.001'
   function: Schalten
   name: Schalten.OG.Badezimmer-Kinder.K1-L3.Schrank.Ein/Aus
   room: Badezimmer Kinder
+  writable: true
 2/3/32:
   dpt: '1.011'
   function: Schalten
   name: Schalten.OG.Badezimmer-Kinder.K1-L3.Schrank.Ein/Aus-Status
   room: Badezimmer Kinder
+  writable: false
 2/3/40:
   dpt: '1.001'
   function: Schalten
   name: Schalten.OG.Badezimmer-Kinder.K2-L3.Heizkörper.Sperren
   room: Badezimmer Kinder
+  writable: true
 2/3/41:
   dpt: '1.001'
   function: Schalten
   name: Schalten.OG.Badezimmer-Kinder.K2-L3.Heizkörper.Ein/Aus
   room: Badezimmer Kinder
+  writable: true
 2/3/42:
   dpt: '1.011'
   function: Schalten
   name: Schalten.OG.Badezimmer-Kinder.K2-L3.Heizkörper.Ein/Aus-Status
   room: Badezimmer Kinder
+  writable: false
 2/3/50:
   dpt: '1.001'
   function: Schalten
   name: Schalten.OG.Schlafzimmer-Gregory.K1-L1.Steckdose.Sperren
   room: Schlafzimmer Gregory
+  writable: true
 2/3/51:
   dpt: '1.001'
   function: Schalten
   name: Schalten.OG.Schlafzimmer-Gregory.K1-L1.Steckdose.Ein/Aus
   room: Schlafzimmer Gregory
+  writable: true
 2/3/52:
   dpt: '1.011'
   function: Schalten
   name: Schalten.OG.Schlafzimmer-Gregory.K1-L1.Steckdose.Ein/Aus-Status
   room: Schlafzimmer Gregory
+  writable: false
 2/3/60:
   dpt: '1.001'
   function: Schalten
   name: Schalten.OG.Schlafzimmer-Gregory.K2-L2.Steckdose.Sperren
   room: Schlafzimmer Gregory
+  writable: true
 2/3/61:
   dpt: '1.001'
   function: Schalten
   name: Schalten.OG.Schlafzimmer-Gregory.K2-L2.Steckdose.Ein/Aus
   room: Schlafzimmer Gregory
+  writable: true
 2/3/62:
   dpt: '1.011'
   function: Schalten
   name: Schalten.OG.Schlafzimmer-Gregory.K2-L2.Steckdose.Ein/Aus-Status
   room: Schlafzimmer Gregory
+  writable: false
 2/3/70:
   dpt: '1.001'
   function: Schalten
   name: Schalten.OG.Schlafzimmer-Luis.K1-L1.Steckdose.Sperren
   room: Schlafzimmer Luis
+  writable: true
 2/3/71:
   dpt: '1.001'
   function: Schalten
   name: Schalten.OG.Schlafzimmer-Luis.K1-L1.Steckdose.Ein/Aus
   room: Schlafzimmer Luis
+  writable: true
 2/3/72:
   dpt: '1.011'
   function: Schalten
   name: Schalten.OG.Schlafzimmer-Luis.K1-L1.Steckdose.Ein/Aus-Status
   room: Schlafzimmer Luis
+  writable: false
 2/3/80:
   dpt: '1.001'
   function: Schalten
   name: Schalten.OG.Schlafzimmer-Luis.K2-L1.Steckdose.Sperren
   room: Schlafzimmer Luis
+  writable: true
 2/3/81:
   dpt: '1.001'
   function: Schalten
   name: Schalten.OG.Schlafzimmer-Luis.K2-L1.Steckdose.Ein/Aus
   room: Schlafzimmer Luis
+  writable: true
 2/3/82:
   dpt: '1.011'
   function: Schalten
   name: Schalten.OG.Schlafzimmer-Luis.K2-L1.Steckdose.Ein/Aus-Status
   room: Schlafzimmer Luis
+  writable: false
 2/3/90:
   dpt: '1.001'
   function: Schalten
   name: Schalten.OG.Schlafzimmer-Eltern.K1-L1.Steckdose.Sperren
   room: Schlafzimmer Eltern
+  writable: true
 2/3/91:
   dpt: '1.001'
   function: Schalten
   name: Schalten.OG.Schlafzimmer-Eltern.K1-L1.Steckdose.Ein/Aus
   room: Schlafzimmer Eltern
+  writable: true
 2/3/92:
   dpt: '1.011'
   function: Schalten
   name: Schalten.OG.Schlafzimmer-Eltern.K1-L1.Steckdose.Ein/Aus-Status
   room: Schlafzimmer Eltern
+  writable: false
 2/4/0:
   dpt: '1.001'
   function: Schalten
   name: Schalten.DG.Speicher.K1-L1.Steckdose.Sperren
   room: Speicher (S)
+  writable: true
 2/4/1:
   dpt: '1.001'
   function: Schalten
   name: Schalten.DG.Speicher.K1-L1.Steckdose.Ein/Aus
   room: Speicher (S)
+  writable: true
 2/4/10:
   dpt: '1.001'
   function: Schalten
   name: Schalten.DG.Speicher.K1-L2.Steckdose.Sperren
   room: Speicher (S)
+  writable: true
 2/4/11:
   dpt: '1.001'
   function: Schalten
   name: Schalten.DG.Speicher.K1-L2.Steckdose.Ein/Aus
   room: Speicher (S)
+  writable: true
 2/4/12:
   dpt: '1.011'
   function: Schalten
   name: Schalten.DG.Speicher.K1-L2.Steckdose.Ein/Aus-Status
   room: Speicher (S)
+  writable: false
 2/4/2:
   dpt: '1.011'
   function: Schalten
   name: Schalten.DG.Speicher.K1-L1.Steckdose.Ein/Aus-Status
   room: Speicher (S)
+  writable: false
 2/5/0:
   dpt: '1.001'
   function: Schalten
   name: Schalten.A.Fassade.K1-L1.Steckdose.Sperren
   room: Fassade
+  writable: true
 2/5/1:
   dpt: '1.001'
   function: Schalten
   name: Schalten.A.Fassade.K1-L1.Steckdose.Ein/Aus
   room: Fassade
+  writable: true
 2/5/10:
   dpt: '1.001'
   function: Schalten
   name: Schalten.A.Terrasse.K1-L1.Steckdose.Sperren
   room: Terrasse
+  writable: true
 2/5/11:
   dpt: '1.001'
   function: Schalten
   name: Schalten.A.Terrasse.K1-L1.Steckdose.Ein/Aus
   room: Terrasse
+  writable: true
 2/5/12:
   dpt: '1.011'
   function: Schalten
   name: Schalten.A.Terrasse.K1-L1.Steckdose.Ein/Aus-Status
   room: Terrasse
+  writable: false
 2/5/2:
   dpt: '1.011'
   function: Schalten
   name: Schalten.A.Fassade.K1-L1.Steckdose.Ein/Aus-Status
   room: Fassade
+  writable: false
 2/5/20:
   dpt: '1.001'
   function: Schalten
   name: Schalten.A.Terrasse.K1-L2.Steckdose.Sperren
   room: Terrasse
+  writable: true
 2/5/21:
   dpt: '1.001'
   function: Schalten
   name: Schalten.A.Terrasse.K1-L2.Steckdose.Ein/Aus
   room: Terrasse
+  writable: true
 2/5/22:
   dpt: '1.011'
   function: Schalten
   name: Schalten.A.Terrasse.K1-L2.Steckdose.Ein/Aus-Status
   room: Terrasse
+  writable: false
 2/5/30:
   dpt: '1.001'
   function: Schalten
   name: Schalten.A.Balkon.K1-L1.Steckdose.Sperren
   room: Balkon
+  writable: true
 2/5/31:
   dpt: '1.001'
   function: Schalten
   name: Schalten.A.Balkon.K1-L1.Steckdose.Ein/Aus
   room: Balkon
+  writable: true
 2/5/32:
   dpt: '1.011'
   function: Schalten
   name: Schalten.A.Balkon.K1-L1.Steckdose.Ein/Aus-Status
   room: Balkon
+  writable: false
 2/5/40:
   dpt: '1.001'
   function: Schalten
   name: Schalten.A.Balkon.K1-L2.Steckdose.Sperren
   room: Balkon
+  writable: true
 2/5/41:
   dpt: '1.001'
   function: Schalten
   name: Schalten.A.Balkon.K1-L2.Steckdose.Ein/Aus
   room: Balkon
+  writable: true
 2/5/42:
   dpt: '1.011'
   function: Schalten
   name: Schalten.A.Balkon.K1-L2.Steckdose.Ein/Aus-Status
   room: Balkon
+  writable: false
 2/6/0:
   dpt: '1.001'
   function: Schalten
   name: Schalten.G.Garten.K1-L1.Steckdose.Sperren
   room: Garten
+  writable: true
 2/6/1:
   dpt: '1.001'
   function: Schalten
   name: Schalten.G.Garten.K1-L1.Steckdose.Ein/Aus
   room: Garten
+  writable: true
 2/6/10:
   dpt: '1.001'
   function: Schalten
   name: Schalten.G.Garten.K1-L2.Steckdose.Sperren
   room: Garten
+  writable: true
 2/6/100:
   dpt: '1.001'
   function: Schalten
   name: Schalten.G.Garten.K3-L5.Steckdose.Sperren
   room: Garten
+  writable: true
 2/6/101:
   dpt: '1.001'
   function: Schalten
   name: Schalten.G.Garten.K3-L5.Steckdose.Ein/Aus
   room: Garten
+  writable: true
 2/6/102:
   dpt: '1.011'
   function: Schalten
   name: Schalten.G.Garten.K3-L5.Steckdose.Ein/Aus-Status
   room: Garten
+  writable: false
 2/6/11:
   dpt: '1.001'
   function: Schalten
   name: Schalten.G.Garten.K1-L2.Steckdose.Ein/Aus
   room: Garten
+  writable: true
 2/6/12:
   dpt: '1.011'
   function: Schalten
   name: Schalten.G.Garten.K1-L2.Steckdose.Ein/Aus-Status
   room: Garten
+  writable: false
 2/6/2:
   dpt: '1.011'
   function: Schalten
   name: Schalten.G.Garten.K1-L1.Steckdose.Ein/Aus-Status
   room: Garten
+  writable: false
 2/6/20:
   dpt: '1.001'
   function: Schalten
   name: Schalten.G.Garten.K1-L3.Steckdose.Sperren
   room: Garten
+  writable: true
 2/6/21:
   dpt: '1.001'
   function: Schalten
   name: Schalten.G.Garten.K1-L3.Steckdose.Ein/Aus
   room: Garten
+  writable: true
 2/6/22:
   dpt: '1.011'
   function: Schalten
   name: Schalten.G.Garten.K1-L3.Steckdose.Ein/Aus-Status
   room: Garten
+  writable: false
 2/6/30:
   dpt: '1.001'
   function: Schalten
   name: Schalten.G.Garten.K2-L1.Steckdose.Sperren
   room: Garten
+  writable: true
 2/6/31:
   dpt: '1.001'
   function: Schalten
   name: Schalten.G.Garten.K2-L1.Steckdose.Ein/Aus
   room: Garten
+  writable: true
 2/6/32:
   dpt: '1.011'
   function: Schalten
   name: Schalten.G.Garten.K2-L1.Steckdose.Ein/Aus-Status
   room: Garten
+  writable: false
 2/6/40:
   dpt: '1.001'
   function: Schalten
   name: Schalten.G.Garten.K2-L2.Steckdose.Sperren
   room: Garten
+  writable: true
 2/6/41:
   dpt: '1.001'
   function: Schalten
   name: Schalten.G.Garten.K2-L2.Steckdose.Ein/Aus
   room: Garten
+  writable: true
 2/6/42:
   dpt: '1.011'
   function: Schalten
   name: Schalten.G.Garten.K2-L2.Steckdose.Ein/Aus-Status
   room: Garten
+  writable: false
 2/6/50:
   dpt: '1.001'
   function: Schalten
   name: Schalten.G.Garten.K2-L3.Steckdose.Sperren
   room: Garten
+  writable: true
 2/6/51:
   dpt: '1.001'
   function: Schalten
   name: Schalten.G.Garten.K2-L3.Steckdose.Ein/Aus
   room: Garten
+  writable: true
 2/6/52:
   dpt: '1.011'
   function: Schalten
   name: Schalten.G.Garten.K2-L3.Steckdose.Ein/Aus-Status
   room: Garten
+  writable: false
 2/6/60:
   dpt: '1.001'
   function: Schalten
   name: Schalten.G.Garten.K3-L1.Steckdose.Sperren
   room: Garten
+  writable: true
 2/6/61:
   dpt: '1.001'
   function: Schalten
   name: Schalten.G.Garten.K3-L1.Steckdose.Ein/Aus
   room: Garten
+  writable: true
 2/6/62:
   dpt: '1.011'
   function: Schalten
   name: Schalten.G.Garten.K3-L1.Steckdose.Ein/Aus-Status
   room: Garten
+  writable: false
 2/6/70:
   dpt: '1.001'
   function: Schalten
   name: Schalten.G.Garten.K3-L2.Steckdose.Sperren
   room: Garten
+  writable: true
 2/6/71:
   dpt: '1.001'
   function: Schalten
   name: Schalten.G.Garten.K3-L2.Steckdose.Ein/Aus
   room: Garten
+  writable: true
 2/6/72:
   dpt: '1.011'
   function: Schalten
   name: Schalten.G.Garten.K3-L2.Steckdose.Ein/Aus-Status
   room: Garten
+  writable: false
 2/6/80:
   dpt: '1.001'
   function: Schalten
   name: Schalten.G.Garten.K3-L3.Steckdose.Sperren
   room: Garten
+  writable: true
 2/6/81:
   dpt: '1.001'
   function: Schalten
   name: Schalten.G.Garten.K3-L3.Steckdose.Ein/Aus
   room: Garten
+  writable: true
 2/6/82:
   dpt: '1.011'
   function: Schalten
   name: Schalten.G.Garten.K3-L3.Steckdose.Ein/Aus-Status
   room: Garten
+  writable: false
 2/6/90:
   dpt: '1.001'
   function: Schalten
   name: Schalten.G.Garten.K3-L4.Steckdose.Sperren
   room: Garten
+  writable: true
 2/6/91:
   dpt: '1.001'
   function: Schalten
   name: Schalten.G.Garten.K3-L4.Steckdose.Ein/Aus
   room: Garten
+  writable: true
 2/6/92:
   dpt: '1.011'
   function: Schalten
   name: Schalten.G.Garten.K3-L4.Steckdose.Ein/Aus-Status
   room: Garten
+  writable: false
 3/0/0:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.KG.Flur.Ein/Aus
   room: Flur
+  writable: true
 3/0/1:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.KG.Flur.Ein/Aus-Status
   room: Flur
+  writable: false
 3/0/10:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.EG.Flur.Ein/Aus
   room: Flur
+  writable: true
 3/0/100:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.KG.Ein/Aus
   room: Kellergeschoss
+  writable: true
 3/0/101:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.KG.Ein/Aus-Status
   room: Kellergeschoss
+  writable: true
 3/0/11:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.EG.Flur.Ein/Aus-Status
   room: Flur
+  writable: false
 3/0/110:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.EG.Ein/Aus
   room: Erdgeschoss
+  writable: true
 3/0/111:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.EG.Ein/Aus-Status
   room: Erdgeschoss
+  writable: true
 3/0/12:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.EG.Gäste-WC.Ein/Aus
   room: Gäste WC
+  writable: true
 3/0/120:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.OG.Ein/Aus
   room: Obergeschoss
+  writable: true
 3/0/121:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.OG.Ein/Aus-Status
   room: Obergeschoss
+  writable: true
 3/0/13:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.EG.Gäste-WC.Ein/Aus-Status
   room: Gäste WC
+  writable: false
 3/0/130:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.DG.Ein/Aus
   room: Dachgeschoss
+  writable: true
 3/0/131:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.DG.Ein/Aus-Status
   room: Dachgeschoss
+  writable: true
 3/0/14:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.EG.Büro.Ein/Aus
   room: Büro
+  writable: true
 3/0/140:
   dpt: '1.001'
   name: Beleuchtung.Zentral.A.Ein/Aus
+  writable: true
 3/0/141:
   dpt: '1.001'
   name: Beleuchtung.Zentral.A.Ein/Aus-Status
+  writable: false
 3/0/15:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.EG.Büro.Ein/Aus-Status
   room: Büro
+  writable: true
 3/0/16:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.EG.Wohnzimmer.Ein/Aus
   room: Wohnzimmer
+  writable: true
 3/0/17:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.EG.Wohnzimmer.Ein/Aus-Status
   room: Wohnzimmer
+  writable: true
 3/0/18:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.EG.Esszimmer.Ein/Aus
   room: Esszimmer
+  writable: true
 3/0/19:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.EG.Esszimmer.Ein/Aus-Status
   room: Esszimmer
+  writable: false
 3/0/2:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.KG.Garage.Ein/Aus
   room: Garage
+  writable: true
 3/0/20:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.EG.Küche.Ein/Aus
   room: Küche
+  writable: true
 3/0/200:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.Gebäude.Ein/Aus
   room: 1 - Gebäude
+  writable: true
 3/0/201:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.Gebäude.Ein/Aus-Status
   room: 1 - Gebäude
+  writable: false
 3/0/21:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.EG.Küche.Ein/Aus-Status
   room: Küche
+  writable: false
 3/0/22:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.OG.Flur.Ein/Aus
   room: Flur
+  writable: true
 3/0/220:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.Garten.Ein/Aus
   room: 2 - Garten
+  writable: true
 3/0/221:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.Garten.Ein/Aus-Status
   room: 2 - Garten
+  writable: true
 3/0/23:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.OG.Flur.Ein/Aus-Status
   room: Flur
+  writable: false
 3/0/24:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.OG.Abstellraum.Ein/Aus
   room: Abstellraum
+  writable: true
 3/0/240:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.Anwesen.Ein/Aus
   room: Anwesen Steinroth 20
+  writable: true
 3/0/241:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.Anwesen.Ein/Aus-Status
   room: Anwesen Steinroth 20
+  writable: false
 3/0/25:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.OG.Abstellraum.Ein/Aus-Status
   room: Abstellraum
+  writable: true
 3/0/26:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.OG.Badezimmer-Kinder.Ein/Aus
   room: Badezimmer Kinder
+  writable: true
 3/0/27:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.OG.Badezimmer-Kinder.Ein/Aus-Status
   room: Badezimmer Kinder
+  writable: true
 3/0/28:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.OG.Schlafzimmer-Gregory.Ein/Aus
   room: Schlafzimmer Gregory
+  writable: true
 3/0/29:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.OG.Schlafzimmer-Gregory.Ein/Aus-Status
   room: Schlafzimmer Gregory
+  writable: true
 3/0/3:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.KG.Garage.Ein/Aus-Status
   room: Garage
+  writable: false
 3/0/30:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.OG.Schlafzimmer-Luis.Ein/Aus
   room: Schlafzimmer Luis
+  writable: true
 3/0/31:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.OG.Schlafzimmer-Luis.Ein/Aus-Status
   room: Schlafzimmer Luis
+  writable: true
 3/0/32:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.OG.Schlafzimmer-Eltern.Ein/Aus
   room: Schlafzimmer Eltern
+  writable: true
 3/0/33:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.OG.Schlafzimmer-Eltern.Ein/Aus-Status
   room: Schlafzimmer Eltern
+  writable: true
 3/0/34:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.OG.Begehbarer-Schrank.Ein/Aus
   room: Begehbarer Schrank
+  writable: true
 3/0/35:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.OG.Begehbarer-Schrank.Ein/Aus-Status
   room: Begehbarer Schrank
+  writable: false
 3/0/36:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.OG.Badezimmer-Eltern.Ein/Aus
   room: Badezimmer Eltern
+  writable: true
 3/0/37:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.OG.Badezimmer-Eltern.Ein/Aus-Status
   room: Badezimmer Eltern
+  writable: true
 3/0/38:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.DG.Speicher.Ein/Aus
   room: Speicher (S)
+  writable: true
 3/0/39:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.DG.Speicher.Ein/Aus-Status
   room: Speicher (S)
+  writable: false
 3/0/4:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.KG.Technikraum.Ein/Aus
   room: Technikraum
+  writable: true
 3/0/40:
   description: 1 - Fassade (A1) Beleuchtung
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.A.Fassade.Ein/Aus
   room: Außenbereich
+  writable: true
 3/0/41:
   description: 1 - Fassade (A1) Beleuchtung
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.A.Fassade.Ein/Aus-Status
   room: Außenbereich
+  writable: false
 3/0/42:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.A.Terrasse.Ein/Aus
   room: Terrasse
+  writable: true
 3/0/43:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.A.Terrasse.Ein/Aus-Status
   room: Terrasse
+  writable: false
 3/0/44:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.A.Balkon.Ein/Aus
   room: Balkon
+  writable: true
 3/0/45:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.A.Balkon.Ein/Aus-Status
   room: Balkon
+  writable: false
 3/0/46:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.A.Dach.Ein/Aus
   room: Dach
+  writable: false
 3/0/47:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.A.Dach.Ein/Aus-Status
   room: Dach
+  writable: false
 3/0/5:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.KG.Technikraum.Ein/Aus-Status
   room: Technikraum
+  writable: false
 3/0/50:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.G.Eingang.Ein/Aus
   room: Eingang
+  writable: true
 3/0/51:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.G.Eingang.Ein/Aus-Status
   room: Eingang
+  writable: false
 3/0/52:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.G.Garten.Ein/Aus
   room: Garten
+  writable: true
 3/0/53:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.G.Garten.Ein/Aus-Status
   room: Garten
+  writable: false
 3/0/6:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.KG.Vorratsraum.Ein/Aus
   room: Vorratsraum
+  writable: true
 3/0/7:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.KG.Vorratsraum.Ein/Aus-Status
   room: Vorratsraum
+  writable: false
 3/0/8:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.Zentral.KG.Hauswirtschaftsraum.Ein/Aus
   room: Hauswirtschaftsraum
+  writable: true
 3/0/9:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.Zentral.KG.Hauswirtschaftsraum.Ein/Aus-Status
   room: Hauswirtschaftsraum
+  writable: false
 3/1/0:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.KG.Flur.Track.Sperren
   room: Flur
+  writable: true
 3/1/1:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.KG.Flur.Track.Ein/Aus
   room: Flur
+  writable: true
 3/1/10:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.KG.Flur.Indirekt.Sperren
   room: Flur
+  writable: true
 3/1/11:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.KG.Flur.Indirekt.Ein/Aus
   room: Flur
+  writable: true
 3/1/12:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.KG.Flur.Indirekt.Ein/Aus-Status
   room: Flur
+  writable: false
 3/1/13:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.KG.Flur.Indirekt.Dimmen-Relativ
   room: Flur
+  writable: true
 3/1/14:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.KG.Flur.Indirekt.Dimmen-Absolut
   room: Flur
+  writable: true
 3/1/15:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.KG.Flur.Indirekt.Dimmen-Status
   room: Flur
+  writable: false
 3/1/2:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.KG.Flur.Track.Ein/Aus-Status
   room: Flur
+  writable: false
 3/1/20:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.KG.Flur.Bodenleuchte.Sperren
   room: Flur
+  writable: true
 3/1/21:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.KG.Flur.Bodenleuchte.Ein/Aus
   room: Flur
+  writable: true
 3/1/22:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.KG.Flur.Bodenleuchte.Ein/Aus-Status
   room: Flur
+  writable: false
 3/1/23:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.KG.Flur.Bodenleuchte.Dimmen-Relativ
   room: Flur
+  writable: true
 3/1/24:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.KG.Flur.Bodenleuchte.Dimmen-Absolut
   room: Flur
+  writable: true
 3/1/25:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.KG.Flur.Bodenleuchte.Dimmen-Status
   room: Flur
+  writable: false
 3/1/3:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.KG.Flur.Track.Dimmen-Relativ
   room: Flur
+  writable: true
 3/1/30:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.KG.Garage.Deckenleuchte.Links.Sperren
   room: Garage
+  writable: true
 3/1/31:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.KG.Garage.Deckenleuchte.Links.Ein/Aus
   room: Garage
+  writable: true
 3/1/32:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.KG.Garage.Deckenleuchte.Links.Ein/Aus-Status
   room: Garage
+  writable: false
 3/1/33:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.KG.Garage.Deckenleuchte.Links.Dimmen-Relativ
   room: Garage
+  writable: true
 3/1/34:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.KG.Garage.Deckenleuchte.Links.Dimmen-Absolut
   room: Garage
+  writable: true
 3/1/35:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.KG.Garage.Deckenleuchte.Links.Dimmen-Status
   room: Garage
+  writable: false
 3/1/4:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.KG.Flur.Track.Dimmen-Absolut
   room: Flur
+  writable: true
 3/1/40:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.KG.Garage.Deckenleuchte.Rechts.Sperren
   room: Garage
+  writable: true
 3/1/41:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.KG.Garage.Deckenleuchte.Rechts.Ein/Aus
   room: Garage
+  writable: true
 3/1/42:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.KG.Garage.Deckenleuchte.Rechts.Ein/Aus-Status
   room: Garage
+  writable: false
 3/1/43:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.KG.Garage.Deckenleuchte.Rechts.Dimmen-Relativ
   room: Garage
+  writable: true
 3/1/44:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.KG.Garage.Deckenleuchte.Rechts.Dimmen-Absolut
   room: Garage
+  writable: true
 3/1/45:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.KG.Garage.Deckenleuchte.Rechts.Dimmen-Status
   room: Garage
+  writable: false
 3/1/5:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.KG.Flur.Track.Dimmen-Status
   room: Flur
+  writable: false
 3/1/50:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.KG.Technikraum.Deckenleuchte.Sperren
   room: Technikraum
+  writable: true
 3/1/51:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.KG.Technikraum.Deckenleuchte.Ein/Aus
   room: Technikraum
+  writable: true
 3/1/52:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.KG.Technikraum.Deckenleuchte.Ein/Aus-Status
   room: Technikraum
+  writable: false
 3/1/53:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.KG.Technikraum.Deckenleuchte.Dimmen-Relativ
   room: Technikraum
+  writable: true
 3/1/54:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.KG.Technikraum.Deckenleuchte.Dimmen-Absolut
   room: Technikraum
+  writable: true
 3/1/55:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.KG.Technikraum.Deckenleuchte.Dimmen-Status
   room: Technikraum
+  writable: false
 3/1/60:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.KG.Vorratsraum.Deckenleuchte.Sperren
   room: Vorratsraum
+  writable: true
 3/1/61:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.KG.Vorratsraum.Deckenleuchte.Ein/Aus
   room: Vorratsraum
+  writable: true
 3/1/62:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.KG.Vorratsraum.Deckenleuchte.Ein/Aus-Status
   room: Vorratsraum
+  writable: false
 3/1/63:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.KG.Vorratsraum.Deckenleuchte.Dimmen-Relativ
   room: Vorratsraum
+  writable: true
 3/1/64:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.KG.Vorratsraum.Deckenleuchte.Dimmen-Absolut
   room: Vorratsraum
+  writable: true
 3/1/65:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.KG.Vorratsraum.Deckenleuchte.Dimmen-Status
   room: Vorratsraum
+  writable: false
 3/1/70:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.KG.Hauswirtschaftsraum.Deckenleuchte.Sperren
   room: Hauswirtschaftsraum
+  writable: true
 3/1/71:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.KG.Hauswirtschaftsraum.Deckenleuchte.Ein/Aus
   room: Hauswirtschaftsraum
+  writable: true
 3/1/72:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.KG.Hauswirtschaftsraum.Deckenleuchte.Ein/Aus-Status
   room: Hauswirtschaftsraum
+  writable: false
 3/1/73:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.KG.Hauswirtschaftsraum.Deckenleuchte.Dimmen-Relativ
   room: Hauswirtschaftsraum
+  writable: true
 3/1/74:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.KG.Hauswirtschaftsraum.Deckenleuchte.Dimmen-Absolut
   room: Hauswirtschaftsraum
+  writable: true
 3/1/75:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.KG.Hauswirtschaftsraum.Deckenleuchte.Dimmen-Status
   room: Hauswirtschaftsraum
+  writable: false
 3/2/0:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.EG.Flur.Downlight.Diele.Sperren
   room: Flur
+  writable: true
 3/2/1:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Flur.Downlight.Diele.Ein/Aus
   room: Flur
+  writable: true
 3/2/10:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.EG.Flur.Downlight.Garderobe.Sperren
   room: Flur
+  writable: true
 3/2/100:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Stripe.Links.Sperren
   room: Wohnzimmer
+  writable: true
 3/2/101:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Stripe.Links.Ein/Aus
   room: Wohnzimmer
+  writable: true
 3/2/102:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Stripe.Links.Ein/Aus-Status
   room: Wohnzimmer
+  writable: true
 3/2/103:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Stripe.Links.Dimmen-Relativ
   room: Wohnzimmer
+  writable: true
 3/2/104:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Stripe.Links.Dimmen-Absolut
   room: Wohnzimmer
+  writable: true
 3/2/105:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Stripe.Links.Dimmen-Status
   room: Wohnzimmer
+  writable: false
 3/2/11:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Flur.Downlight.Garderobe.Ein/Aus
   room: Flur
+  writable: true
 3/2/110:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Spots.Rechts.Sperren
   room: Wohnzimmer
+  writable: true
 3/2/111:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Spots.Rechts.Ein/Aus
   room: Wohnzimmer
+  writable: true
 3/2/112:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Spots.Rechts.Ein/Aus-Status
   room: Wohnzimmer
+  writable: true
 3/2/113:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Spots.Rechts.Dimmen-Relativ
   room: Wohnzimmer
+  writable: true
 3/2/114:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Spots.Rechts.Dimmen-Absolut
   room: Wohnzimmer
+  writable: true
 3/2/115:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Spots.Rechts.Dimmen-Status
   room: Wohnzimmer
+  writable: false
 3/2/12:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.EG.Flur.Downlight.Garderobe.Ein/Aus-Status
   room: Flur
+  writable: false
 3/2/120:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Stripe.Rechts.Sperren
   room: Wohnzimmer
+  writable: true
 3/2/121:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Stripe.Rechts.Ein/Aus
   room: Wohnzimmer
+  writable: true
 3/2/122:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Stripe.Rechts.Ein/Aus-Status
   room: Wohnzimmer
+  writable: true
 3/2/123:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Stripe.Rechts.Dimmen-Relativ
   room: Wohnzimmer
+  writable: true
 3/2/124:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Stripe.Rechts.Dimmen-Absolut
   room: Wohnzimmer
+  writable: true
 3/2/125:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Stripe.Rechts.Dimmen-Status
   room: Wohnzimmer
+  writable: false
 3/2/13:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.EG.Flur.Downlight.Garderobe.Dimmen-Relativ
   room: Flur
+  writable: true
 3/2/130:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Indirekt.Links.Sperren
   room: Wohnzimmer
+  writable: true
 3/2/131:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Indirekt.Links.Ein/Aus
   room: Wohnzimmer
+  writable: true
 3/2/132:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Indirekt.Links.Ein/Aus-Status
   room: Wohnzimmer
+  writable: false
 3/2/133:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Indirekt.Links.Dimmen-Relativ
   room: Wohnzimmer
+  writable: true
 3/2/134:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Indirekt.Links.Dimmen-Absolut
   room: Wohnzimmer
+  writable: true
 3/2/135:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Indirekt.Links.Dimmen-Status
   room: Wohnzimmer
+  writable: false
 3/2/14:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Flur.Downlight.Garderobe.Dimmen-Absolut
   room: Flur
+  writable: true
 3/2/140:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Indirekt.Rechts.Sperren
   room: Wohnzimmer
+  writable: true
 3/2/141:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Indirekt.Rechts.Ein/Aus
   room: Wohnzimmer
+  writable: true
 3/2/142:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Indirekt.Rechts.Ein/Aus-Status
   room: Wohnzimmer
+  writable: false
 3/2/143:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Indirekt.Rechts.Dimmen-Relativ
   room: Wohnzimmer
+  writable: true
 3/2/144:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Indirekt.Rechts.Dimmen-Absolut
   room: Wohnzimmer
+  writable: true
 3/2/145:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Indirekt.Rechts.Dimmen-Status
   room: Wohnzimmer
+  writable: false
 3/2/15:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Flur.Downlight.Garderobe.Dimmen-Status
   room: Flur
+  writable: false
 3/2/150:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.EG.Esszimmer.Pendelleuchte.Sperren
   room: Esszimmer
+  writable: true
 3/2/151:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Esszimmer.Pendelleuchte.Ein/Aus
   room: Esszimmer
+  writable: true
 3/2/152:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.EG.Esszimmer.Pendelleuchte.Ein/Aus-Status
   room: Esszimmer
+  writable: false
 3/2/153:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.EG.Esszimmer.Pendelleuchte.Dimmen-Relativ
   room: Esszimmer
+  writable: true
 3/2/154:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Esszimmer.Pendelleuchte.Dimmen-Absolut
   room: Esszimmer
+  writable: true
 3/2/155:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Esszimmer.Pendelleuchte.Dimmen-Status
   room: Esszimmer
+  writable: false
 3/2/160:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.EG.Esszimmer.Indirekt.Sperren
   room: Esszimmer
+  writable: true
 3/2/161:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Esszimmer.Indirekt.Ein/Aus
   room: Esszimmer
+  writable: true
 3/2/162:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.EG.Esszimmer.Indirekt.Ein/Aus-Status
   room: Esszimmer
+  writable: false
 3/2/163:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.EG.Esszimmer.Indirekt.Dimmen-Relativ
   room: Esszimmer
+  writable: true
 3/2/164:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Esszimmer.Indirekt.Dimmen-Absolut
   room: Esszimmer
+  writable: true
 3/2/165:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Esszimmer.Indirekt.Dimmen-Status
   room: Esszimmer
+  writable: false
 3/2/170:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Track.Sperren
   room: Küche
+  writable: true
 3/2/171:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Track.Ein/Aus
   room: Küche
+  writable: true
 3/2/172:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Track.Ein/Aus-Status
   room: Küche
+  writable: false
 3/2/173:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Track.Dimmen-Relativ
   room: Küche
+  writable: true
 3/2/174:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Track.Dimmen-Absolut
   room: Küche
+  writable: true
 3/2/175:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Track.Dimmen-Status
   room: Küche
+  writable: false
 3/2/180:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Pendelleuchte.Groß.Sperren
   room: Küche
+  writable: true
 3/2/181:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Pendelleuchte.Groß.Ein/Aus
   room: Küche
+  writable: true
 3/2/182:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Pendelleuchte.Groß.Ein/Aus-Status
   room: Küche
+  writable: false
 3/2/183:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Pendelleuchte.Groß.Dimmen-Relativ
   room: Küche
+  writable: true
 3/2/184:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Pendelleuchte.Groß.Dimmen-Absolut
   room: Küche
+  writable: true
 3/2/185:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Pendelleuchte.Groß.Dimmen-Status
   room: Küche
+  writable: false
 3/2/190:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Pendelleuchte.Klein.Sperren
   room: Küche
+  writable: true
 3/2/191:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Pendelleuchte.Klein.Ein/Aus
   room: Küche
+  writable: true
 3/2/192:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Pendelleuchte.Klein.Ein/Aus-Status
   room: Küche
+  writable: false
 3/2/193:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Pendelleuchte.Klein.Dimmen-Relativ
   room: Küche
+  writable: true
 3/2/194:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Pendelleuchte.Klein.Dimmen-Absolut
   room: Küche
+  writable: true
 3/2/195:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Pendelleuchte.Klein.Dimmen-Status
   room: Küche
+  writable: false
 3/2/2:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.EG.Flur.Downlight.Diele.Ein/Aus-Status
   room: Flur
+  writable: false
 3/2/20:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.EG.Flur.Bodenleuchte.Sperren
   room: Flur
+  writable: true
 3/2/200:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Indirekt.Sperren
   room: Küche
+  writable: true
 3/2/201:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Indirekt.Ein/Aus
   room: Küche
+  writable: true
 3/2/202:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Indirekt.Ein/Aus-Status
   room: Küche
+  writable: false
 3/2/203:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Indirekt.Dimmen-Relativ
   room: Küche
+  writable: true
 3/2/204:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Indirekt.Dimmen-Absolut
   room: Küche
+  writable: true
 3/2/205:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Indirekt.Dimmen-Status
   room: Küche
+  writable: false
 3/2/21:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Flur.Bodenleuchte.Ein/Aus
   room: Flur
+  writable: true
 3/2/210:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Kücheninsel.Sperren
   room: Küche
+  writable: true
 3/2/211:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Kücheninsel.Ein/Aus
   room: Küche
+  writable: true
 3/2/212:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Kücheninsel.Ein/Aus-Status
   room: Küche
+  writable: false
 3/2/213:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Kücheninsel.Dimmen-Relativ
   room: Küche
+  writable: true
 3/2/214:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Kücheninsel.Dimmen-Absolut
   room: Küche
+  writable: true
 3/2/215:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Kücheninsel.Dimmen-Status
   room: Küche
+  writable: false
 3/2/216:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Kücheninsel.Farbwert
   room: Küche
+  writable: true
 3/2/217:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Kücheninsel.Farbwert-Status
   room: Küche
+  writable: false
 3/2/218:
   dpt: '7.600'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Kücheninsel.Farbtemparatur
   room: Küche
+  writable: true
 3/2/219:
   dpt: '7.600'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Kücheninsel.Farbtemparatur-Status
   room: Küche
+  writable: false
 3/2/22:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.EG.Flur.Bodenleuchte.Ein/Aus-Status
   room: Flur
+  writable: false
 3/2/220:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Küchenzeile.Sperren
   room: Küche
+  writable: true
 3/2/221:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Küchenzeile.Ein/Aus
   room: Küche
+  writable: true
 3/2/222:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Küchenzeile.Ein/Aus-Status
   room: Küche
+  writable: false
 3/2/223:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Küchenzeile.Dimmen-Relativ
   room: Küche
+  writable: true
 3/2/224:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Küchenzeile.Dimmen-Absolut
   room: Küche
+  writable: true
 3/2/225:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Küchenzeile.Dimmen-Status
   room: Küche
+  writable: false
 3/2/226:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Küchenzeile.Farbwert
   room: Küche
+  writable: true
 3/2/227:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Küchenzeile.Farbwert-Status
   room: Küche
+  writable: false
 3/2/228:
   dpt: '7.600'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Küchenzeile.Farbtemparatur
   room: Küche
+  writable: true
 3/2/229:
   dpt: '7.600'
   function: Beleuchtung
   name: Beleuchtung.EG.Küche.Küchenzeile.Farbtemparatur-Status
   room: Küche
+  writable: false
 3/2/23:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.EG.Flur.Bodenleuchte.Dimmen-Relativ
   room: Flur
+  writable: true
 3/2/24:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Flur.Bodenleuchte.Dimmen-Absolut
   room: Flur
+  writable: true
 3/2/25:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Flur.Bodenleuchte.Dimmen-Status
   room: Flur
+  writable: false
 3/2/3:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.EG.Flur.Downlight.Diele.Dimmen-Relativ
   room: Flur
+  writable: true
 3/2/30:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.EG.Flur.Indirekt.Sperren
   room: Flur
+  writable: true
 3/2/31:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Flur.Indirekt.Ein/Aus
   room: Flur
+  writable: true
 3/2/32:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.EG.Flur.Indirekt.Ein/Aus-Status
   room: Flur
+  writable: false
 3/2/33:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.EG.Flur.Indirekt.Dimmen-Relativ
   room: Flur
+  writable: true
 3/2/34:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Flur.Indirekt.Dimmen-Absolut
   room: Flur
+  writable: true
 3/2/35:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Flur.Indirekt.Dimmen-Status
   room: Flur
+  writable: false
 3/2/4:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Flur.Downlight.Diele.Dimmen-Absolut
   room: Flur
+  writable: true
 3/2/40:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.EG.Gäste-WC.Pendelleuchte.Sperren
   room: Gäste WC
+  writable: true
 3/2/41:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Gäste-WC.Pendelleuchte.Ein/Aus
   room: Gäste WC
+  writable: true
 3/2/42:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.EG.Gäste-WC.Pendelleuchte.Ein/Aus-Status
   room: Gäste WC
+  writable: false
 3/2/43:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.EG.Gäste-WC.Pendelleuchte.Dimmen-Relativ
   room: Gäste WC
+  writable: true
 3/2/44:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Gäste-WC.Pendelleuchte.Dimmen-Absolut
   room: Gäste WC
+  writable: true
 3/2/45:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Gäste-WC.Pendelleuchte.Dimmen-Status
   room: Gäste WC
+  writable: false
 3/2/5:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Flur.Downlight.Diele.Dimmen-Status
   room: Flur
+  writable: false
 3/2/50:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.EG.Gäste-WC.Indirekt.Sperren
   room: Gäste WC
+  writable: true
 3/2/51:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Gäste-WC.Indirekt.Ein/Aus
   room: Gäste WC
+  writable: true
 3/2/52:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.EG.Gäste-WC.Indirekt.Ein/Aus-Status
   room: Gäste WC
+  writable: false
 3/2/53:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.EG.Gäste-WC.Indirekt.Dimmen-Relativ
   room: Gäste WC
+  writable: true
 3/2/54:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Gäste-WC.Indirekt.Dimmen-Absolut
   room: Gäste WC
+  writable: true
 3/2/55:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Gäste-WC.Indirekt.Dimmen-Status
   room: Gäste WC
+  writable: false
 3/2/60:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.EG.Büro.Spots.Sperren
   room: Büro
+  writable: true
 3/2/61:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Büro.Spots.Ein/Aus
   room: Büro
+  writable: true
 3/2/62:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.EG.Büro.Spots.Ein/Aus-Status
   room: Büro
+  writable: false
 3/2/63:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.EG.Büro.Spots.Dimmen-Relativ
   room: Büro
+  writable: true
 3/2/64:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Büro.Spots.Dimmen-Absolut
   room: Büro
+  writable: true
 3/2/65:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Büro.Spots.Dimmen-Status
   room: Büro
+  writable: false
 3/2/70:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.EG.Büro.Stripe.Sperren
   room: Büro
+  writable: true
 3/2/71:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Büro.Stripe.Ein/Aus
   room: Büro
+  writable: true
 3/2/72:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.EG.Büro.Stripe.Ein/Aus-Status
   room: Büro
+  writable: true
 3/2/73:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.EG.Büro.Stripe.Dimmen-Relativ
   room: Büro
+  writable: true
 3/2/74:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Büro.Stripe.Dimmen-Absolut
   room: Büro
+  writable: true
 3/2/75:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Büro.Stripe.Dimmen-Status
   room: Büro
+  writable: false
 3/2/80:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Downlight.Sperren
   room: Wohnzimmer
+  writable: true
 3/2/81:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Downlight.Ein/Aus
   room: Wohnzimmer
+  writable: true
 3/2/82:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Downlight.Ein/Aus-Status
   room: Wohnzimmer
+  writable: false
 3/2/83:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Downlight.Dimmen-Relativ
   room: Wohnzimmer
+  writable: true
 3/2/84:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Downlight.Dimmen-Absolut
   room: Wohnzimmer
+  writable: true
 3/2/85:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Downlight.Dimmen-Status
   room: Wohnzimmer
+  writable: false
 3/2/90:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Spots.Links.Sperren
   room: Wohnzimmer
+  writable: true
 3/2/91:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Spots.Links.Ein/Aus
   room: Wohnzimmer
+  writable: true
 3/2/92:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Spots.Links.Ein/Aus-Status
   room: Wohnzimmer
+  writable: true
 3/2/93:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Spots.Links.Dimmen-Relativ
   room: Wohnzimmer
+  writable: true
 3/2/94:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Spots.Links.Dimmen-Absolut
   room: Wohnzimmer
+  writable: true
 3/2/95:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Spots.Links.Dimmen-Status
   room: Wohnzimmer
+  writable: false
 3/3/0:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.OG.Flur.Pendelleuchte.Sperren
   room: Flur
+  writable: true
 3/3/1:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Flur.Pendelleuchte.Ein/Aus
   room: Flur
+  writable: true
 3/3/10:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.OG.Flur.Downlight.Treppe.Sperren
   room: Flur
+  writable: true
 3/3/100:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Gregory.Downlight.Sperren
   room: Schlafzimmer Gregory
+  writable: true
 3/3/101:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Gregory.Downlight.Ein/Aus
   room: Schlafzimmer Gregory
+  writable: true
 3/3/102:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Gregory.Downlight.Ein/Aus-Status
   room: Schlafzimmer Gregory
+  writable: true
 3/3/103:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Gregory.Downlight.Dimmen-Relativ
   room: Schlafzimmer Gregory
+  writable: true
 3/3/104:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Gregory.Downlight.Dimmen-Absolut
   room: Schlafzimmer Gregory
+  writable: true
 3/3/105:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Gregory.Downlight.Dimmen-Status
   room: Schlafzimmer Gregory
+  writable: false
 3/3/11:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Flur.Downlight.Treppe.Ein/Aus
   room: Flur
+  writable: true
 3/3/110:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Luis.Downlight.Sperren
   room: Schlafzimmer Luis
+  writable: true
 3/3/111:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Luis.Downlight.Ein/Aus
   room: Schlafzimmer Luis
+  writable: true
 3/3/112:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Luis.Downlight.Ein/Aus-Status
   room: Schlafzimmer Luis
+  writable: true
 3/3/113:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Luis.Downlight.Dimmen-Relativ
   room: Schlafzimmer Luis
+  writable: true
 3/3/114:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Luis.Downlight.Dimmen-Absolut
   room: Schlafzimmer Luis
+  writable: true
 3/3/115:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Luis.Downlight.Dimmen-Status
   room: Schlafzimmer Luis
+  writable: false
 3/3/12:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.OG.Flur.Downlight.Treppe.Ein/Aus-Status
   room: Flur
+  writable: false
 3/3/120:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Downlight.Sperren
   room: Schlafzimmer Eltern
+  writable: true
 3/3/121:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Downlight.Ein/Aus
   room: Schlafzimmer Eltern
+  writable: true
 3/3/122:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Downlight.Ein/Aus-Status
   room: Schlafzimmer Eltern
+  writable: true
 3/3/123:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Downlight.Dimmen-Relativ
   room: Schlafzimmer Eltern
+  writable: true
 3/3/124:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Downlight.Dimmen-Absolut
   room: Schlafzimmer Eltern
+  writable: true
 3/3/125:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Downlight.Dimmen-Status
   room: Schlafzimmer Eltern
+  writable: false
 3/3/13:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.OG.Flur.Downlight.Treppe.Dimmen-Relativ
   room: Flur
+  writable: true
 3/3/130:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Leselicht.Links.Sperren
   room: Schlafzimmer Eltern
+  writable: true
 3/3/131:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Leselicht.Links.Ein/Aus
   room: Schlafzimmer Eltern
+  writable: true
 3/3/132:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Leselicht.Links.Ein/Aus-Status
   room: Schlafzimmer Eltern
+  writable: true
 3/3/133:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Leselicht.Links.Dimmen-Relativ
   room: Schlafzimmer Eltern
+  writable: true
 3/3/134:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Leselicht.Links.Dimmen-Absolut
   room: Schlafzimmer Eltern
+  writable: true
 3/3/135:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Leselicht.Links.Dimmen-Status
   room: Schlafzimmer Eltern
+  writable: false
 3/3/14:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Flur.Downlight.Treppe.Dimmen-Absolut
   room: Flur
+  writable: true
 3/3/140:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Leselicht.Rechts.Sperren
   room: Schlafzimmer Eltern
+  writable: true
 3/3/141:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Leselicht.Rechts.Ein/Aus
   room: Schlafzimmer Eltern
+  writable: true
 3/3/142:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Leselicht.Rechts.Ein/Aus-Status
   room: Schlafzimmer Eltern
+  writable: true
 3/3/143:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Leselicht.Rechts.Dimmen-Relativ
   room: Schlafzimmer Eltern
+  writable: true
 3/3/144:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Leselicht.Rechts.Dimmen-Absolut
   room: Schlafzimmer Eltern
+  writable: true
 3/3/145:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Leselicht.Rechts.Dimmen-Status
   room: Schlafzimmer Eltern
+  writable: false
 3/3/15:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Flur.Downlight.Treppe.Dimmen-Status
   room: Flur
+  writable: false
 3/3/150:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Indirekt.TV.Sperren
   room: Schlafzimmer Eltern
+  writable: true
 3/3/151:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Indirekt.TV.Ein/Aus
   room: Schlafzimmer Eltern
+  writable: true
 3/3/152:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Indirekt.TV.Ein/Aus-Status
   room: Schlafzimmer Eltern
+  writable: true
 3/3/153:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Indirekt.TV.Dimmen-Relativ
   room: Schlafzimmer Eltern
+  writable: true
 3/3/154:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Indirekt.TV.Dimmen-Absolut
   room: Schlafzimmer Eltern
+  writable: true
 3/3/155:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Indirekt.TV.Dimmen-Status
   room: Schlafzimmer Eltern
+  writable: false
 3/3/160:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Indirekt.Bett.Sperren
   room: Schlafzimmer Eltern
+  writable: true
 3/3/161:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Indirekt.Bett.Ein/Aus
   room: Schlafzimmer Eltern
+  writable: true
 3/3/162:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Indirekt.Bett.Ein/Aus-Status
   room: Schlafzimmer Eltern
+  writable: false
 3/3/163:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Indirekt.Bett.Dimmen-Relativ
   room: Schlafzimmer Eltern
+  writable: true
 3/3/164:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Indirekt.Bett.Dimmen-Absolut
   room: Schlafzimmer Eltern
+  writable: true
 3/3/165:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Eltern.Indirekt.Bett.Dimmen-Status
   room: Schlafzimmer Eltern
+  writable: false
 3/3/170:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.OG.Begehbarer-Schrank.Deckenleuchte.Sperren
   room: Begehbarer Schrank
+  writable: true
 3/3/171:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Begehbarer-Schrank.Deckenleuchte.Ein/Aus
   room: Begehbarer Schrank
+  writable: true
 3/3/172:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.OG.Begehbarer-Schrank.Deckenleuchte.Ein/Aus-Status
   room: Begehbarer Schrank
+  writable: false
 3/3/173:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.OG.Begehbarer-Schrank.Deckenleuchte.Dimmen-Relativ
   room: Begehbarer Schrank
+  writable: true
 3/3/174:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Begehbarer-Schrank.Deckenleuchte.Dimmen-Absolut
   room: Begehbarer Schrank
+  writable: true
 3/3/175:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Begehbarer-Schrank.Deckenleuchte.Dimmen-Status
   room: Begehbarer Schrank
+  writable: false
 3/3/180:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Downlight.WC.Sperren
   room: Badezimmer Eltern
+  writable: true
 3/3/181:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Downlight.WC.Ein/Aus
   room: Badezimmer Eltern
+  writable: true
 3/3/182:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Downlight.WC.Ein/Aus-Status
   room: Badezimmer Eltern
+  writable: true
 3/3/183:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Downlight.WC.Dimmen-Relativ
   room: Badezimmer Eltern
+  writable: true
 3/3/184:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Downlight.WC.Dimmen-Absolut
   room: Badezimmer Eltern
+  writable: true
 3/3/185:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Downlight.WC.Dimmen-Status
   room: Badezimmer Eltern
+  writable: false
 3/3/190:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Downlight.Becken.Sperren
   room: Badezimmer Eltern
+  writable: true
 3/3/191:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Downlight.Becken.Ein/Aus
   room: Badezimmer Eltern
+  writable: true
 3/3/192:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Downlight.Becken.Ein/Aus-Status
   room: Badezimmer Eltern
+  writable: true
 3/3/193:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Downlight.Becken.Dimmen-Relativ
   room: Badezimmer Eltern
+  writable: true
 3/3/194:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Downlight.Becken.Dimmen-Absolut
   room: Badezimmer Eltern
+  writable: true
 3/3/195:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Downlight.Becken.Dimmen-Status
   room: Badezimmer Eltern
+  writable: false
 3/3/2:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.OG.Flur.Pendelleuchte.Ein/Aus-Status
   room: Flur
+  writable: false
 3/3/20:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.OG.Flur.Downlight.Galerie.Sperren
   room: Flur
+  writable: true
 3/3/200:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Indirekt.WC.Sperren
   room: Badezimmer Eltern
+  writable: true
 3/3/201:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Indirekt.WC.Ein/Aus
   room: Badezimmer Eltern
+  writable: true
 3/3/202:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Indirekt.WC.Ein/Aus-Status
   room: Badezimmer Eltern
+  writable: true
 3/3/203:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Indirekt.WC.Dimmen-Relativ
   room: Badezimmer Eltern
+  writable: true
 3/3/204:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Indirekt.WC.Dimmen-Absolut
   room: Badezimmer Eltern
+  writable: true
 3/3/205:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Indirekt.WC.Dimmen-Status
   room: Badezimmer Eltern
+  writable: false
 3/3/21:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Flur.Downlight.Galerie.Ein/Aus
   room: Flur
+  writable: true
 3/3/210:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Indirekt.Schrank.Sperren
   room: Badezimmer Eltern
+  writable: true
 3/3/211:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Indirekt.Schrank.Ein/Aus
   room: Badezimmer Eltern
+  writable: true
 3/3/212:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Indirekt.Schrank.Ein/Aus-Status
   room: Badezimmer Eltern
+  writable: true
 3/3/213:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Indirekt.Schrank.Dimmen-Relativ
   room: Badezimmer Eltern
+  writable: true
 3/3/214:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Indirekt.Schrank.Dimmen-Absolut
   room: Badezimmer Eltern
+  writable: true
 3/3/215:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Indirekt.Schrank.Dimmen-Status
   room: Badezimmer Eltern
+  writable: false
 3/3/22:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.OG.Flur.Downlight.Galerie.Ein/Aus-Status
   room: Flur
+  writable: false
 3/3/220:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.RGB.Sperren
   room: Badezimmer Eltern
+  writable: true
 3/3/221:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.RGB.Ein/Aus
   room: Badezimmer Eltern
+  writable: true
 3/3/222:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.RGB.Ein/Aus-Status
   room: Badezimmer Eltern
+  writable: false
 3/3/223:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.RGB.Dimmen-Relativ
   room: Badezimmer Eltern
+  writable: true
 3/3/224:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.RGB.Dimmen-Absolut
   room: Badezimmer Eltern
+  writable: true
 3/3/225:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.RGB.Dimmen-Status
   room: Badezimmer Eltern
+  writable: false
 3/3/226:
   dpt: '232.600'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.RGB.Farbsteuerung
   room: Badezimmer Eltern
+  writable: true
 3/3/227:
   dpt: '232.600'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.RGB.Farbsteuerung-Status
   room: Badezimmer Eltern
+  writable: false
 3/3/23:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.OG.Flur.Downlight.Galerie.Dimmen-Relativ
   room: Flur
+  writable: true
 3/3/230:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Spiegel.Sperren
   room: Badezimmer Eltern
+  writable: true
 3/3/231:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Spiegel.Ein/Aus
   room: Badezimmer Eltern
+  writable: true
 3/3/232:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Spiegel.Ein/Aus-Status
   room: Badezimmer Eltern
+  writable: false
 3/3/233:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Spiegel.Dimmen-Relativ
   room: Badezimmer Eltern
+  writable: true
 3/3/234:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Spiegel.Dimmen-Absolut
   room: Badezimmer Eltern
+  writable: true
 3/3/235:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Spiegel.Dimmen-Status
   room: Badezimmer Eltern
+  writable: false
 3/3/236:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Spiegel.Farbwert
   room: Badezimmer Eltern
+  writable: true
 3/3/237:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Spiegel.Farbwert-Status
   room: Badezimmer Eltern
+  writable: false
 3/3/238:
   dpt: '7.600'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Spiegel.Farbtemparatur
   room: Badezimmer Eltern
+  writable: true
 3/3/239:
   dpt: '7.600'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Spiegel.Farbtemparatur-Status
   room: Badezimmer Eltern
+  writable: false
 3/3/24:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Flur.Downlight.Galerie.Dimmen-Absolut
   room: Flur
+  writable: true
 3/3/240:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Schminkspiegel.Sperren
   room: Badezimmer Eltern
+  writable: true
 3/3/241:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Schminkspiegel.Ein/Aus
   room: Badezimmer Eltern
+  writable: true
 3/3/242:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Schminkspiegel.Ein/Aus-Status
   room: Badezimmer Eltern
+  writable: false
 3/3/243:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Schminkspiegel.Dimmen-Relativ
   room: Badezimmer Eltern
+  writable: true
 3/3/244:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Schminkspiegel.Dimmen-Absolut
   room: Badezimmer Eltern
+  writable: true
 3/3/245:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Schminkspiegel.Dimmen-Status
   room: Badezimmer Eltern
+  writable: false
 3/3/246:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Schminkspiegel.Farbwert
   room: Badezimmer Eltern
+  writable: true
 3/3/247:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Schminkspiegel.Farbwert-Status
   room: Badezimmer Eltern
+  writable: false
 3/3/248:
   dpt: '7.600'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Schminkspiegel.Farbtemperatur
   room: Badezimmer Eltern
+  writable: true
 3/3/249:
   dpt: '7.600'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Eltern.Schminkspiegel.Farbtemperatur-Status
   room: Badezimmer Eltern
+  writable: false
 3/3/25:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Flur.Downlight.Galerie.Dimmen-Status
   room: Flur
+  writable: false
 3/3/3:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.OG.Flur.Pendelleuchte.Dimmen-Relativ
   room: Flur
+  writable: true
 3/3/30:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.OG.Flur.Downlight.Gang.Sperren
   room: Flur
+  writable: true
 3/3/31:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Flur.Downlight.Gang.Ein/Aus
   room: Flur
+  writable: true
 3/3/32:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.OG.Flur.Downlight.Gang.Ein/Aus-Status
   room: Flur
+  writable: false
 3/3/33:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.OG.Flur.Downlight.Gang.Dimmen-Relativ
   room: Flur
+  writable: true
 3/3/34:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Flur.Downlight.Gang.Dimmen-Absolut
   room: Flur
+  writable: true
 3/3/35:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Flur.Downlight.Gang.Dimmen-Status
   room: Flur
+  writable: false
 3/3/4:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Flur.Pendelleuchte.Dimmen-Absolut
   room: Flur
+  writable: true
 3/3/40:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.OG.Flur.Bodenleuchte.Sperren
   room: Flur
+  writable: true
 3/3/41:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Flur.Bodenleuchte.Ein/Aus
   room: Flur
+  writable: true
 3/3/42:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.OG.Flur.Bodenleuchte.Ein/Aus-Status
   room: Flur
+  writable: false
 3/3/43:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.OG.Flur.Bodenleuchte.Dimmen-Relativ
   room: Flur
+  writable: true
 3/3/44:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Flur.Bodenleuchte.Dimmen-Absolut
   room: Flur
+  writable: true
 3/3/45:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Flur.Bodenleuchte.Dimmen-Status
   room: Flur
+  writable: false
 3/3/5:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Flur.Pendelleuchte.Dimmen-Status
   room: Flur
+  writable: false
 3/3/50:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.OG.Abstellraum.Downlight.Sperren
   room: Abstellraum
+  writable: true
 3/3/51:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Abstellraum.Downlight.Ein/Aus
   room: Abstellraum
+  writable: true
 3/3/52:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.OG.Abstellraum.Downlight.Ein/Aus-Status
   room: Abstellraum
+  writable: true
 3/3/53:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.OG.Abstellraum.Downlight.Dimmen-Relativ
   room: Abstellraum
+  writable: true
 3/3/54:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Abstellraum.Downlight.Dimmen-Absolut
   room: Abstellraum
+  writable: true
 3/3/55:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Abstellraum.Downlight.Dimmen-Status
   room: Abstellraum
+  writable: false
 3/3/60:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Kinder.Downlight.WC.Sperren
   room: Badezimmer Kinder
+  writable: true
 3/3/61:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Kinder.Downlight.WC.Ein/Aus
   room: Badezimmer Kinder
+  writable: true
 3/3/62:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Kinder.Downlight.WC.Ein/Aus-Status
   room: Badezimmer Kinder
+  writable: true
 3/3/63:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Kinder.Downlight.WC.Dimmen-Relativ
   room: Badezimmer Kinder
+  writable: true
 3/3/64:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Kinder.Downlight.WC.Dimmen-Absolut
   room: Badezimmer Kinder
+  writable: true
 3/3/65:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Kinder.Downlight.WC.Dimmen-Status
   room: Badezimmer Kinder
+  writable: false
 3/3/70:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Kinder.Downlight.Becken.Sperren
   room: Badezimmer Kinder
+  writable: true
 3/3/71:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Kinder.Downlight.Becken.Ein/Aus
   room: Badezimmer Kinder
+  writable: true
 3/3/72:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Kinder.Downlight.Becken.Ein/Aus-Status
   room: Badezimmer Kinder
+  writable: true
 3/3/73:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Kinder.Downlight.Becken.Dimmen-Relativ
   room: Badezimmer Kinder
+  writable: true
 3/3/74:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Kinder.Downlight.Becken.Dimmen-Absolut
   room: Badezimmer Kinder
+  writable: true
 3/3/75:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Kinder.Downlight.Becken.Dimmen-Status
   room: Badezimmer Kinder
+  writable: false
 3/3/80:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Kinder.Indirekt.Sperren
   room: Badezimmer Kinder
+  writable: true
 3/3/81:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Kinder.Indirekt.Ein/Aus
   room: Badezimmer Kinder
+  writable: true
 3/3/82:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Kinder.Indirekt.Ein/Aus-Status
   room: Badezimmer Kinder
+  writable: true
 3/3/83:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Kinder.Indirekt.Dimmen-Relativ
   room: Badezimmer Kinder
+  writable: true
 3/3/84:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Kinder.Indirekt.Dimmen-Absolut
   room: Badezimmer Kinder
+  writable: true
 3/3/85:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Kinder.Indirekt.Dimmen-Status
   room: Badezimmer Kinder
+  writable: false
 3/3/90:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Kinder.Spiegel.Sperren
   room: Badezimmer Kinder
+  writable: true
 3/3/91:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Kinder.Spiegel.Ein/Aus
   room: Badezimmer Kinder
+  writable: true
 3/3/92:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Kinder.Spiegel.Ein/Aus-Status
   room: Badezimmer Kinder
+  writable: false
 3/3/93:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Kinder.Spiegel.Dimmen-Relativ
   room: Badezimmer Kinder
+  writable: true
 3/3/94:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Kinder.Spiegel.Dimmen-Absolut
   room: Badezimmer Kinder
+  writable: true
 3/3/95:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Kinder.Spiegel.Dimmen-Status
   room: Badezimmer Kinder
+  writable: false
 3/3/96:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Kinder.Spiegel.Farbwert
   room: Badezimmer Kinder
+  writable: true
 3/3/97:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Kinder.Spiegel.Farbwert-Status
   room: Badezimmer Kinder
+  writable: false
 3/3/98:
   dpt: '7.600'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Kinder.Spiegel.Farbtemperatur
   room: Badezimmer Kinder
+  writable: true
 3/3/99:
   dpt: '7.600'
   function: Beleuchtung
   name: Beleuchtung.OG.Badezimmer-Kinder.Spiegel.Farbtemperatur-Status
   room: Badezimmer Kinder
+  writable: false
 3/4/0:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.DG.Speicher.Deckenleuchte.Sperren
   room: Speicher (S)
+  writable: true
 3/4/1:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.DG.Speicher.Deckenleuchte.Ein/Aus
   room: Speicher (S)
+  writable: true
 3/4/2:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.DG.Speicher.Deckenleuchte.Ein/Aus-Status
   room: Speicher (S)
+  writable: false
 3/4/3:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.DG.Speicher.Deckenleuchte.Dimmen-Relativ
   room: Speicher (S)
+  writable: true
 3/4/4:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.DG.Speicher.Deckenleuchte.Dimmen-Absolut
   room: Speicher (S)
+  writable: true
 3/4/5:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.DG.Speicher.Deckenleuchte.Dimmen-Status
   room: Speicher (S)
+  writable: false
 3/5/0:
   description: 1 - Fassade (A1) Beleuchtung
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.A.Fassade.Front.Sperren
   room: Außenbereich
+  writable: true
 3/5/1:
   description: 1 - Fassade (A1) Beleuchtung
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.A.Fassade.Front.Ein/Aus
   room: Außenbereich
+  writable: true
 3/5/10:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.A.Terrasse.Spots.Sperren
   room: Terrasse
+  writable: true
 3/5/11:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.A.Terrasse.Spots.Ein/Aus
   room: Terrasse
+  writable: true
 3/5/12:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.A.Terrasse.Spots.Ein/Aus-Status
   room: Terrasse
+  writable: false
 3/5/13:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.A.Terrasse.Spots.Dimmen-Relativ
   room: Terrasse
+  writable: true
 3/5/14:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.A.Terrasse.Spots.Dimmen-Absolut
   room: Terrasse
+  writable: true
 3/5/15:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.A.Terrasse.Spots.Dimmen-Status
   room: Terrasse
+  writable: false
 3/5/2:
   description: 1 - Fassade (A1) Beleuchtung
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.A.Fassade.Front.Ein/Aus-Status
   room: Außenbereich
+  writable: false
 3/5/20:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.A.Terrasse.Stripe.Sperren
   room: Terrasse
+  writable: true
 3/5/21:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.A.Terrasse.Stripe.Ein/Aus
   room: Terrasse
+  writable: true
 3/5/22:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.A.Terrasse.Stripe.Ein/Aus-Status
   room: Terrasse
+  writable: false
 3/5/23:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.A.Terrasse.Stripe.Dimmen-Relativ
   room: Terrasse
+  writable: true
 3/5/24:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.A.Terrasse.Stripe.Dimmen-Absolut
   room: Terrasse
+  writable: true
 3/5/25:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.A.Terrasse.Stripe.Dimmen-Status
   room: Terrasse
+  writable: false
 3/5/3:
   description: 1 - Fassade (A1) Beleuchtung
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.A.Fassade.Front.Dimmen-Relativ
   room: Außenbereich
+  writable: true
 3/5/30:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.A.Balkon.Spots.Sperren
   room: Balkon
+  writable: true
 3/5/31:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.A.Balkon.Spots.Ein/Aus
   room: Balkon
+  writable: true
 3/5/32:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.A.Balkon.Spots.Ein/Aus-Status
   room: Balkon
+  writable: false
 3/5/33:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.A.Balkon.Spots.Dimmen-Relativ
   room: Balkon
+  writable: true
 3/5/34:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.A.Balkon.Spots.Dimmen-Absolut
   room: Balkon
+  writable: true
 3/5/35:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.A.Balkon.Spots.Dimmen-Status
   room: Balkon
+  writable: false
 3/5/4:
   description: 1 - Fassade (A1) Beleuchtung
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.A.Fassade.Front.Dimmen-Absolut
   room: Außenbereich
+  writable: true
 3/5/5:
   description: 1 - Fassade (A1) Beleuchtung
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.A.Fassade.Front.Dimmen-Status
   room: Außenbereich
+  writable: false
 3/6/20:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.G.Eingang.Briefkasten.Sperren
   room: Eingang
+  writable: true
 3/6/21:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.G.Eingang.Briefkasten.Ein/Aus
   room: Eingang
+  writable: true
 3/6/22:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.G.Eingang.Briefkasten.Ein/Aus-Status
   room: Eingang
+  writable: false
 3/6/23:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.G.Eingang.Briefkasten.Dimmen-Relativ
   room: Eingang
+  writable: true
 3/6/24:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.G.Eingang.Briefkasten.Dimmen-Absolut
   room: Eingang
+  writable: true
 3/6/25:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.G.Eingang.Briefkasten.Dimmen-Status
   room: Eingang
+  writable: false
 3/6/30:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.G.Garten.Hochbeet.Poller.Sperren
   room: Garten
+  writable: true
 3/6/31:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.G.Garten.Hochbeet.Poller.Ein/Aus
   room: Garten
+  writable: true
 3/6/32:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.G.Garten.Hochbeet.Poller.Ein/Aus-Status
   room: Garten
+  writable: false
 3/6/33:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.G.Garten.Hochbeet.Poller.Dimmen-Relativ
   room: Garten
+  writable: true
 3/6/34:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.G.Garten.Hochbeet.Poller.Dimmen-Absolut
   room: Garten
+  writable: true
 3/6/35:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.G.Garten.Hochbeet.Poller.Dimmen-Status
   room: Garten
+  writable: false
 4/2/60:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Bordbar.Sperren
   room: Wohnzimmer
+  writable: false
 4/2/61:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Bordbar.Ein/Aus
   room: Wohnzimmer
+  writable: false
 4/2/62:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Bordbar.Ein/Aus-Status
   room: Wohnzimmer
+  writable: false
 4/2/63:
   dpt: '1.007'
   function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Bordbar.Helligkeit-Schritt
   room: Wohnzimmer
+  writable: false
 4/2/64:
   dpt: '1.007'
   function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Bordbar.Farbe-Schritt
   room: Wohnzimmer
+  writable: false
 4/2/65:
   dpt: '1.007'
   function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Bordbar.Modus-Schritt
   room: Wohnzimmer
+  writable: false
 4/2/66:
   dpt: '1.007'
   function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Bordbar.Geschwindigkeit-Schritt
   room: Wohnzimmer
+  writable: false
 4/2/67:
   dpt: '1.015'
   function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Bordbar.Reset
   room: Wohnzimmer
+  writable: false
 4/2/68:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.EG.Wohnzimmer.Bordbar.Verbindung-Status
   room: Wohnzimmer
+  writable: false
 4/3/60:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Gregory.Stripe.Sperren
   room: Schlafzimmer Gregory
+  writable: false
 4/3/61:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Gregory.Stripe.Ein/Aus
   room: Schlafzimmer Gregory
+  writable: false
 4/3/62:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Gregory.Stripe.Ein/Aus-Status
   room: Schlafzimmer Gregory
+  writable: false
 4/3/63:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Gregory.Stripe.Dimmen-Relativ
   room: Schlafzimmer Gregory
+  writable: false
 4/3/64:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Gregory.Stripe.Dimmen-Absolut
   room: Schlafzimmer Gregory
+  writable: false
 4/3/65:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Gregory.Stripe.Dimmen-Status
   room: Schlafzimmer Gregory
+  writable: false
 4/3/66:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Gregory.Stripe.Farbwert
   room: Schlafzimmer Gregory
+  writable: false
 4/3/67:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Gregory.Stripe.Farbwert-Status
   room: Schlafzimmer Gregory
+  writable: false
 4/3/68:
   dpt: '7.600'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Gregory.Stripe.Farbtemparatur
   room: Schlafzimmer Gregory
+  writable: false
 4/3/69:
   dpt: '7.600'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Gregory.Stripe.Farbtemparatur-Status
   room: Schlafzimmer Gregory
+  writable: false
 4/3/70:
   dpt: '232.600'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Gregory.Stripe.Farbsteuerung
   room: Schlafzimmer Gregory
+  writable: false
 4/3/71:
   dpt: '232.600'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Gregory.Stripe.Farbsteuerung-Status
   room: Schlafzimmer Gregory
+  writable: false
 4/3/80:
   dpt: '1.003'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Luis.Stripe.Sperren
   room: Schlafzimmer Luis
+  writable: false
 4/3/81:
   dpt: '1.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Luis.Stripe.Ein/Aus
   room: Schlafzimmer Luis
+  writable: false
 4/3/82:
   dpt: '1.011'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Luis.Stripe.Ein/Aus-Status
   room: Schlafzimmer Luis
+  writable: false
 4/3/83:
   dpt: '3.007'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Luis.Stripe.Dimmen-Relativ
   room: Schlafzimmer Luis
+  writable: false
 4/3/84:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Luis.Stripe.Dimmen-Absolut
   room: Schlafzimmer Luis
+  writable: false
 4/3/85:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Luis.Stripe.Dimmen-Status
   room: Schlafzimmer Luis
+  writable: false
 4/3/86:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Luis.Stripe.Farbwert
   room: Schlafzimmer Luis
+  writable: false
 4/3/87:
   dpt: '5.001'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Luis.Stripe.Farbwert-Status
   room: Schlafzimmer Luis
+  writable: false
 4/3/88:
   dpt: '7.600'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Luis.Stripe.Farbtemparatur
   room: Schlafzimmer Luis
+  writable: false
 4/3/89:
   dpt: '7.600'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Luis.Stripe.Farbtemparatur-Status
   room: Schlafzimmer Luis
+  writable: false
 4/3/90:
   dpt: '232.600'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Luis.Stripe.Farbsteuerung
   room: Schlafzimmer Luis
+  writable: false
 4/3/91:
   dpt: '232.600'
   function: Beleuchtung
   name: Beleuchtung.OG.Schlafzimmer-Luis.Stripe.Farbsteuerung-Status
   room: Schlafzimmer Luis
+  writable: false
 5/0/110:
   dpt: '1.008'
   function: Beschattung
   name: Beschattung.Zentral.EG.Raffstore.Innen.Fahren
   room: Erdgeschoss
+  writable: true
 5/0/111:
   dpt: '1.007'
   function: Beschattung
   name: Beschattung.Zentral.EG.Raffstore.Innen.Stoppen
   room: Erdgeschoss
+  writable: true
 5/0/112:
   dpt: '1.008'
   function: Beschattung
   name: Beschattung.Zentral.EG.Raffstore.Außen.Fahren
   room: Erdgeschoss
+  writable: true
 5/0/113:
   dpt: '1.007'
   function: Beschattung
   name: Beschattung.Zentral.EG.Raffstore.Außen.Stoppen
   room: Erdgeschoss
+  writable: true
 5/0/120:
   dpt: '1.008'
   function: Beschattung
   name: Beschattung.Zentral.OG.Raffstore.Innen.Fahren
   room: Obergeschoss
+  writable: true
 5/0/121:
   dpt: '1.007'
   function: Beschattung
   name: Beschattung.Zentral.OG.Raffstore.Innen.Stoppen
   room: Obergeschoss
+  writable: true
 5/0/122:
   dpt: '1.008'
   function: Beschattung
   name: Beschattung.Zentral.OG.Raffstore.Außen.Fahren
   room: Obergeschoss
+  writable: true
 5/0/123:
   dpt: '1.007'
   function: Beschattung
   name: Beschattung.Zentral.OG.Raffstore.Außen.Stoppen
   room: Obergeschoss
+  writable: true
 5/0/124:
   dpt: '1.008'
   function: Beschattung
   name: Beschattung.Zentral.OG.Vorhang.Fahren
   room: Obergeschoss
+  writable: true
 5/0/125:
   dpt: '1.017'
   function: Beschattung
   name: Beschattung.Zentral.OG.Vorhang.Stoppen
   room: Obergeschoss
+  writable: true
 5/0/200:
   dpt: '1.001'
   function: Beschattung
   name: Beschattung.Zentral.Gebäude.Raffstore.Innen.Automatik.Sperren
   room: 1 - Gebäude
+  writable: true
 5/0/201:
   dpt: '1.008'
   function: Beschattung
   name: Beschattung.Zentral.Gebäude.Raffstore.Innen.Automatik.Fahren
   room: 1 - Gebäude
+  writable: true
 5/0/202:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.Zentral.Gebäude.Raffstore.Innen.Automatik.Position
   room: 1 - Gebäude
+  writable: true
 5/0/203:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.Zentral.Gebäude.Raffstore.Innen.Automatik.Rotation
   room: 1 - Gebäude
+  writable: true
 5/0/204:
   dpt: '9.004'
   function: Beschattung
   name: Beschattung.Zentral.Gebäude.Raffstore.Innen.Automatik.Helligkeitsschwelle
   room: 1 - Gebäude
+  writable: true
 5/0/205:
   dpt: '9.004'
   function: Beschattung
   name: Beschattung.Zentral.Gebäude.Raffstore.Innen.Automatik.Dämmerungsschwelle
   room: 1 - Gebäude
+  writable: true
 5/0/206:
   dpt: '1.001'
   function: Beschattung
   name: Beschattung.Zentral.Gebäude.Raffstore.Außen.Zone-1.Automatik.Sperren
   room: 1 - Gebäude
+  writable: true
 5/0/207:
   dpt: '1.008'
   function: Beschattung
   name: Beschattung.Zentral.Gebäude.Raffstore.Außen.Zone-1.Automatik.Fahren
   room: 1 - Gebäude
+  writable: true
 5/0/208:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.Zentral.Gebäude.Raffstore.Außen.Zone-1.Automatik.Position
   room: 1 - Gebäude
+  writable: true
 5/0/209:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.Zentral.Gebäude.Raffstore.Außen.Zone-1.Automatik.Rotation
   room: 1 - Gebäude
+  writable: true
 5/0/210:
   dpt: '9.004'
   function: Beschattung
   name: Beschattung.Zentral.Gebäude.Raffstore.Außen.Zone-1.Automatik.Helligkeitsschwelle
   room: 1 - Gebäude
+  writable: true
 5/0/211:
   dpt: '9.004'
   function: Beschattung
   name: Beschattung.Zentral.Gebäude.Raffstore.Außen.Zone-1.Automatik.Dämmerungsschwelle
   room: 1 - Gebäude
+  writable: true
 5/0/212:
   dpt: '1.001'
   function: Beschattung
   name: Beschattung.Zentral.Gebäude.Raffstore.Außen.Zone-2.Automatik.Sperren
   room: 1 - Gebäude
+  writable: true
 5/0/213:
   dpt: '1.008'
   function: Beschattung
   name: Beschattung.Zentral.Gebäude.Raffstore.Außen.Zone-2.Automatik.Fahren
   room: 1 - Gebäude
+  writable: true
 5/0/214:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.Zentral.Gebäude.Raffstore.Außen.Zone-2.Automatik.Position
   room: 1 - Gebäude
+  writable: true
 5/0/215:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.Zentral.Gebäude.Raffstore.Außen.Zone-2.Automatik.Rotation
   room: 1 - Gebäude
+  writable: true
 5/0/216:
   dpt: '9.004'
   function: Beschattung
   name: Beschattung.Zentral.Gebäude.Raffstore.Außen.Zone-2.Automatik.Helligkeitsschwelle
   room: 1 - Gebäude
+  writable: true
 5/0/217:
   dpt: '9.004'
   function: Beschattung
   name: Beschattung.Zentral.Gebäude.Raffstore.Außen.Zone-2.Automatik.Dämmerungsschwelle
   room: 1 - Gebäude
+  writable: true
 5/2/0:
   dpt: '1.003'
   function: Beschattung
   name: Beschattung.EG.Büro.Raffstore.Sperren
   room: Büro
+  writable: true
 5/2/1:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.EG.Büro.Raffstore.Sperren-Status
   room: Büro
+  writable: false
 5/2/10:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.EG.Büro.Raffstore.Geschlossen-Status
   room: Büro
+  writable: true
 5/2/100:
   dpt: '1.003'
   function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Rechts.Sperren
   room: Küche
+  writable: true
 5/2/101:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Rechts.Sperren-Status
   room: Küche
+  writable: false
 5/2/102:
   dpt: '1.008'
   function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Rechts.Fahren
   room: Küche
+  writable: true
 5/2/103:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Rechts.Fahren-Status
   room: Küche
+  writable: false
 5/2/104:
   dpt: '1.007'
   function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Rechts.Stoppen
   room: Küche
+  writable: true
 5/2/105:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Rechts.Position
   room: Küche
+  writable: true
 5/2/106:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Rechts.Position-Status
   room: Küche
+  writable: false
 5/2/107:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Rechts.Rotation
   room: Küche
+  writable: true
 5/2/108:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Rechts.Rotation-Status
   room: Küche
+  writable: false
 5/2/109:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Rechts.Geöffnet-Status
   room: Küche
+  writable: false
 5/2/11:
   dpt: '1.010'
   function: Beschattung
   name: Beschattung.EG.Büro.Raffstore.Fahrzeit
   room: Büro
+  writable: true
 5/2/110:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Rechts.Geschlossen-Status
   room: Küche
+  writable: false
 5/2/111:
   dpt: '1.010'
   function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Rechts.Fahrzeit
   room: Küche
+  writable: true
 5/2/2:
   dpt: '1.008'
   function: Beschattung
   name: Beschattung.EG.Büro.Raffstore.Fahren
   room: Büro
+  writable: true
 5/2/20:
   dpt: '1.003'
   function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Links.Sperren
   room: Wohnzimmer
+  writable: true
 5/2/21:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Links.Sperren-Status
   room: Wohnzimmer
+  writable: false
 5/2/22:
   dpt: '1.008'
   function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Links.Fahren
   room: Wohnzimmer
+  writable: true
 5/2/23:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Links.Fahren-Status
   room: Wohnzimmer
+  writable: false
 5/2/24:
   dpt: '1.007'
   function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Links.Stoppen
   room: Wohnzimmer
+  writable: true
 5/2/25:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Links.Position
   room: Wohnzimmer
+  writable: true
 5/2/26:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Links.Position-Status
   room: Wohnzimmer
+  writable: false
 5/2/27:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Links.Rotation
   room: Wohnzimmer
+  writable: true
 5/2/28:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Links.Rotation-Status
   room: Wohnzimmer
+  writable: false
 5/2/29:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Links.Geöffnet-Status
   room: Wohnzimmer
+  writable: false
 5/2/3:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.EG.Büro.Raffstore.Fahren-Status
   room: Büro
+  writable: false
 5/2/30:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Links.Geschlossen-Status
   room: Wohnzimmer
+  writable: true
 5/2/31:
   dpt: '1.010'
   function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Links.Fahrzeit
   room: Wohnzimmer
+  writable: true
 5/2/4:
   dpt: '1.007'
   function: Beschattung
   name: Beschattung.EG.Büro.Raffstore.Stoppen
   room: Büro
+  writable: true
 5/2/40:
   dpt: '1.003'
   function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Rechts.Sperren
   room: Wohnzimmer
+  writable: true
 5/2/41:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Rechts.Sperren-Status
   room: Wohnzimmer
+  writable: false
 5/2/42:
   dpt: '1.008'
   function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Rechts.Fahren
   room: Wohnzimmer
+  writable: true
 5/2/43:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Rechts.Fahren-Status
   room: Wohnzimmer
+  writable: false
 5/2/44:
   dpt: '1.007'
   function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Rechts.Stoppen
   room: Wohnzimmer
+  writable: true
 5/2/45:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Rechts.Position
   room: Wohnzimmer
+  writable: true
 5/2/46:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Rechts.Position-Status
   room: Wohnzimmer
+  writable: false
 5/2/47:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Rechts.Rotation
   room: Wohnzimmer
+  writable: true
 5/2/48:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Rechts.Rotation-Status
   room: Wohnzimmer
+  writable: false
 5/2/49:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Rechts.Geöffnet-Status
   room: Wohnzimmer
+  writable: false
 5/2/5:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.EG.Büro.Raffstore.Position
   room: Büro
+  writable: true
 5/2/50:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Rechts.Geschlossen-Status
   room: Wohnzimmer
+  writable: true
 5/2/51:
   dpt: '1.010'
   function: Beschattung
   name: Beschattung.EG.Wohnzimmer.Raffstore.Rechts.Fahrzeit
   room: Wohnzimmer
+  writable: true
 5/2/6:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.EG.Büro.Raffstore.Position-Status
   room: Büro
+  writable: false
 5/2/60:
   dpt: '1.003'
   function: Beschattung
   name: Beschattung.EG.Esszimmer.Raffstore.Sperren
   room: Esszimmer
+  writable: true
 5/2/61:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.EG.Esszimmer.Raffstore.Sperren-Status
   room: Esszimmer
+  writable: false
 5/2/62:
   dpt: '1.008'
   function: Beschattung
   name: Beschattung.EG.Esszimmer.Raffstore.Fahren
   room: Esszimmer
+  writable: true
 5/2/63:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.EG.Esszimmer.Raffstore.Fahren-Status
   room: Esszimmer
+  writable: false
 5/2/64:
   dpt: '1.007'
   function: Beschattung
   name: Beschattung.EG.Esszimmer.Raffstore.Stoppen
   room: Esszimmer
+  writable: true
 5/2/65:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.EG.Esszimmer.Raffstore.Position
   room: Esszimmer
+  writable: true
 5/2/66:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.EG.Esszimmer.Raffstore.Position-Status
   room: Esszimmer
+  writable: false
 5/2/67:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.EG.Esszimmer.Raffstore.Rotation
   room: Esszimmer
+  writable: true
 5/2/68:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.EG.Esszimmer.Raffstore.Rotation-Status
   room: Esszimmer
+  writable: false
 5/2/69:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.EG.Esszimmer.Raffstore.Geöffnet-Status
   room: Esszimmer
+  writable: false
 5/2/7:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.EG.Büro.Raffstore.Rotation
   room: Büro
+  writable: true
 5/2/70:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.EG.Esszimmer.Raffstore.Geschlossen-Status
   room: Esszimmer
+  writable: false
 5/2/71:
   dpt: '1.010'
   function: Beschattung
   name: Beschattung.EG.Esszimmer.Raffstore.Fahrzeit
   room: Esszimmer
+  writable: true
 5/2/8:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.EG.Büro.Raffstore.Rotation-Status
   room: Büro
+  writable: false
 5/2/80:
   dpt: '1.003'
   function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Links.Sperren
   room: Küche
+  writable: true
 5/2/81:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Links.Sperren-Status
   room: Küche
+  writable: false
 5/2/82:
   dpt: '1.008'
   function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Links.Fahren
   room: Küche
+  writable: true
 5/2/83:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Links.Fahren-Status
   room: Küche
+  writable: false
 5/2/84:
   dpt: '1.007'
   function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Links.Stoppen
   room: Küche
+  writable: true
 5/2/85:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Links.Position
   room: Küche
+  writable: true
 5/2/86:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Links.Position-Status
   room: Küche
+  writable: false
 5/2/87:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Links.Rotation
   room: Küche
+  writable: true
 5/2/88:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Links.Rotation-Status
   room: Küche
+  writable: false
 5/2/89:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Links.Geöffnet-Status
   room: Küche
+  writable: false
 5/2/9:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.EG.Büro.Raffstore.Geöffnet-Status
   room: Büro
+  writable: false
 5/2/90:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Links.Geschlossen-Status
   room: Küche
+  writable: false
 5/2/91:
   dpt: '1.010'
   function: Beschattung
   name: Beschattung.EG.Küche.Raffstore.Links.Fahrzeit
   room: Küche
+  writable: true
 5/3/0:
   dpt: '1.003'
   function: Beschattung
   name: Beschattung.OG.Flur.Raffstore.Sperren
   room: Flur
+  writable: true
 5/3/1:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Flur.Raffstore.Sperren-Status
   room: Flur
+  writable: false
 5/3/10:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Flur.Raffstore.Geschlossen-Status
   room: Flur
+  writable: false
 5/3/100:
   dpt: '1.003'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Raffstore.Sperren
   room: Schlafzimmer Luis
+  writable: true
 5/3/101:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Raffstore.Sperren-Status
   room: Schlafzimmer Luis
+  writable: false
 5/3/102:
   dpt: '1.008'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Raffstore.Fahren
   room: Schlafzimmer Luis
+  writable: true
 5/3/103:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Raffstore.Fahren-Status
   room: Schlafzimmer Luis
+  writable: false
 5/3/104:
   dpt: '1.007'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Raffstore.Stoppen
   room: Schlafzimmer Luis
+  writable: true
 5/3/105:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Raffstore.Postion
   room: Schlafzimmer Luis
+  writable: true
 5/3/106:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Raffstore.Position-Status
   room: Schlafzimmer Luis
+  writable: false
 5/3/107:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Raffstore.Rotation
   room: Schlafzimmer Luis
+  writable: true
 5/3/108:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Raffstore.Rotation-Status
   room: Schlafzimmer Luis
+  writable: false
 5/3/109:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Raffstore.Geöffnet-Status
   room: Schlafzimmer Luis
+  writable: false
 5/3/11:
   dpt: '1.010'
   function: Beschattung
   name: Beschattung.OG.Flur.Raffstore.Fahrzeit
   room: Flur
+  writable: true
 5/3/110:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Raffstore.Geschlossen-Status
   room: Schlafzimmer Luis
+  writable: true
 5/3/111:
   dpt: '1.010'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Raffstore.Fahrzeit
   room: Schlafzimmer Luis
+  writable: true
 5/3/120:
   dpt: '1.003'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Vorhang.Sperren
   room: Schlafzimmer Luis
+  writable: true
 5/3/121:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Vorhang.Sperren-Status
   room: Schlafzimmer Luis
+  writable: false
 5/3/122:
   dpt: '1.008'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Vorhang.Fahren
   room: Schlafzimmer Luis
+  writable: true
 5/3/123:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Vorhang.Fahren-Status
   room: Schlafzimmer Luis
+  writable: false
 5/3/124:
   dpt: '1.017'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Vorhang.Stoppen
   room: Schlafzimmer Luis
+  writable: true
 5/3/125:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Vorhang.Position
   room: Schlafzimmer Luis
+  writable: true
 5/3/126:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Vorhang.Position-Status
   room: Schlafzimmer Luis
+  writable: false
 5/3/129:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Vorhang.Geöffnet-Status
   room: Schlafzimmer Luis
+  writable: false
 5/3/130:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Vorhang.Geschlossen-Status
   room: Schlafzimmer Luis
+  writable: true
 5/3/131:
   dpt: '1.010'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Luis.Vorhang.Fahrzeit
   room: Schlafzimmer Luis
+  writable: false
 5/3/140:
   dpt: '1.003'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Raffstore.Sperren
   room: Schlafzimmer Eltern
+  writable: true
 5/3/141:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Raffstore.Sperren-Status
   room: Schlafzimmer Eltern
+  writable: false
 5/3/142:
   dpt: '1.008'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Raffstore.Fahren
   room: Schlafzimmer Eltern
+  writable: true
 5/3/143:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Raffstore.Fahren-Status
   room: Schlafzimmer Eltern
+  writable: false
 5/3/144:
   dpt: '1.007'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Raffstore.Stoppen
   room: Schlafzimmer Eltern
+  writable: true
 5/3/145:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Raffstore.Position
   room: Schlafzimmer Eltern
+  writable: true
 5/3/146:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Raffstore.Position-Status
   room: Schlafzimmer Eltern
+  writable: false
 5/3/147:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Raffstore.Rotation
   room: Schlafzimmer Eltern
+  writable: true
 5/3/148:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Raffstore.Rotation-Status
   room: Schlafzimmer Eltern
+  writable: false
 5/3/149:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Raffstore.Geöffnet-Status
   room: Schlafzimmer Eltern
+  writable: false
 5/3/150:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Raffstore.Geschlossen-Status
   room: Schlafzimmer Eltern
+  writable: true
 5/3/151:
   dpt: '1.010'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Raffstore.Fahrzeit
   room: Schlafzimmer Eltern
+  writable: true
 5/3/160:
   dpt: '1.003'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Vorhang.Sperren
   room: Schlafzimmer Eltern
+  writable: true
 5/3/161:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Vorhang.Sperren-Status
   room: Schlafzimmer Eltern
+  writable: false
 5/3/162:
   dpt: '1.008'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Vorhang.Fahren
   room: Schlafzimmer Eltern
+  writable: true
 5/3/163:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Vorhang.Fahren-Status
   room: Schlafzimmer Eltern
+  writable: false
 5/3/164:
   dpt: '1.017'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Vorhang.Stoppen
   room: Schlafzimmer Eltern
+  writable: true
 5/3/165:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Vorhang.Position
   room: Schlafzimmer Eltern
+  writable: true
 5/3/166:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Vorhang.Position-Status
   room: Schlafzimmer Eltern
+  writable: false
 5/3/169:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Vorhang.Geöffnet-Status
   room: Schlafzimmer Eltern
+  writable: false
 5/3/170:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Vorhang.Geschlossen-Status
   room: Schlafzimmer Eltern
+  writable: true
 5/3/171:
   dpt: '1.010'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Eltern.Vorhang.Fahrzeit
   room: Schlafzimmer Eltern
+  writable: false
 5/3/180:
   dpt: '1.003'
   function: Beschattung
   name: Beschattung.OG.Badezimmer-Eltern.Raffstore.Sperren
   room: Badezimmer Eltern
+  writable: true
 5/3/181:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Badezimmer-Eltern.Raffstore.Sperren-Status
   room: Badezimmer Eltern
+  writable: false
 5/3/182:
   dpt: '1.008'
   function: Beschattung
   name: Beschattung.OG.Badezimmer-Eltern.Raffstore.Fahren
   room: Badezimmer Eltern
+  writable: true
 5/3/183:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Badezimmer-Eltern.Raffstore.Fahren-Status
   room: Badezimmer Eltern
+  writable: false
 5/3/184:
   dpt: '1.007'
   function: Beschattung
   name: Beschattung.OG.Badezimmer-Eltern.Raffstore.Stoppen
   room: Badezimmer Eltern
+  writable: true
 5/3/185:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Badezimmer-Eltern.Raffstore.Position
   room: Badezimmer Eltern
+  writable: true
 5/3/186:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Badezimmer-Eltern.Raffstore.Position-Status
   room: Badezimmer Eltern
+  writable: false
 5/3/187:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Badezimmer-Eltern.Raffstore.Rotation
   room: Badezimmer Eltern
+  writable: true
 5/3/188:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Badezimmer-Eltern.Raffstore.Rotation-Status
   room: Badezimmer Eltern
+  writable: false
 5/3/189:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Badezimmer-Eltern.Raffstore.Geöffnet-Status
   room: Badezimmer Eltern
+  writable: false
 5/3/190:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Badezimmer-Eltern.Raffstore.Geschlossen-Status
   room: Badezimmer Eltern
+  writable: true
 5/3/191:
   dpt: '1.010'
   function: Beschattung
   name: Beschattung.OG.Badezimmer-Eltern.Raffstore.Fahrzeit
   room: Badezimmer Eltern
+  writable: true
 5/3/2:
   dpt: '1.008'
   function: Beschattung
   name: Beschattung.OG.Flur.Raffstore.Fahren
   room: Flur
+  writable: true
 5/3/20:
   dpt: '1.003'
   function: Beschattung
   name: Beschattung.OG.Abstellraum.Raffstore.Sperren
   room: Abstellraum
+  writable: true
 5/3/21:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Abstellraum.Raffstore.Sperren-Status
   room: Abstellraum
+  writable: false
 5/3/22:
   dpt: '1.008'
   function: Beschattung
   name: Beschattung.OG.Abstellraum.Raffstore.Fahren
   room: Abstellraum
+  writable: true
 5/3/23:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Abstellraum.Raffstore.Fahren-Status
   room: Abstellraum
+  writable: false
 5/3/24:
   dpt: '1.007'
   function: Beschattung
   name: Beschattung.OG.Abstellraum.Raffstore.Stoppen
   room: Abstellraum
+  writable: true
 5/3/25:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Abstellraum.Raffstore.Position
   room: Abstellraum
+  writable: true
 5/3/26:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Abstellraum.Raffstore.Position-Status
   room: Abstellraum
+  writable: false
 5/3/27:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Abstellraum.Raffstore.Rotation
   room: Abstellraum
+  writable: true
 5/3/28:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Abstellraum.Raffstore.Rotation-Status
   room: Abstellraum
+  writable: false
 5/3/29:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Abstellraum.Raffstore.Geöffnet-Status
   room: Abstellraum
+  writable: false
 5/3/3:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Flur.Raffstore.Fahren-Status
   room: Flur
+  writable: false
 5/3/30:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Abstellraum.Raffstore.Geschlossen-Status
   room: Abstellraum
+  writable: true
 5/3/31:
   dpt: '1.010'
   function: Beschattung
   name: Beschattung.OG.Abstellraum.Raffstore.Fahrzeit
   room: Abstellraum
+  writable: true
 5/3/4:
   dpt: '1.007'
   function: Beschattung
   name: Beschattung.OG.Flur.Raffstore.Stoppen
   room: Flur
+  writable: true
 5/3/40:
   dpt: '1.003'
   function: Beschattung
   name: Beschattung.OG.Badezimmer-Kinder.Raffstore.Sperren
   room: Badezimmer Kinder
+  writable: true
 5/3/41:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Badezimmer-Kinder.Raffstore.Sperren-Status
   room: Badezimmer Kinder
+  writable: false
 5/3/42:
   dpt: '1.008'
   function: Beschattung
   name: Beschattung.OG.Badezimmer-Kinder.Raffstore.Fahren
   room: Badezimmer Kinder
+  writable: true
 5/3/43:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Badezimmer-Kinder.Raffstore.Fahren-Status
   room: Badezimmer Kinder
+  writable: false
 5/3/44:
   dpt: '1.007'
   function: Beschattung
   name: Beschattung.OG.Badezimmer-Kinder.Raffstore.Stoppen
   room: Badezimmer Kinder
+  writable: true
 5/3/45:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Badezimmer-Kinder.Raffstore.Postion
   room: Badezimmer Kinder
+  writable: true
 5/3/46:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Badezimmer-Kinder.Raffstore.Position-Status
   room: Badezimmer Kinder
+  writable: false
 5/3/47:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Badezimmer-Kinder.Raffstore.Rotation
   room: Badezimmer Kinder
+  writable: true
 5/3/48:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Badezimmer-Kinder.Raffstore.Rotation-Status
   room: Badezimmer Kinder
+  writable: false
 5/3/49:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Badezimmer-Kinder.Raffstore.Geöffnet-Status
   room: Badezimmer Kinder
+  writable: false
 5/3/5:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Flur.Raffstore.Position
   room: Flur
+  writable: true
 5/3/50:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Badezimmer-Kinder.Raffstore.Geschlossen-Status
   room: Badezimmer Kinder
+  writable: true
 5/3/51:
   dpt: '1.010'
   function: Beschattung
   name: Beschattung.OG.Badezimmer-Kinder.Raffstore.Fahrzeit
   room: Badezimmer Kinder
+  writable: true
 5/3/6:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Flur.Raffstore.Position-Status
   room: Flur
+  writable: false
 5/3/60:
   dpt: '1.003'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Raffstore.Sperren
   room: Schlafzimmer Gregory
+  writable: true
 5/3/61:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Raffstore.Sperren-Status
   room: Schlafzimmer Gregory
+  writable: false
 5/3/62:
   dpt: '1.008'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Raffstore.Fahren
   room: Schlafzimmer Gregory
+  writable: true
 5/3/63:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Raffstore.Fahren-Status
   room: Schlafzimmer Gregory
+  writable: false
 5/3/64:
   dpt: '1.007'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Raffstore.Stoppen
   room: Schlafzimmer Gregory
+  writable: true
 5/3/65:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Raffstore.Position
   room: Schlafzimmer Gregory
+  writable: true
 5/3/66:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Raffstore.Position-Status
   room: Schlafzimmer Gregory
+  writable: false
 5/3/67:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Raffstore.Rotation
   room: Schlafzimmer Gregory
+  writable: true
 5/3/68:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Raffstore.Rotation-Status
   room: Schlafzimmer Gregory
+  writable: false
 5/3/69:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Raffstore.Geöffnet-Status
   room: Schlafzimmer Gregory
+  writable: false
 5/3/7:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Flur.Raffstore.Rotation
   room: Flur
+  writable: true
 5/3/70:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Raffstore.Geschlossen-Status
   room: Schlafzimmer Gregory
+  writable: true
 5/3/71:
   dpt: '1.010'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Raffstore.Fahrzeit
   room: Schlafzimmer Gregory
+  writable: true
 5/3/8:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Flur.Raffstore.Rotation-Status
   room: Flur
+  writable: false
 5/3/80:
   dpt: '1.003'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Vorhang.Sperren
   room: Schlafzimmer Gregory
+  writable: true
 5/3/81:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Vorhang.Sperren-Status
   room: Schlafzimmer Gregory
+  writable: false
 5/3/82:
   dpt: '1.008'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Vorhang.Fahren
   room: Schlafzimmer Gregory
+  writable: true
 5/3/83:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Vorhang.Fahren-Status
   room: Schlafzimmer Gregory
+  writable: false
 5/3/84:
   dpt: '1.017'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Vorhang.Stoppen
   room: Schlafzimmer Gregory
+  writable: true
 5/3/85:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Vorhang.Position
   room: Schlafzimmer Gregory
+  writable: true
 5/3/86:
   dpt: '5.001'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Vorhang.Position-Status
   room: Schlafzimmer Gregory
+  writable: false
 5/3/89:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Vorhang.Geöffnet-Status
   room: Schlafzimmer Gregory
+  writable: false
 5/3/9:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Flur.Raffstore.Geöffnet-Status
   room: Flur
+  writable: false
 5/3/90:
   dpt: '1.011'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Vorhang.Geschlossen-Status
   room: Schlafzimmer Gregory
+  writable: true
 5/3/91:
   dpt: '1.010'
   function: Beschattung
   name: Beschattung.OG.Schlafzimmer-Gregory.Vorhang.Fahrzeit
   room: Schlafzimmer Gregory
+  writable: false
 6/0/200:
   description: 1 - Innen Raumklima
   dpt: '5.010'
   function: Raumklima
   name: Raumklima.Zentral.Gebäude.KWL.Lüftermodi
   room: 1 - Gebäude
+  writable: false
 6/0/201:
   description: 1 - Innen Raumklima
   dpt: '5.010'
   function: Raumklima
   name: Raumklima.Zentral.Gebäude.KWL.Lüftermodi-Status
   room: 1 - Gebäude
+  writable: false
 6/1/100:
   dpt: '1.003'
   function: Raumklima
   name: Raumklima.KG.Hauswirtschaftsraum.Entfeuchter.Sperren
   room: Hauswirtschaftsraum
+  writable: false
 6/1/101:
   dpt: '1.011'
   function: Raumklima
   name: Raumklima.KG.Hauswirtschaftsraum.Entfeuchter.Sperren-Status
   room: Hauswirtschaftsraum
+  writable: false
 6/1/102:
   dpt: '1.001'
   function: Raumklima
   name: Raumklima.KG.Hauswirtschaftsraum.Entfeuchter.Ein/Aus
   room: Hauswirtschaftsraum
+  writable: false
 6/1/103:
   dpt: '1.011'
   function: Raumklima
   name: Raumklima.KG.Hauswirtschaftsraum.Entfeuchter.Ein/Aus-Status
   room: Hauswirtschaftsraum
+  writable: false
 6/1/104:
   dpt: '5.010'
   function: Raumklima
   name: Raumklima.KG.Hauswirtschaftsraum.Entfeuchter.Modus
   room: Hauswirtschaftsraum
+  writable: false
 6/1/105:
   dpt: '5.010'
   function: Raumklima
   name: Raumklima.KG.Hauswirtschaftsraum.Entfeuchter.Modus-Status
   room: Hauswirtschaftsraum
+  writable: false
 6/1/106:
   dpt: '5.010'
   function: Raumklima
   name: Raumklima.KG.Hauswirtschaftsraum.Entfeuchter.Lüfterstufe
   room: Hauswirtschaftsraum
+  writable: false
 6/1/107:
   dpt: '5.010'
   function: Raumklima
   name: Raumklima.KG.Hauswirtschaftsraum.Entfeuchter.Lüfterstufe-Status
   room: Hauswirtschaftsraum
+  writable: false
 6/1/108:
   dpt: '5.001'
   function: Raumklima
   name: Raumklima.KG.Hauswirtschaftsraum.Entfeuchter.Soll-Luftfeuchtigkeit
   room: Hauswirtschaftsraum
+  writable: false
 6/1/109:
   dpt: '5.001'
   function: Raumklima
   name: Raumklima.KG.Hauswirtschaftsraum.Entfeuchter.Soll-Luftfeuchtigkeit-Status
   room: Hauswirtschaftsraum
+  writable: false
 6/1/110:
   dpt: '1.005'
   function: Raumklima
   name: Raumklima.KG.Hauswirtschaftsraum.Entfeuchter.Tank-Voll-Status
   room: Hauswirtschaftsraum
+  writable: false
 6/1/111:
   dpt: '9.007'
   function: Raumklima
   name: Raumklima.KG.Hauswirtschaftsraum.Entfeuchter.Luftfeuchtigkeit
   room: Hauswirtschaftsraum
+  writable: false
 6/1/112:
   dpt: '9.001'
   function: Raumklima
   name: Raumklima.KG.Hauswirtschaftsraum.Entfeuchter.Temperatur
   room: Hauswirtschaftsraum
+  writable: false
 6/1/60:
   dpt: '1.003'
   function: Raumklima
   name: Raumklima.KG.Vorratsraum.Entfeuchter.Sperren
   room: Vorratsraum
+  writable: false
 6/1/61:
   dpt: '1.011'
   function: Raumklima
   name: Raumklima.KG.Vorratsraum.Entfeuchter.Sperren-Status
   room: Vorratsraum
+  writable: false
 6/1/62:
   dpt: '1.001'
   function: Raumklima
   name: Raumklima.KG.Vorratsraum.Entfeuchter.Ein/Aus
   room: Vorratsraum
+  writable: false
 6/1/63:
   dpt: '1.011'
   function: Raumklima
   name: Raumklima.KG.Vorratsraum.Entfeuchter.Ein/Aus-Status
   room: Vorratsraum
+  writable: false
 6/1/64:
   dpt: '5.010'
   function: Raumklima
   name: Raumklima.KG.Vorratsraum.Entfeuchter.Modus
   room: Vorratsraum
+  writable: false
 6/1/65:
   dpt: '5.010'
   function: Raumklima
   name: Raumklima.KG.Vorratsraum.Entfeuchter.Modus-Status
   room: Vorratsraum
+  writable: false
 6/1/66:
   dpt: '5.010'
   function: Raumklima
   name: Raumklima.KG.Vorratsraum.Entfeuchter.Lüfterstufe
   room: Vorratsraum
+  writable: false
 6/1/67:
   dpt: '5.010'
   function: Raumklima
   name: Raumklima.KG.Vorratsraum.Entfeuchter.Lüfterstufe-Status
   room: Vorratsraum
+  writable: false
 6/1/68:
   dpt: '5.001'
   function: Raumklima
   name: Raumklima.KG.Vorratsraum.Entfeuchter.Soll-Luftfeuchtigkeit
   room: Vorratsraum
+  writable: false
 6/1/69:
   dpt: '5.001'
   function: Raumklima
   name: Raumklima.KG.Vorratsraum.Entfeuchter.Soll-Luftfeuchtigkeit-Status
   room: Vorratsraum
+  writable: false
 6/1/70:
   dpt: '1.005'
   function: Raumklima
   name: Raumklima.KG.Vorratsraum.Entfeuchter.Tank-Voll-Status
   room: Vorratsraum
+  writable: false
 6/1/71:
   dpt: '9.007'
   function: Raumklima
   name: Raumklima.KG.Vorratsraum.Entfeuchter.Luftfeuchtigkeit
   room: Vorratsraum
+  writable: false
 6/1/72:
   dpt: '9.001'
   function: Raumklima
   name: Raumklima.KG.Vorratsraum.Entfeuchter.Temperatur
   room: Vorratsraum
+  writable: false
 6/2/0:
   dpt: '1.003'
   function: Raumklima
   name: Raumklima.EG.Flur.FBH.Sperren
   room: Flur
+  writable: true
 6/2/1:
   dpt: '5.001'
   function: Raumklima
   name: Raumklima.EG.Flur.FBH.Stellwert-Status
   room: Flur
+  writable: true
 6/2/10:
   dpt: '16.000'
   function: Raumklima
   name: Raumklima.EG.Flur.FBH.Diagnose
   room: Flur
+  writable: false
 6/2/100:
   dpt: '1.003'
   function: Raumklima
   name: Raumklima.EG.Küche.FBH.Sperren
   room: Küche
+  writable: true
 6/2/101:
   dpt: '5.001'
   function: Raumklima
   name: Raumklima.EG.Küche.FBH.Stellwert-Status
   room: Küche
+  writable: true
 6/2/102:
   dpt: '9.001'
   function: Raumklima
   name: Raumklima.EG.Küche.FBH.Soll-Temperatur
   room: Küche
+  writable: true
 6/2/103:
   dpt: '9.001'
   function: Raumklima
   name: Raumklima.EG.Küche.FBH.Soll-Temperatur-Status
   room: Küche
+  writable: false
 6/2/104:
   dpt: '9.002'
   function: Raumklima
   name: Raumklima.EG.Küche.FBH.Sollwertverschiebung
   room: Küche
+  writable: true
 6/2/105:
   dpt: '20.102'
   function: Raumklima
   name: Raumklima.EG.Küche.FBH.HVAC
   room: Küche
+  writable: true
 6/2/106:
   dpt: '20.102'
   function: Raumklima
   name: Raumklima.EG.Küche.FBH.HVAC-Status
   room: Küche
+  writable: false
 6/2/107:
   dpt: '1.011'
   function: Raumklima
   name: Raumklima.EG.Küche.FBH.Aktiv
   room: Küche
+  writable: false
 6/2/108:
   dpt: '5.010'
   function: Raumklima
   name: Raumklima.EG.Küche.FBH.Aktiv-Anomalie
   room: Küche
+  writable: false
 6/2/109:
   dpt: '5.010'
   function: Raumklima
   name: Raumklima.EG.Küche.FBH.Aktiv-Fenster-Auf-Anomalie
   room: Küche
+  writable: false
 6/2/110:
   dpt: '16.000'
   function: Raumklima
   name: Raumklima.EG.Küche.FBH.Diagnose
   room: Küche
+  writable: false
 6/2/2:
   dpt: '9.001'
   function: Raumklima
   name: Raumklima.EG.Flur.FBH.Soll-Temperatur
   room: Flur
+  writable: true
 6/2/20:
   dpt: '1.003'
   function: Raumklima
   name: Raumklima.EG.Gäste-WC.FBH.Sperren
   room: Gäste WC
+  writable: true
 6/2/21:
   dpt: '5.001'
   function: Raumklima
   name: Raumklima.EG.Gäste-WC.FBH.Stellwert-Status
   room: Gäste WC
+  writable: true
 6/2/22:
   dpt: '9.001'
   function: Raumklima
   name: Raumklima.EG.Gäste-WC.FBH.Soll-Temperatur
   room: Gäste WC
+  writable: true
 6/2/23:
   dpt: '9.001'
   function: Raumklima
   name: Raumklima.EG.Gäste-WC.FBH.Soll-Temperatur-Status
   room: Gäste WC
+  writable: false
 6/2/24:
   dpt: '9.002'
   function: Raumklima
   name: Raumklima.EG.Gäste-WC.FBH.Sollwertverschiebung
   room: Gäste WC
+  writable: true
 6/2/25:
   dpt: '20.102'
   function: Raumklima
   name: Raumklima.EG.Gäste-WC.HVAC
   room: Gäste WC
+  writable: true
 6/2/26:
   dpt: '20.102'
   function: Raumklima
   name: Raumklima.EG.Gäste-WC.HVAC-Status
   room: Gäste WC
+  writable: false
 6/2/27:
   dpt: '1.011'
   function: Raumklima
   name: Raumklima.EG.Gäste-WC.FBH.Aktiv
   room: Gäste WC
+  writable: false
 6/2/28:
   dpt: '5.010'
   function: Raumklima
   name: Raumklima.EG.Gäste-WC.FBH.Aktiv-Anomalie
   room: Gäste WC
+  writable: false
 6/2/29:
   dpt: '5.010'
   function: Raumklima
   name: Raumklima.EG.Gäste-WC.FBH.Aktiv-Fenster-Auf-Anomalie
   room: Gäste WC
+  writable: false
 6/2/3:
   dpt: '9.001'
   function: Raumklima
   name: Raumklima.EG.Flur.FBH.Soll-Temperatur-Status
   room: Flur
+  writable: false
 6/2/30:
   dpt: '16.000'
   function: Raumklima
   name: Raumklima.EG.Gäste-WC.FBH.Diagnose
   room: Gäste WC
+  writable: false
 6/2/4:
   dpt: '9.002'
   function: Raumklima
   name: Raumklima.EG.Flur.FBH.Sollwertverschiebung
   room: Flur
+  writable: true
 6/2/40:
   dpt: '1.003'
   function: Raumklima
   name: Raumklima.EG.Büro.FBH.Sperren
   room: Büro
+  writable: true
 6/2/41:
   dpt: '5.001'
   function: Raumklima
   name: Raumklima.EG.Büro.FBH.Stellwert-Status
   room: Büro
+  writable: true
 6/2/42:
   dpt: '9.001'
   function: Raumklima
   name: Raumklima.EG.Büro.FBH.Soll-Temperatur
   room: Büro
+  writable: true
 6/2/43:
   dpt: '9.001'
   function: Raumklima
   name: Raumklima.EG.Büro.FBH.Soll-Temperatur-Status
   room: Büro
+  writable: false
 6/2/44:
   dpt: '9.002'
   function: Raumklima
   name: Raumklima.EG.Büro.FBH.Sollwertverschiebung
   room: Büro
+  writable: true
 6/2/45:
   dpt: '20.102'
   function: Raumklima
   name: Raumklima.EG.Büro.FBH.HVAC
   room: Büro
+  writable: true
 6/2/46:
   dpt: '20.102'
   function: Raumklima
   name: Raumklima.EG.Büro.FBH.HVAC-Status
   room: Büro
+  writable: false
 6/2/47:
   dpt: '1.011'
   function: Raumklima
   name: Raumklima.EG.Büro.FBH.Aktiv
   room: Büro
+  writable: false
 6/2/48:
   dpt: '5.010'
   function: Raumklima
   name: Raumklima.EG.Büro.FBH.Aktiv-Anomalie
   room: Büro
+  writable: false
 6/2/49:
   dpt: '5.010'
   function: Raumklima
   name: Raumklima.EG.Büro.FBH.Aktiv-Fenster-Auf-Anomalie
   room: Büro
+  writable: false
 6/2/5:
   dpt: '20.102'
   function: Raumklima
   name: Raumklima.EG.Flur.FBH.HVAC
   room: Flur
+  writable: true
 6/2/50:
   dpt: '16.000'
   function: Raumklima
   name: Raumklima.EG.Büro.FBH.Diagnose
   room: Büro
+  writable: false
 6/2/6:
   dpt: '20.102'
   function: Raumklima
   name: Raumklima.EG.Flur.FBH.HVAC-Status
   room: Flur
+  writable: false
 6/2/60:
   dpt: '1.003'
   function: Raumklima
   name: Raumklima.EG.Wohnzimmer.FBH.Sperren
   room: Wohnzimmer
+  writable: true
 6/2/61:
   dpt: '5.001'
   function: Raumklima
   name: Raumklima.EG.Wohnzimmer.FBH.Stellwert-Status
   room: Wohnzimmer
+  writable: true
 6/2/62:
   dpt: '9.001'
   function: Raumklima
   name: Raumklima.EG.Wohnzimmer.FBH.Soll-Temperatur
   room: Wohnzimmer
+  writable: true
 6/2/63:
   dpt: '9.001'
   function: Raumklima
   name: Raumklima.EG.Wohnzimmer.FBH.Soll-Temperatur-Status
   room: Wohnzimmer
+  writable: false
 6/2/64:
   dpt: '9.002'
   function: Raumklima
   name: Raumklima.EG.Wohnzimmer.FBH.Sollwertverschiebung
   room: Wohnzimmer
+  writable: true
 6/2/65:
   dpt: '20.102'
   function: Raumklima
   name: Raumklima.EG.Wohnzimmer.FBH.HVAC
   room: Wohnzimmer
+  writable: true
 6/2/66:
   dpt: '20.102'
   function: Raumklima
   name: Raumklima.EG.Wohnzimmer.FBH.HVAC-Status
   room: Wohnzimmer
+  writable: false
 6/2/67:
   dpt: '1.011'
   function: Raumklima
   name: Raumklima.EG.Wohnzimmer.FBH.Aktiv
   room: Wohnzimmer
+  writable: false
 6/2/68:
   dpt: '5.010'
   function: Raumklima
   name: Raumklima.EG.Wohnzimmer.FBH.Aktiv-Anomalie
   room: Wohnzimmer
+  writable: false
 6/2/69:
   dpt: '5.010'
   function: Raumklima
   name: Raumklima.EG.Wohnzimmer.FBH.Aktiv-Fenster-Auf-Anomalie
   room: Wohnzimmer
+  writable: false
 6/2/7:
   dpt: '1.011'
   function: Raumklima
   name: Raumklima.EG.Flur.FBH.Aktiv
   room: Flur
+  writable: false
 6/2/70:
   dpt: '16.000'
   function: Raumklima
   name: Raumklima.EG.Wohnzimmer.FBH.Diagnose
   room: Wohnzimmer
+  writable: false
 6/2/8:
   dpt: '5.010'
   function: Raumklima
   name: Raumklima.EG.Flur.FBH.Aktiv-Anomalie
   room: Flur
+  writable: false
 6/2/80:
   dpt: '1.003'
   function: Raumklima
   name: Raumklima.EG.Esszimmer.FBH.Sperren
   room: Esszimmer
+  writable: true
 6/2/81:
   dpt: '5.001'
   function: Raumklima
   name: Raumklima.EG.Esszimmer.FBH.Stellwert-Status
   room: Esszimmer
+  writable: true
 6/2/82:
   dpt: '9.001'
   function: Raumklima
   name: Raumklima.EG.Esszimmer.FBH.Soll-Temperatur
   room: Esszimmer
+  writable: true
 6/2/83:
   dpt: '9.001'
   function: Raumklima
   name: Raumklima.EG.Esszimmer.FBH.Soll-Temperatur-Status
   room: Esszimmer
+  writable: false
 6/2/84:
   dpt: '9.002'
   function: Raumklima
   name: Raumklima.EG.Esszimmer.FBH.Sollwertverschiebung
   room: Esszimmer
+  writable: true
 6/2/85:
   dpt: '20.102'
   function: Raumklima
   name: Raumklima.EG.Esszimmer.FBH.HVAC
   room: Esszimmer
+  writable: true
 6/2/86:
   dpt: '20.102'
   function: Raumklima
   name: Raumklima.EG.Esszimmer.FBH.HVAC-Status
   room: Esszimmer
+  writable: false
 6/2/87:
   dpt: '1.011'
   function: Raumklima
   name: Raumklima.EG.Esszimmer.FBH.Aktiv
   room: Esszimmer
+  writable: false
 6/2/88:
   dpt: '5.010'
   function: Raumklima
   name: Raumklima.EG.Esszimmer.FBH.Aktiv-Anomalie
   room: Esszimmer
+  writable: false
 6/2/89:
   dpt: '5.010'
   function: Raumklima
   name: Raumklima.EG.Esszimmer.FBH.Aktiv-Fenster-Auf-Anomalie
   room: Esszimmer
+  writable: false
 6/2/9:
   dpt: '5.010'
   function: Raumklima
   name: Raumklima.EG.Flur.FBH.Aktiv-Fenster-Auf-Anomalie
   room: Flur
+  writable: false
 6/2/90:
   dpt: '16.000'
   function: Raumklima
   name: Raumklima.EG.Esszimmer.FBH.Diagnose
   room: Esszimmer
+  writable: false
 6/3/0:
   dpt: '1.003'
   function: Raumklima
   name: Raumklima.OG.Flur.FBH.Sperren
   room: Flur
+  writable: true
 6/3/1:
   dpt: '5.001'
   function: Raumklima
   name: Raumklima.OG.Flur.FBH.Stellwert-Status
   room: Flur
+  writable: true
 6/3/10:
   dpt: '16.000'
   function: Raumklima
   name: Raumklima.OG.Flur.FBH.Diagnose
   room: Flur
+  writable: false
 6/3/100:
   dpt: '1.003'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Luis.FBH.Sperren
   room: Schlafzimmer Luis
+  writable: true
 6/3/101:
   dpt: '5.001'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Luis.FBH.Stellwert-Status
   room: Schlafzimmer Luis
+  writable: true
 6/3/102:
   dpt: '9.001'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Luis.FBH.Soll-Temperatur
   room: Schlafzimmer Luis
+  writable: true
 6/3/103:
   dpt: '9.001'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Luis.FBH.Soll-Temperatur-Status
   room: Schlafzimmer Luis
+  writable: false
 6/3/104:
   dpt: '9.002'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Luis.FBH.Sollwertverschiebung
   room: Schlafzimmer Luis
+  writable: true
 6/3/105:
   dpt: '20.102'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Luis.FBH.HVAC
   room: Schlafzimmer Luis
+  writable: true
 6/3/106:
   dpt: '20.102'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Luis.FBH.HVAC-Status
   room: Schlafzimmer Luis
+  writable: false
 6/3/107:
   dpt: '1.011'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Luis.FBH.Aktiv
   room: Schlafzimmer Luis
+  writable: false
 6/3/108:
   dpt: '5.010'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Luis.FBH.Aktiv-Anomalie
   room: Schlafzimmer Luis
+  writable: false
 6/3/109:
   dpt: '5.010'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Luis.FBH.Aktiv-Fenster-Auf-Anomalie
   room: Schlafzimmer Luis
+  writable: false
 6/3/110:
   dpt: '16.000'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Luis.FBH.Diagnose
   room: Schlafzimmer Luis
+  writable: false
 6/3/140:
   dpt: '1.003'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.FBH.Sperren
   room: Schlafzimmer Eltern
+  writable: true
 6/3/141:
   dpt: '5.001'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.FBH.Stellwert-Status
   room: Schlafzimmer Eltern
+  writable: true
 6/3/142:
   dpt: '9.001'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.FBH.Soll-Temperatur
   room: Schlafzimmer Eltern
+  writable: true
 6/3/143:
   dpt: '9.001'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.FBH.Soll-Temperatur-Status
   room: Schlafzimmer Eltern
+  writable: false
 6/3/144:
   dpt: '9.002'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.FBH.Sollwertverschiebung
   room: Schlafzimmer Eltern
+  writable: true
 6/3/145:
   dpt: '20.102'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.FBH.HVAC
   room: Schlafzimmer Eltern
+  writable: true
 6/3/146:
   dpt: '20.102'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.FBH.HVAC-Status
   room: Schlafzimmer Eltern
+  writable: false
 6/3/147:
   dpt: '1.011'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.FBH.Aktiv
   room: Schlafzimmer Eltern
+  writable: false
 6/3/148:
   dpt: '5.010'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.FBH.Aktiv-Anomalie
   room: Schlafzimmer Eltern
+  writable: false
 6/3/149:
   dpt: '5.010'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.FBH.Aktiv-Fenster-Auf-Anomalie
   room: Schlafzimmer Eltern
+  writable: false
 6/3/150:
   dpt: '16.000'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.FBH.Diagnose
   room: Schlafzimmer Eltern
+  writable: false
 6/3/160:
   dpt: '1.003'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.Luftreiniger.Sperren
   room: Schlafzimmer Eltern
+  writable: false
 6/3/161:
   dpt: '1.011'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.Luftreiniger.Sperren-Status
   room: Schlafzimmer Eltern
+  writable: false
 6/3/162:
   dpt: '1.001'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.Luftreiniger.Ein/Aus
   room: Schlafzimmer Eltern
+  writable: false
 6/3/163:
   dpt: '1.011'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.Luftreiniger.Ein/Aus-Status
   room: Schlafzimmer Eltern
+  writable: false
 6/3/164:
   dpt: '5.010'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.Luftreiniger.Lüfterstufe
   room: Schlafzimmer Eltern
+  writable: false
 6/3/165:
   dpt: '5.010'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.Luftreiniger.Lüfterstufe-Status
   room: Schlafzimmer Eltern
+  writable: false
 6/3/166:
   dpt: '5.010'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.Luftreiniger.Drehmodus
   room: Schlafzimmer Eltern
+  writable: false
 6/3/167:
   dpt: '5.010'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.Luftreiniger.Drehmodus-Status
   room: Schlafzimmer Eltern
+  writable: false
 6/3/168:
   dpt: '1.001'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.Luftreiniger.Nachtmodus
   room: Schlafzimmer Eltern
+  writable: false
 6/3/169:
   dpt: '1.011'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.Luftreiniger.Nachtmodus-Status
   room: Schlafzimmer Eltern
+  writable: false
 6/3/170:
   dpt: '9.030'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.Luftreiniger.Feinstaub-PM25
   room: Schlafzimmer Eltern
+  writable: false
 6/3/171:
   dpt: '9.030'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.Luftreiniger.Feinstaub-PM10
   room: Schlafzimmer Eltern
+  writable: false
 6/3/172:
   dpt: '5.001'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.Luftreiniger.Filter-Lebensdauer
   room: Schlafzimmer Eltern
+  writable: false
 6/3/173:
   dpt: '1.011'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Eltern.Luftreiniger.Lüfter-Läuft-Status
   room: Schlafzimmer Eltern
+  writable: false
 6/3/180:
   dpt: '1.003'
   function: Raumklima
   name: Raumklima.OG.Begehbarer-Schrank.FBH.Sperren
   room: Begehbarer Schrank
+  writable: true
 6/3/181:
   dpt: '5.001'
   function: Raumklima
   name: Raumklima.OG.Begehbarer-Schrank.FBH.Stellwert-Status
   room: Begehbarer Schrank
+  writable: true
 6/3/182:
   dpt: '9.001'
   function: Raumklima
   name: Raumklima.OG.Begehbarer-Schrank.FBH.Soll-Temperatur
   room: Begehbarer Schrank
+  writable: true
 6/3/183:
   dpt: '9.001'
   function: Raumklima
   name: Raumklima.OG.Begehbarer-Schrank.FBH.Soll-Temperatur-Status
   room: Begehbarer Schrank
+  writable: false
 6/3/184:
   dpt: '9.002'
   function: Raumklima
   name: Raumklima.OG.Begehbarer-Schrank.FBH.Sollwertverschiebung
   room: Begehbarer Schrank
+  writable: true
 6/3/185:
   dpt: '20.102'
   function: Raumklima
   name: Raumklima.OG.Begehbarer-Schrank.FBH.HVAC
   room: Begehbarer Schrank
+  writable: true
 6/3/186:
   dpt: '20.102'
   function: Raumklima
   name: Raumklima.OG.Begehbarer-Schrank.FBH.HVAC-Status
   room: Begehbarer Schrank
+  writable: false
 6/3/187:
   dpt: '1.011'
   function: Raumklima
   name: Raumklima.OG.Begehbarer-Schrank.FBH.Aktiv
   room: Begehbarer Schrank
+  writable: false
 6/3/188:
   dpt: '5.010'
   function: Raumklima
   name: Raumklima.OG.Begehbarer-Schrank.FBH.Aktiv-Anomalie
   room: Begehbarer Schrank
+  writable: false
 6/3/189:
   dpt: '5.010'
   function: Raumklima
   name: Raumklima.OG.Begehbarer-Schrank.FBH.Aktiv-Fenster-Auf-Anomalie
   room: Begehbarer Schrank
+  writable: false
 6/3/190:
   dpt: '16.000'
   function: Raumklima
   name: Raumklima.OG.Begehbarer-Schrank.FBH.Diagnose
   room: Begehbarer Schrank
+  writable: false
 6/3/2:
   dpt: '9.001'
   function: Raumklima
   name: Raumklima.OG.Flur.FBH.Soll-Temperatur
   room: Flur
+  writable: true
 6/3/20:
   dpt: '1.003'
   function: Raumklima
   name: Raumklima.OG.Abstellraum.FBH.Sperren
   room: Abstellraum
+  writable: true
 6/3/200:
   dpt: '1.003'
   function: Raumklima
   name: Raumklima.OG.Badezimmer-Eltern.FBH.Sperren
   room: Badezimmer Eltern
+  writable: true
 6/3/201:
   dpt: '5.001'
   function: Raumklima
   name: Raumklima.OG.Badezimmer-Eltern.FBH.Stellwert-Status
   room: Badezimmer Eltern
+  writable: true
 6/3/202:
   dpt: '9.001'
   function: Raumklima
   name: Raumklima.OG.Badezimmer-Eltern.FBH.Soll-Temperatur
   room: Badezimmer Eltern
+  writable: true
 6/3/203:
   dpt: '9.001'
   function: Raumklima
   name: Raumklima.OG.Badezimmer-Eltern.FBH.Soll-Temperatur-Status
   room: Badezimmer Eltern
+  writable: false
 6/3/204:
   dpt: '9.002'
   function: Raumklima
   name: Raumklima.OG.Badezimmer-Eltern.FBH.Sollwertverschiebung
   room: Badezimmer Eltern
+  writable: true
 6/3/205:
   dpt: '20.102'
   function: Raumklima
   name: Raumklima.OG.Badezimmer-Eltern.FBH.HVAC
   room: Badezimmer Eltern
+  writable: true
 6/3/206:
   dpt: '20.102'
   function: Raumklima
   name: Raumklima.OG.Badezimmer-Eltern.FBH.HVAC-Status
   room: Badezimmer Eltern
+  writable: false
 6/3/207:
   dpt: '1.011'
   function: Raumklima
   name: Raumklima.OG.Badezimmer-Eltern.FBH.Aktiv
   room: Badezimmer Eltern
+  writable: false
 6/3/208:
   dpt: '5.010'
   function: Raumklima
   name: Raumklima.OG.Badezimmer-Eltern.FBH.Aktiv-Anomalie
   room: Badezimmer Eltern
+  writable: false
 6/3/209:
   dpt: '5.010'
   function: Raumklima
   name: Raumklima.OG.Badezimmer-Eltern.FBH.Aktiv-Fenster-Auf-Anomalie
   room: Badezimmer Eltern
+  writable: false
 6/3/21:
   dpt: '5.001'
   function: Raumklima
   name: Raumklima.OG.Abstellraum.FBH.Stellwert-Status
   room: Abstellraum
+  writable: true
 6/3/210:
   dpt: '16.000'
   function: Raumklima
   name: Raumklima.OG.Badezimmer-Eltern.FBH.Diagnose
   room: Badezimmer Eltern
+  writable: false
 6/3/22:
   dpt: '9.001'
   function: Raumklima
   name: Raumklima.OG.Abstellraum.FBH.Soll-Temperatur
   room: Abstellraum
+  writable: true
 6/3/23:
   dpt: '9.001'
   function: Raumklima
   name: Raumklima.OG.Abstellraum.FBH.Soll-Temperatur-Status
   room: Abstellraum
+  writable: false
 6/3/24:
   dpt: '9.002'
   function: Raumklima
   name: Raumklima.OG.Abstellraum.FBH.Sollwertverschiebung
   room: Abstellraum
+  writable: true
 6/3/25:
   dpt: '20.102'
   function: Raumklima
   name: Raumklima.OG.Abstellraum.FBH.HVAC
   room: Abstellraum
+  writable: true
 6/3/26:
   dpt: '20.102'
   function: Raumklima
   name: Raumklima.OG.Abstellraum.FBH.HVAC-Status
   room: Abstellraum
+  writable: false
 6/3/27:
   dpt: '1.011'
   function: Raumklima
   name: Raumklima.OG.Abstellraum.FBH.Aktiv
   room: Abstellraum
+  writable: false
 6/3/28:
   dpt: '5.010'
   function: Raumklima
   name: Raumklima.OG.Abstellraum.FBH.Aktiv-Anomalie
   room: Abstellraum
+  writable: false
 6/3/29:
   dpt: '5.010'
   function: Raumklima
   name: Raumklima.OG.Abstellraum.FBH.Aktiv-Fenster-Auf-Anomalie
   room: Abstellraum
+  writable: false
 6/3/3:
   dpt: '9.001'
   function: Raumklima
   name: Raumklima.OG.Flur.FBH.Soll-Temperatur-Status
   room: Flur
+  writable: false
 6/3/30:
   dpt: '16.000'
   function: Raumklima
   name: Raumklima.OG.Abstellraum.FBH.Diagnose
   room: Abstellraum
+  writable: false
 6/3/4:
   dpt: '9.002'
   function: Raumklima
   name: Raumklima.OG.Flur.FBH.Sollwertverschiebung
   room: Flur
+  writable: true
 6/3/40:
   dpt: '1.003'
   function: Raumklima
   name: Raumklima.OG.Badezimmer-Kinder.FBH.Sperren
   room: Badezimmer Kinder
+  writable: true
 6/3/41:
   dpt: '5.001'
   function: Raumklima
   name: Raumklima.OG.Badezimmer-Kinder.FBH.Stellwert-Status
   room: Badezimmer Kinder
+  writable: true
 6/3/42:
   dpt: '9.001'
   function: Raumklima
   name: Raumklima.OG.Badezimmer-Kinder.FBH.Soll-Temperatur
   room: Badezimmer Kinder
+  writable: true
 6/3/43:
   dpt: '9.001'
   function: Raumklima
   name: Raumklima.OG.Badezimmer-Kinder.FBH.Soll-Temperatur-Status
   room: Badezimmer Kinder
+  writable: false
 6/3/44:
   dpt: '9.002'
   function: Raumklima
   name: Raumklima.OG.Badezimmer-Kinder.FBH.Sollwertveränderung
   room: Badezimmer Kinder
+  writable: true
 6/3/45:
   dpt: '20.102'
   function: Raumklima
   name: Raumklima.OG.Badezimmer-Kinder.FBH.HVAC
   room: Badezimmer Kinder
+  writable: true
 6/3/46:
   dpt: '20.102'
   function: Raumklima
   name: Raumklima.OG.Badezimmer-Kinder.FBH.HVAC-Status
   room: Badezimmer Kinder
+  writable: false
 6/3/47:
   dpt: '1.011'
   function: Raumklima
   name: Raumklima.OG.Badezimmer-Kinder.FBH.Aktiv
   room: Badezimmer Kinder
+  writable: false
 6/3/48:
   dpt: '5.010'
   function: Raumklima
   name: Raumklima.OG.Badezimmer-Kinder.FBH.Aktiv-Anomalie
   room: Badezimmer Kinder
+  writable: false
 6/3/49:
   dpt: '5.010'
   function: Raumklima
   name: Raumklima.OG.Badezimmer-Kinder.FBH.Aktiv-Fenster-Auf-Anomalie
   room: Badezimmer Kinder
+  writable: false
 6/3/5:
   dpt: '20.102'
   function: Raumklima
   name: Raumklima.OG.Flur.FBH.HVAC
   room: Flur
+  writable: true
 6/3/50:
   dpt: '16.000'
   function: Raumklima
   name: Raumklima.OG.Badezimmer-Kinder.FBH.Diagnose
   room: Badezimmer Kinder
+  writable: false
 6/3/6:
   dpt: '20.102'
   function: Raumklima
   name: Raumklima.OG.Flur.FBH.HVAC-Status
   room: Flur
+  writable: false
 6/3/60:
   dpt: '1.003'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Gregory.FBH.Sperren
   room: Schlafzimmer Gregory
+  writable: true
 6/3/61:
   dpt: '5.001'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Gregory.FBH.Stellwert-Status
   room: Schlafzimmer Gregory
+  writable: true
 6/3/62:
   dpt: '9.001'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Gregory.FBH.Soll-Temperatur
   room: Schlafzimmer Gregory
+  writable: true
 6/3/63:
   dpt: '9.001'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Gregory.FBH.Soll-Temperatur-Status
   room: Schlafzimmer Gregory
+  writable: false
 6/3/64:
   dpt: '9.002'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Gregory.FBH.Sollwertverschiebung
   room: Schlafzimmer Gregory
+  writable: true
 6/3/65:
   dpt: '20.102'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Gregory.FBH.HVAC
   room: Schlafzimmer Gregory
+  writable: true
 6/3/66:
   dpt: '20.102'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Gregory.FBH.HVAC-Status
   room: Schlafzimmer Gregory
+  writable: false
 6/3/67:
   dpt: '1.011'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Gregory.FBH.Aktiv
   room: Schlafzimmer Gregory
+  writable: false
 6/3/68:
   dpt: '5.010'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Gregory.FBH.Aktiv-Anomalie
   room: Schlafzimmer Gregory
+  writable: false
 6/3/69:
   dpt: '5.010'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Gregory.FBH.Aktiv-Fenster-Auf-Anomalie
   room: Schlafzimmer Gregory
+  writable: false
 6/3/7:
   dpt: '1.011'
   function: Raumklima
   name: Raumklima.OG.Flur.FBH.Aktiv
   room: Flur
+  writable: false
 6/3/70:
   dpt: '16.000'
   function: Raumklima
   name: Raumklima.OG.Schlafzimmer-Gregory.FBH.Diagnose
   room: Schlafzimmer Gregory
+  writable: false
 6/3/8:
   dpt: '5.010'
   function: Raumklima
   name: Raumklima.OG.Flur.FBH.Aktiv-Anomalie
   room: Flur
+  writable: false
 6/3/9:
   dpt: '5.010'
   function: Raumklima
   name: Raumklima.OG.Flur.FBH.Aktiv-Fenster-Auf-Anomalie
   room: Flur
+  writable: false
 7/0/200:
   description: 1 - Innen Bedienelemente
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.Zentral.Gebäude.Schalter.Sperren
   room: 1 - Gebäude
+  writable: true
 7/0/201:
   description: 1 - Innen Bedienelemente
   dpt: '5.010'
   function: Bedienelemente
   name: Bedienelemente.Zentral.Gebäude.Schalter.Farbe
   room: 1 - Gebäude
+  writable: true
 7/2/0:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.EG.Büro.Schalter.Sperren
   room: Büro
+  writable: true
 7/2/1:
   dpt: '5.010'
   function: Bedienelemente
   name: Bedienelemente.EG.Büro.Schalter.Farbe
   room: Büro
+  writable: true
 7/2/10:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.EG.Büro.Schalter.Multitouch-Kurz
   room: Büro
+  writable: false
 7/2/16:
   dpt: '1.024'
   function: Bedienelemente
   name: Bedienelemente.EG.Büro.Schalter.Tag/Nacht
   room: Büro
+  writable: true
 7/2/2:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.EG.Büro.Schalter.Sensor-1-Kurz
   room: Büro
+  writable: true
 7/2/20:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.EG.Wohnzimmer.Schalter.Sperren
   room: Wohnzimmer
+  writable: true
 7/2/21:
   dpt: '5.010'
   function: Bedienelemente
   name: Bedienelemente.EG.Wohnzimmer.Schalter.Farbe
   room: Wohnzimmer
+  writable: true
 7/2/22:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.EG.Wohnzimmer.Schalter.Sensor-1-Kurz
   room: Wohnzimmer
+  writable: true
 7/2/23:
   dpt: '3.007'
   function: Bedienelemente
   name: Bedienelemente.EG.Wohnzimmer.Schalter.Sensor-1-Lang
   room: Wohnzimmer
+  writable: true
 7/2/24:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.EG.Wohnzimmer.Schalter.Sensor-2-Kurz
   room: Wohnzimmer
+  writable: false
 7/2/25:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.EG.Wohnzimmer.Schalter.Sensor-2-Lang
   room: Wohnzimmer
+  writable: false
 7/2/28:
   dpt: '1.009'
   function: Bedienelemente
   name: Bedienelemente.EG.Wohnzimmer.Schalter.Sensor-4-Kurz
   room: Wohnzimmer
+  writable: true
 7/2/29:
   dpt: '1.009'
   function: Bedienelemente
   name: Bedienelemente.EG.Wohnzimmer.Schalter.Sensor-4-Lang
   room: Wohnzimmer
+  writable: true
 7/2/3:
   dpt: '3.007'
   function: Bedienelemente
   name: Bedienelemente.EG.Büro.Schalter.Sensor-1-Lang
   room: Büro
+  writable: true
 7/2/30:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.EG.Wohnzimmer.Schalter.Multitouch-Kurz
   room: Wohnzimmer
+  writable: false
 7/2/36:
   dpt: '1.024'
   function: Bedienelemente
   name: Bedienelemente.EG.Wohnzimmer.Schalter.Tag/Nacht
   room: Wohnzimmer
+  writable: true
 7/2/4:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.EG.Büro.Schalter.Sensor-2-Kurz
   room: Büro
+  writable: false
 7/2/5:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.EG.Büro.Schalter.Sensor-2-Lang
   room: Büro
+  writable: false
 7/2/8:
   dpt: '1.009'
   function: Bedienelemente
   name: Bedienelemente.EG.Büro.Schalter.Sensor-4-Kurz
   room: Büro
+  writable: true
 7/2/9:
   dpt: '1.009'
   function: Bedienelemente
   name: Bedienelemente.EG.Büro.Schalter.Sensor-4-Lang
   room: Büro
+  writable: true
 7/3/0:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Abstellraum.Schalter.Sperren
   room: Abstellraum
+  writable: true
 7/3/1:
   dpt: '5.010'
   function: Bedienelemente
   name: Bedienelemente.OG.Abstellraum.Schalter.Farbe
   room: Abstellraum
+  writable: true
 7/3/10:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Abstellraum.Schalter.Multitouch-Kurz
   room: Abstellraum
+  writable: false
 7/3/100:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Bett-Links.Sperren
   room: Schlafzimmer Eltern
+  writable: true
 7/3/101:
   dpt: '5.010'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Bett-Links.Farbe
   room: Schlafzimmer Eltern
+  writable: true
 7/3/102:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Bett-Links.Sensor-1-Kurz
   room: Schlafzimmer Eltern
+  writable: true
 7/3/103:
   dpt: '3.007'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Bett-Links.Sensor-1-Lang
   room: Schlafzimmer Eltern
+  writable: true
 7/3/104:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Bett-Links.Sensor-2-Kurz
   room: Schlafzimmer Eltern
+  writable: false
 7/3/105:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Bett-Links.Sensor-2-Lang
   room: Schlafzimmer Eltern
+  writable: false
 7/3/110:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Bett-Links.Multitouch-Kurz
   room: Schlafzimmer Eltern
+  writable: false
 7/3/111:
   dpt: '1.008'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Bett-Links.Multitouch-Lang-1
   room: Schlafzimmer Eltern
+  writable: true
 7/3/112:
   dpt: '1.017'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Bett-Links.Multitouch-Lang-2
   room: Schlafzimmer Eltern
+  writable: true
 7/3/116:
   dpt: '1.024'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Bett-Links.Tag/Nacht
   room: Schlafzimmer Eltern
+  writable: true
 7/3/120:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Bett-Rechts.Sperren
   room: Schlafzimmer Eltern
+  writable: true
 7/3/121:
   dpt: '5.010'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Bett-Rechts.Farbe
   room: Schlafzimmer Eltern
+  writable: true
 7/3/122:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Bett-Rechts.Sensor-1-Kurz
   room: Schlafzimmer Eltern
+  writable: true
 7/3/123:
   dpt: '3.007'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Bett-Rechts.Sensor-1-Lang
   room: Schlafzimmer Eltern
+  writable: true
 7/3/124:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Bett-Rechts.Sensor-2-Kurz
   room: Schlafzimmer Eltern
+  writable: false
 7/3/125:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Bett-Rechts.Sensor-2-Lang
   room: Schlafzimmer Eltern
+  writable: false
 7/3/130:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Bett-Rechts.Multitouch-Kurz
   room: Schlafzimmer Eltern
+  writable: false
 7/3/131:
   dpt: '1.008'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Bett-Rechts.Multitouch-Lang-1
   room: Schlafzimmer Eltern
+  writable: true
 7/3/132:
   dpt: '1.017'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Bett-Rechts.Multitouch-Lang-2
   room: Schlafzimmer Eltern
+  writable: true
 7/3/136:
   dpt: '1.024'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Bett-Rechts.Tag/Nacht
   room: Schlafzimmer Eltern
+  writable: true
 7/3/140:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Eltern.Schalter.Sperren
   room: Badezimmer Eltern
+  writable: true
 7/3/141:
   dpt: '5.010'
   function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Eltern.Schalter.Farbe
   room: Badezimmer Eltern
+  writable: true
 7/3/142:
   dpt: '1.009'
   function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Eltern.Schalter.Sensor-1-Kurz
   room: Badezimmer Eltern
+  writable: true
 7/3/143:
   dpt: '3.007'
   function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Eltern.Schalter.Sensor-1-Lang
   room: Badezimmer Eltern
+  writable: true
 7/3/144:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Eltern.Schalter.Sensor-2-Kurz
   room: Badezimmer Eltern
+  writable: false
 7/3/145:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Eltern.Schalter.Sensor-2-Lang
   room: Badezimmer Eltern
+  writable: false
 7/3/148:
   dpt: '1.009'
   function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Eltern.Schalter.Sensor-4-Kurz
   room: Badezimmer Eltern
+  writable: true
 7/3/149:
   dpt: '1.009'
   function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Eltern.Schalter.Sensor-4-Lang
   room: Badezimmer Eltern
+  writable: true
 7/3/150:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Eltern.Schalter.Multitouch-Kurz
   room: Badezimmer Eltern
+  writable: false
 7/3/153:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Eltern.Schalter.Multitouch-RGB-Rot
   room: Badezimmer Eltern
+  writable: false
 7/3/156:
   dpt: '1.024'
   function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Eltern.Schalter.Tag/Nacht
   room: Badezimmer Eltern
+  writable: true
 7/3/16:
   dpt: '1.024'
   function: Bedienelemente
   name: Bedienelemente.OG.Abstellraum.Schalter.Tag/Nacht
   room: Abstellraum
+  writable: true
 7/3/2:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Abstellraum.Schalter.Sensor-1-Kurz
   room: Abstellraum
+  writable: true
 7/3/20:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Kinder.Schalter.Sperren
   room: Badezimmer Kinder
+  writable: true
 7/3/21:
   dpt: '5.010'
   function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Kinder.Schalter.Farbe
   room: Badezimmer Kinder
+  writable: true
 7/3/22:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Kinder.Schalter.Sensor-1-Kurz
   room: Badezimmer Kinder
+  writable: true
 7/3/23:
   dpt: '3.007'
   function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Kinder.Schalter.Sensor-1-Lang
   room: Badezimmer Kinder
+  writable: true
 7/3/24:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Kinder.Schalter.Sensor-2-Kurz
   room: Badezimmer Kinder
+  writable: false
 7/3/25:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Kinder.Schalter.Sensor-2-Lang
   room: Badezimmer Kinder
+  writable: false
 7/3/28:
   dpt: '1.009'
   function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Kinder.Schalter.Sensor-4-Kurz
   room: Badezimmer Kinder
+  writable: true
 7/3/29:
   dpt: '1.009'
   function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Kinder.Schalter.Sensor-4-Lang
   room: Badezimmer Kinder
+  writable: true
 7/3/3:
   dpt: '3.007'
   function: Bedienelemente
   name: Bedienelemente.OG.Abstellraum.Schalter.Sensor-1-Lang
   room: Abstellraum
+  writable: true
 7/3/30:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Kinder.Schalter.Multitouch-Kurz
   room: Badezimmer Kinder
+  writable: false
 7/3/36:
   dpt: '1.024'
   function: Bedienelemente
   name: Bedienelemente.OG.Badezimmer-Kinder.Schalter.Tag/Nacht
   room: Badezimmer Kinder
+  writable: true
 7/3/4:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Abstellraum.Schalter.Sensor-2-Kurz
   room: Abstellraum
+  writable: false
 7/3/40:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Gregory.Schalter.Sperren
   room: Schlafzimmer Gregory
+  writable: true
 7/3/41:
   dpt: '5.010'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Gregory.Schalter.Farbe
   room: Schlafzimmer Gregory
+  writable: true
 7/3/42:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Gregory.Schalter.Sensor-1-Kurz
   room: Schlafzimmer Gregory
+  writable: true
 7/3/43:
   dpt: '3.007'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Gregory.Schalter.Sensor-1-Lang
   room: Schlafzimmer Gregory
+  writable: true
 7/3/44:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Gregory.Schalter.Sensor-2-Kurz
   room: Schlafzimmer Gregory
+  writable: false
 7/3/45:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Gregory.Schalter.Sensor-2-Lang
   room: Schlafzimmer Gregory
+  writable: false
 7/3/48:
   dpt: '1.009'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Gregory.Schalter.Sensor-4-Kurz
   room: Schlafzimmer Gregory
+  writable: true
 7/3/49:
   dpt: '1.009'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Gregory.Schalter.Sensor-4-Lang
   room: Schlafzimmer Gregory
+  writable: true
 7/3/5:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Abstellraum.Schalter.Sensor-2-Lang
   room: Abstellraum
+  writable: false
 7/3/50:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Gregory.Schalter.Multitouch-Kurz
   room: Schlafzimmer Gregory
+  writable: false
 7/3/51:
   dpt: '1.008'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Gregory.Schalter.Multitouch-Lang-1
   room: Schlafzimmer Gregory
+  writable: true
 7/3/52:
   dpt: '1.017'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Gregory.Schalter.Multitouch-Lang-2
   room: Schlafzimmer Gregory
+  writable: true
 7/3/56:
   dpt: '1.024'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Gregory.Schalter.Tag/Nacht
   room: Schlafzimmer Gregory
+  writable: true
 7/3/60:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Luis.Schalter.Sperren
   room: Schlafzimmer Luis
+  writable: true
 7/3/61:
   dpt: '5.005'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Luis.Schalter.Farbe
   room: Schlafzimmer Luis
+  writable: true
 7/3/62:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Luis.Schalter.Sensor-1-Kurz
   room: Schlafzimmer Luis
+  writable: true
 7/3/63:
   dpt: '3.007'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Luis.Schalter.Sensor-1-Lang
   room: Schlafzimmer Luis
+  writable: true
 7/3/64:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Luis.Schalter.Sensor-2-Kurz
   room: Schlafzimmer Luis
+  writable: false
 7/3/65:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Luis.Schalter.Sensor-2-Lang
   room: Schlafzimmer Luis
+  writable: false
 7/3/68:
   dpt: '1.009'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Luis.Schalter.Sensor-4-Kurz
   room: Schlafzimmer Luis
+  writable: true
 7/3/69:
   dpt: '1.009'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Luis.Schalter.Sensor-4-Lang
   room: Schlafzimmer Luis
+  writable: true
 7/3/70:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Luis.Schalter.Multitouch-Kurz
   room: Schlafzimmer Luis
+  writable: false
 7/3/71:
   dpt: '1.009'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Luis.Schalter.Multitouch-Lang-1
   room: Schlafzimmer Luis
+  writable: true
 7/3/72:
   dpt: '1.009'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Luis.Schalter.Multitouch-Lang-2
   room: Schlafzimmer Luis
+  writable: true
 7/3/76:
   dpt: '1.024'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Luis.Schalter.Tag/Nacht
   room: Schlafzimmer Luis
+  writable: true
 7/3/8:
   dpt: '1.009'
   function: Bedienelemente
   name: Bedienelemente.OG.Abstellraum.Schalter.Sensor-4-Kurz
   room: Abstellraum
+  writable: true
 7/3/80:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Sperren
   room: Schlafzimmer Eltern
+  writable: true
 7/3/81:
   dpt: '5.010'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Farbe
   room: Schlafzimmer Eltern
+  writable: true
 7/3/82:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Sensor-1-Kurz
   room: Schlafzimmer Eltern
+  writable: true
 7/3/83:
   dpt: '3.007'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Sensor-1-Lang
   room: Schlafzimmer Eltern
+  writable: true
 7/3/84:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Sensor-2-Kurz
   room: Schlafzimmer Eltern
+  writable: false
 7/3/85:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Sensor-2-Lang
   room: Schlafzimmer Eltern
+  writable: false
 7/3/88:
   dpt: '1.009'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Sensor-4-Kurz
   room: Schlafzimmer Eltern
+  writable: true
 7/3/89:
   dpt: '1.009'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Sensor-4-Lang
   room: Schlafzimmer Eltern
+  writable: true
 7/3/9:
   dpt: '1.009'
   function: Bedienelemente
   name: Bedienelemente.OG.Abstellraum.Schalter.Sensor-4-Lang
   room: Abstellraum
+  writable: true
 7/3/90:
   dpt: '1.001'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Multitouch-Kurz
   room: Schlafzimmer Eltern
+  writable: false
 7/3/91:
   dpt: '1.009'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Multitouch-Lang-1
   room: Schlafzimmer Eltern
+  writable: true
 7/3/92:
   dpt: '1.009'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Multitouch-Lang-2
   room: Schlafzimmer Eltern
+  writable: true
 7/3/96:
   dpt: '1.024'
   function: Bedienelemente
   name: Bedienelemente.OG.Schlafzimmer-Eltern.Schalter.Tag/Nacht
   room: Schlafzimmer Eltern
+  writable: true
 8/0/140:
   dpt: '9.004'
   function: Sensorik
   name: Sensorik.Zentral.A.Helligkeit-SO
   room: Außenbereich
+  writable: true
 8/0/141:
   dpt: '9.004'
   function: Sensorik
   name: Sensorik.Zentral.A.Helligkeit-NW
   room: Außenbereich
+  writable: true
 8/0/142:
   dpt: '9.004'
   function: Sensorik
   name: Sensorik.Zentral.A.Helligkeit-Alle
   room: Außenbereich
+  writable: false
 8/0/143:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.Zentral.A.Temperatur-Alle
   room: Außenbereich
+  writable: false
 8/1/100:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Vorratsraum.Sensor.VOC-Alarm-1
   room: Vorratsraum
+  writable: false
 8/1/101:
   dpt: '9.008'
   function: Sensorik
   name: Sensorik.KG.Vorratsraum.Sensor.CO2
   room: Vorratsraum
+  writable: false
 8/1/102:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Vorratsraum.Sensor.CO2-Alarm-1
   room: Vorratsraum
+  writable: false
 8/1/103:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Vorratsraum.Sensor.CO2-Alarm-2
   room: Vorratsraum
+  writable: false
 8/1/104:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Vorratsraum.Sensor.CO2-Alarm-3
   room: Vorratsraum
+  writable: false
 8/1/105:
   dpt: '14.058'
   function: Sensorik
   name: Sensorik.KG.Vorratsraum.Sensor.Luftdruck-Relativ
   room: Vorratsraum
+  writable: false
 8/1/106:
   dpt: '14.058'
   function: Sensorik
   name: Sensorik.KG.Vorratsraum.Sensor.Luftdruck-Absolut
   room: Vorratsraum
+  writable: false
 8/1/107:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Vorratsraum.Sensor.Luftdruck-Alarm-1
   room: Vorratsraum
+  writable: false
 8/1/121:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.KG.Hauswirtschaftsraum.Sensor.Temperatur
   room: Hauswirtschaftsraum
+  writable: false
 8/1/122:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Hauswirtschaftsraum.Sensor.Temperatur-Alarm-1
   room: Hauswirtschaftsraum
+  writable: false
 8/1/123:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Hauswirtschaftsraum.Sensor.Temperatur-Alarm-2
   room: Hauswirtschaftsraum
+  writable: false
 8/1/124:
   dpt: '9.007'
   function: Sensorik
   name: Sensorik.KG.Hauswirtschaftsraum.Sensor.Luftfeuchtigkeit
   room: Hauswirtschaftsraum
+  writable: false
 8/1/125:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Hauswirtschaftsraum.Sensor.Luftfeuchtigkeit-Alarm-1
   room: Hauswirtschaftsraum
+  writable: false
 8/1/126:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Hauswirtschaftsraum.Sensor.Luftfeuchtigkeit-Alarm-2
   room: Hauswirtschaftsraum
+  writable: false
 8/1/127:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.KG.Hauswirtschaftsraum.Sensor.Taupunkt
   room: Hauswirtschaftsraum
+  writable: false
 8/1/128:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Hauswirtschaftsraum.Sensor.Taupunkt-Alarm-1
   room: Hauswirtschaftsraum
+  writable: false
 8/1/129:
   dpt: '9.008'
   function: Sensorik
   name: Sensorik.KG.Hauswirtschaftsraum.Sensor.VOC
   room: Hauswirtschaftsraum
+  writable: false
 8/1/130:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Hauswirtschaftsraum.Sensor.VOC-Alarm-1
   room: Hauswirtschaftsraum
+  writable: false
 8/1/131:
   dpt: '9.008'
   function: Sensorik
   name: Sensorik.KG.Hauswirtschaftsraum.Sensor.CO2
   room: Hauswirtschaftsraum
+  writable: false
 8/1/132:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Hauswirtschaftsraum.Sensor.CO2-Alarm-1
   room: Hauswirtschaftsraum
+  writable: false
 8/1/133:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Hauswirtschaftsraum.Sensor.CO2-Alarm-2
   room: Hauswirtschaftsraum
+  writable: false
 8/1/134:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Hauswirtschaftsraum.Sensor.CO2-Alarm-3
   room: Hauswirtschaftsraum
+  writable: false
 8/1/135:
   dpt: '14.058'
   function: Sensorik
   name: Sensorik.KG.Hauswirtschaftsraum.Sensor.Luftdruck-Relativ
   room: Hauswirtschaftsraum
+  writable: false
 8/1/136:
   dpt: '14.058'
   function: Sensorik
   name: Sensorik.KG.Hauswirtschaftsraum.Sensor.Luftdruck-Absolut
   room: Hauswirtschaftsraum
+  writable: false
 8/1/137:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Hauswirtschaftsraum.Sensor.Luftdruck-Alarm-1
   room: Hauswirtschaftsraum
+  writable: false
 8/1/20:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.KG.Flur.BWM.Decke.Temperatur
   room: Flur
+  writable: false
 8/1/21:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.KG.Flur.BWM.Wand.Temperatur
   room: Flur
+  writable: false
 8/1/31:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.KG.Garage.Sensor.Temperatur
   room: Garage
+  writable: false
 8/1/32:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Garage.Sensor.Temperatur-Alarm-1
   room: Garage
+  writable: false
 8/1/33:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Garage.Sensor.Temperatur-Alarm-2
   room: Garage
+  writable: false
 8/1/34:
   dpt: '9.007'
   function: Sensorik
   name: Sensorik.KG.Garage.Sensor.Luftfeuchtigkeit
   room: Garage
+  writable: false
 8/1/35:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Garage.Sensor.Luftfeuchtigkeit-Alarm-1
   room: Garage
+  writable: false
 8/1/36:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Garage.Sensor.Luftfeuchtigkeit-Alarm-2
   room: Garage
+  writable: true
 8/1/37:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.KG.Garage.Sensor.Taupunkt
   room: Garage
+  writable: false
 8/1/38:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Garage.Sensor.Taupunkt-Alarm-1
   room: Garage
+  writable: false
 8/1/39:
   dpt: '9.008'
   function: Sensorik
   name: Sensorik.KG.Garage.Sensor.VOC
   room: Garage
+  writable: false
 8/1/40:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Garage.Sensor.VOC-Alarm-1
   room: Garage
+  writable: false
 8/1/41:
   dpt: '9.008'
   function: Sensorik
   name: Sensorik.KG.Garage.Sensor.CO2
   room: Garage
+  writable: false
 8/1/42:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Garage.Sensor.CO2-Alarm-1
   room: Garage
+  writable: false
 8/1/43:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Garage.Sensor.CO2-Alarm-2
   room: Garage
+  writable: false
 8/1/44:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Garage.Sensor.CO2-Alarm-3
   room: Garage
+  writable: false
 8/1/45:
   dpt: '14.058'
   function: Sensorik
   name: Sensorik.KG.Garage.Sensor.Luftdruck-Relativ
   room: Garage
+  writable: false
 8/1/46:
   dpt: '14.058'
   function: Sensorik
   name: Sensorik.KG.Garage.Sensor.Luftdruck-Absolut
   room: Garage
+  writable: false
 8/1/47:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Garage.Sensor.Luftdruck-Alarm-1
   room: Garage
+  writable: false
 8/1/61:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.KG.Technikraum.Sensor.Temperatur
   room: Technikraum
+  writable: false
 8/1/62:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Technikraum.Sensor.Temperatur-Alarm-1
   room: Technikraum
+  writable: false
 8/1/63:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Technikraum.Sensor.Temperatur-Alarm-2
   room: Technikraum
+  writable: false
 8/1/64:
   dpt: '9.007'
   function: Sensorik
   name: Sensorik.KG.Technikraum.Sensor.Luftfeuchtigkeit
   room: Technikraum
+  writable: false
 8/1/65:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Technikraum.Sensor.Luftfeuchtigkeit-Alarm-1
   room: Technikraum
+  writable: false
 8/1/66:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Technikraum.Sensor.Luftfeuchtigkeit-Alarm-2
   room: Technikraum
+  writable: true
 8/1/67:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.KG.Technikraum.Sensor.Taupunkt
   room: Technikraum
+  writable: false
 8/1/68:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Technikraum.Sensor.Taupunkt-Alarm-1
   room: Technikraum
+  writable: false
 8/1/69:
   dpt: '9.008'
   function: Sensorik
   name: Sensorik.KG.Technikraum.Sensor.VOC
   room: Technikraum
+  writable: false
 8/1/70:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Technikraum.Sensor.VOC-Alarm-1
   room: Technikraum
+  writable: false
 8/1/71:
   dpt: '9.008'
   function: Sensorik
   name: Sensorik.KG.Technikraum.Sensor.CO2
   room: Technikraum
+  writable: false
 8/1/72:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Technikraum.Sensor.CO2-Alarm-1
   room: Technikraum
+  writable: false
 8/1/73:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Technikraum.Sensor.CO2-Alarm-2
   room: Technikraum
+  writable: false
 8/1/74:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Technikraum.Sensor.CO2-Alarm-3
   room: Technikraum
+  writable: false
 8/1/75:
   dpt: '14.058'
   function: Sensorik
   name: Sensorik.KG.Technikraum.Sensor.Luftdruck-Relativ
   room: Technikraum
+  writable: false
 8/1/76:
   dpt: '14.058'
   function: Sensorik
   name: Sensorik.KG.Technikraum.Sensor.Luftdruck-Absolut
   room: Technikraum
+  writable: false
 8/1/77:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Technikraum.Sensor.Luftdruck-Alarm-1
   room: Technikraum
+  writable: false
 8/1/91:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.KG.Vorratsraum.Sensor.Temperatur
   room: Vorratsraum
+  writable: false
 8/1/92:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Vorratsraum.Sensor.Temperatur-Alarm-1
   room: Vorratsraum
+  writable: false
 8/1/93:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Vorratsraum.Sensor.Temperatur-Alarm-2
   room: Vorratsraum
+  writable: false
 8/1/94:
   dpt: '9.007'
   function: Sensorik
   name: Sensorik.KG.Vorratsraum.Sensor.Luftfeuchtigkeit
   room: Vorratsraum
+  writable: false
 8/1/95:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Vorratsraum.Sensor.Luftfeuchtigkeit-Alarm-1
   room: Vorratsraum
+  writable: false
 8/1/96:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Vorratsraum.Sensor.Luftfeuchtigkeit-Alarm-2
   room: Vorratsraum
+  writable: false
 8/1/97:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.KG.Vorratsraum.Sensor.Taupunkt
   room: Vorratsraum
+  writable: false
 8/1/98:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.KG.Vorratsraum.Sensor.Taupunkt-Alarm-1
   room: Vorratsraum
+  writable: false
 8/1/99:
   dpt: '9.008'
   function: Sensorik
   name: Sensorik.KG.Vorratsraum.Sensor.VOC
   room: Vorratsraum
+  writable: false
 8/2/101:
   dpt: '9.008'
   function: Sensorik
   name: Sensorik.EG.Wohnzimmer.Sensor.CO2
   room: Wohnzimmer
+  writable: false
 8/2/102:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Wohnzimmer.Sensor.CO2-Alarm-1
   room: Wohnzimmer
+  writable: false
 8/2/103:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Wohnzimmer.Sensor.CO2-Alarm-2
   room: Wohnzimmer
+  writable: false
 8/2/104:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Wohnzimmer.Sensor.CO2-Alarm-3
   room: Wohnzimmer
+  writable: false
 8/2/110:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.EG.Wohnzimmer.Schalter.Temperatur
   room: Wohnzimmer
+  writable: true
 8/2/121:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.EG.Esszimmer.Sensor.Temperatur
   room: Esszimmer
+  writable: true
 8/2/122:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Esszimmer.Sensor.Temperatur-Alarm-1
   room: Esszimmer
+  writable: false
 8/2/123:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Esszimmer.Sensor.Temperatur-Alarm-2
   room: Esszimmer
+  writable: false
 8/2/124:
   dpt: '9.007'
   function: Sensorik
   name: Sensorik.EG.Esszimmer.Sensor.Luftfeuchtigkeit
   room: Esszimmer
+  writable: false
 8/2/125:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Esszimmer.Sensor.Luftfeuchtigkeit-Alarm-1
   room: Esszimmer
+  writable: true
 8/2/126:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Esszimmer.Sensor.Luftfeuchtigkeit-Alarm-2
   room: Esszimmer
+  writable: true
 8/2/127:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.EG.Esszimmer.Sensor.Taupunkt
   room: Esszimmer
+  writable: false
 8/2/128:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Esszimmer.Sensor.Taupunkt-Alarm-1
   room: Esszimmer
+  writable: true
 8/2/131:
   dpt: '9.008'
   function: Sensorik
   name: Sensorik.EG.Esszimmer.Sensor.CO2
   room: Esszimmer
+  writable: false
 8/2/132:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Esszimmer.Sensor.CO2-Alarm-1
   room: Esszimmer
+  writable: false
 8/2/133:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Esszimmer.Sensor.CO2-Alarm-2
   room: Esszimmer
+  writable: false
 8/2/134:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Esszimmer.Sensor.CO2-Alarm-3
   room: Esszimmer
+  writable: false
 8/2/151:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.EG.Küche.Sensor.Temperatur
   room: Küche
+  writable: true
 8/2/152:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Küche.Sensor.Temperatur-Alarm-1
   room: Küche
+  writable: false
 8/2/153:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Küche.Sensor.Temperatur-Alarm-2
   room: Küche
+  writable: false
 8/2/154:
   dpt: '9.007'
   function: Sensorik
   name: Sensorik.EG.Küche.Sensor.Luftfeuchtigkeit
   room: Küche
+  writable: false
 8/2/155:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Küche.Sensor.Luftfeuchtigkeit-Alarm-1
   room: Küche
+  writable: true
 8/2/156:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Küche.Sensor.Luftfeuchtigkeit-Alarm-2
   room: Küche
+  writable: true
 8/2/157:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.EG.Küche.Sensor.Taupunkt
   room: Küche
+  writable: false
 8/2/158:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Küche.Sensor.Taupunkt-Alarm-1
   room: Küche
+  writable: true
 8/2/161:
   dpt: '9.008'
   function: Sensorik
   name: Sensorik.EG.Küche.Sensor.CO2
   room: Küche
+  writable: false
 8/2/162:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Küche.Sensor.CO2-Alarm-1
   room: Küche
+  writable: false
 8/2/163:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Küche.Sensor.CO2-Alarm-2
   room: Küche
+  writable: false
 8/2/164:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Küche.Sensor.CO2-Alarm-3
   room: Küche
+  writable: false
 8/2/20:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.EG.Flur.BWM.Eingang.Temperatur
   room: Flur
+  writable: true
 8/2/21:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.EG.Flur.BWM.Diele.Temperatur
   room: Flur
+  writable: false
 8/2/22:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.EG.Flur.BWM.Garderobe.Temperatur
   room: Flur
+  writable: false
 8/2/31:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.EG.Gäste-WC.Sensor.Temperatur
   room: Gäste WC
+  writable: true
 8/2/32:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Gäste-WC.Sensor.Temperatur-Alarm-1
   room: Gäste WC
+  writable: false
 8/2/33:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Gäste-WC.Sensor.Temperatur-Alarm-2
   room: Gäste WC
+  writable: false
 8/2/34:
   dpt: '9.007'
   function: Sensorik
   name: Sensorik.EG.Gäste-WC.Sensor.Luftfeuchtigkeit
   room: Gäste WC
+  writable: false
 8/2/35:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Gäste-WC.Sensor.Luftfeuchtigkeit-Alarm-1
   room: Gäste WC
+  writable: true
 8/2/36:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Gäste-WC.Sensor.Luftfeuchtigkeit-Alarm-2
   room: Gäste WC
+  writable: true
 8/2/37:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.EG.Gäste-WC.Sensor.Taupunkt
   room: Gäste WC
+  writable: false
 8/2/38:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Gäste-WC.Sensor.Taupunkt-Alarm-1
   room: Gäste WC
+  writable: true
 8/2/41:
   dpt: '9.008'
   function: Sensorik
   name: Sensorik.EG.Gäste-WC.Sensor.CO2
   room: Gäste WC
+  writable: false
 8/2/42:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Gäste-WC.Sensor.CO2-Alarm-1
   room: Gäste WC
+  writable: false
 8/2/43:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Gäste-WC.Sensor.CO2-Alarm-2
   room: Gäste WC
+  writable: false
 8/2/44:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Gäste-WC.Sensor.CO2-Alarm-3
   room: Gäste WC
+  writable: false
 8/2/50:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.EG.Gäste-WC.BWM.Temperatur
   room: Gäste WC
+  writable: true
 8/2/61:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.EG.Büro.Sensor.Temperatur
   room: Büro
+  writable: true
 8/2/62:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Büro.Sensor.Temperatur-Alarm-1
   room: Büro
+  writable: false
 8/2/63:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Büro.Sensor.Temperatur-Alarm-2
   room: Büro
+  writable: false
 8/2/64:
   dpt: '9.007'
   function: Sensorik
   name: Sensorik.EG.Büro.Sensor.Luftfeuchtigkeit
   room: Büro
+  writable: false
 8/2/65:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Büro.Sensor.Luftfeuchtigkeit-Alarm-1
   room: Büro
+  writable: true
 8/2/66:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Büro.Sensor.Luftfeuchtigkeit-Alarm-2
   room: Büro
+  writable: true
 8/2/67:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.EG.Büro.Sensor.Taupunkt
   room: Büro
+  writable: false
 8/2/68:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Büro.Sensor.Taupunkt-Alarm-1
   room: Büro
+  writable: true
 8/2/71:
   dpt: '9.008'
   function: Sensorik
   name: Sensorik.EG.Büro.Sensor.CO2
   room: Büro
+  writable: false
 8/2/72:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Büro.Sensor.CO2-Alarm-1
   room: Büro
+  writable: false
 8/2/73:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Büro.Sensor.CO2-Alarm-2
   room: Büro
+  writable: false
 8/2/74:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Büro.Sensor.CO2-Alarm-3
   room: Büro
+  writable: false
 8/2/80:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.EG.Büro.Schalter.Temperatur
   room: Büro
+  writable: true
 8/2/91:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.EG.Wohnzimmer.Sensor.Temperatur
   room: Wohnzimmer
+  writable: true
 8/2/92:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Wohnzimmer.Sensor.Temperatur-Alarm-1
   room: Wohnzimmer
+  writable: false
 8/2/93:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Wohnzimmer.Sensor.Temperatur-Alarm-2
   room: Wohnzimmer
+  writable: false
 8/2/94:
   dpt: '9.007'
   function: Sensorik
   name: Sensorik.EG.Wohnzimmer.Sensor.Luftfeuchtigkeit
   room: Wohnzimmer
+  writable: false
 8/2/95:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Wohnzimmer.Sensor.Luftfeuchtigkeit-Alarm-1
   room: Wohnzimmer
+  writable: true
 8/2/96:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Wohnzimmer.Sensor.Luftfeuchtigkeit-Alarm-2
   room: Wohnzimmer
+  writable: true
 8/2/97:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.EG.Wohnzimmer.Sensor.Taupunkt
   room: Wohnzimmer
+  writable: false
 8/2/98:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.EG.Wohnzimmer.Sensor.Taupunkt-Alarm-1
   room: Wohnzimmer
+  writable: true
 8/3/100:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Gregory.Sensor.VOC-Alarm-1
   room: Schlafzimmer Gregory
+  writable: false
 8/3/101:
   dpt: '9.008'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Gregory.Sensor.CO2
   room: Schlafzimmer Gregory
+  writable: false
 8/3/102:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Gregory.Sensor.CO2-Alarm-1
   room: Schlafzimmer Gregory
+  writable: false
 8/3/103:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Gregory.Sensor.CO2-Alarm-2
   room: Schlafzimmer Gregory
+  writable: false
 8/3/104:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Gregory.Sensor.CO2-Alarm-3
   room: Schlafzimmer Gregory
+  writable: false
 8/3/110:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Gregory.Schalter.Temperatur
   room: Schlafzimmer Gregory
+  writable: true
 8/3/121:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Luis.Sensor.Temperatur
   room: Schlafzimmer Luis
+  writable: true
 8/3/122:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Luis.Sensor.Temperatur-Alarm-1
   room: Schlafzimmer Luis
+  writable: false
 8/3/123:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Luis.Sensor.Temperatur-Alarm-2
   room: Schlafzimmer Luis
+  writable: false
 8/3/124:
   dpt: '9.007'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Luis.Sensor.Luftfeuchtigkeit
   room: Schlafzimmer Luis
+  writable: false
 8/3/125:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Luis.Sensor.Luftfeuchtigkeit-Alarm-1
   room: Schlafzimmer Luis
+  writable: true
 8/3/126:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Luis.Sensor.Luftfeuchtigkeit-Alarm-2
   room: Schlafzimmer Luis
+  writable: true
 8/3/127:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Luis.Sensor.Taupunkt
   room: Schlafzimmer Luis
+  writable: false
 8/3/128:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Luis.Sensor.Taupunkt-Alarm-1
   room: Schlafzimmer Luis
+  writable: true
 8/3/130:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Luis.Sensor.VOC-Alarm-1
   room: Schlafzimmer Luis
+  writable: false
 8/3/131:
   dpt: '9.008'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Luis.Sensor.CO2
   room: Schlafzimmer Luis
+  writable: false
 8/3/132:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Luis.Sensor.CO2-Alarm-1
   room: Schlafzimmer Luis
+  writable: false
 8/3/133:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Luis.Sensor.CO2-Alarm-2
   room: Schlafzimmer Luis
+  writable: false
 8/3/134:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Luis.Sensor.CO2-Alarm-3
   room: Schlafzimmer Luis
+  writable: false
 8/3/140:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Luis.Schalter.Temperatur
   room: Schlafzimmer Luis
+  writable: true
 8/3/151:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Eltern.Sensor.Temperatur
   room: Schlafzimmer Eltern
+  writable: true
 8/3/152:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Eltern.Sensor.Temperatur-Alarm-1
   room: Schlafzimmer Eltern
+  writable: false
 8/3/153:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Eltern.Sensor.Temperatur-Alarm-2
   room: Schlafzimmer Eltern
+  writable: false
 8/3/154:
   dpt: '9.007'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Eltern.Sensor.Luftfeuchtigkeit
   room: Schlafzimmer Eltern
+  writable: false
 8/3/155:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Eltern.Sensor.Luftfeuchtigkeit-Alarm-1
   room: Schlafzimmer Eltern
+  writable: true
 8/3/156:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Eltern.Sensor.Luftfeuchtigkeit-Alarm-2
   room: Schlafzimmer Eltern
+  writable: true
 8/3/157:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Eltern.Sensor.Taupunkt
   room: Schlafzimmer Eltern
+  writable: false
 8/3/158:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Eltern.Sensor.Taupunkt-Alarm-1
   room: Schlafzimmer Eltern
+  writable: true
 8/3/160:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Eltern.Sensor.VOC-Alarm-1
   room: Schlafzimmer Eltern
+  writable: false
 8/3/161:
   dpt: '9.008'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Eltern.Sensor.CO2
   room: Schlafzimmer Eltern
+  writable: false
 8/3/162:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Eltern.Sensor.CO2-Alarm-1
   room: Schlafzimmer Eltern
+  writable: false
 8/3/163:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Eltern.Sensor.CO2-Alarm-2
   room: Schlafzimmer Eltern
+  writable: false
 8/3/164:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Eltern.Sensor.CO2-Alarm-3
   room: Schlafzimmer Eltern
+  writable: false
 8/3/170:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Eltern.Schalter.Temperatur
   room: Schlafzimmer Eltern
+  writable: true
 8/3/171:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Eltern.Schalter.Bett-Links.Temperatur
   room: Schlafzimmer Eltern
+  writable: true
 8/3/172:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Eltern.Schalter.Bett-Rechts.Temperatur
   room: Schlafzimmer Eltern
+  writable: true
 8/3/173:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Eltern.BWM.Temperatur
   room: Schlafzimmer Eltern
+  writable: false
 8/3/183:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.OG.Begehbarer-Schrank.Sensor.Temperatur-Alarm-2
   room: Begehbarer Schrank
+  writable: false
 8/3/20:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.OG.Flur.BWM.Treppe.Temperatur
   room: Flur
+  writable: true
 8/3/200:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.OG.Begehbarer-Schrank.BWM.Temperatur
   room: Begehbarer Schrank
+  writable: true
 8/3/21:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.OG.Flur.BWM.Gang.Temperatur
   room: Flur
+  writable: false
 8/3/211:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.OG.Badezimmer-Eltern.Sensor.Temperatur
   room: Badezimmer Eltern
+  writable: true
 8/3/212:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Badezimmer-Eltern.Sensor.Temperatur-Alarm-1
   room: Badezimmer Eltern
+  writable: false
 8/3/213:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Badezimmer-Eltern.Sensor.Temperatur-Alarm-2
   room: Badezimmer Eltern
+  writable: false
 8/3/214:
   dpt: '9.007'
   function: Sensorik
   name: Sensorik.OG.Badezimmer-Eltern.Sensor.Luftfeuchtigkeit
   room: Badezimmer Eltern
+  writable: false
 8/3/215:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Badezimmer-Eltern.Sensor.Luftfeuchtigkeit-Alarm-1
   room: Badezimmer Eltern
+  writable: true
 8/3/216:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Badezimmer-Eltern.Sensor.Luftfeuchtigkeit-Alarm-2
   room: Badezimmer Eltern
+  writable: true
 8/3/217:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.OG.Badezimmer-Eltern.Sensor.Taupunkt
   room: Badezimmer Eltern
+  writable: false
 8/3/218:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Badezimmer-Eltern.Sensor.Taupunkt-Alarm-1
   room: Badezimmer Eltern
+  writable: true
 8/3/220:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Badezimmer-Eltern.Sensor.VOC-Alarm-1
   room: Badezimmer Eltern
+  writable: false
 8/3/221:
   dpt: '9.008'
   function: Sensorik
   name: Sensorik.OG.Badezimmer-Eltern.Sensor.CO2
   room: Badezimmer Eltern
+  writable: false
 8/3/222:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Badezimmer-Eltern.Sensor.CO2-Alarm-1
   room: Badezimmer Eltern
+  writable: false
 8/3/223:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Badezimmer-Eltern.Sensor.CO2-Alarm-2
   room: Badezimmer Eltern
+  writable: false
 8/3/224:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Badezimmer-Eltern.Sensor.CO2-Alarm-3
   room: Badezimmer Eltern
+  writable: false
 8/3/230:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.OG.Badezimmer-Eltern.Schalter.Temperatur
   room: Badezimmer Eltern
+  writable: true
 8/3/231:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.OG.Badezimmer-Eltern.BWM.Temperatur
   room: Badezimmer Eltern
+  writable: false
 8/3/31:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.OG.Abstellraum.Sensor.Temperatur
   room: Abstellraum
+  writable: true
 8/3/32:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Abstellraum.Sensor.Temperatur-Alarm-1
   room: Abstellraum
+  writable: false
 8/3/33:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Abstellraum.Sensor.Temperatur-Alarm-2
   room: Abstellraum
+  writable: false
 8/3/34:
   dpt: '9.007'
   function: Sensorik
   name: Sensorik.OG.Abstellraum.Sensor.Luftfeuchtigkeit
   room: Abstellraum
+  writable: false
 8/3/35:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Abstellraum.Sensor.Luftfeuchtigkeit-Alarm-1
   room: Abstellraum
+  writable: true
 8/3/36:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Abstellraum.Sensor.Luftfeuchtigkeit-Alarm-2
   room: Abstellraum
+  writable: true
 8/3/37:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.OG.Abstellraum.Sensor.Taupunkt
   room: Abstellraum
+  writable: false
 8/3/38:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Abstellraum.Sensor.Taupunkt-Alarm-1
   room: Abstellraum
+  writable: true
 8/3/40:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Abstellraum.Sensor.VOC-Alarm-1
   room: Abstellraum
+  writable: false
 8/3/41:
   dpt: '9.008'
   function: Sensorik
   name: Sensorik.OG.Abstellraum.Sensor.CO2
   room: Abstellraum
+  writable: false
 8/3/42:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Abstellraum.Sensor.CO2-Alarm-1
   room: Abstellraum
+  writable: false
 8/3/43:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Abstellraum.Sensor.CO2-Alarm-2
   room: Abstellraum
+  writable: false
 8/3/44:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Abstellraum.Sensor.CO2-Alarm-3
   room: Abstellraum
+  writable: false
 8/3/50:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.OG.Abstellraum.Schalter.Temperatur
   room: Abstellraum
+  writable: true
 8/3/61:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.OG.Badezimmer-Kinder.Sensor.Temperatur
   room: Badezimmer Kinder
+  writable: true
 8/3/62:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Badezimmer-Kinder.Sensor.Temperatur-Alarm-1
   room: Badezimmer Kinder
+  writable: false
 8/3/63:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Badezimmer-Kinder.Sensor.Temperatur-Alarm-2
   room: Badezimmer Kinder
+  writable: false
 8/3/64:
   dpt: '9.007'
   function: Sensorik
   name: Sensorik.OG.Badezimmer-Kinder.Sensor.Luftfeuchtigkeit
   room: Badezimmer Kinder
+  writable: false
 8/3/65:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Badezimmer-Kinder.Sensor.Luftfeuchtigkeit-Alarm-1
   room: Badezimmer Kinder
+  writable: true
 8/3/66:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Badezimmer-Kinder.Sensor.Luftfeuchtigkeit-Alarm-2
   room: Badezimmer Kinder
+  writable: true
 8/3/67:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.OG.Badezimmer-Kinder.Sensor.Taupunkt
   room: Badezimmer Kinder
+  writable: false
 8/3/68:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Badezimmer-Kinder.Sensor.Taupunkt-Alarm-1
   room: Badezimmer Kinder
+  writable: true
 8/3/70:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Badezimmer-Kinder.Sensor.VOC-Alarm-1
   room: Badezimmer Kinder
+  writable: false
 8/3/71:
   dpt: '9.008'
   function: Sensorik
   name: Sensorik.OG.Badezimmer-Kinder.Sensor.CO2
   room: Badezimmer Kinder
+  writable: false
 8/3/72:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Badezimmer-Kinder.Sensor.CO2-Alarm-1
   room: Badezimmer Kinder
+  writable: false
 8/3/73:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Badezimmer-Kinder.Sensor.CO2-Alarm-2
   room: Badezimmer Kinder
+  writable: false
 8/3/74:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Badezimmer-Kinder.Sensor.CO2-Alarm-3
   room: Badezimmer Kinder
+  writable: false
 8/3/80:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.OG.Badezimmer-Kinder.Schalter.Temperatur
   room: Badezimmer Kinder
+  writable: true
 8/3/81:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.OG.Badezimmer-Kinder.BWM.Temperatur
   room: Badezimmer Kinder
+  writable: false
 8/3/91:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Gregory.Sensor.Temperatur
   room: Schlafzimmer Gregory
+  writable: true
 8/3/92:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Gregory.Sensor.Temperatur-Alarm-1
   room: Schlafzimmer Gregory
+  writable: false
 8/3/93:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Gregory.Sensor.Temperatur-Alarm-2
   room: Schlafzimmer Gregory
+  writable: false
 8/3/94:
   dpt: '9.007'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Gregory.Sensor.Luftfeuchtigkeit
   room: Schlafzimmer Gregory
+  writable: false
 8/3/95:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Gregory.Sensor.Luftfeuchtigkeit-Alarm-1
   room: Schlafzimmer Gregory
+  writable: true
 8/3/96:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Gregory.Sensor.Luftfeuchtigkeit-Alarm-2
   room: Schlafzimmer Gregory
+  writable: true
 8/3/97:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Gregory.Sensor.Taupunkt
   room: Schlafzimmer Gregory
+  writable: false
 8/3/98:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.OG.Schlafzimmer-Gregory.Sensor.Taupunkt-Alarm-1
   room: Schlafzimmer Gregory
+  writable: true
 8/4/1:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.DG.Speicher.Sensor.Temperatur
   room: Speicher (S)
+  writable: false
 8/4/10:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.DG.Speicher.Sensor.VOC-Alarm-1
   room: Speicher (S)
+  writable: false
 8/4/11:
   dpt: '9.008'
   function: Sensorik
   name: Sensorik.DG.Speicher.Sensor.CO2
   room: Speicher (S)
+  writable: false
 8/4/12:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.DG.Speicher.Sensor.CO2-Alarm-1
   room: Speicher (S)
+  writable: false
 8/4/13:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.DG.Speicher.Sensor.CO2-Alarm-2
   room: Speicher (S)
+  writable: false
 8/4/14:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.DG.Speicher.Sensor.CO2-Alarm-3
   room: Speicher (S)
+  writable: false
 8/4/15:
   dpt: '14.058'
   function: Sensorik
   name: Sensorik.DG.Speicher.Sensor.Luftdruck-Relativ
   room: Speicher (S)
+  writable: false
 8/4/16:
   dpt: '14.058'
   function: Sensorik
   name: Sensorik.DG.Speicher.Sensor.Luftdruck-Absolut
   room: Speicher (S)
+  writable: false
 8/4/17:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.DG.Speicher.Sensor.Luftdruck-Alarm-1
   room: Speicher (S)
+  writable: false
 8/4/2:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.DG.Speicher.Sensor.Temperatur-Alarm-1
   room: Speicher (S)
+  writable: false
 8/4/3:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.DG.Speicher.Sensor.Temperatur-Alarm-2
   room: Speicher (S)
+  writable: false
 8/4/4:
   dpt: '9.007'
   function: Sensorik
   name: Sensorik.DG.Speicher.Sensor.Luftfeuchtigkeit
   room: Speicher (S)
+  writable: false
 8/4/5:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.DG.Speicher.Sensor.Luftfeuchtigkeit-Alarm-1
   room: Speicher (S)
+  writable: false
 8/4/6:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.DG.Speicher.Sensor.Luftfeuchtigkeit-Alarm-2
   room: Speicher (S)
+  writable: false
 8/4/7:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.DG.Speicher.Sensor.Taupunkt
   room: Speicher (S)
+  writable: false
 8/4/8:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.DG.Speicher.Sensor.Taupunkt-Alarm-1
   room: Speicher (S)
+  writable: false
 8/4/9:
   dpt: '9.008'
   function: Sensorik
   name: Sensorik.DG.Speicher.Sensor.VOC
   room: Speicher (S)
+  writable: false
 8/5/1:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.A.Fassade.Außensensor.Temperatur
   room: Fassade
+  writable: true
 8/5/10:
   dpt: '9.004'
   function: Sensorik
   name: Sensorik.A.Fassade.Außensensor.Helligkeit-Mitte
   room: Fassade
+  writable: false
 8/5/101:
   dpt: '9.007'
   function: Sensorik
   name: Sensorik.A.Dach.Außensensor.SO.Luftfeuchtigkeit
   room: Dach
+  writable: false
 8/5/102:
   dpt: '9.007'
   function: Sensorik
   name: Sensorik.A.Dach.Außensensor.SO.Luftfeuchtigkeit-Alle
   room: Dach
+  writable: false
 8/5/103:
   dpt: '1.001'
   function: Sensorik
   name: Sensorik.A.Dach.Außensensor.SO.Luftfeuchtigkeit-Alarm-1
   room: Dach
+  writable: false
 8/5/104:
   dpt: '1.001'
   function: Sensorik
   name: Sensorik.A.Dach.Außensensor.SO.Luftfeuchtigkeit-Alarm-2
   room: Dach
+  writable: false
 8/5/105:
   dpt: '1.001'
   function: Sensorik
   name: Sensorik.A.Dach.Außensensor.SO.Luftfeuchtigkeit-Status
   room: Dach
+  writable: false
 8/5/106:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.A.Dach.Außensensor.SO.Taupunkt
   room: Dach
+  writable: false
 8/5/108:
   dpt: '14.058'
   function: Sensorik
   name: Sensorik.A.Dach.Außensensor.SO.Luftdruck-Relativ
   room: Dach
+  writable: false
 8/5/109:
   dpt: '14.058'
   function: Sensorik
   name: Sensorik.A.Dach.Außensensor.SO.Luftdruck-Absolut
   room: Dach
+  writable: false
 8/5/11:
   dpt: '9.004'
   function: Sensorik
   name: Sensorik.A.Fassade.Außensensor.Helligkeit-Rechts
   room: Fassade
+  writable: false
 8/5/110:
   dpt: '1.001'
   function: Sensorik
   name: Sensorik.A.Dach.Außensensor.SO.Luftdruck-Alarm-1
   room: Dach
+  writable: false
 8/5/111:
   dpt: '1.001'
   function: Sensorik
   name: Sensorik.A.Dach.Außensensor.SO.Luftdruck-Status
   room: Dach
+  writable: false
 8/5/12:
   dpt: '9.004'
   function: Sensorik
   name: Sensorik.A.Fassade.Außensensor.Helligkeit-Alle
   room: Fassade
+  writable: true
 8/5/121:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.A.Dach.Außensensor.NW.Temperatur
   room: Dach
+  writable: true
 8/5/122:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.A.Dach.Außensensor.NW.Temperatur-Alle
   room: Dach
+  writable: false
 8/5/123:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.A.Dach.Außensensor.NW.Temperatur-Alarm-1
   room: Dach
+  writable: false
 8/5/124:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.A.Dach.Außensensor.NW.Temperatur-Alarm-2
   room: Dach
+  writable: false
 8/5/125:
   dpt: '1.001'
   function: Sensorik
   name: Sensorik.A.Dach.Außensensor.NW.Temperatur-Status
   room: Dach
+  writable: false
 8/5/129:
   dpt: '9.004'
   function: Sensorik
   name: Sensorik.A.Dach.Außensensor.NW.Helligkeit-Links
   room: Dach
+  writable: false
 8/5/130:
   dpt: '9.004'
   function: Sensorik
   name: Sensorik.A.Dach.Außensensor.NW.Helligkeit-Mitte
   room: Dach
+  writable: false
 8/5/131:
   dpt: '9.004'
   function: Sensorik
   name: Sensorik.A.Dach.Außensensor.NW.Helligkeit-Rechts
   room: Dach
+  writable: false
 8/5/132:
   dpt: '9.004'
   function: Sensorik
   name: Sensorik.A.Dach.Außensensor.NW.Helligkeit-Alle
   room: Dach
+  writable: true
 8/5/2:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.A.Fassade.Außensensor.Temperatur-Alle
   room: Fassade
+  writable: false
 8/5/3:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.A.Fassade.Außensensor.Temperatur-Alarm-1
   room: Fassade
+  writable: false
 8/5/4:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.A.Fassade.Außensensor.Temperatur-Alarm-2
   room: Fassade
+  writable: false
 8/5/41:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.A.Dach.Wetterstation.Temperatur
   room: Dach
+  writable: true
 8/5/43:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.A.Dach.Wetterstation.Temperatur-Alarm-1
   room: Dach
+  writable: false
 8/5/44:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.A.Dach.Wetterstation.Temperatur-Alarm-2
   room: Dach
+  writable: false
 8/5/45:
   dpt: '1.001'
   function: Sensorik
   name: Sensorik.A.Dach.Wetterstation.Temperatur-Status
   room: Dach
+  writable: false
 8/5/46:
   dpt: '9.005'
   function: Sensorik
   name: Sensorik.A.Dach.Wetterstation.Windgeschwindigkeit
   room: Dach
+  writable: false
 8/5/47:
   dpt: '1.001'
   function: Sensorik
   name: Sensorik.A.Dach.Wetterstation.Windgeschwindigkeit-Alarm-1
   room: Dach
+  writable: false
 8/5/48:
   dpt: '1.005'
   function: Sensorik
   name: Sensorik.A.Dach.Wetterstation.Windgeschwindigkeit-Alarm-Erweitert-1
   room: Dach
+  writable: true
 8/5/49:
   dpt: '9.004'
   function: Sensorik
   name: Sensorik.A.Dach.Wetterstation.Helligkeit-Links
   room: Dach
+  writable: false
 8/5/5:
   dpt: '1.001'
   function: Sensorik
   name: Sensorik.A.Fassade.Außensensor.Temperatur-Status
   room: Fassade
+  writable: false
 8/5/50:
   dpt: '9.004'
   function: Sensorik
   name: Sensorik.A.Dach.Wetterstation.Helligkeit-Mitte
   room: Dach
+  writable: false
 8/5/51:
   dpt: '9.004'
   function: Sensorik
   name: Sensorik.A.Dach.Wetterstation.Helligkeit-Rechts
   room: Dach
+  writable: false
 8/5/52:
   dpt: '9.004'
   function: Sensorik
   name: Sensorik.A.Dach.Wetterstation.Helligkeit-Alle
   room: Dach
+  writable: true
 8/5/53:
   dpt: '1.001'
   function: Sensorik
   name: Sensorik.A.Dach.Wetterstation.Regen
   room: Dach
+  writable: false
 8/5/54:
   dpt: '1.001'
   function: Sensorik
   name: Sensorik.A.Dach.Wetterstation.Regen-Alarm-1
   room: Dach
+  writable: true
 8/5/55:
   dpt: '1.001'
   function: Sensorik
   name: Sensorik.A.Dach.Wetterstation.Frost
   room: Dach
+  writable: false
 8/5/56:
   dpt: '1.001'
   function: Sensorik
   name: Sensorik.A.Dach.Wetterstation.Frost-Alarm-1
   room: Dach
+  writable: false
 8/5/57:
   dpt: '14.007'
   function: Sensorik
   name: Sensorik.A.Dach.Wetterstation.Azimut
   room: Dach
+  writable: false
 8/5/58:
   dpt: '14.007'
   function: Sensorik
   name: Sensorik.A.Dach.Wetterstation.Elevation
   room: Dach
+  writable: false
 8/5/59:
   dpt: '14.007'
   function: Sensorik
   name: Sensorik.A.Dach.Wetterstation.GPS-Breitengrad
   room: Dach
+  writable: false
 8/5/60:
   dpt: '14.007'
   function: Sensorik
   name: Sensorik.A.Dach.Wetterstation.GPS-Längengrad
   room: Dach
+  writable: false
 8/5/81:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.A.Dach.Außensensor.SO.Temperatur
   room: Dach
+  writable: true
 8/5/82:
   dpt: '9.001'
   function: Sensorik
   name: Sensorik.A.Dach.Außensensor.SO.Temperatur-Alle
   room: Dach
+  writable: false
 8/5/83:
   dpt: '1.001'
   function: Sensorik
   name: Sensorik.A.Dach.Außensensor.SO.Temperatur-Alarm-1
   room: Dach
+  writable: false
 8/5/84:
   dpt: '1.001'
   function: Sensorik
   name: Sensorik.A.Dach.Außensensor.SO.Temperatur-Alarm-2
   room: Dach
+  writable: false
 8/5/85:
   dpt: '1.001'
   function: Sensorik
   name: Sensorik.A.Dach.Außensensor.SO.Temperatur-Status
   room: Dach
+  writable: false
 8/5/9:
   dpt: '9.004'
   function: Sensorik
   name: Sensorik.A.Fassade.Außensensor.Helligkeit-Links
   room: Fassade
+  writable: false
 9/1/0:
   dpt: '1.003'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Flur.KNX.Decke.Sperren
   room: Flur
+  writable: true
 9/1/1:
   dpt: '1.011'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Flur.KNX.Decke.Sperren-Status
   room: Flur
+  writable: false
 9/1/10:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Flur.KNX.Decke.Slave
   room: Flur
+  writable: true
 9/1/100:
   dpt: '1.003'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Garage.EMA.Sperren
   room: Garage
+  writable: false
 9/1/101:
   dpt: '1.011'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Garage.EMA.Sperren-Staus
   room: Garage
+  writable: false
 9/1/102:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Garage.EMA.Ein/Aus
   room: Garage
+  writable: false
 9/1/106:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Garage.EMA.HLK
   room: Garage
+  writable: false
 9/1/107:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Garage.EMA.Präsenz
   room: Garage
+  writable: false
 9/1/109:
   dpt: '1.024'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Garage.EMA.Tag/Nacht
   room: Garage
+  writable: false
 9/1/120:
   dpt: '1.003'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Technikraum.KNX.Sperren
   room: Technikraum
+  writable: true
 9/1/121:
   dpt: '1.011'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Technikraum.KNX.Sperren-Status
   room: Technikraum
+  writable: false
 9/1/122:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Technikraum.KNX.Ein/Aus
   room: Technikraum
+  writable: true
 9/1/123:
   dpt: '5.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Technikraum.KNX.Dimmen
   room: Technikraum
+  writable: true
 9/1/124:
   dpt: '9.004'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Technikraum.KNX.Schaltschwelle
   room: Technikraum
+  writable: true
 9/1/126:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Technikraum.KNX.HLK
   room: Technikraum
+  writable: false
 9/1/127:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Technikraum.KNX.Präsenz
   room: Technikraum
+  writable: false
 9/1/128:
   dpt: '9.004'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Technikraum.KNX.Helligkeit
   room: Technikraum
+  writable: false
 9/1/129:
   dpt: '1.024'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Technikraum.KNX.Tag/Nacht
   room: Technikraum
+  writable: true
 9/1/130:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Technikraum.KNX.Slave
   room: Technikraum
+  writable: true
 9/1/140:
   dpt: '1.003'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Vorratsraum.KNX.Sperren
   room: Vorratsraum
+  writable: true
 9/1/141:
   dpt: '1.011'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Vorratsraum.KNX.Sperren-Status
   room: Vorratsraum
+  writable: false
 9/1/142:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Vorratsraum.KNX.Ein/Aus
   room: Vorratsraum
+  writable: true
 9/1/143:
   dpt: '5.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Vorratsraum.KNX.Dimmen
   room: Vorratsraum
+  writable: false
 9/1/144:
   dpt: '9.004'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Vorratsraum.KNX.Schaltschwelle
   room: Vorratsraum
+  writable: true
 9/1/146:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Vorratsraum.KNX.HLK
   room: Vorratsraum
+  writable: false
 9/1/147:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Vorratsraum.KNX.Präsenz
   room: Vorratsraum
+  writable: false
 9/1/148:
   dpt: '9.004'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Vorratsraum.KNX.Helligkeit
   room: Vorratsraum
+  writable: false
 9/1/149:
   dpt: '1.024'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Vorratsraum.KNX.Tag/Nacht
   room: Vorratsraum
+  writable: true
 9/1/150:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Vorratsraum.KNX.Slave
   room: Vorratsraum
+  writable: true
 9/1/160:
   dpt: '1.003'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Hauswirtschaftsraum.KNX.Sperren
   room: Hauswirtschaftsraum
+  writable: true
 9/1/161:
   dpt: '1.011'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Hauswirtschaftsraum.KNX.Sperren-Status
   room: Hauswirtschaftsraum
+  writable: false
 9/1/162:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Hauswirtschaftsraum.KNX.Ein/Aus
   room: Hauswirtschaftsraum
+  writable: true
 9/1/163:
   dpt: '5.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Hauswirtschaftsraum.KNX.Dimmen
   room: Hauswirtschaftsraum
+  writable: true
 9/1/164:
   dpt: '9.004'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Hauswirtschaftsraum.KNX.Schaltschwelle
   room: Hauswirtschaftsraum
+  writable: true
 9/1/166:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Hauswirtschaftsraum.KNX.HLK
   room: Hauswirtschaftsraum
+  writable: false
 9/1/167:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Hauswirtschaftsraum.KNX.Präsenz
   room: Hauswirtschaftsraum
+  writable: false
 9/1/168:
   dpt: '9.004'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Hauswirtschaftsraum.KNX.Helligkeit
   room: Hauswirtschaftsraum
+  writable: false
 9/1/169:
   dpt: '1.024'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Hauswirtschaftsraum.KNX.Tag/Nacht
   room: Hauswirtschaftsraum
+  writable: true
 9/1/170:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Hauswirtschaftsraum.KNX.Slave
   room: Hauswirtschaftsraum
+  writable: true
 9/1/2:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Flur.KNX.Decke.Ein/Aus
   room: Flur
+  writable: true
 9/1/20:
   dpt: '1.003'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Flur.KNX.Wand.Sperren
   room: Flur
+  writable: true
 9/1/21:
   dpt: '1.011'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Flur.KNX.Wand.Sperren-Status
   room: Flur
+  writable: false
 9/1/22:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Flur.KNX.Wand.Ein/Aus
   room: Flur
+  writable: true
 9/1/23:
   dpt: '5.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Flur.KNX.Wand.Dimmen
   room: Flur
+  writable: true
 9/1/25:
   dpt: '1.011'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Flur.KNX.Wand.Schaltschwelle-Status
   room: Flur
+  writable: false
 9/1/26:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Flur.KNX.Wand.HLK
   room: Flur
+  writable: false
 9/1/27:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Flur.KNX.Wand.Präsenz
   room: Flur
+  writable: true
 9/1/28:
   dpt: '9.004'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Flur.KNX.Wand.Helligkeit
   room: Flur
+  writable: false
 9/1/29:
   dpt: '1.024'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Flur.KNX.Wand.Tag/Nacht
   room: Flur
+  writable: true
 9/1/3:
   dpt: '5.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Flur.KNX.Decke.Dimmen
   room: Flur
+  writable: true
 9/1/30:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Flur.KNX.Wand.Slave
   room: Flur
+  writable: true
 9/1/40:
   dpt: '1.003'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Flur.EMA.Sperren
   room: Flur
+  writable: false
 9/1/41:
   dpt: '1.011'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Flur.EMA.Sperren-Status
   room: Flur
+  writable: false
 9/1/42:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Flur.EMA.Ein/Aus
   room: Flur
+  writable: false
 9/1/46:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Flur.EMA.HLK
   room: Flur
+  writable: false
 9/1/47:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Flur.EMA.Präsenz
   room: Flur
+  writable: false
 9/1/49:
   dpt: '1.024'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Flur.EMA.Tag/Nacht
   room: Flur
+  writable: false
 9/1/5:
   dpt: '1.011'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Flur.KNX.Decke.Schaltschwelle-Status
   room: Flur
+  writable: false
 9/1/6:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Flur.KNX.Decke.HLK
   room: Flur
+  writable: false
 9/1/60:
   dpt: '1.003'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Garage.KNX.Decke.Sperren
   room: Garage
+  writable: true
 9/1/61:
   dpt: '1.011'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Garage.KNX.Decke.Sperren-Status
   room: Garage
+  writable: false
 9/1/62:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Garage.KNX.Decke.Ein/Aus
   room: Garage
+  writable: true
 9/1/63:
   dpt: '5.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Garage.KNX.Decke.Dimmen
   room: Garage
+  writable: true
 9/1/64:
   dpt: '9.004'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Garage.KNX.Decke.Schaltschwelle
   room: Garage
+  writable: true
 9/1/66:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Garage.KNX.Decke.HLK
   room: Garage
+  writable: false
 9/1/67:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Garage.KNX.Decke.Präsenz
   room: Garage
+  writable: false
 9/1/68:
   dpt: '9.004'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Garage.KNX.Decke.Helligkeit
   room: Garage
+  writable: false
 9/1/69:
   dpt: '1.024'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Garage.KNX.Decke.Tag/Nacht
   room: Garage
+  writable: true
 9/1/7:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Flur.KNX.Decke.Präsenz
   room: Flur
+  writable: true
 9/1/70:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Garage.KNX.Decke.Slave
   room: Garage
+  writable: true
 9/1/8:
   dpt: '9.004'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Flur.KNX.Decke.Helligkeit
   room: Flur
+  writable: false
 9/1/82:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Garage.KNX.Wand.Ein/Aus
   room: Garage
+  writable: false
 9/1/83:
   dpt: '5.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Garage.KNX.Wand.Dimmen
   room: Garage
+  writable: false
 9/1/86:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Garage.KNX.Wand.HLK
   room: Garage
+  writable: false
 9/1/87:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Garage.KNX.Wand.Präsenz
   room: Garage
+  writable: false
 9/1/88:
   dpt: '9.004'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Garage.KNX.Wand.Helligkeit
   room: Garage
+  writable: false
 9/1/89:
   dpt: '1.024'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Garage.KNX.Wand.Tag/Nacht
   room: Garage
+  writable: false
 9/1/9:
   dpt: '1.024'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Flur.KNX.Decke.Tag/Nacht
   room: Flur
+  writable: true
 9/1/90:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.KG.Garage.KNX.Wand.Slave
   room: Garage
+  writable: false
 9/2/0:
   dpt: '1.003'
   function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.KNX.Eingang.Sperren
   room: Flur
+  writable: true
 9/2/1:
   dpt: '1.011'
   function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.KNX.Eingang.Sperren-Status
   room: Flur
+  writable: false
 9/2/10:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.KNX.Eingang.Slave
   room: Flur
+  writable: true
 9/2/100:
   dpt: '1.003'
   function: Bewegungsmelder
   name: Bewegungsmelder.EG.Büro.EMA.Sperren
   room: Büro
+  writable: false
 9/2/101:
   dpt: '1.011'
   function: Bewegungsmelder
   name: Bewegungsmelder.EG.Büro.EMA.Sperren-Status
   room: Büro
+  writable: false
 9/2/102:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.EG.Büro.EMA.Ein/Aus
   room: Büro
+  writable: false
 9/2/106:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.EG.Büro.EMA.HLK
   room: Büro
+  writable: false
 9/2/107:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.EG.Büro.EMA.Präsenz
   room: Büro
+  writable: false
 9/2/109:
   dpt: '1.024'
   function: Bewegungsmelder
   name: Bewegungsmelder.EG.Büro.EMA.Tag/Nacht
   room: Büro
+  writable: false
 9/2/120:
   dpt: '1.003'
   function: Bewegungsmelder
   name: Bewegungsmelder.EG.Wohnzimmer.EMA.Sperren
   room: Wohnzimmer
+  writable: false
 9/2/121:
   dpt: '1.011'
   function: Bewegungsmelder
   name: Bewegungsmelder.EG.Wohnzimmer.EMA.Sperren-Status
   room: Wohnzimmer
+  writable: false
 9/2/122:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.EG.Wohnzimmer.EMA.Ein/Aus
   room: Wohnzimmer
+  writable: false
 9/2/126:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.EG.Wohnzimmer.EMA.HLK
   room: Wohnzimmer
+  writable: false
 9/2/127:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.EG.Wohnzimmer.EMA.Präsenz
   room: Wohnzimmer
+  writable: false
 9/2/129:
   dpt: '1.024'
   function: Bewegungsmelder
   name: Bewegungsmelder.EG.Wohnzimmer.EMA.Tag/Nacht
   room: Wohnzimmer
+  writable: false
 9/2/140:
   dpt: '1.003'
   function: Bewegungsmelder
   name: Bewegungsmelder.EG.Esszimmer.EMA.Sperren
   room: Esszimmer
+  writable: false
 9/2/141:
   dpt: '1.011'
   function: Bewegungsmelder
   name: Bewegungsmelder.EG.Esszimmer.EMA.Sperren-Status
   room: Esszimmer
+  writable: false
 9/2/142:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.EG.Esszimmer.EMA.Ein/Aus
   room: Esszimmer
+  writable: false
 9/2/146:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.EG.Esszimmer.EMA.HLK
   room: Esszimmer
+  writable: false
 9/2/147:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.EG.Esszimmer.EMA.Präsenz
   room: Esszimmer
+  writable: false
 9/2/149:
   dpt: '1.024'
   function: Bewegungsmelder
   name: Bewegungsmelder.EG.Esszimmer.EMA.Tag/Nacht
   room: Esszimmer
+  writable: false
 9/2/2:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.KNX.Eingang.Ein/Aus
   room: Flur
+  writable: true
 9/2/20:
   dpt: '1.003'
   function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.KNX.Diele.Sperren
   room: Flur
+  writable: true
 9/2/21:
   dpt: '1.011'
   function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.KNX.Diele.Sperren-Status
   room: Flur
+  writable: false
 9/2/22:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.KNX.Diele.Ein/Aus
   room: Flur
+  writable: true
 9/2/23:
   dpt: '5.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.KNX.Diele.Dimmen
   room: Flur
+  writable: true
 9/2/25:
   dpt: '1.011'
   function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.KNX.Diele.Schaltschwelle-Status
   room: Flur
+  writable: false
 9/2/26:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.KNX.Diele.HLK
   room: Flur
+  writable: false
 9/2/27:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.KNX.Diele.Präsenz
   room: Flur
+  writable: true
 9/2/28:
   dpt: '9.004'
   function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.KNX.Diele.Helligkeit
   room: Flur
+  writable: false
 9/2/29:
   dpt: '1.024'
   function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.KNX.Diele.Tag/Nacht
   room: Flur
+  writable: true
 9/2/3:
   dpt: '5.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.KNX.Eingang.Dimmen
   room: Flur
+  writable: true
 9/2/30:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.KNX.Diele.Slave
   room: Flur
+  writable: true
 9/2/42:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.KNX.Garderobe.Ein/Aus
   room: Flur
+  writable: false
 9/2/46:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.KNX.Garderobe.HLK
   room: Flur
+  writable: false
 9/2/47:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.KNX.Garderobe.Präsenz
   room: Flur
+  writable: true
 9/2/48:
   dpt: '9.004'
   function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.KNX.Garderobe.Helligkeit
   room: Flur
+  writable: false
 9/2/49:
   dpt: '1.024'
   function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.KNX.Garderobe.Tag/Nacht
   room: Flur
+  writable: false
 9/2/5:
   dpt: '1.011'
   function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.KNX.Eingang.Schaltschwelle-Status
   room: Flur
+  writable: false
 9/2/50:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.KNX.Garderobe.Slave
   room: Flur
+  writable: false
 9/2/6:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.KNX.Eingang.HLK
   room: Flur
+  writable: false
 9/2/60:
   dpt: '1.003'
   function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.EMA.Sperren
   room: Flur
+  writable: false
 9/2/61:
   dpt: '1.011'
   function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.EMA.Sperren-Status
   room: Flur
+  writable: false
 9/2/62:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.EMA.Ein/Aus
   room: Flur
+  writable: false
 9/2/66:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.EMA.HLK
   room: Flur
+  writable: false
 9/2/67:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.EMA.Präsenz
   room: Flur
+  writable: false
 9/2/69:
   dpt: '1.024'
   function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.EMA.Tag/Nacht
   room: Flur
+  writable: false
 9/2/7:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.KNX.Eingang.Präsenz
   room: Flur
+  writable: true
 9/2/8:
   dpt: '9.004'
   function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.KNX.Eingang.Helligkeit
   room: Flur
+  writable: false
 9/2/80:
   dpt: '1.003'
   function: Bewegungsmelder
   name: Bewegungsmelder.EG.Gäste-WC.KNX.Sperren
   room: Gäste WC
+  writable: true
 9/2/81:
   dpt: '1.011'
   function: Bewegungsmelder
   name: Bewegungsmelder.EG.Gäste-WC.KNX.Sperren-Status
   room: Gäste WC
+  writable: false
 9/2/82:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.EG.Gäste-WC.KNX.Ein/Aus
   room: Gäste WC
+  writable: true
 9/2/83:
   dpt: '5.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.EG.Gäste-WC.KNX.Dimmen
   room: Gäste WC
+  writable: true
 9/2/85:
   dpt: '1.011'
   function: Bewegungsmelder
   name: Bewegungsmelder.EG.Gäste-WC.KNX.Schaltschwelle-Status
   room: Gäste WC
+  writable: false
 9/2/86:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.EG.Gäste-WC.KNX.HLK
   room: Gäste WC
+  writable: false
 9/2/87:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.EG.Gäste-WC.KNX.Präsenz
   room: Gäste WC
+  writable: true
 9/2/88:
   dpt: '9.004'
   function: Bewegungsmelder
   name: Bewegungsmelder.EG.Gäste-WC.KNX.Helligkeit
   room: Gäste WC
+  writable: false
 9/2/89:
   dpt: '1.024'
   function: Bewegungsmelder
   name: Bewegungsmelder.EG.Gäste-WC.KNX.Tag/Nacht
   room: Gäste WC
+  writable: true
 9/2/9:
   dpt: '1.024'
   function: Bewegungsmelder
   name: Bewegungsmelder.EG.Flur.KNX.Eingang.Tag/Nacht
   room: Flur
+  writable: true
 9/2/90:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.EG.Gäste-WC.KNX.Slave
   room: Gäste WC
+  writable: true
 9/3/10:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Flur.KNX.Treppe.Slave
   room: Flur
+  writable: false
 9/3/100:
   dpt: '1.003'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Badezimmer-Kinder.KNX.Sperren
   room: Badezimmer Kinder
+  writable: true
 9/3/101:
   dpt: '1.011'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Badezimmer-Kinder.KNX.Sperren-Status
   room: Badezimmer Kinder
+  writable: false
 9/3/102:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Badezimmer-Kinder.KNX.Ein/Aus
   room: Badezimmer Kinder
+  writable: true
 9/3/103:
   dpt: '5.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Badezimmer-Kinder.KNX.Dimmen
   room: Badezimmer Kinder
+  writable: false
 9/3/105:
   dpt: '1.011'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Badezimmer-Kinder.KNX.Schaltschwelle-Status
   room: Badezimmer Kinder
+  writable: false
 9/3/106:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Badezimmer-Kinder.KNX.HLK
   room: Badezimmer Kinder
+  writable: false
 9/3/107:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Badezimmer-Kinder.KNX.Präsenz
   room: Badezimmer Kinder
+  writable: true
 9/3/108:
   dpt: '9.004'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Badezimmer-Kinder.KNX.Helligkeit
   room: Badezimmer Kinder
+  writable: false
 9/3/109:
   dpt: '1.024'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Badezimmer-Kinder.KNX.Tag/Nacht
   room: Badezimmer Kinder
+  writable: true
 9/3/110:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Badezimmer-Kinder.KNX.Slave
   room: Badezimmer Kinder
+  writable: true
 9/3/160:
   dpt: '1.003'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Schlafzimmer-Eltern.KNX.Sperren
   room: Schlafzimmer Eltern
+  writable: true
 9/3/161:
   dpt: '1.011'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Schlafzimmer-Eltern.KNX.Sperren-Status
   room: Schlafzimmer Eltern
+  writable: false
 9/3/162:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Schlafzimmer-Eltern.KNX.Ein/Aus
   room: Schlafzimmer Eltern
+  writable: true
 9/3/163:
   dpt: '5.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Schlafzimmer-Eltern.KNX.Dimmen
   room: Schlafzimmer Eltern
+  writable: false
 9/3/165:
   dpt: '1.011'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Schlafzimmer-Eltern.KNX.Schaltschwelle-Status
   room: Schlafzimmer Eltern
+  writable: false
 9/3/166:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Schlafzimmer-Eltern.KNX.HLK
   room: Schlafzimmer Eltern
+  writable: false
 9/3/167:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Schlafzimmer-Eltern.KNX.Präsenz
   room: Schlafzimmer Eltern
+  writable: false
 9/3/168:
   dpt: '9.004'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Schlafzimmer-Eltern.KNX.Helligkeit
   room: Schlafzimmer Eltern
+  writable: false
 9/3/169:
   dpt: '1.024'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Schlafzimmer-Eltern.KNX.Tag/Nacht
   room: Schlafzimmer Eltern
+  writable: true
 9/3/170:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Schlafzimmer-Eltern.KNX.Slave
   room: Schlafzimmer Eltern
+  writable: true
 9/3/180:
   dpt: '1.003'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Begehbarer-Schrank.KNX.Sperren
   room: Begehbarer Schrank
+  writable: true
 9/3/181:
   dpt: '1.011'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Begehbarer-Schrank.KNX.Sperren-Status
   room: Begehbarer Schrank
+  writable: false
 9/3/182:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Begehbarer-Schrank.KNX.Ein/Aus
   room: Begehbarer Schrank
+  writable: true
 9/3/183:
   dpt: '5.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Begehbarer-Schrank.KNX.Dimmen
   room: Begehbarer Schrank
+  writable: true
 9/3/185:
   dpt: '1.011'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Begehbarer-Schrank.KNX.Schaltschwelle-Status
   room: Begehbarer Schrank
+  writable: false
 9/3/186:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Begehbarer-Schrank.KNX.HLK
   room: Begehbarer Schrank
+  writable: false
 9/3/187:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Begehbarer-Schrank.KNX.Präsenz
   room: Begehbarer Schrank
+  writable: true
 9/3/188:
   dpt: '9.004'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Begehbarer-Schrank.KNX.Helligkeit
   room: Begehbarer Schrank
+  writable: false
 9/3/189:
   dpt: '1.024'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Begehbarer-Schrank.KNX.Tag/Nacht
   room: Begehbarer Schrank
+  writable: true
 9/3/190:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Begehbarer-Schrank.KNX.Slave
   room: Begehbarer Schrank
+  writable: true
 9/3/2:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Flur.KNX.Treppe.Ein/Aus
   room: Flur
+  writable: false
 9/3/20:
   dpt: '1.003'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Flur.KNX.Gang.Sperren
   room: Flur
+  writable: true
 9/3/200:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Badezimmer-Eltern.KNX.Sperren
   room: Badezimmer Eltern
+  writable: true
 9/3/201:
   dpt: '1.011'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Badezimmer-Eltern.KNX.Sperren-Status
   room: Badezimmer Eltern
+  writable: false
 9/3/202:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Badezimmer-Eltern.KNX.Ein/Aus
   room: Badezimmer Eltern
+  writable: true
 9/3/203:
   dpt: '5.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Badezimmer-Eltern.KNX.Dimmen
   room: Badezimmer Eltern
+  writable: false
 9/3/205:
   dpt: '1.011'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Badezimmer-Eltern.KNX.Schaltschwelle-Status
   room: Badezimmer Eltern
+  writable: false
 9/3/206:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Badezimmer-Eltern.KNX.HLK
   room: Badezimmer Eltern
+  writable: false
 9/3/207:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Badezimmer-Eltern.KNX.Präsenz
   room: Badezimmer Eltern
+  writable: true
 9/3/208:
   dpt: '9.004'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Badezimmer-Eltern.KNX.Helligkeit
   room: Badezimmer Eltern
+  writable: false
 9/3/209:
   dpt: '1.024'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Badezimmer-Eltern.KNX.Tag/Nacht
   room: Badezimmer Eltern
+  writable: true
 9/3/21:
   dpt: '1.011'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Flur.KNX.Gang.Sperren-Status
   room: Flur
+  writable: false
 9/3/210:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Badezimmer-Eltern.KNX.Slave
   room: Badezimmer Eltern
+  writable: true
 9/3/22:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Flur.KNX.Gang.Ein/Aus
   room: Flur
+  writable: true
 9/3/23:
   dpt: '5.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Flur.KNX.Gang.Dimmen
   room: Flur
+  writable: true
 9/3/25:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Flur.KNX.Gang.Schaltschwelle-Status
   room: Flur
+  writable: false
 9/3/26:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Flur.KNX.Gang.HLK
   room: Flur
+  writable: false
 9/3/27:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Flur.KNX.Gang.Präsenz
   room: Flur
+  writable: true
 9/3/28:
   dpt: '9.004'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Flur.KNX.Gang.Helligkeit
   room: Flur
+  writable: false
 9/3/29:
   dpt: '1.024'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Flur.KNX.Gang.Tag/Nacht
   room: Flur
+  writable: true
 9/3/30:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Flur.KNX.Gang.Slave
   room: Flur
+  writable: true
 9/3/40:
   dpt: '1.003'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Flur.EMA.Treppe.Sperren
   room: Flur
+  writable: false
 9/3/41:
   dpt: '1.011'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Flur.EMA.Treppe.Sperren-Status
   room: Flur
+  writable: false
 9/3/42:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Flur.EMA.Treppe.Ein/Aus
   room: Flur
+  writable: false
 9/3/46:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Flur.EMA.Treppe.HLK
   room: Flur
+  writable: false
 9/3/47:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Flur.EMA.Treppe.Präsenz
   room: Flur
+  writable: false
 9/3/49:
   dpt: '1.024'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Flur.EMA.Treppe.Tag/Nacht
   room: Flur
+  writable: false
 9/3/6:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Flur.KNX.Treppe.HLK
   room: Flur
+  writable: false
 9/3/60:
   dpt: '1.003'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Flur.EMA.Gang.Sperren
   room: Flur
+  writable: false
 9/3/61:
   dpt: '1.011'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Flur.EMA.Gang.Sperren-Status
   room: Flur
+  writable: false
 9/3/62:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Flur.EMA.Gang.Ein/Aus
   room: Flur
+  writable: false
 9/3/66:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Flur.EMA.Gang.HLK
   room: Flur
+  writable: false
 9/3/67:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Flur.EMA.Gang.Präsenz
   room: Flur
+  writable: false
 9/3/69:
   dpt: '1.024'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Flur.EMA.Gang.Tag/Nacht
   room: Flur
+  writable: false
 9/3/7:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Flur.KNX.Treppe.Präsenz
   room: Flur
+  writable: true
 9/3/8:
   dpt: '9.004'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Flur.KNX.Treppe.Helligkeit
   room: Flur
+  writable: false
 9/3/9:
   dpt: '1.024'
   function: Bewegungsmelder
   name: Bewegungsmelder.OG.Flur.KNX.Treppe.Tag/Nacht
   room: Flur
+  writable: false
 9/4/0:
   dpt: '1.003'
   function: Bewegungsmelder
   name: Bewegungsmelder.DG.KNX.Sperren
   room: Speicher (S)
+  writable: true
 9/4/1:
   dpt: '1.011'
   function: Bewegungsmelder
   name: Bewegungsmelder.DG.KNX.Sperren-Status
   room: Speicher (S)
+  writable: false
 9/4/10:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.DG.KNX.Slave
   room: Speicher (S)
+  writable: true
 9/4/2:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.DG.KNX.Ein/Aus
   room: Speicher (S)
+  writable: true
 9/4/3:
   dpt: '5.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.DG.KNX.Dimmen
   room: Speicher (S)
+  writable: true
 9/4/4:
   dpt: '9.004'
   function: Bewegungsmelder
   name: Bewegungsmelder.DG.KNX.Schaltschwelle
   room: Speicher (S)
+  writable: true
 9/4/6:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.DG.KNX.HLK
   room: Speicher (S)
+  writable: false
 9/4/7:
   dpt: '1.001'
   function: Bewegungsmelder
   name: Bewegungsmelder.DG.KNX.Präsenz
   room: Speicher (S)
+  writable: false
 9/4/8:
   dpt: '9.004'
   function: Bewegungsmelder
   name: Bewegungsmelder.DG.KNX.Helligkeit
   room: Speicher (S)
+  writable: false
 9/4/9:
   dpt: '1.024'
   function: Bewegungsmelder
   name: Bewegungsmelder.DG.KNX.Tag/Nacht
   room: Speicher (S)
+  writable: true

--- a/tasks/knx.yaml
+++ b/tasks/knx.yaml
@@ -39,9 +39,14 @@ tasks:
       - sh: test -f "{{.KNXPROJ}}"
         msg: "'{{.KNXPROJ}}' not found"
     cmds:
+      # --ignore-write-from Dummy: the GIRA placeholder device receives ~1850
+      # addresses purely to get them into the coupler filter tables. Counting
+      # its Write flag would mark almost everything writable, status mirrors
+      # included.
       - uv run --directory "{{.KNX_BRIDGE_DIR}}" --extra tools knxproj-to-yaml
         --input "{{.KNXPROJ}}"
         --output "{{.KNX_CATALOG_PATH}}"
+        --ignore-write-from Dummy
         {{if .KNXPROJ_PASSWORD}}--password "$KNXPROJ_PASSWORD"{{end}}
 
   enrich-catalog:


### PR DESCRIPTION
Closes the lares half of #1543. The generator side shipped in knx-nats-bridge #134 and #136, released as 0.16.0 and already running in-cluster.

## What changed

Two commits:

1. `task knx:catalog` now passes `--ignore-write-from Dummy`
2. The catalog regenerated with that flag — `writable` on all 2559 entries

## Why the exclusion is not optional

Without it the flag is useless. Measured on the real export:

| | naive | `--ignore-write-from Dummy` |
|---|---:|---:|
| writable | 2237 (87%) | **1069 (41%)** |
| status mirrors, known false | 229/276 | **0/276** |
| `-Status`-named addresses | 572/610 | 73/610 |

A single `GIRA Giersiepen Dummy` device supplied the Write flag on 1850 addresses. Its objects exist so group addresses enter the line couplers' filter tables — the flag means the telegram is forwarded, not that anything acts on it.

## Verification

- `task knx:validate-catalog` → `OK: 2559 entries valid`
- 0 of the 276 writer-rule targets writable
- `6/2/42` (room setpoint, real heating actuator) `true`; `6/2/43` (its `-Status` twin) `false`; `15/2/25` and `15/2/55` (status mirrors) `false`
- **Diff is 2559 added lines and 0 removed** — no name, room or description changed, so nothing but the new field

## Expected `false`, by design

The 26 addresses consumed by the `*_from_knx` streams (`6/1/62`, `15/6/20`, …) come out `false`. Their actuator is a NATS-side bridge, which has no ETS communication object, so ETS genuinely cannot see them. A consumer gating writes unions that set in itself — it is enumerated in the stream configs and disjoint from the 276 writer-rule targets. #1552's policy does exactly that. #1557 would remove the need for it by modelling the bridge as a real device.

## Ordering

Safe to merge: the running pod is on 0.16.0, whose schema accepts `writable`. Verified before regenerating — the reverse order would have CrashLooped the bridge, since the ConfigMap name hash rolls the pod and `mapping.py` validates at startup with `additionalProperties: false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)