### PR TITLE
fix(knx): follow the 15/2 and 17/1 group-address renumbering

### DIFF
--- a/kubernetes/applications/knx-nats-bridge/base/config/ga-catalog.yaml
+++ b/kubernetes/applications/knx-nats-bridge/base/config/ga-catalog.yaml
@@ -2490,42 +2490,36 @@
   room: Technikraum
   writable: false
 15/2/22:
-  dpt: '5.010'
-  function: Versorgerungstechnik
-  name: Versorgungstechnik.Gastherme.Heizung.Aktiv-Saisonal-Anomalie
-  room: Technikraum
-  writable: false
-15/2/23:
   dpt: '9.001'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Gastherme.Heizung.Vorlauf.Ist-Temperatur
   room: Technikraum
   writable: false
-15/2/24:
+15/2/23:
   dpt: '5.010'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Gastherme.Heizung.Vorlauf.Ist-Temperatur-Anomalie
   room: Technikraum
   writable: false
-15/2/25:
+15/2/24:
   dpt: '9.001'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Gastherme.Heizung.Vorlauf.Soll-Temperatur
   room: Technikraum
   writable: false
-15/2/26:
+15/2/25:
   dpt: '9.001'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Gastherme.Heizung.Rücklauf.Ist-Temperatur
   room: Technikraum
   writable: false
-15/2/27:
+15/2/26:
   dpt: '5.010'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Gastherme.Heizung.Rücklauf.Ist-Temperatur-Anomalie
   room: Technikraum
   writable: false
-15/2/28:
+15/2/27:
   dpt: '1.001'
   function: Versorgerungstechnik
   name: Versorgungstechnik.Gastherme.Heizung.Pumpe-Aktiv
@@ -3274,9 +3268,9 @@
   room: Küche
   writable: false
 17/1/10:
-  dpt: '5.010'
+  dpt: '1.005'
   function: Haushaltstechnik
-  name: Haushaltstechnik.Geschirrspüler.Salz-Füllstand
+  name: Haushaltstechnik.Geschirrspüler.Hinweis-Fertig
   room: Küche
   writable: false
 17/1/100:
@@ -3310,75 +3304,81 @@
   room: Küche
   writable: false
 17/1/105:
+  dpt: '16.001'
+  function: Haushaltstechnik
+  name: Haushaltstechnik.Mikrowelle.Statustext
+  room: Küche
+  writable: false
+17/1/106:
   dpt: '1.005'
   function: Haushaltstechnik
   name: Haushaltstechnik.Mikrowelle.Störung
   room: Küche
   writable: false
-17/1/106:
+17/1/107:
   dpt: '1.019'
   function: Haushaltstechnik
   name: Haushaltstechnik.Mikrowelle.Tür-Offen
   room: Küche
   writable: false
-17/1/107:
+17/1/108:
   dpt: '5.010'
   function: Haushaltstechnik
   name: Haushaltstechnik.Mikrowelle.Programm
   room: Küche
   writable: false
-17/1/108:
+17/1/109:
   dpt: '5.010'
   function: Haushaltstechnik
   name: Haushaltstechnik.Mikrowelle.Programm-Phase
   room: Küche
   writable: false
-17/1/109:
-  dpt: '7.006'
-  function: Haushaltstechnik
-  name: Haushaltstechnik.Mikrowelle.Restzeit
-  room: Küche
-  writable: false
 17/1/11:
   dpt: '5.010'
   function: Haushaltstechnik
-  name: Haushaltstechnik.Geschirrspüler.Klarspüler-Füllstand
+  name: Haushaltstechnik.Geschirrspüler.Salz-Füllstand
   room: Küche
   writable: false
 17/1/110:
   dpt: '7.006'
   function: Haushaltstechnik
-  name: Haushaltstechnik.Mikrowelle.Startzeit
+  name: Haushaltstechnik.Mikrowelle.Restzeit
   room: Küche
   writable: false
 17/1/111:
-  dpt: '9.001'
+  dpt: '7.006'
   function: Haushaltstechnik
-  name: Haushaltstechnik.Mikrowelle.Ist-Temperatur
+  name: Haushaltstechnik.Mikrowelle.Startzeit
   room: Küche
   writable: false
 17/1/112:
   dpt: '9.001'
   function: Haushaltstechnik
-  name: Haushaltstechnik.Mikrowelle.Soll-Temperatur
+  name: Haushaltstechnik.Mikrowelle.Ist-Temperatur
   room: Küche
   writable: false
 17/1/113:
+  dpt: '9.001'
+  function: Haushaltstechnik
+  name: Haushaltstechnik.Mikrowelle.Soll-Temperatur
+  room: Küche
+  writable: false
+17/1/114:
   dpt: '1.005'
   function: Haushaltstechnik
   name: Haushaltstechnik.Mikrowelle.Hinweis
   room: Küche
   writable: false
