### PR TITLE
feat(midea): alert on undelivered commands and mirror reachability to KNX

### DIFF
--- a/kubernetes/applications/knx-nats-bridge/base/config/writer-rules.yaml
+++ b/kubernetes/applications/knx-nats-bridge/base/config/writer-rules.yaml
@@ -1509,6 +1509,16 @@ mappings:
     description: "Raumklima.KG.Vorratsraum.Entfeuchter.Temperatur"
     min_delta: 0.5  # °C
     seed_on_start: true
+  # `power` is what the appliance reports; while the bridge holds no connection
+  # to it there is nothing to report and every status GA above keeps its last
+  # value, which reads exactly like a settled appliance.
+  - subject: "midea.entfeuchter-kg4.availability"
+    ga: "6/1/73"
+    dpt: "1.011"
+    payload_path: "$.online"
+    description: "Raumklima.KG.Vorratsraum.Entfeuchter.Verbindung-Status"
+    min_delta: 0  # bool state: write only on change
+    seed_on_start: true
 
   # Entfeuchter Hauswirtschaftsraum status feedback (KNX<-NATS). The command GAs
   # (100/102/104/106/108) are driven KNX->device by the
@@ -1569,6 +1579,13 @@ mappings:
     payload_path: "$.temperature_c"
     description: "Raumklima.KG.Hauswirtschaftsraum.Entfeuchter.Temperatur"
     min_delta: 0.5  # °C
+    seed_on_start: true
+  - subject: "midea.entfeuchter-kg5.availability"
+    ga: "6/1/113"
+    dpt: "1.011"
+    payload_path: "$.online"
+    description: "Raumklima.KG.Hauswirtschaftsraum.Entfeuchter.Verbindung-Status"
+    min_delta: 0  # bool state: write only on change
     seed_on_start: true
 
   # Bordbar LED status feedback (KNX<-NATS). The command GAs (4/2/61/63-67) are

--- a/kubernetes/applications/prometheus/base/prometheus-rule.yaml
+++ b/kubernetes/applications/prometheus/base/prometheus-rule.yaml
@@ -259,6 +259,21 @@ spec:
             summary: "Dehumidifier {{ $labels.device }} unreachable"
             description: "The bridge has not held a connection for 30m — device unplugged, moved, or off the WLAN."
 
+        # The disconnect alert above is deliberately slow, because these units
+        # drop off the WLAN constantly and recover on their own. This one fires
+        # on the damage instead: a commanded state the appliance still has not
+        # been given. The bridge holds it and re-sends on every reconnect, so
+        # anything still pending after 15m means the appliance is not coming
+        # back on its own.
+        - alert: MideaCommandNotDelivered
+          expr: midea_pending_commands > 0
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Dehumidifier {{ $labels.device }} has not received a command"
+            description: "{{ $value }} command(s) have been waiting 15m for {{ $labels.device }} — the humidity alarm may be switching a device that never hears it."
+
     # The only cloud-dependent bridge in the stack: appliance state goes stale
     # whenever the WAN link or Miele is down, and the access token is a second
     # way to lose the stream without the pod noticing. Warning throughout —


### PR DESCRIPTION
The two remaining gaps from the 2026-08-29 incident, where the humidity alarm switched the Hauswirtschaftsraum dehumidifier on at 13:12 while it was off the WLAN, the command was dropped, and nothing noticed for 7.5 hours.

## `MideaCommandNotDelivered`

Watches `midea_pending_commands`, the gauge the bridge gained in v0.5.0 (already deployed).

`MideaDeviceDisconnected` deliberately stays at `for: 30m`. These units drop off the WLAN constantly — `entfeuchter-kg5` has 625 failed reconnects against 221 successful ones — and recover on their own, and the bridge now re-sends held commands on every reconnect. Alerting on the disconnect would be near-permanent noise. What actually hurt was a commanded state the appliance never received, and that is what this fires on: anything still pending after 15 minutes is not coming back by itself.

## `Verbindung-Status` on `6/1/73` and `6/1/113`

`power` is what the appliance reports. While the bridge holds no connection there is nothing to report, so every status GA keeps its last value — on the bus an unreachable appliance looks exactly like a settled one. These rules mirror `midea.<device>.availability` (DPT 1.011) so Basalte can show "nicht erreichbar" instead of a stale on/off.

**Both addresses still need to be created in ETS** (`Raumklima.KG.Vorratsraum.Entfeuchter.Verbindung-Status` and `…Hauswirtschaftsraum…`) and the catalog re-exported with `task knx:catalog` — they are not in `ga-catalog.yaml` yet. The subject also does not exist until the bridge release carrying alexander-zimmermann/midea-nats-bridge#21 is deployed. Until both are true the rules are inert: nothing publishes on the subject, so nothing is written.

Validated against the bridge's `writer-rules.schema.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)