### PR TITLE
fix(talos): prune unused container images via imageMaximumGCAge

### DIFF
--- a/cluster/patches/global-settings.yaml
+++ b/cluster/patches/global-settings.yaml
@@ -31,6 +31,7 @@ machine:
       rotate-server-certificates: "true" # Enable kubelet serving cert rotation
     extraConfig:
       serverTLSBootstrap: true # Allow kubelet to request TLS certs
+      imageMaximumGCAge: 168h # Prune images unused for 7d; disk-based GC only fires at 85% and never triggers here
       memorySwap: # Kubernetes swap support (K8s 1.32+)
         swapBehavior: LimitedSwap
 


### PR DESCRIPTION
## Problem

Worker nodes accumulate container images indefinitely. kubelet's disk-based image GC only starts at `imageGCHighThresholdPercent: 85`, and the workers sit at 55-63% — so it never runs. Every Renovate image bump leaves the previous version behind:

| Node | images |
|---|---|
| talos-dp-01 | **32.05 GB** |
| talos-dp-02 | 15.23 GB |
| talos-dp-03 | 14.28 GB |

Three versions each of `longhorn-instance-manager`, `holmes` and `iot-insights-engine` are currently resident, among others.

## Why it matters

Longhorn replicas share the same `/var` partition as the image store — `fs.capacityBytes`, `imageFs.capacityBytes` and Longhorn's `storageMaximum` all report the same 66.32 GB. Longhorn marks a disk unschedulable once `StorageAvailable - storageReserved` falls below 15% of the disk:

```
talos-dp-01   CurrentAvailable  10.47G  vs  9.95G   +0.52G
talos-dp-02   CurrentAvailable  13.30G  vs  9.95G   +3.35G
talos-dp-03   CurrentAvailable   8.17G  vs  9.95G   -1.78G   ← below
```

This is not hypothetical. Earlier today talos-dp-03 crossed that line, its replicas failed, and Longhorn rebuilt them onto the remaining nodes. The resulting ~22 GB of rebuild traffic (Prometheus 9.8 G + TimescaleDB 9.0 G + NATS 3.4 G) pushed talos-dp-02 over the same threshold within minutes. A crowdsec CNPG standby lost its WAL volume as collateral — `longhorn-postgres` runs `numberOfReplicas: 1` with `strict-local`, so there was no second replica to rebuild from, and Longhorn's auto-salvage reported "no data exists".

## Change

Sets `imageMaximumGCAge: 168h`, so kubelet reclaims images unused for 7 days regardless of disk usage. Images backing running containers are never collected; the only cost is a re-pull on a rollback to a version older than a week.

Expected to free roughly 18-22 GB on talos-dp-01 and give every node real headroom above Longhorn's threshold.

## Applying

The patch feeds both the prod and dev Omni templates, so it lands via:

```
task cluster:create -- prod
```

Worth watching on the first apply: a kubelet `extraConfig` change should restart the kubelet service rather than reboot the node, but please confirm against the node roll before assuming it.

## Follow-up (not in this PR)

Once this is applied and the reclaimed space is measured, moving NATS off talos-dp-03 becomes safe and should lift that node above the threshold. It is deliberately **not** bundled here: with today's numbers the move would push the target node below the line instead (dp-01 → 7.11 G, dp-02 → 9.94 G), so it depends on this landing first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)