-17/1/114:
+17/1/115:
   dpt: '1.003'
   function: Haushaltstechnik
   name: Haushaltstechnik.Mikrowelle.Fernsteuerung
   room: Küche
   writable: false
 17/1/12:
-  dpt: '1.003'
+  dpt: '5.010'
   function: Haushaltstechnik
-  name: Haushaltstechnik.Geschirrspüler.Fernsteuerung
+  name: Haushaltstechnik.Geschirrspüler.Klarspüler-Füllstand
   room: Küche
   writable: false
 17/1/120:
@@ -3406,48 +3406,60 @@
   room: Küche
   writable: false
 17/1/124:
+  dpt: '16.001'
+  function: Haushaltstechnik
+  name: Haushaltstechnik.Kaffeemaschine.Statustext
+  room: Küche
+  writable: false
+17/1/125:
   dpt: '1.005'
   function: Haushaltstechnik
   name: Haushaltstechnik.Kaffeemaschine.Störung
   room: Küche
   writable: false
-17/1/125:
+17/1/126:
   dpt: '5.010'
   function: Haushaltstechnik
   name: Haushaltstechnik.Kaffeemaschine.Programm
   room: Küche
   writable: false
-17/1/126:
+17/1/127:
   dpt: '5.010'
   function: Haushaltstechnik
   name: Haushaltstechnik.Kaffeemaschine.Programm-Phase
   room: Küche
   writable: false
-17/1/127:
+17/1/128:
   dpt: '1.005'
   function: Haushaltstechnik
   name: Haushaltstechnik.Kaffeemaschine.Hinweis
   room: Küche
   writable: false
-17/1/128:
+17/1/129:
   dpt: '1.005'
   function: Haushaltstechnik
   name: Haushaltstechnik.Kaffeemaschine.Entkalken-Fällig
   room: Küche
   writable: false
-17/1/129:
-  dpt: '1.005'
+17/1/13:
+  dpt: '1.003'
   function: Haushaltstechnik
-  name: Haushaltstechnik.Kaffeemaschine.Reinigen-Fällig
+  name: Haushaltstechnik.Geschirrspüler.Fernsteuerung
   room: Küche
   writable: false
 17/1/130:
   dpt: '1.005'
   function: Haushaltstechnik
-  name: Haushaltstechnik.Kaffeemaschine.Milchsystem-Reinigen
+  name: Haushaltstechnik.Kaffeemaschine.Reinigen-Fällig
   room: Küche
   writable: false
 17/1/131:
+  dpt: '1.005'
+  function: Haushaltstechnik
+  name: Haushaltstechnik.Kaffeemaschine.Milchsystem-Reinigen
+  room: Küche
+  writable: false
+17/1/132:
   dpt: '1.003'
   function: Haushaltstechnik
   name: Haushaltstechnik.Kaffeemaschine.Fernsteuerung
@@ -3484,60 +3496,66 @@
   room: Küche
   writable: false
 17/1/145:
+  dpt: '16.001'
+  function: Haushaltstechnik
+  name: Haushaltstechnik.Dampfgarer.Statustext
+  room: Küche
+  writable: false
+17/1/146:
   dpt: '1.005'
   function: Haushaltstechnik
   name: Haushaltstechnik.Dampfgarer.Störung
   room: Küche
   writable: false
-17/1/146:
+17/1/147:
   dpt: '1.019'
   function: Haushaltstechnik
   name: Haushaltstechnik.Dampfgarer.Tür-Offen
   room: Küche
   writable: false
-17/1/147:
+17/1/148:
   dpt: '5.010'
   function: Haushaltstechnik
   name: Haushaltstechnik.Dampfgarer.Programm
   room: Küche
   writable: false
-17/1/148:
+17/1/149:
   dpt: '5.010'
   function: Haushaltstechnik
   name: Haushaltstechnik.Dampfgarer.Programm-Phase
   room: Küche
   writable: false
-17/1/149:
+17/1/150:
   dpt: '7.006'
   function: Haushaltstechnik
   name: Haushaltstechnik.Dampfgarer.Restzeit
   room: Küche
   writable: false
-17/1/150:
+17/1/151:
   dpt: '7.006'
   function: Haushaltstechnik
   name: Haushaltstechnik.Dampfgarer.Startzeit
   room: Küche
   writable: false
-17/1/151:
+17/1/152:
   dpt: '9.001'
   function: Haushaltstechnik
   name: Haushaltstechnik.Dampfgarer.Ist-Temperatur
   room: Küche
   writable: false
-17/1/152:
+17/1/153:
   dpt: '9.001'
   function: Haushaltstechnik
   name: Haushaltstechnik.Dampfgarer.Soll-Temperatur
   room: Küche
   writable: false
