### PR TITLE
fix(knx): drop the writer rule for the retired boiler_heatingactive

### DIFF
--- a/kubernetes/applications/knx-nats-bridge/base/config/writer-rules.yaml
+++ b/kubernetes/applications/knx-nats-bridge/base/config/writer-rules.yaml
@@ -625,12 +625,6 @@ mappings:
     description: "Versorgungstechnik.Gastherme.Brenner.Modulation-Anomalie"
     min_delta: 0
     seed_on_start: true
-  - subject: "anomaly.boiler_heatingactive"
-    ga: "15/2/21"
-    dpt: "5.010"
-    payload_path: "$.severity_level"
-    description: "Versorgungstechnik.Gastherme.Heizung.Aktiv-Anomalie"
-    min_delta: 0
     seed_on_start: true
   - subject: "anomaly.heating_activity_seasonal"
     ga: "15/2/22"


### PR DESCRIPTION
lares half of #1551. Pairs with iot-insights-engine#101, which deletes the detector.

Removes the rule routing `anomaly.boiler_heatingactive` to `15/2/21`. Anomaly writer rules go from 96 to 95.

## Merge order — this is the part that can bite

`clear.py` drops a group address back to 0 only when its entity is absent from a **running** detector. Once the use-case leaves the registry, nothing can ever clear `15/2/21` again: **whatever value it holds when the engine deploy lands is the value it keeps, permanently.**

It currently reads **0** (last written 2026-08-27 08:00), but it cycles — 1107 writes in 90 days, firing to 3 and clearing an hour or two later. If the deploy lands inside an open window, the address freezes at critical and Basalte keeps reporting it.

So:

1. Merge and deploy iot-insights-engine#101 — the detector stops publishing
2. **Check `15/2/21`.** If it is not 0, publish one final `severity_level: 0` on `anomaly.boiler_heatingactive` while this rule still exists
3. Merge this PR
4. `kubectl -n knx-nats-bridge rollout restart deploy/knx-nats-bridge` — no Reloader in-cluster, the ConfigMap change alone does not roll the pod

## Still to do afterwards, manually

- delete group address `15/2/21` in ETS, then `task knx:catalog`
- remove the Basalte mail rule for `15/2/21`

Nothing to do about stored data: `mcp_anomalies.uc` has no CHECK constraint and the table has 90-day retention, so rows for the retired use-case age out on their own.

## Note on the coverage check

#1551 asks that `15/2/22` still carries a signal after the naive detector goes. It cannot be verified yet: that address has received **no value in 90 days**. The seasonal detector is demonstrably running — it fits on 8517 samples and forecasts every run — but has never fired, which is correct for a summer with the heating off. The first real test comes with the heating season.

🤖 Generated with [Claude Code](https://claude.com/claude-code)