-17/1/153:
+17/1/154:
   dpt: '1.005'
   function: Haushaltstechnik
   name: Haushaltstechnik.Dampfgarer.Hinweis
   room: Küche
   writable: false
-17/1/154:
+17/1/155:
   dpt: '1.003'
   function: Haushaltstechnik
   name: Haushaltstechnik.Dampfgarer.Fernsteuerung
@@ -3568,30 +3586,36 @@
   room: Küche
   writable: false
 17/1/164:
+  dpt: '16.001'
+  function: Haushaltstechnik
+  name: Haushaltstechnik.Gefrierschrank.Statustext
+  room: Küche
+  writable: false
+17/1/165:
   dpt: '1.005'
   function: Haushaltstechnik
   name: Haushaltstechnik.Gefrierschrank.Störung
   room: Küche
   writable: false
-17/1/165:
+17/1/166:
   dpt: '1.019'
   function: Haushaltstechnik
   name: Haushaltstechnik.Gefrierschrank.Tür-Offen
   room: Küche
   writable: false
-17/1/166:
+17/1/167:
   dpt: '9.001'
   function: Haushaltstechnik
   name: Haushaltstechnik.Gefrierschrank.Ist-Temperatur
   room: Küche
   writable: false
-17/1/167:
+17/1/168:
   dpt: '9.001'
   function: Haushaltstechnik
   name: Haushaltstechnik.Gefrierschrank.Soll-Temperatur
   room: Küche
   writable: false
-17/1/168:
+17/1/169:
   dpt: '1.003'
   function: Haushaltstechnik
   name: Haushaltstechnik.Gefrierschrank.Fernsteuerung
@@ -3634,18 +3658,24 @@
   room: Küche
   writable: false
 17/1/25:
+  dpt: '16.001'
+  function: Haushaltstechnik
+  name: Haushaltstechnik.Haubenlüfter.Statustext
+  room: Küche
+  writable: false
+17/1/26:
   dpt: '1.005'
   function: Haushaltstechnik
   name: Haushaltstechnik.Haubenlüfter.Störung
   room: Küche
   writable: false
-17/1/26:
+17/1/27:
   dpt: '5.001'
   function: Haushaltstechnik
   name: Haushaltstechnik.Haubenlüfter.Fettfilter
   room: Küche
   writable: false
-17/1/27:
+17/1/28:
   dpt: '1.003'
   function: Haushaltstechnik
   name: Haushaltstechnik.Haubenlüfter.Fernsteuerung
@@ -3658,9 +3688,9 @@
   room: Küche
   writable: false
 17/1/4:
-  dpt: '1.005'
+  dpt: '16.001'
   function: Haushaltstechnik
-  name: Haushaltstechnik.Geschirrspüler.Störung
+  name: Haushaltstechnik.Geschirrspüler.Statustext
   room: Küche
   writable: false
 17/1/40:
@@ -3688,45 +3718,51 @@
   room: Küche
   writable: false
 17/1/44:
+  dpt: '16.001'
+  function: Haushaltstechnik
+  name: Haushaltstechnik.Kühlschrank.Statustext
+  room: Küche
+  writable: false
+17/1/45:
   dpt: '1.005'
   function: Haushaltstechnik
   name: Haushaltstechnik.Kühlschrank.Störung
   room: Küche
   writable: false
-17/1/45:
+17/1/46:
   dpt: '1.019'
   function: Haushaltstechnik
   name: Haushaltstechnik.Kühlschrank.Tür-Offen
   room: Küche
   writable: false
-17/1/46:
+17/1/47:
   dpt: '9.001'
   function: Haushaltstechnik
   name: Haushaltstechnik.Kühlschrank.Ist-Temperatur
   room: Küche
   writable: false
-17/1/47:
+17/1/48:
   dpt: '9.002'
   function: Haushaltstechnik
   name: Haushaltstechnik.Kühlschrank.Soll-Temperatur
   room: Küche
   writable: false
-17/1/48:
+17/1/49:
   dpt: '1.003'
   function: Haushaltstechnik
   name: Haushaltstechnik.Kühlschrank.Fernsteuerung
   room: Küche
   writable: false
 17/1/5:
-  dpt: '5.010'
+  dpt: '1.005'
   function: Haushaltstechnik
-  name: Haushaltstechnik.Geschirrspüler.Programm
+  name: Haushaltstechnik.Geschirrspüler.Störung
   room: Küche
   writable: false
 17/1/6:
   dpt: '5.010'
   function: Haushaltstechnik
-  name: Haushaltstechnik.Geschirrspüler.Programm-Phase
+  name: Haushaltstechnik.Geschirrspüler.Programm
   room: Küche
   writable: false
 17/1/60:
@@ -3760,78 +3796,84 @@
   room: Küche
   writable: false
 17/1/65:
+  dpt: '16.001'
+  function: Haushaltstechnik
+  name: Haushaltstechnik.Backofen.Statustext
+  room: Küche
+  writable: false
+17/1/66:
   dpt: '1.005'
   function: Haushaltstechnik
   name: Haushaltstechnik.Backofen.Störung
   room: Küche
   writable: false
-17/1/66:
+17/1/67:
   dpt: '1.019'
   function: Haushaltstechnik
   name: Haushaltstechnik.Backofen.Tür-Offen
   room: Küche
   writable: false
-17/1/67:
+17/1/68:
   dpt: '5.010'
   function: Haushaltstechnik
   name: Haushaltstechnik.Backofen.Programm
   room: Küche
   writable: false
-17/1/68:
+17/1/69:
   dpt: '5.010'
   function: Haushaltstechnik
   name: Haushaltstechnik.Backofen.Programm-Phase
   room: Küche
   writable: false
-17/1/69:
-  dpt: '7.006'
-  function: Haushaltstechnik
-  name: Haushaltstechnik.Backofen.Restzeit
-  room: Küche
-  writable: false
 17/1/7:
-  dpt: '7.006'
+  dpt: '5.010'
   function: Haushaltstechnik
-  name: Haushaltstechnik.Geschirrspüler.Restzeit
+  name: Haushaltstechnik.Geschirrspüler.Programm-Phase
   room: Küche
   writable: false
 17/1/70:
   dpt: '7.006'
   function: Haushaltstechnik
-  name: Haushaltstechnik.Backofen.Startzeit
+  name: Haushaltstechnik.Backofen.Restzeit
   room: Küche
   writable: false
 17/1/71:
-  dpt: '9.001'
+  dpt: '7.006'
   function: Haushaltstechnik
-  name: Haushaltstechnik.Backofen.Ist-Temperatur
+  name: Haushaltstechnik.Backofen.Startzeit
   room: Küche
   writable: false
 17/1/72:
   dpt: '9.001'
   function: Haushaltstechnik
-  name: Haushaltstechnik.Backofen.Soll-Temperatur
+  name: Haushaltstechnik.Backofen.Ist-Temperatur
   room: Küche
   writable: false
 17/1/73:
   dpt: '9.001'
   function: Haushaltstechnik
-  name: Haushaltstechnik.Backofen.Kern-Ist-Temperatur
+  name: Haushaltstechnik.Backofen.Soll-Temperatur
   room: Küche
   writable: false
 17/1/74:
   dpt: '9.001'
   function: Haushaltstechnik
-  name: Haushaltstechnik.Backofen.Kern-Soll-Temperatur
+  name: Haushaltstechnik.Backofen.Kern-Ist-Temperatur
   room: Küche
   writable: false
 17/1/75:
+  dpt: '9.001'
+  function: Haushaltstechnik
+  name: Haushaltstechnik.Backofen.Kern-Soll-Temperatur
+  room: Küche
+  writable: false
+17/1/76:
   dpt: '1.005'
   function: Haushaltstechnik
   name: Haushaltstechnik.Backofen.Hinweis-Fertig
   room: Küche
   writable: false
-17/1/76:
+17/1/77:
   dpt: '1.003'
   function: Haushaltstechnik
   name: Haushaltstechnik.Backofen.Fernsteuerung
@@ -3840,7 +3882,7 @@
 17/1/8:
   dpt: '7.006'
   function: Haushaltstechnik
-  name: Haushaltstechnik.Geschirrspüler.Startzeit
+  name: Haushaltstechnik.Geschirrspüler.Restzeit
   room: Küche
   writable: false
 17/1/80:
@@ -3862,33 +3904,39 @@
   room: Küche
   writable: false
 17/1/83:
+  dpt: '16.001'
+  function: Haushaltstechnik
+  name: Haushaltstechnik.Tellerwärmer.Statustext
+  room: Küche
+  writable: false
+17/1/84:
   dpt: '1.005'
   function: Haushaltstechnik
   name: Haushaltstechnik.Tellerwärmer.Störung
   room: Küche
   writable: false
-17/1/84:
+17/1/85:
   dpt: '9.001'
   function: Haushaltstechnik
   name: Haushaltstechnik.Tellerwärmer.Ist-Temperatur
   room: Küche
   writable: false
-17/1/85:
+17/1/86:
   dpt: '9.001'
   function: Haushaltstechnik
   name: Haushaltstechnik.Tellerwärmer.Soll-Temperatur
   room: Küche
   writable: false
-17/1/86:
+17/1/87:
   dpt: '1.003'
   function: Haushaltstechnik
   name: Haushaltstechnik.Tellerwärmer.Fernsteuerung
   room: Küche
   writable: false
 17/1/9:
-  dpt: '1.005'
+  dpt: '7.006'
   function: Haushaltstechnik
-  name: Haushaltstechnik.Geschirrspüler.Hinweis-Fertig
+  name: Haushaltstechnik.Geschirrspüler.Startzeit
   room: Küche
   writable: false
 2/0/240:

--- a/kubernetes/applications/knx-nats-bridge/base/config/writer-rules.yaml
+++ b/kubernetes/applications/knx-nats-bridge/base/config/writer-rules.yaml
@@ -331,25 +331,25 @@ mappings:
     description: "Versorgungstechnik.Gastherme.Heizung.Aktiv"
     min_delta: 0  # binary status: write only on change
   - subject: "ems-esp.boiler_data"
-    ga: "15/2/28"
+    ga: "15/2/27"
     dpt: "1.001"
     payload_path: "$.heatingpump"
     description: "Versorgungstechnik.Gastherme.Heizung.Pumpe-Aktiv"
     min_delta: 0  # binary status: write only on change
   - subject: "ems-esp.boiler_data"
-    ga: "15/2/23"
+    ga: "15/2/22"
     dpt: "9.001"
     payload_path: "$.curflowtemp"
     description: "Versorgungstechnik.Gastherme.Heizung.Vorlauf.Ist-Temperatur"
     min_delta: 0.5  # °C
   - subject: "ems-esp.boiler_data"
-    ga: "15/2/25"
+    ga: "15/2/24"
     dpt: "9.001"
     payload_path: "$.selflowtemp"
     description: "Versorgungstechnik.Gastherme.Heizung.Vorlauf.Soll-Temperatur"
     min_delta: 0.5  # °C
   - subject: "ems-esp.boiler_data"
-    ga: "15/2/26"
+    ga: "15/2/25"
     dpt: "9.001"
     payload_path: "$.rettemp"
     description: "Versorgungstechnik.Gastherme.Heizung.Rücklauf.Ist-Temperatur"
@@ -627,21 +627,21 @@ mappings:
     seed_on_start: true
     seed_on_start: true
   - subject: "anomaly.heating_activity_seasonal"
-    ga: "15/2/22"
+    ga: "15/2/21"
     dpt: "5.010"
     payload_path: "$.severity_level"
-    description: "Versorgungstechnik.Gastherme.Heizung.Aktiv-Saisonal-Anomalie"
+    description: "Versorgungstechnik.Gastherme.Heizung.Aktiv-Anomalie"
     min_delta: 0
     seed_on_start: true
   - subject: "anomaly.boiler_curflowtemp"
-    ga: "15/2/24"
+    ga: "15/2/23"
     dpt: "5.010"
     payload_path: "$.severity_level"
     description: "Versorgungstechnik.Gastherme.Heizung.Vorlauf.Ist-Temperatur-Anomalie"
     min_delta: 0
     seed_on_start: true
   - subject: "anomaly.boiler_rettemp"
-    ga: "15/2/27"
+    ga: "15/2/26"
     dpt: "5.010"
     payload_path: "$.severity_level"
     description: "Versorgungstechnik.Gastherme.Heizung.Rücklauf.Ist-Temperatur-Anomalie"
@@ -1610,42 +1610,42 @@ mappings:
     min_delta: 0  # enum state: write only on change
     seed_on_start: true
   - subject: "miele.geschirrspueler.state"
-    ga: "17/1/4"
+    ga: "17/1/5"
     dpt: "1.005"
     payload_path: "$.failure"
     description: "Haushaltstechnik.Geschirrspüler.Störung"
     min_delta: 0  # bool state: write only on change
     seed_on_start: true
   - subject: "miele.geschirrspueler.state"
-    ga: "17/1/5"
+    ga: "17/1/6"
     dpt: "5.010"
     payload_path: "$.program"
     description: "Haushaltstechnik.Geschirrspüler.Programm"
     min_delta: 0  # enum state: write only on change
     seed_on_start: true
   - subject: "miele.geschirrspueler.state"
-    ga: "17/1/6"
+    ga: "17/1/7"
     dpt: "5.010"
     payload_path: "$.phase"
     description: "Haushaltstechnik.Geschirrspüler.Programm-Phase"
     min_delta: 0  # enum state: write only on change
     seed_on_start: true
   - subject: "miele.geschirrspueler.state"
-    ga: "17/1/7"
+    ga: "17/1/8"
     dpt: "7.006"
     payload_path: "$.remaining_minutes"
     description: "Haushaltstechnik.Geschirrspüler.Restzeit"
     min_delta: 1  # minutes
     seed_on_start: true
   - subject: "miele.geschirrspueler.state"
-    ga: "17/1/9"
+    ga: "17/1/10"
     dpt: "1.005"
     payload_path: "$.info"
     description: "Haushaltstechnik.Geschirrspüler.Hinweis-Fertig"
     min_delta: 0  # bool state: write only on change
     seed_on_start: true
   - subject: "miele.geschirrspueler.state"
-    ga: "17/1/12"
+    ga: "17/1/13"
     dpt: "1.003"
     payload_path: "$.remote_control"
     description: "Haushaltstechnik.Geschirrspüler.Fernsteuerung"
@@ -1663,63 +1663,63 @@ mappings:
     min_delta: 0  # enum state: write only on change
     seed_on_start: true
   - subject: "miele.backofen.state"
-    ga: "17/1/65"
+    ga: "17/1/66"
     dpt: "1.005"
     payload_path: "$.failure"
     description: "Haushaltstechnik.Backofen.Störung"
     min_delta: 0  # bool state: write only on change
     seed_on_start: true
   - subject: "miele.backofen.state"
-    ga: "17/1/66"
+    ga: "17/1/67"
     dpt: "1.019"
     payload_path: "$.door_open"
     description: "Haushaltstechnik.Backofen.Tür-Offen"
     min_delta: 0  # bool state: write only on change
     seed_on_start: true
   - subject: "miele.backofen.state"
-    ga: "17/1/67"
+    ga: "17/1/68"
     dpt: "5.010"
     payload_path: "$.program"
     description: "Haushaltstechnik.Backofen.Programm"
     min_delta: 0  # enum state: write only on change
     seed_on_start: true
   - subject: "miele.backofen.state"
-    ga: "17/1/68"
+    ga: "17/1/69"
     dpt: "5.010"
     payload_path: "$.phase"
     description: "Haushaltstechnik.Backofen.Programm-Phase"
     min_delta: 0  # enum state: write only on change
     seed_on_start: true
   - subject: "miele.backofen.state"
-    ga: "17/1/69"
+    ga: "17/1/70"
     dpt: "7.006"
     payload_path: "$.remaining_minutes"
     description: "Haushaltstechnik.Backofen.Restzeit"
     min_delta: 1  # minutes
     seed_on_start: true
   - subject: "miele.backofen.state"
-    ga: "17/1/71"
+    ga: "17/1/72"
     dpt: "9.001"
     payload_path: "$.temperature_c"
     description: "Haushaltstechnik.Backofen.Ist-Temperatur"
     min_delta: 0.5  # °C
     seed_on_start: true
   - subject: "miele.backofen.state"
-    ga: "17/1/73"
+    ga: "17/1/74"
     dpt: "9.001"
     payload_path: "$.core_temperature_c"
     description: "Haushaltstechnik.Backofen.Kern-Ist-Temperatur"
     min_delta: 0.5  # °C
     seed_on_start: true
   - subject: "miele.backofen.state"
-    ga: "17/1/75"
+    ga: "17/1/76"
     dpt: "1.005"
     payload_path: "$.info"
     description: "Haushaltstechnik.Backofen.Hinweis-Fertig"
     min_delta: 0  # bool state: write only on change
     seed_on_start: true
   - subject: "miele.backofen.state"
-    ga: "17/1/76"
+    ga: "17/1/77"
     dpt: "1.003"
     payload_path: "$.remote_control"
     description: "Haushaltstechnik.Backofen.Fernsteuerung"
@@ -1736,21 +1736,21 @@ mappings:
     min_delta: 0  # enum state: write only on change
     seed_on_start: true
   - subject: "miele.tellerwaermer.state"
-    ga: "17/1/83"
+    ga: "17/1/84"
     dpt: "1.005"
     payload_path: "$.failure"
     description: "Haushaltstechnik.Tellerwärmer.Störung"
     min_delta: 0  # bool state: write only on change
     seed_on_start: true
   - subject: "miele.tellerwaermer.state"
-    ga: "17/1/84"
+    ga: "17/1/85"
     dpt: "9.001"
     payload_path: "$.temperature_c"
     description: "Haushaltstechnik.Tellerwärmer.Ist-Temperatur"
     min_delta: 0.5  # °C
     seed_on_start: true
   - subject: "miele.tellerwaermer.state"
-    ga: "17/1/86"
+    ga: "17/1/87"
     dpt: "1.003"
     payload_path: "$.remote_control"
     description: "Haushaltstechnik.Tellerwärmer.Fernsteuerung"
@@ -1766,56 +1766,56 @@ mappings:
     min_delta: 0  # enum state: write only on change
     seed_on_start: true
   - subject: "miele.mikrowelle.state"
-    ga: "17/1/105"
+    ga: "17/1/106"
     dpt: "1.005"
     payload_path: "$.failure"
     description: "Haushaltstechnik.Mikrowelle.Störung"
     min_delta: 0  # bool state: write only on change
     seed_on_start: true
   - subject: "miele.mikrowelle.state"
-    ga: "17/1/106"
+    ga: "17/1/107"
     dpt: "1.019"
     payload_path: "$.door_open"
     description: "Haushaltstechnik.Mikrowelle.Tür-Offen"
     min_delta: 0  # bool state: write only on change
     seed_on_start: true
   - subject: "miele.mikrowelle.state"
-    ga: "17/1/107"
+    ga: "17/1/108"
     dpt: "5.010"
     payload_path: "$.program"
     description: "Haushaltstechnik.Mikrowelle.Programm"
     min_delta: 0  # enum state: write only on change
     seed_on_start: true
   - subject: "miele.mikrowelle.state"
-    ga: "17/1/108"
+    ga: "17/1/109"
     dpt: "5.010"
     payload_path: "$.phase"
     description: "Haushaltstechnik.Mikrowelle.Programm-Phase"
     min_delta: 0  # enum state: write only on change
     seed_on_start: true
   - subject: "miele.mikrowelle.state"
-    ga: "17/1/109"
+    ga: "17/1/110"
     dpt: "7.006"
     payload_path: "$.remaining_minutes"
     description: "Haushaltstechnik.Mikrowelle.Restzeit"
     min_delta: 1  # minutes
     seed_on_start: true
   - subject: "miele.mikrowelle.state"
-    ga: "17/1/111"
+    ga: "17/1/112"
     dpt: "9.001"
     payload_path: "$.temperature_c"
     description: "Haushaltstechnik.Mikrowelle.Ist-Temperatur"
     min_delta: 0.5  # °C
     seed_on_start: true
   - subject: "miele.mikrowelle.state"
-    ga: "17/1/113"
+    ga: "17/1/114"
     dpt: "1.005"
     payload_path: "$.info"
     description: "Haushaltstechnik.Mikrowelle.Hinweis"
     min_delta: 0  # bool state: write only on change
     seed_on_start: true
   - subject: "miele.mikrowelle.state"
-    ga: "17/1/114"
+    ga: "17/1/115"
     dpt: "1.003"
     payload_path: "$.remote_control"
     description: "Haushaltstechnik.Mikrowelle.Fernsteuerung"
@@ -1833,35 +1833,35 @@ mappings:
     min_delta: 0  # enum state: write only on change
     seed_on_start: true
   - subject: "miele.kaffeemaschine.state"
-    ga: "17/1/124"
+    ga: "17/1/125"
     dpt: "1.005"
     payload_path: "$.failure"
     description: "Haushaltstechnik.Kaffeemaschine.Störung"
     min_delta: 0  # bool state: write only on change
     seed_on_start: true
   - subject: "miele.kaffeemaschine.state"
-    ga: "17/1/125"
+    ga: "17/1/126"
     dpt: "5.010"
     payload_path: "$.program"
     description: "Haushaltstechnik.Kaffeemaschine.Programm"
     min_delta: 0  # enum state: write only on change
     seed_on_start: true
   - subject: "miele.kaffeemaschine.state"
-    ga: "17/1/126"
+    ga: "17/1/127"
     dpt: "5.010"
     payload_path: "$.phase"
     description: "Haushaltstechnik.Kaffeemaschine.Programm-Phase"
     min_delta: 0  # enum state: write only on change
     seed_on_start: true
   - subject: "miele.kaffeemaschine.state"
-    ga: "17/1/127"
+    ga: "17/1/128"
     dpt: "1.005"
     payload_path: "$.info"
     description: "Haushaltstechnik.Kaffeemaschine.Hinweis"
     min_delta: 0  # bool state: write only on change
     seed_on_start: true
   - subject: "miele.kaffeemaschine.state"
-    ga: "17/1/131"
+    ga: "17/1/132"
     dpt: "1.003"
     payload_path: "$.remote_control"
     description: "Haushaltstechnik.Kaffeemaschine.Fernsteuerung"
@@ -1877,56 +1877,56 @@ mappings:
     min_delta: 0  # enum state: write only on change
     seed_on_start: true
   - subject: "miele.dampfgarer.state"
-    ga: "17/1/145"
+    ga: "17/1/146"
     dpt: "1.005"
     payload_path: "$.failure"
     description: "Haushaltstechnik.Dampfgarer.Störung"
     min_delta: 0  # bool state: write only on change
     seed_on_start: true
   - subject: "miele.dampfgarer.state"
-    ga: "17/1/146"
+    ga: "17/1/147"
     dpt: "1.019"
     payload_path: "$.door_open"
     description: "Haushaltstechnik.Dampfgarer.Tür-Offen"
     min_delta: 0  # bool state: write only on change
     seed_on_start: true
   - subject: "miele.dampfgarer.state"
-    ga: "17/1/147"
+    ga: "17/1/148"
     dpt: "5.010"
     payload_path: "$.program"
     description: "Haushaltstechnik.Dampfgarer.Programm"
     min_delta: 0  # enum state: write only on change
     seed_on_start: true
   - subject: "miele.dampfgarer.state"
-    ga: "17/1/148"
+    ga: "17/1/149"
     dpt: "5.010"
     payload_path: "$.phase"
     description: "Haushaltstechnik.Dampfgarer.Programm-Phase"
     min_delta: 0  # enum state: write only on change
     seed_on_start: true
   - subject: "miele.dampfgarer.state"
-    ga: "17/1/149"
+    ga: "17/1/150"
     dpt: "7.006"
     payload_path: "$.remaining_minutes"
     description: "Haushaltstechnik.Dampfgarer.Restzeit"
     min_delta: 1  # minutes
     seed_on_start: true
   - subject: "miele.dampfgarer.state"
-    ga: "17/1/151"
+    ga: "17/1/152"
     dpt: "9.001"
     payload_path: "$.temperature_c"
     description: "Haushaltstechnik.Dampfgarer.Ist-Temperatur"
     min_delta: 0.5  # °C
     seed_on_start: true
   - subject: "miele.dampfgarer.state"
-    ga: "17/1/153"
+    ga: "17/1/154"
     dpt: "1.005"
     payload_path: "$.info"
     description: "Haushaltstechnik.Dampfgarer.Hinweis"
     min_delta: 0  # bool state: write only on change
     seed_on_start: true
   - subject: "miele.dampfgarer.state"
-    ga: "17/1/154"
+    ga: "17/1/155"
     dpt: "1.003"
     payload_path: "$.remote_control"
     description: "Haushaltstechnik.Dampfgarer.Fernsteuerung"


### PR DESCRIPTION
**Draft on purpose — must not merge before the ETS project is downloaded to Basalte and the placeholder device.** The bus still runs on the old numbering; merging first would make the bridge write past Basalte.

The ETS project was renumbered in two places and the catalog regenerated. Both shifts leave affected writer rules pointing at the wrong datapoint, so the rules move with the catalog in the same commit.

## 15/2 — gap closed

Removing the seasonal anomaly address pulled everything above it down by one:

| datapoint | was | now |
|---|---|---|
| Heizung.Aktiv-Anomalie | 21 (retired detector) | **21** — seasonal anomaly moves here |
| Vorlauf.Ist-Temperatur | 23 | **22** |
| Vorlauf.Ist-Temperatur-Anomalie | 24 | **23** |
| Vorlauf.Soll-Temperatur | 25 | **24** |
| Rücklauf.Ist-Temperatur | 26 | **25** |
| Rücklauf.Ist-Temperatur-Anomalie | 27 | **26** |
| Pumpe-Aktiv | 28 | **27** |

Without this the bridge would write boiler telemetry onto anomaly addresses and anomaly severities onto temperature addresses — a severity (DPT 5.010) would land on Pumpe-Aktiv (DPT 1.001).

## 17/1 — a Statustext address inserted per appliance

39 rules move up by one, across dishwasher, oven, plate warmer, microwave, coffee machine and steamer.

## How the remapping was done

**By datapoint name, not arithmetic** — so neither the direction nor the step size of a shift matters, and an unresolvable name fails loudly instead of silently mis-assigning.

Exactly one rule could not be resolved that way: `anomaly.heating_activity_seasonal`, whose old name `Heizung.Aktiv-Saisonal-Anomalie` no longer exists in the catalog. That is how it was caught — it still pointed at 15/2/22, which is now a temperature. Handled explicitly.

All 275 rules verify against the catalog: address present, DPT equal, description equal to the catalog name, and no address carrying two rules.

## Merge order

1. **ETS download** to Basalte and the placeholder device — the bus switches
2. Merge this PR — the ConfigMap hash rolls the bridge natively, no manual restart
3. Verify the bridge log reports 275 rules and spot-check a `15/2/2x` value against Basalte
4. **Then** the history migration in TimescaleDB (below) — last, so there is only one cutover

## Still to do: the `knx` history

129,061 rows for `15/2/21-28` since 2026-06-12 and 3,534 for `17/1` since 2026-08-20 carry the old numbering. Until they are rewritten, any query spanning the cutover mixes two different datapoints.

The migration has to run **after** step 2, so the cutover timestamp is fixed. Order matters to avoid colliding with the `(time, ga)` primary key — 15/2 ascending because it shifts down, 17/1 descending because it shifts up — and `knx_1h` plus `knx_baseline_30d` need re-materialising for the affected range afterwards. To be applied manually against the database, chunk-wise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)